### PR TITLE
[RISCV] Disable default attribute mix warnings

### DIFF
--- a/lib/Target/RISCV/RISCVEmulation.cpp
+++ b/lib/Target/RISCV/RISCVEmulation.cpp
@@ -23,11 +23,6 @@ static bool ELDEmulateRISCVELF(LinkerScript &pScript, LinkerConfig &pConfig) {
   else
     pConfig.targets().setBitClass(64);
 
-  // Always show attribute mix warnings on RISC-V unless the user has
-  // explicitly set the option.
-  if (!pConfig.hasShowAttributeMixWarnings())
-    pConfig.setShowAttributeMixWarning(true);
-
   if (!ELDEmulateELF(pScript, pConfig))
     return false;
 

--- a/test/RISCV/standalone/AttributeMixWarn/AttributeMixWarn.test
+++ b/test/RISCV/standalone/AttributeMixWarn/AttributeMixWarn.test
@@ -1,19 +1,33 @@
 #------AttributeMixWarn.test-----------------Executable------------------------#
 #BEGIN_COMMENT
-# Check that the linker, by default, generates a warning when object files of
-# different attributes are being linked and generates no warning if the
+# Check that the linker by default does not generate a warning when object
+# files of different attributes are being linked, but generates the warning
+# when -Wattribute-mix option is passed, and generates no warning if the
 # -Wno-attribute-mix option is passed.
+# Attribute mix that causes ABI incompatibility issues are treated as errors
+# by the linker.
 #END_COMMENT
 #-------------------------------------------------------------------------------
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/attr1.s -o %t1.attr1.o
 RUN: %clang %clangopts -c %p/Inputs/attr2.s -o %t1.attr2.o
 RUN: %clang %clangopts -c %p/Inputs/attr3.s -o %t1.attr3.o
+RUN: %clang %clangopts -c %p/Inputs/attr4.s -o %t1.attr4.o
+
 # This should not produce a warning
 RUN: %link %linkopts %t1.attr1.o %t1.attr2.o -o %t.out
-# This should produce a error for stack alignment
-RUN: %not %link %linkopts %t1.attr1.o %t1.attr3.o -o %t.out 2>&1 | %filecheck %s
-#CHECK: Reading incompatible attributes in file {{.*}}attr3.o, Error mixing attribute STACK_ALIGN, seen previous value 16 from input file {{.*}}attr1.o, now seen 8
+
+# This should produce an error for stack alignment
+RUN: %not %link %linkopts %t1.attr1.o %t1.attr3.o -o %t.out 2>&1 | %filecheck %s --check-prefix=ERROR
+ERROR: Reading incompatible attributes in file {{.*}}attr3.o, Error mixing attribute STACK_ALIGN, seen previous value 16 from input file {{.*}}attr1.o, now seen 8
+
+# This should produce a warning
+RUN: %link %linkopts -Wattribute-mix %t1.attr1.o %t1.attr4.o -o %t.out 2>&1 | %filecheck %s --check-prefix=WARN
+WARN:  Reading incompatible attributes in file {{.*}}attr4.o, Warning mixing attribute ARCH, seen previous value rv32i{{.*}}_m{{.*}}_a{{.*}}_c{{.*}} from input file {{.*}}attr1.o, now seen rv32i{{.*}}_m{{.*}}_c
+
+# This should not produce a warning by default
+RUN: %link %linkopts --fatal-warnings %t1.attr1.o %t1.attr4.o -o %t.out
+
 # This should not produce any warning
 RUN: %link %linkopts -Wno-attribute-mix --fatal-warnings %t1.attr1.o %t1.attr2.o -o %t.out
 #END_TEST

--- a/test/RISCV/standalone/AttributeMixWarn/Inputs/attr4.s
+++ b/test/RISCV/standalone/AttributeMixWarn/Inputs/attr4.s
@@ -1,0 +1,6 @@
+.attribute stack_align, 16
+.attribute arch, "rv32i2p1_m2p0_c2p0"
+.attribute unaligned_access, 1
+.attribute priv_spec, 2
+.attribute priv_spec_minor, 0
+.attribute priv_spec_revision, 0

--- a/test/RISCV/standalone/Attributes/Attributes.test
+++ b/test/RISCV/standalone/Attributes/Attributes.test
@@ -14,23 +14,25 @@ RUN: %clang %clangopts -c %p/Inputs/attr8.s -o %t1.attr8.o
 # Create executables
 RUN: %link %linkopts %t1.attr1.o %t1.attr2.o -o %t.out
 RUN: %readelf -A %t.out 2>&1 | %filecheck %s -check-prefix=ATTRS
-# Fails for bad attributes
+# Fails for bad attributes. Some attribute mixes require enabling warnings,
+# e.g., unaligned access, priv spec version.
 RUN: %not %link --fatal-warnings %linkopts %p/Inputs/BadAttr.o -o %t.out
 RUN: %not %link --fatal-warnings %linkopts %t1.attr1.o %t1.attr3.o -o %t.out
-RUN: %not %link --fatal-warnings %linkopts %t1.attr1.o %t1.attr5.o -o %t.out
-RUN: %not %link --fatal-warnings %linkopts %t1.attr1.o %t1.attr6.o -o %t.out
+RUN: %not %link --fatal-warnings -Wattribute-mix %linkopts %t1.attr1.o %t1.attr5.o -o %t.out
+RUN: %not %link --fatal-warnings -Wattribute-mix %linkopts %t1.attr1.o %t1.attr6.o -o %t.out
 RUN: %not %link --fatal-warnings %linkopts %t1.attr1.o %t1.attr7.o -o %t.out
-RUN: %not %link --fatal-warnings %linkopts %t1.attr1.o %t1.attr8.o -o %t.out
+RUN: %not %link --fatal-warnings -Wattribute-mix %linkopts %t1.attr1.o %t1.attr8.o -o %t.out
 # Create partial links
 RUN: %link %linkopts %t1.attr1.o %t1.attr2.o -o %t.r.out
 RUN: %readelf -A %t.r.out 2>&1 | %filecheck %s -check-prefix=ATTRS
-# Fails for bad attributes
+# Fails for bad attributes. Some attribute mixes require enabling warnings,
+# e.g., unaligned access, priv spec version.
 RUN: %not %link --fatal-warnings %linkopts -r %p/Inputs/BadAttr.o -o %t.out
 RUN: %not %link --fatal-warnings %linkopts -r %t1.attr1.o %t1.attr3.o -o %t.out
-RUN: %not %link --fatal-warnings %linkopts -r %t1.attr1.o %t1.attr5.o -o %t.out
-RUN: %not %link --fatal-warnings %linkopts -r %t1.attr1.o %t1.attr6.o -o %t.out
+RUN: %not %link --fatal-warnings -Wattribute-mix %linkopts -r %t1.attr1.o %t1.attr5.o -o %t.out
+RUN: %not %link --fatal-warnings -Wattribute-mix %linkopts -r %t1.attr1.o %t1.attr6.o -o %t.out
 RUN: %not %link --fatal-warnings %linkopts -r %t1.attr1.o %t1.attr7.o -o %t.out
-RUN: %not %link --fatal-warnings %linkopts -r %t1.attr1.o %t1.attr8.o -o %t.out
+RUN: %not %link --fatal-warnings -Wattribute-mix %linkopts -r %t1.attr1.o %t1.attr8.o -o %t.out
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
 RUN: %link %linkopts %t1.1.o -T %p/Inputs/script.t -o %t.script.out
 RUN: %readelf -S -W %t.script.out 2>&1 | %filecheck -check-prefix=SECTIONS %s


### PR DESCRIPTION
Display attribute mix warnings on RISC-V when explicitly setting -Wattribute-mix option.

Projects currently building with -Werror enabled are failing due to the default-enabled attribute mix warnings.

It is acceptable to disable these attribute mix warnings because attribute mixes that can lead to ABI incompatibility issues are treated as errors by the linker.