### PR TITLE
Change __FUNCSIG__ guard to _MSC_VER

### DIFF
--- a/include/eld/Support/MsgHandling.h
+++ b/include/eld/Support/MsgHandling.h
@@ -14,7 +14,7 @@
 #define ELD_SUPPORT_MSGHANDLING_H
 #include "eld/Diagnostics/MsgHandler.h"
 
-#ifdef _WIN32
+#if defined(_MSC_VER)
 #define __PRETTY_FUNCTION__ __FUNCSIG__
 #endif
 #endif


### PR DESCRIPTION
`__FUNCSIG__` is a compiler-specific feature, but not a platform-specific one.  Before this commit, building eld for Windows with a non-MS compiler would fail.  For example, this failure from a libclang based compiler:

	In file included from /root/hexagon-toolchain/llvm-project/llvm/include/llvm/IR/PassManager.h:46:
	/root/hexagon-toolchain/llvm-project/llvm/include/llvm/Support/TypeName.h:19:20: error: use of undeclared identifier '__FUNCSIG__'
	  StringRef Name = __PRETTY_FUNCTION__;
			   ^
	/root/hexagon-toolchain/llvm-project/eld/include/eld/Support/MsgHandling.h:18:29: note: expanded from macro '__PRETTY_FUNCTION__'
	#define __PRETTY_FUNCTION__ __FUNCSIG__
				    ^