### PR TITLE
eld version output should be emitted to stdout (#42)

### DIFF
--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -143,21 +143,22 @@ bool GnuLdDriver::checkAndRaiseTraceDiagEntry(eld::Expected<void> E) const {
 const char *GnuLdDriver::getLtoStatus() const { return "Enabled"; }
 
 void GnuLdDriver::printVersionInfo() const {
-  errs() << "Supported Targets: ";
+  outs() << "Supported Targets: ";
   for (const auto &x : m_SupportedTargets)
-    errs() << x << " ";
-  errs() << "\n";
+    outs() << x << " ";
+  outs() << "\n";
   if (!eld::getVendorName().empty()) {
-    errs() << "Linker from " << eld::getVendorName() << " Version "
+    outs() << "Linker from " << eld::getVendorName() << " Version "
            << eld::getVendorVersion() << "\n";
   }
-  errs() << "Linker based on LLVM version: " << eld::getELDVersion() << "\n";
-  errs() << "Linker Plugin Support Enabled\n";
-  errs() << "Linker Plugin Interface Version "
+  outs() << "Linker based on LLVM version: " << eld::getELDVersion() << "\n";
+  outs() << "Linker Plugin Support Enabled\n";
+  outs() << "Linker Plugin Interface Version "
          << LINKER_PLUGIN_API_MAJOR_VERSION << "."
          << LINKER_PLUGIN_API_MINOR_VERSION << "\n";
-  errs() << "LTO Support " << getLtoStatus() << "\n";
+  outs() << "LTO Support " << getLtoStatus() << "\n";
 }
+
 // Some command line options or some combinations of them are not allowed.
 // This function checks for such errors.
 template <class T>

--- a/test/ARM/standalone/CommandLine/Version/Version.test
+++ b/test/ARM/standalone/CommandLine/Version/Version.test
@@ -4,5 +4,5 @@
 # targets.
 #END_COMMENT
 #START_TEST
-RUN: %link --version 2>&1 | %filecheck %s
+RUN: %link --version | %filecheck %s
 #CHECK-NOT: thumb


### PR DESCRIPTION
eld version was emitted to stderr, and zephyr builds assume that version output is emitted to stdout.

This is similar to how other linkers emit version output

Change-Id: I99397ede5087e2f3176fb25c8011cf6bc7f949dc