### PR TITLE
Allow --patch-enable and local symbol stripping

### DIFF
--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -1109,11 +1109,6 @@ public:
 
   void setNoDefaultPlugins() { UseDefaultPlugins = false; }
 
-  // -X or --discard-locals
-  bool isStripTemporaryOrLocalSymbols() const {
-    return (StripSymbols == StripTemporaries || StripSymbols == StripLocals);
-  }
-
 private:
   bool appendMapStyle(const std::string MapStyle);
   enum Status { YES, NO, Unknown };

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -908,9 +908,10 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
   }
 
   if (m_Config.options().isPatchEnable()) {
-    if (!m_Config.options().isStripTemporaryOrLocalSymbols())
+    if (m_Config.options().getStripSymbolMode() ==
+        GeneralOptions::StripAllSymbols)
       m_Config.raise(Diag::warn_strip_symbols) << "--patch-enable";
-    m_Config.options().setStripSymbols(eld::GeneralOptions::KeepAllSymbols);
+    m_Config.options().setStripSymbols(eld::GeneralOptions::StripLocals);
   }
 
   //

--- a/test/Common/standalone/Patching/PatchBase/PatchOptions.test
+++ b/test/Common/standalone/Patching/PatchBase/PatchOptions.test
@@ -8,5 +8,8 @@ RUN: %clang %clangopts %p/Inputs/1.c -o %t.o -c
 RUN: %link %linkopts --no-emit-relocs --strip-all --patch-enable %t.o -o %t.out 2>&1 | %filecheck %s
 CHECK: Warning: Strip symbols is disabled, as its incompatible with --patch-enable
 # linker should not error here
-RUN: %link %linkopts --fatal-warnings --no-emit-relocs -X --patch-enable %t.o -o %t.out 2>&1
+### --discard-all actually means "strip locals".
+RUN: %link %linkopts --fatal-warnings --no-emit-relocs -x --patch-enable %t.o -o %t.out 2>&1 | %filecheck %s --check-prefix=NOWARNING
+RUN: %link %linkopts --fatal-warnings --no-emit-relocs -X --patch-enable %t.o -o %t.out 2>&1 | %filecheck %s --check-prefix=NOWARNING
+NOWARNING-NOT: Warning: Strip symbols is disabled
 #END_TEST


### PR DESCRIPTION
If stripping local symbols does not break patching, allow both to coexist without warnings.