### PR TITLE
Change sort-section to permit space-delim

### DIFF
--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -542,9 +542,9 @@ defm unresolved_symbols
           "report-all(Default), ignore-in-object-files, ignore-in-shared-libs">,
       MetaVarName<"<option>">,
       Group<grp_scriptopts>;
-defm sort_section : smDashOnlyEq<"sort-section", "sort_section",
-                       "Sort sections. Options availabe are name , alignment">,
-                       MetaVarName<"<option>">,
+defm sort_section : EEq<"sort-section",
+                       "Sort sections. Options available are name , alignment">,
+                       MetaVarName<"<sort_section>">,
                         Group<grp_scriptopts>;
 
 //===----------------------------------------------------------------------===//

--- a/test/Common/standalone/CommandLine/PrintHelp/PrintModHelp.test
+++ b/test/Common/standalone/CommandLine/PrintHelp/PrintModHelp.test
@@ -71,7 +71,7 @@ RUN: %link --help 2>&1 | %filecheck %s
 #CHECK:   --map-section=<section>
 #CHECK:   --script=<linkerscriptfile>
 #CHECK:   --section-start=<address>
-#CHECK:   --sort-section=<option>
+#CHECK:   --sort-section=<sort_section>
 #CHECK:   -T=<linkerscriptfile>
 #CHECK:   --Tbss=<address>
 #CHECK:   -Ttext-segment=<address>

--- a/test/Common/standalone/linkerscript/Sorting/SortByAlignment/SortByAlignment.test
+++ b/test/Common/standalone/linkerscript/Sorting/SortByAlignment/SortByAlignment.test
@@ -6,7 +6,8 @@
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
 RUN: %link %linkopts %t1.1.o -T %p/Inputs/script.t -o %t2.out -M 2>&1 | %filecheck %s
-RUN: %link %linkopts %t1.1.o --sort=section=alignment -T %p/Inputs/sortalignment.t -o %t2.out.1 -M 2>&1 | %filecheck %s
+RUN: %link %linkopts %t1.1.o --sort-section=alignment -T %p/Inputs/sortalignment.t -o %t2.out.1 -M 2>&1 | %filecheck %s
+RUN: %link %linkopts %t1.1.o --sort-section alignment -T %p/Inputs/sortalignment.t -o %t2.out.1 -M 2>&1 | %filecheck %s
 #END_TEST
 
 #CHECK: .text.b1


### PR DESCRIPTION
This clang command `clang -std=c99 -nostdinc -ffreestanding ... -Wl,--sort-section,alignment` from musl (https://github.com/quic/musl/blob/721ca8b60ec4180ff767c317f8869a5eca13fd92/configure#L566) fails like so:

	Fatal: cannot read file alignment
	Fatal: Linking had errors.