### PR TITLE
Add primitive support of emulation options with ld.eld

### DIFF
--- a/include/eld/Diagnostics/DiagnosticEngine.h
+++ b/include/eld/Diagnostics/DiagnosticEngine.h
@@ -48,6 +48,8 @@ class LinkerConfig;
 class MsgHandler;
 class Plugin;
 
+using DiagnosticEntry = plugin::DiagnosticEntry;
+
 /** \class DiagnosticEngine
  *  \brief DiagnosticEngine is used to report problems and issues.
  *

--- a/include/eld/Driver/ARMLinkDriver.h
+++ b/include/eld/Driver/ARMLinkDriver.h
@@ -30,9 +30,10 @@ public:
 
 class ARMLinkDriver : public GnuLdDriver {
 public:
-  static ARMLinkDriver *Create(Flavor F, std::string Triple);
+  static ARMLinkDriver *Create(eld::LinkerConfig &C, Flavor F,
+                               std::string Triple);
 
-  ARMLinkDriver(Flavor F, std::string Triple);
+  ARMLinkDriver(eld::LinkerConfig &C, Flavor F, std::string Triple);
 
   virtual ~ARMLinkDriver() {}
 

--- a/include/eld/Driver/GnuLdDriver.h
+++ b/include/eld/Driver/GnuLdDriver.h
@@ -49,17 +49,20 @@ public:
   OPT_GnuLdOptTable();
 };
 
-class GnuLdDriver : public Driver {
+class GnuLdDriver {
 public:
-  static GnuLdDriver *Create(Flavor F, std::string Triple);
+  static GnuLdDriver *Create(eld::LinkerConfig &C, Flavor F,
+                             std::string Triple);
 
-  GnuLdDriver(Flavor F = Flavor::Invalid);
+  GnuLdDriver(eld::LinkerConfig &C, Flavor F = Flavor::Invalid);
 
   virtual ~GnuLdDriver();
 
+  int link(llvm::ArrayRef<const char *> Args);
+
   // Main entry point.
   virtual int link(llvm::ArrayRef<const char *> Args,
-                   llvm::ArrayRef<llvm::StringRef> ELDFlagsArgs) override = 0;
+                   llvm::ArrayRef<llvm::StringRef> ELDFlagsArgs) = 0;
 
   virtual llvm::opt::OptTable *
   parseOptions(llvm::ArrayRef<const char *> ArgsArr,
@@ -136,22 +139,22 @@ protected:
   // Returns the driver's flavor name.
   std::string getFlavorName() const;
 
+  const std::string &getProgramName() const { return LinkerProgramName; }
+
 private:
-  /// Returns a sensible default value for whether or not the colors should be
-  /// used in the terminal output.
-  static bool ShouldColorize();
   // Raise diag entry for trace.
   bool checkAndRaiseTraceDiagEntry(eld::Expected<void> E) const;
 
 protected:
-  eld::DiagnosticEngine *m_DiagEngine;
-  eld::LinkerConfig m_Config;
+  eld::LinkerConfig &Config;
+  eld::DiagnosticEngine *DiagEngine;
   eld::LinkerScript m_Script;
   static eld::Module *ThisModule;
   llvm::opt::OptTable *Table;
   std::once_flag once_flag;
   const Flavor m_Flavor;
   std::vector<std::string> m_SupportedTargets;
+  std::string LinkerProgramName;
 };
 
 #endif

--- a/include/eld/Driver/HexagonLinkDriver.h
+++ b/include/eld/Driver/HexagonLinkDriver.h
@@ -32,9 +32,10 @@ public:
 
 class HexagonLinkDriver : public GnuLdDriver {
 public:
-  static HexagonLinkDriver *Create(Flavor F, std::string Triple);
+  static HexagonLinkDriver *Create(eld::LinkerConfig &C, Flavor F,
+                                   std::string Triple);
 
-  HexagonLinkDriver(Flavor F, std::string Triple);
+  HexagonLinkDriver(eld::LinkerConfig &C, Flavor F, std::string Triple);
 
   virtual ~HexagonLinkDriver() {}
 

--- a/include/eld/Driver/RISCVLinkDriver.h
+++ b/include/eld/Driver/RISCVLinkDriver.h
@@ -31,9 +31,10 @@ public:
 
 class RISCVLinkDriver : public GnuLdDriver {
 public:
-  static RISCVLinkDriver *Create(Flavor F, std::string Triple);
+  static RISCVLinkDriver *Create(eld::LinkerConfig &C, Flavor F,
+                                 std::string Triple);
 
-  RISCVLinkDriver(Flavor F, std::string Triple);
+  RISCVLinkDriver(eld::LinkerConfig &C, Flavor F, std::string Triple);
 
   virtual ~RISCVLinkDriver() {}
 
@@ -64,6 +65,10 @@ public:
   template <class T = OPT_RISCVLinkOptTable>
   bool createInputActions(llvm::opt::InputArgList &Args,
                           std::vector<eld::InputAction *> &actions);
+
+  static bool isSupportedEmulation(llvm::StringRef Emulation) {
+    return Emulation == "elf64lriscv" || Emulation == "elf32lriscv";
+  }
 };
 
 #endif

--- a/include/eld/Driver/x86_64LinkDriver.h
+++ b/include/eld/Driver/x86_64LinkDriver.h
@@ -33,9 +33,10 @@ public:
 
 class x86_64LinkDriver : public GnuLdDriver {
 public:
-  static x86_64LinkDriver *Create(Flavor F, std::string Triple);
+  static x86_64LinkDriver *Create(eld::LinkerConfig &C, Flavor F,
+                                  std::string Triple);
 
-  x86_64LinkDriver(Flavor F, std::string Triple);
+  x86_64LinkDriver(eld::LinkerConfig &C, Flavor F, std::string Triple);
 
   virtual ~x86_64LinkDriver() {}
 

--- a/lib/LinkerWrapper/HexagonLinkDriver.cpp
+++ b/lib/LinkerWrapper/HexagonLinkDriver.cpp
@@ -45,16 +45,18 @@ static constexpr llvm::opt::OptTable::Info infoTable[] = {
 OPT_HexagonLinkOptTable::OPT_HexagonLinkOptTable()
     : GenericOptTable(OptionStrTable, OptionPrefixesTable, infoTable) {}
 
-HexagonLinkDriver *HexagonLinkDriver::Create(Flavor F, std::string Triple) {
-  return eld::make<HexagonLinkDriver>(F, Triple);
+HexagonLinkDriver *HexagonLinkDriver::Create(eld::LinkerConfig &C, Flavor F,
+                                             std::string Triple) {
+  return eld::make<HexagonLinkDriver>(C, F, Triple);
 }
 
-HexagonLinkDriver::HexagonLinkDriver(Flavor F, std::string Triple)
-    : GnuLdDriver(F) {
-  m_Config.targets().setArch("hexagon");
+HexagonLinkDriver::HexagonLinkDriver(eld::LinkerConfig &C, Flavor F,
+                                     std::string Triple)
+    : GnuLdDriver(C, F) {
+  Config.targets().setArch("hexagon");
 
   if (!Triple.empty())
-    m_Config.targets().setTriple(Triple);
+    Config.targets().setTriple(Triple);
 }
 
 opt::OptTable *
@@ -65,7 +67,7 @@ HexagonLinkDriver::parseOptions(ArrayRef<const char *> Args,
   unsigned missingCount;
   ArgList = Table->ParseArgs(Args.slice(1), missingIndex, missingCount);
   if (missingCount) {
-    m_Config.raise(eld::Diag::error_missing_arg_value)
+    Config.raise(eld::Diag::error_missing_arg_value)
         << ArgList.getArgString(missingIndex) << missingCount;
     return nullptr;
   }
@@ -96,12 +98,12 @@ int HexagonLinkDriver::link(llvm::ArrayRef<const char *> Args,
                             llvm::ArrayRef<llvm::StringRef> ELDFlagsArgs) {
   std::vector<const char *> allArgs = getAllArgs(Args, ELDFlagsArgs);
   if (!ELDFlagsArgs.empty())
-    m_Config.raise(eld::Diag::note_eld_flags_without_output_name)
+    Config.raise(eld::Diag::note_eld_flags_without_output_name)
         << llvm::join(ELDFlagsArgs, " ");
 
   llvm::opt::InputArgList ArgList(allArgs.data(),
                                   allArgs.data() + allArgs.size());
-  m_Config.options().setArgs(Args);
+  Config.options().setArgs(Args);
 
   std::vector<eld::InputAction *> Action;
 
@@ -114,7 +116,7 @@ int HexagonLinkDriver::link(llvm::ArrayRef<const char *> Args,
       llvm::sys::fs::getMainExecutable(allArgs[0], &StaticSymbol);
   SmallString<128> lpath(lfile);
   llvm::sys::path::remove_filename(lpath);
-  m_Config.options().setLinkerPath(std::string(lpath));
+  Config.options().setLinkerPath(std::string(lpath));
   //===--------------------------------------------------------------------===//
   // Begin Link preprocessing
   //===--------------------------------------------------------------------===//
@@ -138,9 +140,8 @@ int HexagonLinkDriver::link(llvm::ArrayRef<const char *> Args,
       return LINK_FAIL;
 
     if (!ELDFlagsArgs.empty())
-      m_Config.raise(eld::Diag::note_eld_flags)
-          << m_Config.options().outputFileName()
-          << llvm::join(ELDFlagsArgs, " ");
+      Config.raise(eld::Diag::note_eld_flags)
+          << Config.options().outputFileName() << llvm::join(ELDFlagsArgs, " ");
 
     if (!overrideOptions<OPT_HexagonLinkOptTable>(ArgList))
       return LINK_FAIL;
@@ -162,21 +163,21 @@ bool HexagonLinkDriver::checkOptions(llvm::opt::InputArgList &Args) {
 template <class T>
 bool HexagonLinkDriver::processOptions(llvm::opt::InputArgList &Args) {
   // --gpsize
-  m_Config.options().setGPSize(getInteger(Args, T::gpsize, 8));
+  Config.options().setGPSize(getInteger(Args, T::gpsize, 8));
 
   // --disable-guard-for-weak-undefs
   if (Args.hasArg(T::disable_guard_for_weak_undef))
-    m_Config.options().setDisableGuardForWeakUndefs();
+    Config.options().setDisableGuardForWeakUndefs();
 
   // --relax
   if (Args.hasArg(T::relax))
-    m_Config.options().enableRelaxation();
+    Config.options().enableRelaxation();
 
   // --relax=<regex>
   for (auto *arg : Args.filtered(T::relax_value)) {
     // Enable relaxation when a pattern is provided.
-    m_Config.options().enableRelaxation();
-    m_Config.options().addRelaxSection(arg->getValue());
+    Config.options().enableRelaxation();
+    Config.options().addRelaxSection(arg->getValue());
   }
 
   return GnuLdDriver::processOptions<T>(Args);

--- a/lib/LinkerWrapper/LW.exports
+++ b/lib/LinkerWrapper/LW.exports
@@ -1,5 +1,6 @@
 extern "C++" { #
   Driver::*
+  GnuLdDriver::*
   eld::plugin::AutoTimer::*
   eld::plugin::BitcodeFile::*
   eld::plugin::Chunk::*

--- a/test/RISCV/standalone/Emulation/Emulation.test
+++ b/test/RISCV/standalone/Emulation/Emulation.test
@@ -1,0 +1,20 @@
+#----------Emulation.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+# This test checks the behavior of '-m elf32lriscv|elf64lriscv' option.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.32.o %p/Inputs/1.c -c -target riscv32
+RUN: %eld -o %t1.1.32.out %t1.1.32.o -m elf32lriscv
+RUN: %readelf -h %t1.1.32.out | %filecheck %s --check-prefix RISCV32
+RUN: %clang %clangopts -o %t1.1.64.o %p/Inputs/1.c -c -target riscv64
+RUN: %not %eld -o %t1.1.64.out %t1.1.64.o -m elf32lriscv 2>&1 | %filecheck %s --check-prefix RISCV64ERR
+RUN: %eld -o %t1.1.64.out %t1.1.64.o -m elf64lriscv
+RUN: %readelf -h %t1.1.64.out | %filecheck %s --check-prefix RISCV64
+#END_TEST
+RISCV32: ELF32
+RISCV32: RISC-V
+
+RISCV64ERR: Error: Invalid ELF file {{.*}}1.64.o for target riscv32
+
+RISCV64: ELF64
+RISCV64: RISC-V

--- a/test/RISCV/standalone/Emulation/Inputs/1.c
+++ b/test/RISCV/standalone/Emulation/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -135,6 +135,7 @@ addr2line = 'llvm-addr2line'
 cnot = 'not'
 # ARM/AArch64 can use ld.eld instead of arm-link.
 # arm-link is slightly misleading on AArch64 unit tests
+eld = 'ld.eld'
 link = 'ld.eld'
 elfcopy = 'llvm-objcopy'
 strip = 'llvm-strip'
@@ -418,6 +419,7 @@ clangas = which(clangas)
 clang = which(clang)
 elfcopy = which(elfcopy)
 strip = which(strip)
+eld = which(eld)
 link = which(link)
 if (hlink != ''):
   hlink = which(hlink)
@@ -458,6 +460,7 @@ lit_config.note('using clangas: {}'.format(which(clangas)))
 lit_config.note('using clang: {}'.format(which(clang)))
 lit_config.note('using elfcopy: {}'.format(which(elfcopy)))
 lit_config.note('using strip: {}'.format(which(strip)))
+lit_config.note('using eld: {}'.format(eld))
 lit_config.note('using link: {}'.format(link))
 lit_config.note('using link-option: {}'.format(linkopts))
 lit_config.note('using link-option-name: {}'.format(config.eld_option_name))
@@ -519,6 +522,7 @@ config.substitutions.append( ("%clangas","".join(clangas)) )
 config.substitutions.append( ("%clang","".join(clang)) )
 config.substitutions.append( ("%elfcopy","".join(elfcopy)) )
 config.substitutions.append( ("%strip","".join(strip)) )
+config.substitutions.append( ("%eld","".join(eld)) )
 config.substitutions.append( ("%link","".join(link)) )
 config.substitutions.append( ("%driverxx", driverxx) )
 config.substitutions.append( ("%driver", driver) )

--- a/tools/eld/eld.cpp
+++ b/tools/eld/eld.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 #include "eld/Config/Config.h"
 #include "eld/Driver/Driver.h"
+#include "eld/Driver/GnuLdDriver.h"
 #include "eld/Support/Memory.h"
 #include "eld/Support/TargetRegistry.h"
 #include "eld/Support/TargetSelect.h"
@@ -29,69 +30,6 @@
 using namespace llvm;
 using namespace llvm::sys;
 typedef std::vector<std::string> strings;
-
-
-
-static std::string ParseProgName(llvm::StringRef ProgName) {
-  std::vector<llvm::StringRef> suffixes;
-  llvm::StringRef altName(LINKER_ALT_NAME);
-  suffixes.push_back("ld");
-  suffixes.push_back("ld.eld");
-  if (altName.size())
-    suffixes.push_back(altName);
-
-  for (auto suffix : suffixes) {
-    if (!ProgName.ends_with(suffix))
-      continue;
-    llvm::StringRef::size_type LastComponent =
-        ProgName.rfind('-', ProgName.size() - suffix.size());
-    if (LastComponent == llvm::StringRef::npos)
-      continue;
-    llvm::StringRef Prefix = ProgName.slice(0, LastComponent);
-    return Prefix.str();
-  }
-  return std::string();
-}
-
-static std::pair<Flavor, std::string> getFlavor(StringRef S) {
-  std::string Triple;
-  Flavor F;
-  F = StringSwitch<Flavor>(S)
-          .Case("hexagon-link", Flavor::Hexagon)
-          .Case("hexagon-linux-link", Flavor::Hexagon)
-          .Case("arm-link", Flavor::ARM)
-          .Case("aarch64-link", Flavor::AArch64)
-          .Case("x86_64-link", Flavor::x86_64)
-          .Case("riscv-link", Flavor::RISCV32)
-          .Case("riscv32-link", Flavor::RISCV32)
-          .Case("riscv64-link", Flavor::RISCV64)
-          .Default(Invalid);
-  // Try to get the Flavor from the triple.
-  if (F == Invalid) {
-    Triple = ParseProgName(S);
-    if (!Triple.empty()) {
-      llvm::StringRef TripleRef = Triple;
-      F = StringSwitch<Flavor>(TripleRef)
-              .StartsWith("hexagon", Flavor::Hexagon)
-              .StartsWith("arm", Flavor::ARM)
-              .StartsWith("aarch64", Flavor::AArch64)
-              .StartsWith("riscv", Flavor::RISCV32)
-              .StartsWith("riscv32", Flavor::RISCV32)
-              .StartsWith("riscv64", Flavor::RISCV64)
-              .StartsWith("x86", Flavor::x86_64);
-    }
-  }
-  return std::make_pair(F, Triple);
-}
-
-// Check if the linker is Hexagon, ARM
-static std::pair<Flavor, std::string> parseFlavor(const char *argv0) {
-  // Deduct the flavor from argv[0].
-  StringRef Arg0 = path::filename(argv0);
-  if (Arg0.ends_with_insensitive(".exe"))
-    Arg0 = Arg0.drop_back(4);
-  return getFlavor(Arg0);
-}
 
 // If a command line option starts with "@", the driver reads its suffix as a
 // file, parse its contents as a list of command line options, and insert them
@@ -126,25 +64,16 @@ int main(int Argc, const char **Argv) {
 
   std::vector<const char *> Args(Argv, Argv + Argc);
 
-  Driver *driver = nullptr;
-
-  std::pair<Flavor, std::string> P = parseFlavor(Argv[0]);
-
   // Parse all the options.
-  driver = new Driver(P.first, P.second);
+  Driver driver(Flavor::Invalid, /*Triple=*/"");
 
