### PR TITLE
Add exidx_start and exidx_end symbols with PROVIDE_HIDDEN semantics

### DIFF
--- a/lib/Target/ARM/ARMLDBackend.cpp
+++ b/lib/Target/ARM/ARMLDBackend.cpp
@@ -149,37 +149,44 @@ void ARMGNULDBackend::initTargetSymbols() {
   if (m_Module.getScript().linkerScriptHasSectionsCommand())
     return;
 
+  const NamePool& NP = m_Module.getNamePool();
   SymbolName = "__exidx_start";
-  m_pEXIDXStart =
-      m_Module.getIRBuilder()
-          ->addSymbol<IRBuilder::Force, IRBuilder::Unresolve>(
-              m_Module.getInternalInput(Module::Script), SymbolName,
-              ResolveInfo::NoType, ResolveInfo::Define, ResolveInfo::Global,
-              0x0, // size
-              0x0, // value
-              FragmentRef::null(), ResolveInfo::Default);
-  if (m_pEXIDXStart)
-    m_pEXIDXStart->setShouldIgnore(false);
-  if (m_Module.getConfig().options().isSymbolTracingRequested() &&
-      m_Module.getConfig().options().traceSymbol(SymbolName))
-    config().raise(Diag::target_specific_symbol) << SymbolName;
-
+  const ResolveInfo *EXIDXStartInfo = NP.findInfo(SymbolName);
+  if (EXIDXStartInfo && EXIDXStartInfo->isUndef()) {
+    m_pEXIDXStart =
+        m_Module.getIRBuilder()
+            ->addSymbol<IRBuilder::Force, IRBuilder::Unresolve>(
+                m_Module.getInternalInput(Module::Script), SymbolName,
+                ResolveInfo::NoType, ResolveInfo::Define, ResolveInfo::Global,
+                0x0, // size
+                0x0, // value
+                FragmentRef::null(), ResolveInfo::Visibility::Hidden);
+    if (m_pEXIDXStart) {
+      m_pEXIDXStart->setShouldIgnore(false);
+      if (m_Module.getConfig().options().isSymbolTracingRequested() &&
+          m_Module.getConfig().options().traceSymbol(SymbolName))
+        config().raise(Diag::target_specific_symbol) << SymbolName;
+    }
+  }
   SymbolName = "__exidx_end";
-  m_pEXIDXEnd =
-      m_Module.getIRBuilder()
-          ->addSymbol<IRBuilder::Force, IRBuilder::Unresolve>(
-              m_Module.getInternalInput(Module::Script), SymbolName,
-              ResolveInfo::NoType, ResolveInfo::Define, ResolveInfo::Global,
-              0x0, // size
-              0x0, // value
-              FragmentRef::null(), ResolveInfo::Default);
+  const ResolveInfo *EXIDXEndInfo = NP.findInfo(SymbolName);
+  if (EXIDXEndInfo && EXIDXEndInfo->isUndef()) {
+    m_pEXIDXEnd =
+        m_Module.getIRBuilder()
+            ->addSymbol<IRBuilder::Force, IRBuilder::Unresolve>(
+                m_Module.getInternalInput(Module::Script), SymbolName,
+                ResolveInfo::NoType, ResolveInfo::Define, ResolveInfo::Global,
+                0x0, // size
+                0x0, // value
+                FragmentRef::null(), ResolveInfo::Visibility::Hidden);
 
-  if (m_pEXIDXEnd)
-    m_pEXIDXEnd->setShouldIgnore(false);
-  if (m_Module.getConfig().options().isSymbolTracingRequested() &&
-      m_Module.getConfig().options().traceSymbol(SymbolName))
-    config().raise(Diag::target_specific_symbol) << SymbolName;
-
+    if (m_pEXIDXEnd) {
+      m_pEXIDXEnd->setShouldIgnore(false);
+      if (m_Module.getConfig().options().isSymbolTracingRequested() &&
+          m_Module.getConfig().options().traceSymbol(SymbolName))
+        config().raise(Diag::target_specific_symbol) << SymbolName;
+    }
+  }
   SymbolName = "__RWPI_BASE__";
   m_pRWPIBase =
       m_Module.getIRBuilder()->addSymbol<IRBuilder::Force, IRBuilder::Resolve>(

--- a/test/ARM/standalone/EXIDXSyms/EXIDXSyms.test
+++ b/test/ARM/standalone/EXIDXSyms/EXIDXSyms.test
@@ -1,11 +1,11 @@
 # Test that linker is able to create a PLT entry for the symbol.
 RUN: %clang %clangopts -c -fPIC %p/Inputs/1.cpp -o %t1.o
-RUN: %link %linkopts -march arm  -shared %t1.o -o %t1.so
-RUN: %link %linkopts -march arm  %t1.o -o %t1.out --noinhibit-exec
-RUN: %readelf --dyn-syms %t1.so | %filecheck %s --check-prefix="SHLIB"
+RUN: %link %linkopts -march arm  -shared %t1.o -o %t1.so -u __exidx_start -u __exidx_end
+RUN: %link %linkopts -march arm  %t1.o -o %t1.out --noinhibit-exec -u __exidx_start -u __exidx_end
+RUN: %readelf -s %t1.so | %filecheck %s --check-prefix="SHLIB"
 RUN: %readelf -s %t1.out | %filecheck %s --check-prefix="STATIC"
 
-#SHLIB: {{[0-9a-f]+}}     0 OBJECT  GLOBAL DEFAULT   8 __exidx_start
-#SHLIB-NOT: 00000000     0 OBJECT  GLOBAL DEFAULT   8 __exidx_start
-#STATIC: {{[0-9a-f]+}}     0 OBJECT  GLOBAL DEFAULT    2 __exidx_end
-#STATIC-NOT: 00000000     0 OBJECT  GLOBAL DEFAULT    2 __exidx_end
+#SHLIB: {{[0-9a-f]+}}     0 OBJECT  GLOBAL HIDDEN   8 __exidx_start
+#SHLIB-NOT: 00000000     0 OBJECT  GLOBAL HIDDEN   8 __exidx_start
+#STATIC: {{[0-9a-f]+}}     0 OBJECT  GLOBAL HIDDEN    2 __exidx_end
+#STATIC-NOT: 00000000     0 OBJECT  GLOBAL HIDDEN    2 __exidx_end

--- a/test/ARM/standalone/MappingSymbolsForVeneers/A2A.test
+++ b/test/ARM/standalone/MappingSymbolsForVeneers/A2A.test
@@ -15,7 +15,7 @@ RUN: %objdump -d %t2.a2a.2.out 2>&1 | %filecheck %s -check-prefix=SHARED
 #STATIC:       {{.*}}:       00 00 00 80 .word 0x80000000
 
 #SHARED: {{.*}} <__bar_A2A_veneer@island-1>:
-#SHARED:      {{.*}}: e59fc000      ldr     r12, [pc]               @ 0x1bc <__bar_A2A_veneer@island-1+0x8>
+#SHARED:      {{.*}}: e59fc000      ldr     r12, [pc]               @ 0x174 <__bar_A2A_veneer@island-1+0x8>
 #SHARED:      {{.*}}: e08ff00c      add     pc, pc, r12
 #SHARED:      {{.*}}:       d4 ff ff ff     .word   0xffffffd4
 

--- a/test/ARM/standalone/MappingSymbolsForVeneers/A2T.test
+++ b/test/ARM/standalone/MappingSymbolsForVeneers/A2T.test
@@ -19,6 +19,6 @@ RUN: %objdump -d %t2.a2t.2.out | %filecheck %s -check-prefix=SHARED
 #SHARED:      {{.*}}: e59fc004      ldr     r12, [pc, #0x4]
 #SHARED:      {{.*}}: e08fc00c      add     r12, pc, r12
 #SHARED:      {{.*}}: e12fff1c      bx      r12
-#SHARED:      1c0:        d4 ff ff ff     .word   {{.*}}
+#SHARED:      178:        d4 ff ff ff     .word   {{.*}}
 
 #END_TEST

--- a/test/Common/standalone/AsNeeded/AsNeeded.test
+++ b/test/Common/standalone/AsNeeded/AsNeeded.test
@@ -4,5 +4,8 @@ RUN: %clang %clangopts -c %p/Inputs/2.c -fPIC %clangg0opts -o %t1.2.o
 RUN: %link %linkopts -shared %t1.2.o -o %t2.lib2.so -T %p/Inputs/script.t
 RUN: %link %linkopts -Bdynamic %t1.1.o  --as-needed %t2.lib2.so --no-as-needed -o %t1.out -T %p/Inputs/script.t
 RUN: %readelf -d %t1.out 2>&1 | %filecheck %s
+RUN: %link %linkopts -shared %t1.2.o -o %t2.lib2.without_ls.so
+RUN: %link %linkopts -Bdynamic -o %t1.1.without_ls.out %t1.1.o --as-needed %t2.lib2.without_ls.so --no-as-needed
+RUN: %readelf -d %t1.1.without_ls.out 2>&1 | %filecheck %s
 
-#CHECK-NOT: lib2.so
+#CHECK-NOT: lib2


### PR DESCRIPTION
Previously, we used to unconditionally add __exidx_start and __exidx_end symbols. This was causing incorrect --as-needed behavior where we were emitting DT_NEEDED entries for unused shared libraries.

Additionally, we were adding these symbols with default visibility and thus these symbols were unnecessarily getting exported to dynamic table as well.

This commit fixes these issues by adding these two symbols with PROVIDE_HIDDEN semantics.

Closes #24