### PR TITLE
Add delimiter to "cannot read" diagnostic

### DIFF
--- a/include/eld/Diagnostics/DiagReaders.inc
+++ b/include/eld/Diagnostics/DiagReaders.inc
@@ -11,8 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-DIAG(fatal_cannot_read_input, DiagnosticEngine::Fatal, "cannot read file %0")
-DIAG(err_cannot_read_input, DiagnosticEngine::Error, "cannot read file %0")
+DIAG(fatal_cannot_read_input, DiagnosticEngine::Fatal, "cannot read file '%0'")
+DIAG(err_cannot_read_input, DiagnosticEngine::Error, "cannot read file '%0'")
 DIAG(fatal_cannot_read_input_err, DiagnosticEngine::Fatal,
      "cannot read file %0, because of error %1")
 DIAG(fatal_cannot_make_module, DiagnosticEngine::Fatal,

--- a/test/AArch64/standalone/linkerscript/includefileLPath/includeLpath.test
+++ b/test/AArch64/standalone/linkerscript/includefileLPath/includeLpath.test
@@ -2,5 +2,5 @@ RUN: %clang %clangopts -target aarch64 -c %p/Inputs/1.c -o %t.o
 RUN: %link %linkopts -march aarch64 -L%p/Inputs/ -T %p/script_with_archive.t %t.o -o %t.out 2>&1
 RUN: %not %link %linkopts -march aarch64 -L%p/Inputs/ -T %p/script_with_include_notfound.t %t.o -o %t.out 2>&1 | %filecheck %s
 
-CHECK: Fatal: cannot read file newinclude.t
+CHECK: Fatal: cannot read file 'newinclude.t'
 

--- a/test/ARM/standalone/linkerscript/includefileLPath/includeLpath.test
+++ b/test/ARM/standalone/linkerscript/includefileLPath/includeLpath.test
@@ -2,5 +2,5 @@ RUN: %clang %clangopts -target arm -c %p/Inputs/1.c -o %t.o
 RUN: %link %linkopts -march arm -L%p/Inputs/ -T %p/script_with_archive.t %t.o -o %t.out 2>&1
 RUN: %not %link %linkopts -march arm -L%p/Inputs/ -T %p/script_with_include_notfound.t %t.o -o %t.out 2>&1 | %filecheck %s
 
-CHECK: Fatal: cannot read file newinclude.t
+CHECK: Fatal: cannot read file 'newinclude.t'
 

--- a/test/Common/standalone/CommandLine/Reproduce/InvalidInputFile.test
+++ b/test/Common/standalone/CommandLine/Reproduce/InvalidInputFile.test
@@ -4,7 +4,7 @@
 #END_COMMENT
 #START_TEST
 RUN: %not %link %linkopts  nonexistent.o -lnonexistent --reproduce a.tar 2>&1 | %filecheck %s
-#CHECK: Fatal: cannot read file nonexistent.o
+#CHECK: Fatal: cannot read file 'nonexistent.o'
 #CHECK: Note: Creating tarball {{.*}}.tar
 #CHECK: Fatal: Linking had errors.
 #END_TEST

--- a/test/Common/standalone/MissingInput/MissingInput.test
+++ b/test/Common/standalone/MissingInput/MissingInput.test
@@ -5,5 +5,5 @@
 #START_TEST
 RUN: %not %link %linkopts -o %t1.1.elf %t1.1.o -T %p/Inputs/1.linker.script 2>&1 | %filecheck %s
 #END_TEST
-CHECK: Fatal: cannot read file {{.*}}1.o
+CHECK: Fatal: cannot read file '{{.*}}1.o'
 CHECK-NOT: Fatal: Linker script

--- a/test/Common/standalone/linkerscript/BadIncludeFile/BadIncludeFile.test
+++ b/test/Common/standalone/linkerscript/BadIncludeFile/BadIncludeFile.test
@@ -7,7 +7,7 @@
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
 RUN: %not %link %linkopts %t1.1.o -T %p/Inputs/f.t -o %t2.out 2>&1 | %filecheck %s
 
-#CHECK: Fatal: cannot read file doenotexist.t
+#CHECK: Fatal: cannot read file 'doenotexist.t'
 #CHECK: Linker script {{.*}}f.t has errors, Please check
 #CHECK: Linking had errors.
 #END_TEST

--- a/test/Common/standalone/linkerscript/includefileLPath/includeLpath.test
+++ b/test/Common/standalone/linkerscript/includefileLPath/includeLpath.test
@@ -2,5 +2,5 @@ RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.o
 RUN: %link %linkopts -L%p/Inputs -T %p/script_with_archive.t %t.o -o %t.out 2>&1
 RUN: %not %link %linkopts -L%p/Inputs -T %p/script_with_include_notfound.t %t.o -o %t.out 2>&1 | %filecheck %s
 
-CHECK: Fatal: cannot read file newinclude.t
+CHECK: Fatal: cannot read file 'newinclude.t'
 

--- a/test/Hexagon/linux/linkerscript/includefileLPath/includeLpath.test
+++ b/test/Hexagon/linux/linkerscript/includefileLPath/includeLpath.test
@@ -2,5 +2,5 @@ RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.o
 RUN: %link %linkopts -L%p/Inputs/ -T %p/script_with_archive.t %t.o -o %t.out 2>&1
 RUN: %not %link %linkopts -L%p/Inputs/ -T %p/script_with_include_notfound.t %t.o -o %t.out 2>&1 | %filecheck %s
 
-CHECK: Fatal: cannot read file newinclude.t
+CHECK: Fatal: cannot read file 'newinclude.t'
 

--- a/test/Hexagon/standalone/linkerscript/includefileLPath/includeLpath.test
+++ b/test/Hexagon/standalone/linkerscript/includefileLPath/includeLpath.test
@@ -2,5 +2,5 @@ RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.o
 RUN: %link %linkopts -L%p/Inputs -T %p/script_with_archive.t %t.o -o %t.out 2>&1
 RUN: %not %link %linkopts -L%p/Inputs -T %p/script_with_include_notfound.t %t.o -o %t.out 2>&1 | %filecheck %s
 
-CHECK: Fatal: cannot read file newinclude.t
+CHECK: Fatal: cannot read file 'newinclude.t'
 


### PR DESCRIPTION
While working on #17, I got the error below:

	Fatal: cannot read file alignment

This error message suggests that there's a problem reading the alignment of something in a file.  But in fact, it's indicating that it couldn't open a file called "alignment."  This error message would be clearer if the delimiters indicated where the filename started/stopped.