### PR TITLE
Fix generation of duplicate DT_NEEDED entries

### DIFF
--- a/include/eld/Target/ELFDynamic.h
+++ b/include/eld/Target/ELFDynamic.h
@@ -16,6 +16,7 @@
 #ifndef ELD_TARGET_ELFDYNAMIC_H
 #define ELD_TARGET_ELFDYNAMIC_H
 
+#include "eld/Input/ELFDynObjectFile.h"
 #include "eld/Readers/ELFSection.h"
 #include "eld/Support/MemoryRegion.h"
 #include "llvm/BinaryFormat/ELF.h"
@@ -161,6 +162,12 @@ public:
 
   static std::string TagToString(uint64_t Tag);
 
+  void addDTNeededLib(const ELFDynObjectFile &dynObjFile);
+
+  const std::vector<const ELFDynObjectFile *> &getDTNeededLibs() const {
+    return DTNeededLibs;
+  }
+
 protected:
   /// reserveTargetEntries - reserve target dependent entries
   virtual void reserveTargetEntries() = 0;
@@ -185,6 +192,7 @@ private:
   // For better performance, we use a simple counter and apply entry one-by-one
   // by the counter. m_Idx is the counter indicating to the entry being applied.
   size_t m_Idx;
+  std::vector<const ELFDynObjectFile *> DTNeededLibs;
 
 protected:
   GNULDBackend &m_Backend;

--- a/lib/Target/ELFDynamic.cpp
+++ b/lib/Target/ELFDynamic.cpp
@@ -427,3 +427,8 @@ void ELFDynamic::emit(const ELFSection &pSection, MemoryRegion &pRegion) const {
 void ELFDynamic::applySoname(uint64_t pStrTabIdx) {
   applyOne(llvm::ELF::DT_SONAME, pStrTabIdx); // DT_SONAME
 }
+
+void ELFDynamic::addDTNeededLib(const ELFDynObjectFile &dynObjFile) {
+  reserveNeedEntry();
+  DTNeededLibs.push_back(&dynObjFile);
+}

--- a/test/Common/standalone/DTNeededForRepeatedDynLibs/DTNeededForRepeatedDynLibs.test
+++ b/test/Common/standalone/DTNeededForRepeatedDynLibs/DTNeededForRepeatedDynLibs.test
@@ -1,0 +1,14 @@
+#---DTNeededForRepeatedDynLibs.test------------- Executable, SharedLibrary ----------#
+#BEGIN_COMMENT
+#This test checks that DT_NEEDED entry is not repeated for repeated shared libs.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -fPIC
+RUN: %clang %clangopts -o %t1.2.o %p/Inputs/2.c -c
+RUN: %link %linkopts -shared -o %t1.lib1.so %t1.1.o
+RUN: %link %linkopts -dy -o %t1.2.out %t1.2.o %t1.lib1.so
+RUN: %readelf --dynamic %t1.2.out | %filecheck %s
+#END_TEST
+
+CHECK: {{.*}}NEEDED{{.*}}lib1.so
+CHECK-NOT: {{.*}}NEEDED{{.*}}lib1.so

--- a/test/Common/standalone/DTNeededForRepeatedDynLibs/Inputs/1.c
+++ b/test/Common/standalone/DTNeededForRepeatedDynLibs/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/Common/standalone/DTNeededForRepeatedDynLibs/Inputs/2.c
+++ b/test/Common/standalone/DTNeededForRepeatedDynLibs/Inputs/2.c
@@ -1,0 +1,1 @@
+int bar() { return 3; }

--- a/test/Common/standalone/RepeatedDynLibAsNeeded/Inputs/1.c
+++ b/test/Common/standalone/RepeatedDynLibAsNeeded/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/Common/standalone/RepeatedDynLibAsNeeded/Inputs/2.c
+++ b/test/Common/standalone/RepeatedDynLibAsNeeded/Inputs/2.c
@@ -1,0 +1,1 @@
+int bar() { return 3; }

--- a/test/Common/standalone/RepeatedDynLibAsNeeded/Inputs/3.c
+++ b/test/Common/standalone/RepeatedDynLibAsNeeded/Inputs/3.c
@@ -1,0 +1,1 @@
+int main() { return 5; }

--- a/test/Common/standalone/RepeatedDynLibAsNeeded/RepeatedDynLibsAsNeeded.test
+++ b/test/Common/standalone/RepeatedDynLibAsNeeded/RepeatedDynLibsAsNeeded.test
@@ -1,0 +1,18 @@
+#---RepeatedDynLibsAsNeeded.test------------- Executable, SharedLibrary ----------#
+#BEGIN_COMMENT
+# This test checks that DT_NEEDED order is correct when a
+# shared library is specified with both --as-needed and --no-as-needed
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -fPIC
+RUN: %clang %clangopts -o %t1.2.o %p/Inputs/2.c -c -fPIC
+RUN: %clang %clangopts -o %t1.3.o %p/Inputs/3.c -c
+RUN: %link %linkopts -shared -o %t1.lib1.so %t1.1.o
+RUN: %link %linkopts -shared -o %t1.lib2.so %t1.2.o
+RUN: %link %linkopts -dy -o %t1.3.out %t1.3.o --as-needed %t1.lib1.so --no-as-needed %t1.lib2.so %t1.lib1.so
+RUN: %readelf --dynamic %t1.3.out | %filecheck %s
+#END_TEST
+
+CHECK: {{.*}}NEEDED{{.*}}lib2.so
+CHECK: {{.*}}NEEDED{{.*}}lib1.so
+CHECK-NOT: {{.*}}NEEDED{{.*}}lib1.so


### PR DESCRIPTION
This commit fixes generation of duplicate DT_NEEDED entries. Duplicate DT_NEEDED entries were previously emitted when a shared library was specified multiple times in the link command-line.

Closes #47