### PR TITLE
[Target] Fix typos discovered by codespell (NFC)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   build:
     runs-on: self-hosted
-    concurrency: 
+    concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
       cancel-in-progress: false
     permissions:
@@ -71,13 +71,13 @@ jobs:
       run: |
            cd pr-${{ env.PR_NUMBER }}/obj
            ccache -s --dir /local/mnt/workspace/ccache/${{ env.BASE_BRANCH_NAME }}
-           
+
     - name: Build Project
       run: |
           cd pr-${{ env.PR_NUMBER }}/obj
           ninja
 
-    - name: Cache Usage after build 
+    - name: Cache Usage after build
       run: |
          cd pr-${{ env.PR_NUMBER }}/obj
          ccache -s --dir /local/mnt/workspace/ccache/${{ env.BASE_BRANCH_NAME }}
@@ -86,23 +86,6 @@ jobs:
       run: |
         cd pr-${{ env.PR_NUMBER }}/obj
         ninja check-eld
-
-    - name: Update PR status
-      if: success()
-      uses: actions/github-script@v5
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const { owner, repo } = context.repo;
-          const sha = context.sha;
-          await github.rest.repos.createCommitStatus({
-            owner,
-            repo,
-            sha,
-            state: 'success',
-            description: 'Build verified',
-            context: 'ci/build'
-          });
 
     - name: Save repository cache
       uses: actions/cache@v4

