### PR TITLE
include <windows.h> for case-sensitive targets

### DIFF
--- a/lib/Support/Windows/Path.inc
+++ b/lib/Support/Windows/Path.inc
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //===----------------------------------------------------------------------===//
 
-#include <Windows.h>
+#include <windows.h>
 #undef max
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>


### PR DESCRIPTION
On a Windows system, the windows.h header file will normally appear to be available as Windows.h because its filesystems are case-insensitive. But when building on a linux host, for example, the header files from the cross-toolchain will be found instead as `windows.h`.