### PR TITLE
[risc-v] Zero-page (offset from 0) relaxation

### DIFF
--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -858,6 +858,10 @@ public:
 
   bool getRISCVRelax() const { return BRiscvRelax; }
 
+  void setRISCVZeroRelax(bool Relax) { RiscvZeroRelax = Relax; }
+
+  bool getRISCVZeroRelax() const { return RiscvZeroRelax; }
+
   void setRISCVGPRelax(bool Relax) { RiscvGPRelax = Relax; }
 
   bool getRISCVGPRelax() const { return RiscvGPRelax; }
@@ -1218,6 +1222,7 @@ private:
   bool DisableGuardForWeakUndefs = false; // hexagon specific option to
                                           // disable guard functionality.
   bool BRiscvRelax = true;                // enable riscv relaxation
+  bool RiscvZeroRelax = true;             // Zero-page relaxation
   bool RiscvGPRelax = true;               // GP relaxation
   bool BRiscvRelaxToC = true; // enable riscv relax to compressed code
   bool AllowIncompatibleSectionsMix = false; // Allow incompatibleSections;

--- a/include/eld/Driver/RISCVLinkerOptions.td
+++ b/include/eld/Driver/RISCVLinkerOptions.td
@@ -28,9 +28,13 @@ def no_riscv_relax : Flag<["--"], "no-relax">,
                      HelpText<"Disable relaxation">,
                      Group<grp_riscv_linker>;
 
+def no_relax_zero : Flag<["--"], "no-relax-zero">,
+                    HelpText<"Disable zero-page relaxation">,
+                    Group<grp_riscv_linker>;
+
 def no_relax_gp : Flag<["--"], "no-relax-gp">,
-                     HelpText<"Disable GP relaxation">,
-                     Group<grp_riscv_linker>;
+                  HelpText<"Disable GP relaxation">,
+                  Group<grp_riscv_linker>;
 
 def no_riscv_relax_compressed
     : Flag<["--"], "no-relax-c">,