--- a/lib/Target/AArch64/AArch64Errata843419Stub.cpp
+++ b/lib/Target/AArch64/AArch64Errata843419Stub.cpp
@@ -30,7 +30,7 @@ namespace eld {
 //===----------------------------------------------------------------------===//
 const uint32_t AArch64Errata843419Stub::TEMPLATE[] = {
     0x00000000, // Placeholder for erratum insn
-    0x00000000, // Palceholder for branch instruction
+    0x00000000, // Placeholder for branch instruction
 };
 
 AArch64Errata843419Stub::AArch64Errata843419Stub()

--- a/lib/Target/AArch64/AArch64InsnHelpers.h
+++ b/lib/Target/AArch64/AArch64InsnHelpers.h
@@ -79,7 +79,7 @@ public:
     uint64_t imm = ((adrp >> 29) & mask2) | (((adrp >> 5) & mask19) << 2);
     // Retrieve msb of 21-bit-signed imm for sign extension.
     uint64_t msbt = (imm >> 20) & 1;
-    // Real value is imm multipled by 4k. Value now has 33-bit information.
+    // Real value is imm multiplied by 4k. Value now has 33-bit information.
     int64_t value = imm << 12;
     // Sign extend to 64-bit by repeating msbt 31 (64-33) times and merge it
     // with value.
@@ -288,7 +288,7 @@ public:
   static bool mac(InsnType insn) { return (insn & 0xff000000) == 0x9b000000; }
 
   // Return true if INSN is multiply-accumulate.
-  // (This is similar to implementaton in elfnn-aarch64.c.)
+  // (This is similar to implementation in elfnn-aarch64.c.)
   static bool mlxl(InsnType insn) {
     uint32_t Op31 = op31(insn);
     if (mac(insn) &&

--- a/lib/Target/AArch64/AArch64LDBackend.cpp
+++ b/lib/Target/AArch64/AArch64LDBackend.cpp
@@ -945,7 +945,7 @@ void AArch64GNUInfoLDBackend::initializeAttributes() {
 namespace eld {
 
 //===----------------------------------------------------------------------===//
-//  createAArch64LDBackend - the help funtion to create corresponding
+//  createAArch64LDBackend - the help function to create corresponding
 //  AArch64LDBackend
 //===----------------------------------------------------------------------===//
 GNULDBackend *createAArch64LDBackend(Module &pModule) {

--- a/lib/Target/AArch64/AArch64LinuxInfo.h
+++ b/lib/Target/AArch64/AArch64LinuxInfo.h
@@ -49,7 +49,7 @@ public:
       return true;
     }
     // When linker script is present, unless SIZEOF_HEADERS is used in the
-    // linker script, the linker really doesnot know whether to load the program
+    // linker script, the linker really doesn't know whether to load the program
     // headers or not.
     if (linkerScriptHasSectionsCommand)
       return false;

--- a/lib/Target/AArch64/AArch64RelocationHelpers.h
+++ b/lib/Target/AArch64/AArch64RelocationHelpers.h
@@ -59,7 +59,7 @@ static inline uint32_t helper_reencode_adr_imm(uint32_t pInst, uint32_t pImm) {
          ((pImm & get_mask(2)) << 29) | ((pImm & (get_mask(19) << 2)) << 3);
 }
 
-// Reencode the imm field of add immediate.
+// Re-encode the imm field of add immediate.
 static inline uint32_t helper_reencode_add_imm(uint32_t pInst, uint32_t pImm) {
   return (pInst & ~(get_mask(12) << 10)) | ((pImm & get_mask(12)) << 10);
 }
@@ -82,7 +82,7 @@ static inline uint32_t helper_reencode_tbz_imm_14(uint32_t pInst,
   return (pInst & ~(get_mask(14) << 5)) | ((pImm & get_mask(14)) << 5);
 }
 
-// Reencode the imm field of ld/st pos immediate.
+// Re-encode the imm field of ld/st pos immediate.
 static inline uint32_t helper_reencode_ldst_pos_imm(uint32_t pInst,
                                                     uint32_t pImm) {
   return (pInst & ~(get_mask(12) << 10)) | ((pImm & get_mask(12)) << 10);
@@ -94,7 +94,7 @@ static inline uint32_t helper_reencode_ld_literal_19(uint32_t pInst,
   return (pInst & ~(get_mask(19) << 5)) | ((pImm & get_mask(19)) << 5);
 }
 
-// Reencode the imm field of movz/movk
+// Re-encode the imm field of movz/movk
 static inline uint32_t helper_reencode_movzk_imm(uint32_t pInst,
                                                  uint32_t pImm) {
   return (pInst & ~(get_mask(16) << 5)) | ((pImm & get_mask(16)) << 5);

--- a/lib/Target/AArch64/AArch64Relocator.cpp
+++ b/lib/Target/AArch64/AArch64Relocator.cpp
@@ -66,7 +66,7 @@ AArch64GOT &CreateGOT(ELFObjectFile *Obj, Relocation &pReloc, bool pHasRel,
     return *G;
   }
 
-  // If the symbol is not preemptable and we are not building an executable,
+  // If the symbol is not preemptible and we are not building an executable,
   // then try to use a relative reloc. We use a relative reloc if the symbol is
   // hidden otherwise.
   bool useRelative =
@@ -188,7 +188,7 @@ void AArch64Relocator::scanLocalReloc(InputFile &pInput, Relocation &pReloc,
   ResolveInfo *rsym = pReloc.symInfo();
   switch (pReloc.type()) {
   case llvm::ELF::R_AARCH64_ABS64:
-    // If buiding PIC object (shared library or PIC executable),
+    // If building PIC object (shared library or PIC executable),
     // a dynamic relocations with RELATIVE type to this location is needed.
     // Reserve an entry in .rel.dyn
     if (config().isCodeIndep()) {
@@ -205,7 +205,7 @@ void AArch64Relocator::scanLocalReloc(InputFile &pInput, Relocation &pReloc,
 
   case llvm::ELF::R_AARCH64_ABS32:
   case llvm::ELF::R_AARCH64_ABS16:
-    // If buiding PIC object (shared library or PIC executable),
+    // If building PIC object (shared library or PIC executable),
     // a dynamic relocations with RELATIVE type to this location is needed.
     // Reserve an entry in .rel.dyn
     if (config().isCodeIndep()) {
@@ -386,7 +386,7 @@ void AArch64Relocator::scanGlobalReloc(InputFile &pInput, Relocation &pReloc,
       backend.defineIRelativeRange(*rsym);
       return;
     }
-    // if symbol is defined in the ouput file and it's not
+    // if symbol is defined in the output file and it's not
     // preemptible, no need plt
     if (!getTarget().isSymbolPreemptible(*rsym)) {
       return;

--- a/lib/Target/AArch64/AArch64Relocator.h
+++ b/lib/Target/AArch64/AArch64Relocator.h
@@ -26,7 +26,7 @@ namespace eld {
 enum {
   // static relocations
   R_AARCH64_ADR_PREL_PG_HI21_NC = 0x114,
-  // dyanmic rlocations
+  // dynamic rlocations
   R_AARCH64_COPY = 1024,
   R_AARCH64_GLOB_DAT = 1025,
   R_AARCH64_JUMP_SLOT = 1026,

--- a/lib/Target/ARM/ARMLDBackend.cpp
+++ b/lib/Target/ARM/ARMLDBackend.cpp
@@ -1255,7 +1255,7 @@ void ARMGNULDBackend::setDefaultConfigs() {
 namespace eld {
 
 //===----------------------------------------------------------------------===//
-/// createARMLDBackend - the help funtion to create corresponding ARMLDBackend
+/// createARMLDBackend - the help function to create corresponding ARMLDBackend
 ///
 GNULDBackend *createARMLDBackend(Module &pModule) {
   return make<ARMGNULDBackend>(pModule, make<ARMInfo>(pModule.getConfig()));

--- a/lib/Target/ARM/ARMRelocator.cpp
+++ b/lib/Target/ARM/ARMRelocator.cpp
@@ -99,7 +99,7 @@ static ARMGOT *CreateGOT(ELFObjectFile *Obj, Relocation &pReloc, bool pHasRel,
     return G;
   }
 
-  // If the symbol is not preemptable and we are not building an executable,
+  // If the symbol is not preemptible and we are not building an executable,
   // then try to use a relative reloc. We use a relative reloc if the symbol is
   // hidden otherwise.
   bool useRelative =
@@ -325,7 +325,7 @@ Relocator::Size ARMRelocator::getSize(Relocation::Type pType) const {
 }
 
 /// checkValidReloc - When we attempt to generate a dynamic relocation for
-/// ouput file, check if the relocation is supported by dynamic linker.
+/// output file, check if the relocation is supported by dynamic linker.
 bool ARMRelocator::checkValidReloc(Relocation &pReloc) const {
   // If not PIC object, no relocation type is invalid
   if (!config().isCodeIndep())
@@ -369,7 +369,7 @@ void ARMRelocator::scanLocalReloc(InputFile &pInput, Relocation::Type Type,
     LLVM_FALLTHROUGH;
   case llvm::ELF::R_ARM_ABS32:
   case llvm::ELF::R_ARM_ABS32_NOI: {
-    // If buiding PIC object (shared library or PIC executable),
+    // If building PIC object (shared library or PIC executable),
     // a dynamic relocations with RELATIVE type to this location is needed.
     // Reserve an entry in .rel.dyn
     if (config().isCodeIndep()) {
@@ -433,7 +433,7 @@ void ARMRelocator::scanLocalReloc(InputFile &pInput, Relocation::Type Type,
   case llvm::ELF::R_ARM_GLOB_DAT:
   case llvm::ELF::R_ARM_JUMP_SLOT:
   case llvm::ELF::R_ARM_RELATIVE: {
-    // These are relocation type for dynamic linker, shold not
+    // These are relocation type for dynamic linker, should not
     // appear in object file.
     config().raise(Diag::dynamic_relocation) << (int)pReloc.type();
     m_Target.getModule().setFailure(true);
@@ -698,7 +698,7 @@ void ARMRelocator::scanGlobalReloc(InputFile &pInput, Relocation::Type Type,
       return;
     }
 
-    // if symbol is defined in the ouput file and it's not
+    // if symbol is defined in the output file and it's not
     // preemptible, no need plt
     if (!getTarget().isSymbolPreemptible(*rsym))
       return;
@@ -736,7 +736,7 @@ void ARMRelocator::scanGlobalReloc(InputFile &pInput, Relocation::Type Type,
   case llvm::ELF::R_ARM_GLOB_DAT:
   case llvm::ELF::R_ARM_JUMP_SLOT:
   case llvm::ELF::R_ARM_RELATIVE: {
-    // These are relocation type for dynamic linker, shold not
+    // These are relocation type for dynamic linker, should not
     // appear in object file.
     config().raise(Diag::dynamic_relocation) << (int)pReloc.type();
     m_Target.getModule().setFailure(true);

--- a/lib/Target/CreateProgramHeaders.hpp
+++ b/lib/Target/CreateProgramHeaders.hpp
@@ -271,7 +271,7 @@ bool GNULDBackend::createProgramHdrs() {
       // If the output section descriptor has an alignment specified
       // honor the alignment specified, the alignment would have been
       // reflected in the section alignment.
-      // The linker doesnot align the section if there was no alignment
+      // The linker doesn't align the section if there was no alignment
       // specified for the output section but a "VMA" was specified.
       if (!(*out)->prolog().hasAlign())
         doAlign = false;
@@ -379,7 +379,7 @@ bool GNULDBackend::createProgramHdrs() {
                            ->getMemorySpec()
                            ->getMemoryDescriptor();
 
-    // If the user specifies the linker to create a seperate rosegment, do that.
+    // If the user specifies the linker to create a separate rosegment, do that.
     if (!config().options().rosegment())
       cur_flag = (cur_flag & ~llvm::ELF::PF_X);
 
@@ -542,7 +542,7 @@ bool GNULDBackend::createProgramHdrs() {
       // If the previous section is a RELRO section and the current section is
       // not a RELRO section, move the non RELRO section to a new page, as the
       // dynamic linker will mprotect the page after dynamic relocation.
-      // If this doesnot move to the next page, then any writes to the section
+      // If this doesn't move to the next page, then any writes to the section
       // will incur a pagefault and crash!. If there is a linker script dont do
       // any of this, as the user may want to configure sections to be in the
       // same page. This is a difference between ELD and GNU linker. This is

--- a/lib/Target/CreateScriptProgramHeaders.hpp
+++ b/lib/Target/CreateScriptProgramHeaders.hpp
@@ -174,7 +174,7 @@ bool GNULDBackend::createScriptProgramHdrs() {
       // If the output section descriptor has an alignment specified
       // honor the alignment specified, the alignment would have been
       // reflected in the section alignment.
-      // The linker doesnot align the section if there was no alignment
+      // The linker doesn't align the section if there was no alignment
       // specified for the output section but a "VMA" was specified.
       if (!(*out)->prolog().hasAlign())
         doAlign = false;

--- a/lib/Target/ELFDynamic.cpp
+++ b/lib/Target/ELFDynamic.cpp
@@ -411,7 +411,7 @@ void ELFDynamic::reserveNeedEntry() {
 void ELFDynamic::emit(const ELFSection &pSection, MemoryRegion &pRegion) const {
   if (pRegion.size() < pSection.size()) {
     llvm::report_fatal_error(llvm::Twine("the given memory is smaller") +
-                             llvm::Twine(" than the section's demaind.\n"));
+                             llvm::Twine(" than the section's demand.\n"));
   }
 
   uint8_t *address = (uint8_t *)pRegion.begin();

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -1583,7 +1583,7 @@ int64_t GNULDBackend::getSectionIdx(ELFSection *S) const {
   return entry->second->getIndex();
 }
 
-/// getSymbolIdx - called by emitRelocation to get the ouput symbol table index
+/// getSymbolIdx - called by emitRelocation to get the output symbol table index
 size_t GNULDBackend::getSymbolIdx(LDSymbol *pSymbol, bool IgnoreUnknown) const {
   // TODO: IgnoreUnknown was added as a kludge before QTOOL-102747 is resolved.
   // Given that this function dereferenced the past the end iterator, this error
@@ -2295,7 +2295,7 @@ GNULDBackend::setupSegmentOffset(ELFSegment *Seg, ELFSection *P,
 
   int64_t offset = BeginOffset;
   // Sort the sections in the segment. This is to allow decreasing addresses
-  // in the same segment and making sure file offset is sane and doesnot
+  // in the same segment and making sure file offset is sane and doesn't
   // become negative. If we are doing a compact representation of the layout
   // this is just not needed, since the fileoffsets are incremented in the
   // order the sections are seen.
@@ -2868,7 +2868,7 @@ bool GNULDBackend::placeOutputSections() {
   bool debugSectionSeen = false;
   OutputSectDesc::Type type = OutputSectDesc::LOAD;
   {
-    eld::RegisterTimer T("Set Section Permssions", "Place Output Sections",
+    eld::RegisterTimer T("Set Section Permissions", "Place Output Sections",
                          m_Module.getConfig().options().printTimingStats());
     for (auto &elem : sectionMap) {
       ELFSection *cur = (elem)->getSection();
@@ -2969,7 +2969,7 @@ bool GNULDBackend::placeOutputSections() {
       if ((orphan)->getKind() == LDFileFormat::Null)
         out = sectionMap.insert(outBegin, orphan);
       else {
-        // Orphan placemenet Doesnot matter so much for partial link steps.
+        // Orphan placement Doesn't matter so much for partial link steps.
         // Skip the first discard section if any. We cannot skip the discard
         // later
         // though. The value is initialized to -1, to skip the Null section
@@ -3030,7 +3030,7 @@ bool GNULDBackend::placeOutputSections() {
         }
         (*out)->prolog().setType(OutputSectDesc::LOAD);
       }
-      // If the prolog doesnot have a flag specified, then move on.
+      // If the prolog doesn't have a flag specified, then move on.
       if (!(*out)->prolog().hasFlag())
         continue;
       uint32_t flag = (*out)->prolog().flag();
@@ -4140,7 +4140,7 @@ LDSymbol &GNULDBackend::defineSymbolforCopyReloc(eld::IRBuilder &pBuilder,
     return *cpy_sym;
   }
 
-  // If the alias symbol doesnot have a fragment, first create a fragment for
+  // If the alias symbol doesn't have a fragment, first create a fragment for
   // the alias.
   if (aliasSym && aliasSym->outSymbol() && !aliasSym->outSymbol()->hasFragRef())
     pSym = aliasSym;

--- a/lib/Target/Hexagon/HexagonLDBackend.cpp
+++ b/lib/Target/Hexagon/HexagonLDBackend.cpp
@@ -1172,7 +1172,7 @@ bool HexagonLDBackend::isRelocationRelaxed(Relocation *R) const {
 }
 
 //===----------------------------------------------------------------------===//
-/// createHexagonLDBackend - the help funtion to create corresponding
+/// createHexagonLDBackend - the help function to create corresponding
 /// HexagonLDBackend
 GNULDBackend *createHexagonLDBackend(eld::Module &pModule) {
   if (pModule.getConfig().targets().triple().isOSLinux())

--- a/lib/Target/Hexagon/HexagonLinuxInfo.h
+++ b/lib/Target/Hexagon/HexagonLinuxInfo.h
@@ -32,7 +32,7 @@ public:
   bool needEhdr(Module &pModule, bool linkerScriptHasSectionsCommand,
                 bool isPhdr) override {
     // When linker script is present, unless SIZEOF_HEADERS is used in the
-    // linker script, the linker really doesnot know whether to load the program
+    // linker script, the linker really doesn't know whether to load the program
     // headers or not.
     if (linkerScriptHasSectionsCommand)
       return false;

--- a/lib/Target/Hexagon/HexagonRelocator.cpp
+++ b/lib/Target/Hexagon/HexagonRelocator.cpp
@@ -68,7 +68,7 @@ void HexagonRelocator::CreateGOTAbsolute(ELFObjectFile *Obj,
     return;
   }
 
-  // If the symbol is not preemptable and we are not building an executable,
+  // If the symbol is not preemptible and we are not building an executable,
   // then try to use a relative reloc. We use a relative reloc if the symbol is
   // hidden otherwise.
   bool useRelative =
@@ -361,7 +361,7 @@ void HexagonRelocator::scanLocalReloc(InputFile &InputFile, Relocation &pReloc,
 
   switch (pReloc.type()) {
   case llvm::ELF::R_HEX_32:
-    // If buiding PIC object (shared library or PIC executable),
+    // If building PIC object (shared library or PIC executable),
     // a dynamic relocations with RELATIVE type to this location is needed.
     // Reserve an entry in .rel.dyn
     if (config().isCodeIndep()) {

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -631,7 +631,7 @@ bool RISCVLDBackend::shouldIgnoreRelocSync(Relocation *pReloc) const {
   case llvm::ELF::R_RISCV_RELAX:
   case llvm::ELF::R_RISCV_ALIGN:
   case llvm::ELF::R_RISCV_VENDOR:
-  // ULEB128 relocations are handled seperately
+  // ULEB128 relocations are handled separately
   case llvm::ELF::R_RISCV_SET_ULEB128:
   case llvm::ELF::R_RISCV_SUB_ULEB128:
     return true;
@@ -686,7 +686,7 @@ void RISCVLDBackend::mayBeRelax(int relaxation_pass, bool &pFinished) {
   if (m_pGlobalPointer)
     GP = m_pGlobalPointer->value();
 
-  // Compres
+  // Compress
   bool DoCompressed = config().options().getRISCVRelaxToC();
 
   // start relocation relaxation
@@ -945,7 +945,7 @@ bool RISCVLDBackend::handleRelocation(ELFSection *pSection,
       Relocation *VendorReloc =
           pSection->findRelocation(pOffset, llvm::ELF::R_RISCV_VENDOR);
       if (!VendorReloc) {
-        // The ABI requires that R_RISCV_VENDOR preceeds any R_RISCV_CUSTOM<n>
+        // The ABI requires that R_RISCV_VENDOR precedes any R_RISCV_CUSTOM<n>
         // Relocation.
         config().raise(Diag::error_rv_vendor_not_found)
             << getRISCVRelocName(pType)
@@ -1448,7 +1448,7 @@ RISCVLDBackend::postProcessing(llvm::FileOutputBuffer &pOutput) {
 namespace eld {
 
 //===----------------------------------------------------------------------===//
-/// createRISCVLDBackend - the help funtion to create corresponding
+/// createRISCVLDBackend - the help function to create corresponding
 /// RISCVLDBackend
 GNULDBackend *createRISCVLDBackend(Module &pModule) {
   return make<RISCVLDBackend>(pModule,

--- a/lib/Target/RISCV/RISCVRelocationCompute.cpp
+++ b/lib/Target/RISCV/RISCVRelocationCompute.cpp
@@ -203,7 +203,7 @@ uint64_t doRelocHelper(const RelocationInfo &RelocInfo, uint64_t Instruction,
     Value = encode8(Value);
     break;
   case EncTy_LEB128:
-    /* Handled seperately by backend */
+    /* Handled separately by backend */
     LLVM_FALLTHROUGH;
   case EncTy_None:
     break;

--- a/lib/Target/RISCV/RISCVRelocator.cpp
+++ b/lib/Target/RISCV/RISCVRelocator.cpp
@@ -221,7 +221,7 @@ RISCVGOT &CreateGOT(ELFObjectFile *Obj, Relocation &pReloc, bool pHasRel,
   uint8_t Reloc = llvm::ELF::R_RISCV_32;
   if (!B.config().targets().is32Bits())
     Reloc = llvm::ELF::R_RISCV_64;
-  // If the symbol is not preemptable and we are not building an executable,
+  // If the symbol is not preemptible and we are not building an executable,
   // then try to use a relative reloc. We use a relative reloc if the symbol is
   // hidden otherwise.
   bool useRelative =
@@ -420,7 +420,7 @@ void RISCVRelocator::scanLocalReloc(InputFile &pInput, Relocation &pReloc,
   switch (pReloc.type()) {
   case llvm::ELF::R_RISCV_32:
   case llvm::ELF::R_RISCV_64:
-    // If buiding PIC object (shared library or PIC executable),
+    // If building PIC object (shared library or PIC executable),
     // a dynamic relocations with RELATIVE type to this location is needed.
     // Reserve an entry in .rel.dyn
     if (config().isCodeIndep()) {
@@ -963,7 +963,7 @@ RISCVRelocator::Result applyJumpOrCall(Relocation &pReloc,
     return RISCVRelocator::Unsupport;
 
   // Normally, relocations are resolved to the PLT if it exists for a symbol.
-  // Direct calls can be optimzied to use the real symbol.
+  // Direct calls can be optimized to use the real symbol.
   bool IsPatchSection = pReloc.targetRef()
                             ->frag()
                             ->getOwningSection()
@@ -1014,7 +1014,7 @@ RISCVRelocator::Result applyCompressedLUI(Relocation &pReloc,
                                           RISCVLDBackend &Backend,
                                           RelocationDescription &pRelocDesc) {
   // TODO: TEst what lld/bfd does.
-  // LUI has bottom 12 bits or 4K addressible target bits 0.
+  // LUI has bottom 12 bits or 4K addressable target bits 0.
   uint64_t Result =
       Backend.getRelocator()->getSymValue(&pReloc) + pReloc.addend();
   // The bottom 12 bits are signed.

--- a/lib/Target/Template/TemplateEmulation.cpp
+++ b/lib/Target/Template/TemplateEmulation.cpp
@@ -17,7 +17,7 @@ namespace eld {
 
 static bool ELDEmulateTemplateELF(LinkerScript &pScript,
                                   LinkerConfig &pConfig) {
-  // Set Endianess and BitClass(32/64).
+  // Set Endianness and BitClass(32/64).
   pConfig.targets().setEndian(TargetOptions::Little);
   pConfig.targets().setBitClass(32);
 

--- a/lib/Target/Template/TemplateLDBackend.cpp
+++ b/lib/Target/Template/TemplateLDBackend.cpp
@@ -119,7 +119,7 @@ void TemplateLDBackend::initializeAttributes() {
 namespace eld {
 
 //===----------------------------------------------------------------------===//
-/// createTemplateLDBackend - the help funtion to create corresponding
+/// createTemplateLDBackend - the help function to create corresponding
 /// TemplateLDBackend
 GNULDBackend *createTemplateLDBackend(Module &pModule) {
   return new TemplateLDBackend(pModule,

--- a/lib/Target/x86_64/x86_64Emulation.cpp
+++ b/lib/Target/x86_64/x86_64Emulation.cpp
@@ -17,7 +17,7 @@ using namespace llvm;
 namespace eld {
 
 static bool ELDEmulatex86_64ELF(LinkerScript &pScript, LinkerConfig &pConfig) {
-  // Set Endianess and BitClass(32/64).
+  // Set Endianness and BitClass(32/64).
   pConfig.targets().setEndian(TargetOptions::Little);
   pConfig.targets().setBitClass(64);
 

--- a/lib/Target/x86_64/x86_64LDBackend.cpp
+++ b/lib/Target/x86_64/x86_64LDBackend.cpp
@@ -250,7 +250,7 @@ void x86_64LDBackend::setDefaultConfigs() {
 namespace eld {
 
 //===----------------------------------------------------------------------===//
-/// createx86_64LDBackend - the help funtion to create corresponding
+/// createx86_64LDBackend - the help function to create corresponding
 /// x86_64LDBackend
 GNULDBackend *createx86_64LDBackend(Module &pModule) {
   return make<x86_64LDBackend>(pModule,


### PR DESCRIPTION
Found using https://github.com/codespell-project/codespell

`codespell Target --ignore-words-list=unsupport,THATS,thats --write-changes -i 2`

Signed-off-by: Sudharsan Veeravalli <quic_svs@quicinc.com>