### PR TITLE
Free plugin resources before unloading the plugin

### DIFF
--- a/include/eld/Script/Plugin.h
+++ b/include/eld/Script/Plugin.h
@@ -218,6 +218,8 @@ private:
 
   std::string findInRPath(llvm::StringRef LibraryName, llvm::StringRef RPath);
 
+  void clearResources();
+
 private:
   plugin::Plugin::Type ThisType;
   uint32_t CurID;

--- a/lib/Script/Plugin.cpp
+++ b/lib/Script/Plugin.cpp
@@ -245,6 +245,7 @@ bool Plugin::cleanup() {
       "Cleanup", ThisModule.saveString(UserPluginHandle->GetName()), Stats);
   if (PluginCleanupFunction)
     (*PluginCleanupFunction)();
+  clearResources();
   return true;
 }
 
@@ -608,4 +609,8 @@ void Plugin::callActBeforeWritingOutputHook() {
   if (ThisModule.getPrinter()->tracePlugins())
     ThisConfig.raise(Diag::trace_plugin_hook) << getPluginName() << HookName;
   P->ActBeforeWritingOutput();
+}
+
+void Plugin::clearResources() {
+  PluginCommandLineOptions.clear();
 }


### PR DESCRIPTION
This commit fixes PluginCommandLineOptions test failure on windows by fixing the underlying root cause -- undefined behavior caused due to reading code contained in plugin shared library after unloading the said plugin shared library. We were storing the command line option handlers inside eld::Plugin class. These objects were being destructed after unloading the shared library, but the destructor for the command line option handler was housed in the plugin shared library. In this particular example, command-line option handler passed by the plugin to the linker was a lambda and had an implicit destructor.

Closes #32