### PR TITLE
Fix cleanup step to always run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,6 @@ jobs:
         script: |
           const { owner, repo } = context.repo;
           const sha = context.sha;
-
           await github.rest.repos.createCommitStatus({
             owner,
             repo,
@@ -117,7 +116,9 @@ jobs:
   cleanup:
     runs-on: self-hosted
     needs: build
+    if: always()
     steps:
     - name: Cleanup build directory
       run: |
-        rm -rf pr-${{ needs.build.outputs.PR_NUMBER }}
+        rm -rf pr-${{ github.event.number }}
+


### PR DESCRIPTION
    - Added `if: always()` condition to the cleanup job to ensure it runs regardless of the build job's success or failure.
    - Corrected the passing of `PR_NUMBER` between jobs to ensure the cleanup step correctly references the build directory.