--- a/lib/LinkerWrapper/RISCVLinkDriver.cpp
+++ b/lib/LinkerWrapper/RISCVLinkDriver.cpp
@@ -104,6 +104,10 @@ opt::OptTable *RISCVLinkDriver::parseOptions(ArrayRef<const char *> Args,
   if (ArgList.hasArg(OPT_RISCVLinkOptTable::no_riscv_relax))
     Config.options().setRISCVRelax(false);
 
+  // --no-relax-zero
+  if (ArgList.hasArg(OPT_RISCVLinkOptTable::no_relax_zero))
+    Config.options().setRISCVZeroRelax(false);
+
   // --no-relax-gp
   if (ArgList.hasArg(OPT_RISCVLinkOptTable::no_relax_gp))
     Config.options().setRISCVGPRelax(false);

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -325,6 +325,7 @@ bool RISCVLDBackend::doRelaxationLui(Relocation *reloc, Relocator::DWord G) {
 
   // First, try zero-page relaxation. It's the cheapest and does not need GP.
   bool canRelaxZero = config().options().getRISCVRelax() &&
+                      config().options().getRISCVZeroRelax() &&
                       llvm::isInt<12>(Value) && S != 0;
 
   // HI will be deleted, LO will be converted to use GP as base.

--- a/test/RISCV/standalone/Relaxation/HI20_LO12_I_TO_CLUI/HI20_LO12_I_TO_CLUI.test
+++ b/test/RISCV/standalone/Relaxation/HI20_LO12_I_TO_CLUI/HI20_LO12_I_TO_CLUI.test
@@ -169,3 +169,7 @@ CHECK-NEXT: 00001037  	lui	zero, 1
 CHECK-NEXT: 80402503  	lw	a0, -2044(zero)
 CHECK-NEXT: 00001137  	lui	sp, 1
 CHECK-NEXT: 80412503  	lw	a0, -2044(sp)
+
+RUN: %clang %clangopts -c  %p/Inputs/1.s -o %t.1.o
+RUN: %link %linkopts -MapStyle txt -Map %t.1.map --verbose --no-relax-zero %t.1.o -o %t.1.no-relax-zero.out -T %p/Inputs/1.t 2>&1 | %filecheck %s --check-prefix=VERBOSE-NO-RELAX-ZERO
+VERBOSE-NO-RELAX-ZERO-NOT: RISCV_LUI_ZERO : Deleting [[#]] bytes

--- a/test/RISCV/standalone/Relaxation/HI20_LO12_I_TO_CLUI/HI20_LO12_I_TO_CLUI.test
+++ b/test/RISCV/standalone/Relaxation/HI20_LO12_I_TO_CLUI/HI20_LO12_I_TO_CLUI.test
@@ -1,6 +1,6 @@
 #----------HI20_LO12_I_TO_CLUI.test----------------- Executable------------------#
 #BEGIN_COMMENT
-# Relax LUI with a small operand to comppressed C.LUI.
+# Relax LUI with a small operand to comppressed C.LUI or eliminate it (zero-page).
 # This test was generated with the help of gcc:
 # riscv64-linux-gnu-gcc -march=rv32imac -mabi=ilp32 Inputs/1.s -Wl,-T,Inputs/1.t -nostdlib
 # Note that ld.bfd does not relax LUI with the immiate equal to 31 (0x1f) and -1 (0x3f).
@@ -16,94 +16,94 @@
 # a: 0555      	addi	a0, a0, 21
 # c: 8082      	ret
 # The output from bfd.ld is prefixed with LD-NEXT for reference.
-# Note that zero page relaxation is not yet supported (QTOOL-46847).
 #END_COMMENT
 #--------------------------------------------------------------------
 
 RUN: %clang %clangopts -c  %p/Inputs/1.s -o %t.1.o
 RUN: %link %linkopts -MapStyle txt -Map %t.1.map --verbose %t.1.o -o %t.1.out -T %p/Inputs/1.t 2>&1 | %filecheck %s --check-prefix=VERBOSE
 
-VERBOSE: RISCV_LUI_GP : Cannot relax 4 bytes for symbol 'A' in section .text+0x0 file {{.*}}1.o
-VERBOSE: RISCV_LUI_GP : Cannot relax 4 bytes for symbol 'B' in section .text+0x8 file {{.*}}1.o
-VERBOSE: RISCV_LUI_GP : Cannot relax 4 bytes for symbol 'C' in section .text+0x10 file {{.*}}1.o
-VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'D' in section .text+0x18 file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'D' in section .text+0x1a file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol D in section .text+0x18 file {{.*}}1.o
-VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'E' in section .text+0x1e file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'E' in section .text+0x20 file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol E in section .text+0x1e file {{.*}}1.o
-VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'F' in section .text+0x24 file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'F' in section .text+0x26 file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol F in section .text+0x24 file {{.*}}1.o
-VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'G' in section .text+0x2a file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'G' in section .text+0x2c file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol G in section .text+0x2a file {{.*}}1.o
-VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'H' in section .text+0x30 file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'H' in section .text+0x32 file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol H in section .text+0x30 file {{.*}}1.o
-VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'I' in section .text+0x36 file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'I' in section .text+0x38 file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol I in section .text+0x36 file {{.*}}1.o
-VERBOSE: RISCV_LUI_GP : Cannot relax 4 bytes for symbol 'J' in section .text+0x3c file {{.*}}1.o
-VERBOSE: RISCV_LUI_GP : Cannot relax 4 bytes for symbol 'K' in section .text+0x44 file {{.*}}1.o
-VERBOSE: RISCV_LUI_GP : Cannot relax 4 bytes for symbol 'L' in section .text+0x4c file {{.*}}1.o
-VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'M' in section .text+0x54 file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'M' in section .text+0x56 file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol M in section .text+0x54 file {{.*}}1.o
-VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'N' in section .text+0x5a file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'N' in section .text+0x5c file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol N in section .text+0x5a file {{.*}}1.o
-VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'O' in section .text+0x60 file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'O' in section .text+0x62 file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol O in section .text+0x60 file {{.*}}1.o
-VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'P' in section .text+0x66 file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'P' in section .text+0x68 file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol P in section .text+0x66 file {{.*}}1.o
-VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'Q' in section .text+0x6c file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'Q' in section .text+0x6e file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol Q in section .text+0x6c file {{.*}}1.o
-VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'R' in section .text+0x72 file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'R' in section .text+0x74 file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol R in section .text+0x72 file {{.*}}1.o
-VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'S' in section .text+0x78 file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'S' in section .text+0x7a file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol S in section .text+0x78 file {{.*}}1.o
-VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'T' in section .text+0x7e file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'T' in section .text+0x80 file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol T in section .text+0x7e file {{.*}}1.o
-VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'U' in section .text+0x84 file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'U' in section .text+0x86 file {{.*}}1.o
-VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol U in section .text+0x84 file {{.*}}1.o
+### This line is for relaxing value = 0.
+VERBOSE-ZERO: RISCV_LUI_ZERO : Deleting 4 bytes in Section .text File {{.*}}1.o
+
+### This line is for NOT relaxing value = 0.
+VERBOSE:RISCV_LUI_GP : Cannot relax 4 bytes for symbol 'A' in section .text+0x0 file {{.*}}1.o
+
+VERBOSE: RISCV_LUI_ZERO : Deleting 4 bytes for symbol 'B' in section .text+0x8 file {{.*}}1.o
+VERBOSE: RISCV_LUI_ZERO : Deleting 4 bytes for symbol 'C' in section .text+0xc file {{.*}}1.o
+VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'D' in section .text+0x10 file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'D' in section .text+0x12 file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol D in section .text+0x10 file {{.*}}1.o
+VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'E' in section .text+0x16 file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'E' in section .text+0x18 file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol E in section .text+0x16 file {{.*}}1.o
+VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'F' in section .text+0x1c file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'F' in section .text+0x1e file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol F in section .text+0x1c file {{.*}}1.o
+VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'G' in section .text+0x22 file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'G' in section .text+0x24 file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol G in section .text+0x22 file {{.*}}1.o
+VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'H' in section .text+0x28 file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'H' in section .text+0x2a file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol H in section .text+0x28 file {{.*}}1.o
+VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'I' in section .text+0x2e file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'I' in section .text+0x30 file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol I in section .text+0x2e file {{.*}}1.o
+VERBOSE: RISCV_LUI_GP : Cannot relax 4 bytes for symbol 'J' in section .text+0x34 file {{.*}}1.o
+VERBOSE: RISCV_LUI_GP : Cannot relax 4 bytes for symbol 'K' in section .text+0x3c file {{.*}}1.o
+VERBOSE: RISCV_LUI_GP : Cannot relax 4 bytes for symbol 'L' in section .text+0x44 file {{.*}}1.o
+VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'M' in section .text+0x4c file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'M' in section .text+0x4e file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol M in section .text+0x4c file {{.*}}1.o
+VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'N' in section .text+0x52 file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'N' in section .text+0x54 file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol N in section .text+0x52 file {{.*}}1.o
+VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'O' in section .text+0x58 file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'O' in section .text+0x5a file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol O in section .text+0x58 file {{.*}}1.o
+VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'P' in section .text+0x5e file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'P' in section .text+0x60 file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol P in section .text+0x5e file {{.*}}1.o
+VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'Q' in section .text+0x64 file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'Q' in section .text+0x66 file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol Q in section .text+0x64 file {{.*}}1.o
+VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'R' in section .text+0x6a file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'R' in section .text+0x6c file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol R in section .text+0x6a file {{.*}}1.o
+VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'S' in section .text+0x70 file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'S' in section .text+0x72 file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol S in section .text+0x70 file {{.*}}1.o
+VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'T' in section .text+0x76 file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'T' in section .text+0x78 file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol T in section .text+0x76 file {{.*}}1.o
+VERBOSE: RISCV_LUI_GP : Cannot relax 2 bytes for symbol 'U' in section .text+0x7c file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : Deleting 2 bytes for symbol 'U' in section .text+0x7e file {{.*}}1.o
+VERBOSE: RISCV_LUI_C : relaxing instruction 0x00000537 to compressed instruction 0x6501 for symbol U in section .text+0x7c file {{.*}}1.o
+VERBOSE: RISCV_LUI_GP : Cannot relax 4 bytes for symbol 'D' in section .text+0x82 file {{.*}}1.o
 VERBOSE: RISCV_LUI_GP : Cannot relax 4 bytes for symbol 'D' in section .text+0x8a file {{.*}}1.o
-VERBOSE: RISCV_LUI_GP : Cannot relax 4 bytes for symbol 'D' in section .text+0x92 file {{.*}}1.o
 VERBOSE-NOT: RISCV_LUI_C
 
 RUN: %filecheck %s --input-file=%t.1.map --check-prefix=MAP
 MAP: # LinkStats Begin
-MAP: # RelaxationBytesDeleted : 30
-MAP: # RelaxationBytesMissed : 62
+MAP: # RelaxationBytesDeleted : 38
+MAP: # RelaxationBytesMissed : 54
 MAP: # LinkStats End
 
 MAP: .text {{.+}}, Alignment: 0x2, Flags: SHF_ALLOC|SHF_EXECINSTR, Type: SHT_PROGBITS
-MAP: # RelaxationBytesDeleted : 30
-MAP: # RelaxationBytesMissed : 62
+MAP: # RelaxationBytesDeleted : 38
+MAP: # RelaxationBytesMissed : 54
 MAP: .text {{.+}}.o     #SHT_PROGBITS,SHF_ALLOC|SHF_EXECINSTR,2
 
 RUN: %objdump --no-print-imm-hex -d %t.1.out 2>&1 | %filecheck %s
 
 CHECK: <.text>:
 
-## TODO: zero page relaxation is not supported yet
-## TODO: 00002503  	lw	a0, 0(zero)
-## TODO: 7fc02503  	lw	a0, 2044(zero)
-## TODO: 80402503  	lw	a0, -2044(zero)
+## See above for relaxation of absolute zeroes.
+VERBOSE-ZERO-NEXT: 00002503  	lw	a0, 0(zero)
 
-CHECK-NEXT: 00000537  	lui	a0, 0
-CHECK-NEXT: 00052503  	lw	a0, 0(a0)
-CHECK-NEXT: 00000537  	lui	a0, 0
-CHECK-NEXT: 7fc52503  	lw	a0, 2044(a0)
-CHECK-NEXT: 00000537  	lui	a0, 0
-CHECK-NEXT: 80452503  	lw	a0, -2044(a0)
+CHECK-NEXT: 00000537      lui     a0, 0
+CHECK-NEXT: 00052503      lw      a0, 0(a0)
+CHECK-NEXT: 7fc02503  	lw	a0, 2044(zero)
+CHECK-NEXT: 80402503  	lw	a0, -2044(zero)
 
 ## positive addresses
 CHECK-NEXT: 6505      	lui	a0, 1

--- a/test/RISCV/standalone/Relaxation/HI20_LO12_I_TO_GP/HI20_LO12_I_TO_GP_zero.test
+++ b/test/RISCV/standalone/Relaxation/HI20_LO12_I_TO_GP/HI20_LO12_I_TO_GP_zero.test
@@ -1,0 +1,5 @@
+# Check that relaxation does not occur for zero values even when they reachable from GP.
+
+RUN: %clang %clangopts -O2 -c  %p/Inputs/gp-zero.c -o %t.gp-zero.o
+RUN: %link %linkopts --verbose %t.gp-zero.o -o %t.gp-zero.out -T %p/Inputs/gp-zero.t 2>&1 | %filecheck %s --check-prefix=VERBOSE
+VERBOSE: RISCV_LUI_GP : Cannot relax 4 bytes for symbol 'near' in section .text+0x0 file {{.*}}.o

--- a/test/RISCV/standalone/Relaxation/HI20_LO12_I_TO_GP/Inputs/gp-zero.c
+++ b/test/RISCV/standalone/Relaxation/HI20_LO12_I_TO_GP/Inputs/gp-zero.c
@@ -1,0 +1,5 @@
+int __attribute__((section(".sdata"))) near;
+
+int main() {
+  return near;
+}

--- a/test/RISCV/standalone/Relaxation/HI20_LO12_I_TO_GP/Inputs/gp-zero.t
+++ b/test/RISCV/standalone/Relaxation/HI20_LO12_I_TO_GP/Inputs/gp-zero.t
@@ -1,0 +1,8 @@
+SECTIONS {
+  .data 0x0: {
+    __global_pointer$ = . + 4;
+     *(.sdata)
+  }
+  .text : { *(.text*) }
+  . = ALIGN(4K);
+}

--- a/test/lld/ELF/riscv-relax-hi20-lo12.s
+++ b/test/lld/ELF/riscv-relax-hi20-lo12.s
@@ -1,0 +1,141 @@
+# REQUIRES: riscv32 || riscv64
+
+## This test is based on the lld test with the same name. The differences
+## with the lld output:
+## -- We don't gp-relax at the exact maximum distance for now,
+## -- We don't relax the exact zero,
+## -- __global_pointer$ must be defined in the linker script.
+## In addition, I added test cases for zero-page boundaries.
+# RUN: rm -rf %t && split-file %s %t && cd %t
+
+# RUN: %clang %clangopts -c a.s -o %t.o
+
+# RUN: %link %linkopts --defsym baz=420 %t.o lds -o %t.out
+# RUN: %objdump -td -M no-aliases --no-show-raw-insn %t.out | FileCheck %s
+
+# CHECK: 00000084 l       .text {{0*}}0 a
+
+# CHECK-NOT:  lui
+# CHECK:      addi    a0, gp, -0x7ff
+# CHECK-NEXT: lw      a0, -0x7ff(gp)
+# CHECK-NEXT: sw      a0, -0x7ff(gp)
+# CHECK-NOT:  lui
+# CHECK-NEXT: addi    a0, gp, 0x7fe
+# CHECK-NEXT: lb      a0, 0x7fe(gp)
+# CHECK-NEXT: sb      a0, 0x7fe(gp)
+# CHECK-NEXT: lui     a0, 0x201
+# CHECK-NEXT: addi    a0, a0, 0x0
+# CHECK-NEXT: lw      a0, 0x0(a0)
+# CHECK-NEXT: sw      a0, 0x0(a0)
+# CHECK-NOT:  lui
+# CHECK:      addi    a0, zero, 0x1
+# CHECK-NEXT: lw      a0, 0x1(zero)
+# CHECK-NEXT: sw      a0, 0x1(zero)
+# CHECK-NOT:  lui
+# CHECK:      addi    a0, zero, 0x1a4
+# CHECK-NEXT: lw      a0, 0x1a4(zero)
+# CHECK-NEXT: sw      a0, 0x1a4(zero)
+
+# CHECK-NEXT: c.lui   a0, 0xfffff
+# CHECK-NEXT: addi    a0, a0, 0x7ff
+# CHECK-NEXT: lw      a0, 0x7ff(a0)
+# CHECK-NEXT: sw      a0, 0x7ff(a0)
+
+# CHECK-NEXT: addi    a0, zero, -0x800
+# CHECK-NEXT: lw      a0, -0x800(zero)
+# CHECK-NEXT: sw      a0, -0x800(zero)
+
+# CHECK-NEXT: lui     a0, 0x0
+# CHECK-NEXT: addi    a0, a0, 0x0
+# CHECK-NEXT: lw      a0, 0x0(a0)
+# CHECK-NEXT: sw      a0, 0x0(a0)
+
+# CHECK-NEXT: addi    a0, zero, 0x7ff
+# CHECK-NEXT: lw      a0, 0x7ff(zero)
+# CHECK-NEXT: sw      a0, 0x7ff(zero)
+
+# CHECK-NEXT: c.lui   a0, 0x1
+# CHECK-NEXT: addi    a0, a0, -0x800
+# CHECK-NEXT: lw      a0, -0x800(a0)
+# CHECK-NEXT: sw      a0, -0x800(a0)
+
+# CHECK-EMPTY:
+# CHECK-NEXT: <a>:
+# CHECK-NEXT: addi a0, a0, 0x1
+
+#--- a.s
+.global _start
+_start:
+  lui a0, %hi(foo)
+  addi a0, a0, %lo(foo)
+  lw a0, %lo(foo)(a0)
+  sw a0, %lo(foo)(a0)
+  lui a0, %hi(bar)
+  addi a0, a0, %lo(bar)
+  lb a0, %lo(bar)(a0)
+  sb a0, %lo(bar)(a0)
+  lui a0, %hi(norelax)
+  addi a0, a0, %lo(norelax)
+  lw a0, %lo(norelax)(a0)
+  sw a0, %lo(norelax)(a0)
+  lui a0, %hi(almost_zero)
+  addi a0, a0, %lo(almost_zero)
+  lw a0, %lo(almost_zero)(a0)
+  sw a0, %lo(almost_zero)(a0)
+  lui a0, %hi(baz)
+  addi a0, a0, %lo(baz)
+  lw a0, %lo(baz)(a0)
+  sw a0, %lo(baz)(a0)
+
+  lui a0, %hi(below_neg_end)
+  addi a0, a0, %lo(below_neg_end)
+  lw a0, %lo(below_neg_end)(a0)
+  sw a0, %lo(below_neg_end)(a0)
+
+  lui a0, %hi(neg_end)
+  addi a0, a0, %lo(neg_end)
+  lw a0, %lo(neg_end)(a0)
+  sw a0, %lo(neg_end)(a0)
+
+  lui a0, %hi(zero)
+  addi a0, a0, %lo(zero)
+  lw a0, %lo(zero)(a0)
+  sw a0, %lo(zero)(a0)
+
+  lui a0, %hi(pos_end)
+  addi a0, a0, %lo(pos_end)
+  lw a0, %lo(pos_end)(a0)
+  sw a0, %lo(pos_end)(a0)
+
+  lui a0, %hi(past_pos_end)
+  addi a0, a0, %lo(past_pos_end)
+  lw a0, %lo(past_pos_end)(a0)
+  sw a0, %lo(past_pos_end)(a0)
+a:
+  .option norvc
+  addi a0, a0, 1
+
+.section .sdata,"aw"
+  .space 1
+foo:
+  .word 0
+  .space 4089
+bar:
+  .byte 0
+  .space 1
+norelax:
+  .word 0
+
+#--- lds
+SECTIONS {
+  .text : {*(.text) }
+  .sdata 0x200000 : {
+    __global_pointer$ = . + 0x800;
+  }
+  below_neg_end = -(0x800 + 1);
+  neg_end = -0x800;
+  zero = 0;
+  almost_zero = 1;
+  pos_end = 0x800 - 1;
+  past_pos_end = 0x800;
+}


### PR DESCRIPTION
Absolute relocations accessing +-2KB around the zero address can use the hard-wired zero register as the base address instead of a value loaded with LUI. The LUI instruction can be deleted.

Zero-page relaxations are not enabled for exact zeroes because not yet assigned addresses may temporarily have the value of zero, which may incorrectly relax them.