### PR TITLE
[arm] Support --target2=abs/rel/got-rel

### DIFF
--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -765,6 +765,12 @@ public:
 
   void setROPI() { BROPI = true; }
 
+  enum class Target2Policy { Abs, Rel, GotRel };
+
+  void setTarget2Policy(Target2Policy Value) { Target2 = Value; }
+
+  Target2Policy getTarget2Policy() const { return Target2; }
+
   // --------------------AArch64 execute-only Support ------------------
 
   bool hasExecuteOnlySegments() { return BExecuteOnly; }
@@ -1204,6 +1210,7 @@ private:
   bool Compact = false;                   // --compact
   bool BRWPI = false;                     // --frwpi
   bool BROPI = false;                     // --fropi
+  Target2Policy Target2 = Target2Policy::GotRel; // --target2
   bool BExecuteOnly = false;              // --execute-only
   bool BPrintTimeStats = false;           // --print-stats
   bool BPrintAllUserPluginTimeStats = false;

--- a/include/eld/Diagnostics/DiagCommonKinds.inc
+++ b/include/eld/Diagnostics/DiagCommonKinds.inc
@@ -180,3 +180,5 @@ DIAG(err_patch_base_not_executable, DiagnosticEngine::Error,
      "The file %0, specified by --patch-base, must be an executable ELF file")
 DIAG(err_patch_not_static, DiagnosticEngine::Error,
      "Patching is only supported for static linking")
+DIAG(error_invalid_target2, DiagnosticEngine::Error,
+     "unknown --target2 option: %0")

--- a/include/eld/Driver/ARMLinkerOptions.td
+++ b/include/eld/Driver/ARMLinkerOptions.td
@@ -53,6 +53,12 @@ def execute_only : Flag<["-", "--"], "execute-only">,
                    HelpText<"Mark executable sections execute-only on AArch64">,
                    Group<grp_arm_linker_only>;
 
+defm target2 : smDash<"target2", "target2",
+                      "Interpret R_ARM_TARGET2 as <type>, where <type> is one "
+                      "of abs, rel, or got-rel (default).">,
+               MetaVarName<"<type>">,
+               Group<grp_arm_linker_only>;
+
 //===----------------------------------------------------------------------===//
 /// Compatibility or ignored options
 //===----------------------------------------------------------------------===//

--- a/lib/LinkerWrapper/ARMLinkDriver.cpp
+++ b/lib/LinkerWrapper/ARMLinkDriver.cpp
@@ -139,6 +139,21 @@ opt::OptTable *ARMLinkDriver::parseOptions(ArrayRef<const char *> Args,
     m_Config.options().setROSegment(true);
   }
 
+  // -target2
+  if (llvm::opt::Arg *arg = ArgList.getLastArg(OPT_ARMLinkOptTable::target2)) {
+    llvm::StringRef Value = arg->getValue();
+    if (auto ValueOpt =
+            llvm::StringSwitch<std::optional<GeneralOptions::Target2Policy>>(
+                Value)
+                .Case("rel", GeneralOptions::Target2Policy::Rel)
+                .Case("abs", GeneralOptions::Target2Policy::Abs)
+                .Case("got-rel", GeneralOptions::Target2Policy::GotRel)
+                .Default(std::nullopt)) {
+      m_Config.options().setTarget2Policy(*ValueOpt);
+    } else
+      m_Config.raise(eld::Diag::error_invalid_target2) << Value;
+  }
+
   return Table;
 }
 

--- a/lib/Target/ARM/ARMRelocationFunctions.h
+++ b/lib/Target/ARM/ARMRelocationFunctions.h
@@ -39,6 +39,7 @@
   DECL_ARM_APPLY_RELOC_FUNC(thm_movw_brel)                                     \
   DECL_ARM_APPLY_RELOC_FUNC(thm_movt_abs)                                      \
   DECL_ARM_APPLY_RELOC_FUNC(thm_movt_prel)                                     \
+  DECL_ARM_APPLY_RELOC_FUNC(target2)                                           \
   DECL_ARM_APPLY_RELOC_FUNC(prel31)                                            \
   DECL_ARM_APPLY_RELOC_FUNC(got_prel)                                          \
   DECL_ARM_APPLY_RELOC_FUNC(tls)                                               \
@@ -79,7 +80,7 @@
       {&unsupport, 36, "R_ARM_ALU_SBREL_19_12_NC"},                            \
       {&unsupport, 37, "R_ARM_ALU_SBREL_27_20_CK"},                            \
       {&abs32, 38, "R_ARM_TARGET1"}, {&unsupport, 39, "R_ARM_SBREL31"},        \
-      {&none, 40, "R_ARM_V4BX"}, {&got_prel, 41, "R_ARM_TARGET2"},             \
+      {&none, 40, "R_ARM_V4BX"}, {&target2, 41, "R_ARM_TARGET2"},              \
       {&prel31, 42, "R_ARM_PREL31"}, {&movw_abs_nc, 43, "R_ARM_MOVW_ABS_NC"},  \
       {&movt_abs, 44, "R_ARM_MOVT_ABS"},                                       \
       {&movw_prel_nc, 45, "R_ARM_MOVW_PREL_NC"},                               \

