### PR TITLE
[NFC] Refactor RISC-V relocation functions

### DIFF
--- a/lib/Target/RISCV/RISCVLDBackend.h
+++ b/lib/Target/RISCV/RISCVLDBackend.h
@@ -175,6 +175,9 @@ public:
     return reloc->second;
   }
 
+  // Get the value of the symbol, using the PLT slot if one exists.
+  Relocation::Address getSymbolValuePLT(Relocation &R);
+
 private:
   Relocation *findHIRelocation(ELFSection *S, uint64_t Value);
 

--- a/lib/Target/RISCV/RISCVRelocator.h
+++ b/lib/Target/RISCV/RISCVRelocator.h
@@ -49,8 +49,6 @@ public:
 
   bool is32bit() const { return config().targets().is32Bits(); }
 
-  Relocation::Address getSymbolValuePLT(Relocation &R);
-
 private:
   virtual void scanLocalReloc(InputFile &pInput, Relocation &pReloc,
                               eld::IRBuilder &pBuilder, ELFSection &pSection);


### PR DESCRIPTION
-- RISCVLDBackend is passed instead of RISCVRelocator, 
-- getSymbolValuePLT() moved to RISCVLDBackend.

Now RISCVLDBackend can use getSymbolValuePLT() without going back to Relocator.