### PR TITLE
fix name of RISC-V extension

### DIFF
--- a/About.md
+++ b/About.md
@@ -21,7 +21,7 @@ The linker supports the following targets:
 - ARM
 - AArch64
 - Hexagon
-- RISC-V (including the Xqiu extension)
+- RISC-V (including the Xqci extension)
 
 The linker incorporates various features commonly available in GNU-compliant linkers, including:
 - Partial linking


### PR DESCRIPTION
Change-Id: Iec63205c8a1f57a79b861d21db5c8d0968ef1e97