### PR TITLE
RISCV PLT addresses

### DIFF
--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -317,7 +317,7 @@ bool RISCVLDBackend::doRelaxationLui(Relocation *reloc, Relocator::DWord G) {
     return false;
 
   size_t SymbolSize = reloc->symInfo()->outSymbol()->size();
-  Relocator::DWord S = getRelocator()->getSymValue(reloc);
+  Relocator::DWord S = getSymbolValuePLT(*reloc);
   Relocator::DWord A = reloc->addend();
   uint64_t offset = reloc->targetRef()->offset();
   Relocation::Type type = reloc->type();
@@ -561,7 +561,7 @@ bool RISCVLDBackend::doRelaxationPC(Relocation *reloc, Relocator::DWord G) {
 
   // Test if the symbol with size can fall in 12 bits.
   size_t SymbolSize = reloc->symInfo()->outSymbol()->size();
-  Relocator::DWord S = getRelocator()->getSymValue(reloc);
+  Relocator::DWord S = getSymbolValuePLT(*reloc);
   Relocator::DWord A = reloc->addend();
 
   Relocation::Type new_type = 0x0;
@@ -586,7 +586,7 @@ bool RISCVLDBackend::doRelaxationPC(Relocation *reloc, Relocator::DWord G) {
       return false;
     if (!HIReloc)
       ASSERT(0, "HIReloc not found! Internal Error!");
-    S = getRelocator()->getSymValue(HIReloc);
+    S = getSymbolValuePLT(*HIReloc);
     A = HIReloc->addend();
     SymbolSize = HIReloc->symInfo()->outSymbol()->size();
   }

--- a/lib/Target/RISCV/RISCVRelocator.cpp
+++ b/lib/Target/RISCV/RISCVRelocator.cpp
@@ -809,7 +809,7 @@ RISCVRelocator::Result applyRel(Relocation &pReloc, RISCVLDBackend &Backend,
   if (RelocDescs.count(pReloc.type()) == 0)
     return RISCVRelocator::Unsupport;
 
-  int64_t S = Backend.getRelocator()->getSymValue(&pReloc);
+  int64_t S = Backend.getSymbolValuePLT(pReloc);
   int64_t A = pReloc.addend();
   int64_t P = pReloc.place(Backend.getModule());
 
@@ -990,12 +990,12 @@ RISCVRelocator::Result applyGPRel(Relocation &pReloc, RISCVLDBackend &Backend,
   if (RelocDescs.count(pReloc.type()) == 0)
     return RISCVRelocator::Unsupport;
 
-  int64_t S = Backend.getRelocator()->getSymValue(&pReloc);
+  int64_t S = Backend.getSymbolValuePLT(pReloc);
 
   // Get the symbol value always from the HIRELOC.
   Relocation *HIReloc = Backend.m_PairedRelocs[&pReloc];
   if (HIReloc)
-    S = Backend.getRelocator()->getSymValue(HIReloc);
+    S = Backend.getSymbolValuePLT(*HIReloc);
 
   int64_t A = pReloc.addend();
   int64_t G = 0x0;
@@ -1014,9 +1014,8 @@ RISCVRelocator::Result applyCompressedLUI(Relocation &pReloc,
                                           RISCVLDBackend &Backend,
                                           RelocationDescription &pRelocDesc) {
   // TODO: TEst what lld/bfd does.
-  // LUI has bottom 12 bits or 4K addressable target bits 0.
-  uint64_t Result =
-      Backend.getRelocator()->getSymValue(&pReloc) + pReloc.addend();
+  // LUI has bottom 12 bits or 4K addressible target bits 0.
+  uint64_t Result = Backend.getSymbolValuePLT(pReloc) + pReloc.addend();
   // The bottom 12 bits are signed.
   uint64_t LoImm = llvm::SignExtend64<12>(Result);
   return ApplyReloc(pReloc, Result - LoImm, pRelocDesc, Backend.config());

--- a/test/RISCV/standalone/Relaxation/HI20_LO12_I_PLT/HI20_LO12_I_PLT.test
+++ b/test/RISCV/standalone/Relaxation/HI20_LO12_I_PLT/HI20_LO12_I_PLT.test
@@ -1,0 +1,27 @@
+# BEGIN_COMMENT
+## Test that relaxations use the PLT address (not the dynamic symbol address!)
+# END_COMMENT
+#--------------------------------------------------------------------
+
+# RUN: %clang %clangopts -fno-pic -O3 -c %p/Inputs/main.c -o %t.main.o
+
+## The dynamic symbol address (~0x3000) is c.lui-relaxable.
+# RUN: %clang %clangopts -O3 -fPIC -c %p/Inputs/f.c -o %t.f.o
+# RUN: %link %linkopts -shared --no-align-segments --section-start .text=0x3000 %t.f.o -o %t.f.clui.so
+# RUN: %link %linkopts --no-align-segments --section-start .plt=0x100000 -o %t.clui.out %t.main.o %t.f.clui.so
+# RUXN: %objdump -d %t.clui.out | %filecheck %s --check-prefix=INSTR
+
+## The same as above but lure it into relaxing into GP-rel.
+# RUN: %clang %clangopts -O3 -fPIC -c %p/Inputs/f.c -o %t.f.o
+# RUN: %link %linkopts -shared --no-align-segments --section-start .text=0x33000 %t.f.o -o %t.f.gp.so
+# RUN: %link %linkopts --no-align-segments --section-start .plt=0x100000 -o %t.gp.out -T %p/Inputs/main.gp.t %t.main.o %t.f.gp.so
+# RUN: %objdump -d %t.gp.out | %filecheck %s --check-prefix=INSTR
+
+## The same as above but with zero-page relaxation.
+# RUN: %clang %clangopts -O3 -fPIC -c %p/Inputs/f.c -o %t.f.o
+# RUN: %link %linkopts -shared --no-align-segments --section-start .text=0 %t.f.o -o %t.f.zero.so
+# RUN: %link %linkopts --no-align-segments --section-start .plt=0x100000 -o %t.zero.out %t.main.o %t.f.zero.so
+# RUN: %objdump -d %t.zero.out | %filecheck %s --check-prefix=INSTR
+
+INSTR:   100030: 00100537     lui	a0, 0x100
+INSTR:   100034: 02050513     addi a0, a0, 0x20

--- a/test/RISCV/standalone/Relaxation/HI20_LO12_I_PLT/Inputs/f.c
+++ b/test/RISCV/standalone/Relaxation/HI20_LO12_I_PLT/Inputs/f.c
@@ -1,0 +1,1 @@
+void f(void) {}

--- a/test/RISCV/standalone/Relaxation/HI20_LO12_I_PLT/Inputs/main.c
+++ b/test/RISCV/standalone/Relaxation/HI20_LO12_I_PLT/Inputs/main.c
@@ -1,0 +1,3 @@
+void f();
+
+int main() { return (int)f; }

--- a/test/RISCV/standalone/Relaxation/HI20_LO12_I_PLT/Inputs/main.gp.t
+++ b/test/RISCV/standalone/Relaxation/HI20_LO12_I_PLT/Inputs/main.gp.t
@@ -1,0 +1,3 @@
+__global_pointer$=0x33000;
+SECTIONS {
+}

--- a/test/RISCV/standalone/Relocs/RelocPLT/relocations.s
+++ b/test/RISCV/standalone/Relocs/RelocPLT/relocations.s
@@ -1,0 +1,49 @@
+# RUN: %clang %clangopts -O3 -fPIC -c %p/Inputs/f.c -o %t.f.o
+# RUN: %link %linkopts -shared %t.f.o -o %t.f.so
+
+# RUN: %clang %clangopts -fno-pic -mno-relax -c %s -o %t.o
+# RUN: %link %linkopts -o %t.out --no-align-segments \
+# RUN:  --section-start .data=0x1000 \
+# RUN:  --section-start .text=0xa00000 \
+# RUN:  --section-start .plt=0xabc000 %t.o %t.f.so
+# RUN: %readelf -x .data -d %t.out | %filecheck %s --check-prefix=DATA
+# RUN: %objdump -d %t.out | %filecheck %s --check-prefix=INSTR
+
+.data
+.long f
+.quad f
+
+# DATA: Hex dump of section '.data':
+# DATA-NEXT: 20c0ab00 20c0ab00 00000000
+
+.text
+lui t1, %hi(f)
+# INSTR:      a00000: 00abc337      lui t1, 0xabc
+
+lui t1, %hi(f+4)
+# INSTR-NEXT: a00004: 00abc337      lui t1, 0xabc
+
+addi t1, t1, %lo(f)
+# INSTR-NEXT: a00008: 02030313      addi t1, t1, 0x20
+
+addi t1, t1, %lo(f+4)
+# INSTR-NEXT: a0000c: 02430313      addi t1, t1, 0x24
+
+sb t1, %lo(f)(a2)
+# INSTR-NEXT: a00010: 02660023      sb t1, 0x20(a2)
+
+sb t1, %lo(f+4)(a2)
+# INSTR-NEXT: a00014: 02660223      sb t1, 0x24(a2)
+
+auipc t1, %pcrel_hi(f)
+# INSTR-NEXT: a00018: 000bc317     	auipc	t1, 0xbc
+
+auipc t1, %pcrel_hi(f+4)
+# INSTR-NEXT: a0001c: 000bc317     	auipc	t1, 0xbc
+
+j f
+# INSTR-NEXT: a00020: 000bc06f      j 0xabc020
+
+call f
+# INSTR-NEXT: a00024: 000bc097     	auipc	ra, 0xbc
+# INSTR-NEXT: a00028: ffc080e7     	jalr	-0x4(ra)


### PR DESCRIPTION
When code compiled with no PIC is linked with dynamic symbols, materializing a pointer should take the address of the PLT entry. It happens that the current dynamic address from the shared library is taken instead, which is meaningless.

This changes switches to using the PLT address in two cases: processing relocations and relaxations.