### PR TITLE
[lld-test] Extend range of AARCH64_ABS16/32

### DIFF
--- a/lib/Target/AArch64/AArch64Relocator.cpp
+++ b/lib/Target/AArch64/AArch64Relocator.cpp
@@ -610,11 +610,11 @@ Relocator::Result abs(Relocation &pReloc, AArch64Relocator &pParent) {
 
   switch (pReloc.type()) {
   case llvm::ELF::R_AARCH64_ABS32:
-    if (!llvm::isUInt<32>(S + A))
+    if (!llvm::isUInt<32>(S + A) && !llvm::isInt<32>(S + A))
       return Relocator::Overflow;
     break;
   case llvm::ELF::R_AARCH64_ABS16:
-    if (!llvm::isUInt<16>(S + A))
+    if (!llvm::isUInt<16>(S + A) && !llvm::isInt<16>(S + A))
       return Relocator::Overflow;
     break;
   default:

--- a/test/lld/ELF/Inputs/abs255.s
+++ b/test/lld/ELF/Inputs/abs255.s
@@ -1,0 +1,2 @@
+.global foo
+foo = 255

--- a/test/lld/ELF/Inputs/abs256.s
+++ b/test/lld/ELF/Inputs/abs256.s
@@ -1,0 +1,2 @@
+.global foo
+foo = 256

--- a/test/lld/ELF/Inputs/abs257.s
+++ b/test/lld/ELF/Inputs/abs257.s
@@ -1,0 +1,2 @@
+.global foo
+foo = 257

--- a/test/lld/ELF/aarch64-abs16.s
+++ b/test/lld/ELF/aarch64-abs16.s
@@ -1,0 +1,27 @@
+// REQUIRES: aarch64
+// RUN: llvm-mc -filetype=obj -triple=aarch64 %s -o %t.o
+// RUN: llvm-mc -filetype=obj -triple=aarch64 %S/Inputs/abs255.s -o %t255.o
+// RUN: llvm-mc -filetype=obj -triple=aarch64 %S/Inputs/abs256.s -o %t256.o
+// RUN: llvm-mc -filetype=obj -triple=aarch64 %S/Inputs/abs257.s -o %t257.o
+
+.globl _start
+_start:
+.data
+  .hword foo + 0xfeff
+  .hword foo - 0x8100
+
+// RUN: %link %linkopts --section-start=.data=0x220158 --no-align-segments %t.o %t256.o -o %t
+// RUN: llvm-objdump -s --section=.data %t | FileCheck %s --check-prefixes=CHECK,LE
+
+// CHECK: Contents of section .data:
+// 220158: S = 0x100, A = 0xfeff
+//         S + A = 0xffff
+// 22015c: S = 0x100, A = -0x8100
+//         S + A = 0x8000
+// LE-NEXT: 220158 ffff0080
+
+// RUN: not %link %linkopts %t.o %t255.o -o /dev/null 2>&1 | FileCheck %s --check-prefix=OVERFLOW1
+// OVERFLOW1: Relocation overflow when applying relocation `R_AARCH64_ABS16' for symbol `foo' referred from {{.+}}.o[.data] symbol defined in {{.+}}.o
+
+// RUN: not %link %linkopts %t.o %t257.o -o /dev/null 2>&1 | FileCheck %s --check-prefix=OVERFLOW2
+// OVERFLOW2: Relocation overflow when applying relocation `R_AARCH64_ABS16' for symbol `foo' referred from {{.+}}.o[.data] symbol defined in {{.+}}.o

--- a/test/lld/ELF/aarch64-abs32.s
+++ b/test/lld/ELF/aarch64-abs32.s
@@ -1,0 +1,27 @@
+// REQUIRES: aarch64
+// RUN: llvm-mc -filetype=obj -triple=aarch64 %s -o %t.o
+// RUN: llvm-mc -filetype=obj -triple=aarch64 %S/Inputs/abs255.s -o %t255.o
+// RUN: llvm-mc -filetype=obj -triple=aarch64 %S/Inputs/abs256.s -o %t256.o
+// RUN: llvm-mc -filetype=obj -triple=aarch64 %S/Inputs/abs257.s -o %t257.o
+
+.globl _start
+_start:
+.data
+  .word foo + 0xfffffeff
+  .word foo - 0x80000100
+
+// RUN: %link %linkopts --section-start=.data=0x220158 --no-align-segments %t.o %t256.o -o %t
+// RUN: llvm-objdump -s --section=.data %t | FileCheck %s --check-prefixes=CHECK,LE
+
+// CHECK: Contents of section .data:
+// 220158: S = 0x100, A = 0xfffffeff
+//         S + A = 0xffffffff
+// 22015c: S = 0x100, A = -0x80000100
+//         S + A = 0x80000000
+// LE-NEXT: 220158 ffffffff 00000080
+
+// RUN: not %link %linkopts %t.o %t255.o -o /dev/null 2>&1 | FileCheck %s --check-prefix=OVERFLOW1
+// OVERFLOW1: Relocation overflow when applying relocation `R_AARCH64_ABS32' for symbol `foo' referred from {{.+}}.o[.data] symbol defined in {{.+}}.o
+
+// RUN: not %link %linkopts %t.o %t257.o -o /dev/null 2>&1 | FileCheck %s --check-prefix=OVERFLOW2
+// OVERFLOW2: Relocation overflow when applying relocation `R_AARCH64_ABS32' for symbol `foo' referred from {{.+}}.o[.data] symbol defined in {{.+}}.o


### PR DESCRIPTION
Per aarch64 ABI, the range of absolute relocations includes both signed and unsigned intervals (-2^(N-1) .. 2^N-1).