--- a/lib/Target/ARM/ARMRelocator.h
+++ b/lib/Target/ARM/ARMRelocator.h
@@ -68,10 +68,10 @@ public:
 
 private:
   bool isInvalidReloc(Relocation &pType) const;
-  void scanLocalReloc(InputFile &pInput, Relocation &pReloc,
+  void scanLocalReloc(InputFile &pInput, Relocation::Type, Relocation &pReloc,
                       const ELFSection &pSection);
 
-  void scanGlobalReloc(InputFile &pInput, Relocation &pReloc,
+  void scanGlobalReloc(InputFile &pInput, Relocation::Type, Relocation &pReloc,
                        eld::IRBuilder &pBuilder, ELFSection &pSection,
                        CopyRelocs &);
 

--- a/test/ARM/FromLLD/arm-target2-got.t
+++ b/test/ARM/FromLLD/arm-target2-got.t
@@ -1,0 +1,7 @@
+SECTIONS {
+  .ARM.exidx 0x10114 : { *(.ARM.exidx) }
+  .ARM.extab 0x10124 : { *(.ARM.exidx) }
+  .rodata 0x10130 : { *(.rodata*) }
+  .text 0x20134 : { *(.text*) }
+  .got 0x3013c: { *(.got) }
+}

--- a/test/ARM/FromLLD/arm-target2.s
+++ b/test/ARM/FromLLD/arm-target2.s
@@ -1,0 +1,59 @@
+// RUN: llvm-mc -filetype=obj -triple=armv7a-none-linux-gnueabi %s -o %t.o
+// RUN: %link --no-align-segments -T %S/arm-target2-got.t %t.o -o %t
+// RUN: %objdump -s --triple=armv7a-none-linux-gnueabi %t | %filecheck %s
+// RUN: %link --no-align-segments -T %S/arm-target2-got.t %t.o --target2=got-rel -o %t2
+// RUN: %objdump -s --triple=armv7a-none-linux-gnueabi %t2 | %filecheck %s
+// RUN: %link  --no-align-segments -T %S/arm-target2.t %t.o --target2=abs -o %t3
+// RUN: %objdump -s --triple=armv7a-none-linux-gnueabi %t3 | %filecheck --check-prefix=CHECK-ABS %s
+// RUN: %link --no-align-segments -T %S/arm-target2.t %t.o --target2=rel -o %t4
+// RUN: %objdump -s --triple=armv7a-none-linux-gnueabi %t4 | %filecheck --check-prefix=CHECK-REL %s
+
+// The R_ARM_TARGET2 is present in .ARM.extab sections. It can be handled as
+// either R_ARM_ABS32, R_ARM_REL32 or R_ARM_GOT_PREL. For ARM linux the default
+// is R_ARM_GOT_PREL. The other two options are primarily used for bare-metal,
+// they can be selected with the --target2=abs or --target2=rel option.
+ .syntax unified
+ .text
+ .globl _start
+ .align 2
+_start:
+ .type function, %function
+ .fnstart
+ bx lr
+ .personality   __gxx_personality_v0
+ .handlerdata
+ .word  _ZTIi(TARGET2)
+ .text
+ .fnend
+ .global __gxx_personality_v0
+ .type function, %function
+__gxx_personality_v0:
+ bx lr
+
+ .rodata
+_ZTIi:  .word 0
+
+// CHECK: Contents of section .ARM.extab:
+// 0x1012c + 0x2010 = 0x1213c = .got
+// CHECK-NEXT:  10124 14000100 b0b0b000 10000200
+
+// CHECK-ABS: Contents of section .ARM.extab:
+// 0x100f0 = .rodata
+// CHECK-ABS-NEXT: 100e4 14000100 b0b0b000 f0000100
+
+// CHECK-REL: Contents of section .ARM.extab:
+// 0x100ec + 4 = 0x100f0 = .rodata
+// CHECK-REL-NEXT: 100e4 14000100 b0b0b000 04000000
+
+// CHECK: Contents of section .rodata:
+// CHECK-NEXT: 10130 00000000
+
+// CHECK-ABS: Contents of section .rodata:
+// CHECK-ABS-NEXT: 100f0 00000000
+
+// CHECK-REL: Contents of section .rodata:
+// CHECK-REL-NEXT: 100f0 00000000
+
+// CHECK: Contents of section .got:
+// 10130 = _ZTIi
+// CHECK-NEXT: 3013c 30010100

--- a/test/ARM/FromLLD/arm-target2.t
+++ b/test/ARM/FromLLD/arm-target2.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  .ARM.exidx 0x100d4 : { *(.ARM.exidx) }
+  .ARM.extab 0x100e4 : { *(.ARM.exidx) }
+  .rodata 0x100f0 : { *(.rodata*) }
+  .text 0x200f4 : { *(.text*) }
+}


### PR DESCRIPTION
Add lld-compatible implementation of R_ARM_TARGET2 relocation controlled by the --target2=abs/rel/got-rel option.