-  if (nullptr == driver) {
-    llvm::errs() << Argv[0] << "is not a recognized flavor"
-                 << "\n";
-    return LINK_FAIL;
-  }
+  Args = maybeExpandResponseFiles(Args, Alloc);
+  if (!driver.setFlavorAndTripleFromLinkCommand(Args))
+    return 1;
 
-  Driver *Linker = driver->getLinker();
+  GnuLdDriver *Linker = driver.getLinker();
 
-  bool Status =
-      Linker->link(maybeExpandResponseFiles(Args, Alloc));
-
-  delete driver;
+  bool Status = Linker->link(Args);
 
   return Status;
 }


### PR DESCRIPTION
This commit adds initial support of emulation options when used with the actual linker (ld.eld, not the target symlinks). Some important design changes were required to support this functionality:

- The ownership of `DiagnosticEngine` and `LinkerConfig` has been moved from `GnuLdDriver` to `Driver`. This is required because we now do basic emulation options processing in `eld::Driver` and we may need to report errors if there are conflicing emulation options such as `-march arm -m elf32lriscv`. (`LinkerConfig` is required to initialize `DiagnosticsInfos`)
- `GnuLdDriver` now does not inherit from the `eld::Driver` class. The inheritance chain needed to be broken because we were creating two `eld::Driver` classes and both cannot have the ownership of `DiagnosticEngine` and `LinkerConfig`. The breaking of inheritance chain is fine here because `eld::Driver` and `GnuLdDriver` did not share any common component nor did they represent the same entity -- `eld::Driver` and `eld::GnuLdDriver` represents different kinds of driver. `eld::Driver` is responsible for creating the target driver, and target driver is responsible for the actual linking.

This patch only adds the framework for supporting emulation options. It does not add complete support of the functionality. In particular, only `-m <emulation>` option is supported, and that too only for RISCV. The future patches will complete the feature.

Closes #22