### PR TITLE
[LinkerScript] Add support for ALIGN_WITH_INPUT

### DIFF
--- a/docs/userguide/documentation/linker_script.rst
+++ b/docs/userguide/documentation/linker_script.rst
@@ -307,3 +307,67 @@ NOCROSSREFS
      * A linker script can contain multiple NOCROSSREFS commands.
 
      * Each command is treated as an independent set of output sections that are checked for cross references.
+
+Output Section Description
+==========================
+
+A ``SECTIONS`` command can contain one or more output section descriptions.
+
+.. code-block:: plaintext
+
+    <section-name> [<virtual_addr>][(<type>)] :
+    [AT(<load_addr>)] [ALIGN(<section_align>) | ALIGN_WITH_INPUT]
+    [SUBALIGN(<subsection_align>)] [<constraint>]
+    {
+       ...
+       <output-section-command> <output-section-command>
+    }[><region>][AT><lma_region>][:<phdr>...][
+    =<fillexp>]
+
+Syntax
+------
+
+<section-name>
+    Specifies the name of the output section.
+
+<virtual_addr>
+    Specifies the virtual address of the output section (optional). The address value can be an expression (see Expressions).
+
+<type>
+    Specifies the section load property (optional).
+
+    - NOLOAD: Marks a section as not loadable.
+    - INFO: Parsed only; has no effect on linking.
+
+<load_addr>
+    Specifies the load address of the output section (optional). The address value can be specified as an expression (see Expressions).
+
+<section_align>
+    Specifies the section alignment of the output section (optional). The alignment value can be an expression (see Expressions).
+
+<subsection_align>
+    Specifies the subsection alignment of the output section (optional). The alignment value can be an expression (see Expressions).
+
+<constraint>
+    Specifies the access type of the input sections (optional).
+
+    - NOLOAD: All input sections are read-only.
+
+<output-section-command>
+    Specifies an output section command (see Output section commands). An output section description contains one or more output section commands.
+
+<region>
+    Specifies the region of the output section (optional). The region is expressed as a string. This option is parsed but has no effect on linking.
+
+<lma-region>
+    Specifies the load memory address (LMA) region of the output section (optional). The value can be an expression. This option is parsed, but it has no effect on linking.
+
+<fillexp>
+    Specifies the fill value of the output section (optional). The value can be an expression. This option is parsed, but it has no effect on linking.
+
+<phdr>
+    Specifies a program segment for the output section (optional). To assign multiple program segments to an output section, this option can appear more than once in an output section description.
+
+.. note::
+
+    ALIGN_WITH_INPUT currently does not do anything in the linker, linker defaults to always align the physical address according to the requirements of the output section

--- a/include/eld/Script/OutputSectDesc.h
+++ b/include/eld/Script/OutputSectDesc.h
@@ -156,7 +156,12 @@ public:
       SectionConstraint = OutputSectDesc::Constraint::NO_CONSTRAINT;
       PluginCmd = nullptr;
       ThisPlugin = nullptr;
+      HasAlignWithInput = false;
     }
+
+    void setAlignWithInput() { HasAlignWithInput = true; }
+
+    bool hasAlignWithInput() const { return HasAlignWithInput; }
 
     Expression *OutputSectionVMA;
     Type ThisType;
@@ -167,6 +172,7 @@ public:
     Constraint SectionConstraint;
     eld::PluginCmd *PluginCmd;
     eld::Plugin *ThisPlugin;
+    bool HasAlignWithInput;
   };
 
   struct Epilog {

--- a/lib/Script/OutputSectDesc.cpp
+++ b/lib/Script/OutputSectDesc.cpp
@@ -86,6 +86,11 @@ void OutputSectDesc::dump(llvm::raw_ostream &Outs) const {
     Outs << ")\n";
   }
 
+  if (OutpuSectDescProlog.hasAlignWithInput()) {
+    Outs << "\tALIGN_WITH_INPUT";
+    Outs << ")\n";
+  }
+
   if (OutpuSectDescProlog.hasSubAlign()) {
     Outs << "\tSUBALIGN(";
     OutpuSectDescProlog.subAlign().dump(Outs);
@@ -187,6 +192,10 @@ void OutputSectDesc::dumpOnlyThis(llvm::raw_ostream &Outs) const {
     Outs << ")";
   }
 
+  if (OutpuSectDescProlog.hasAlignWithInput()) {
+    Outs << " ALIGN_WITH_INPUT";
+  }
+
   if (OutpuSectDescProlog.hasSubAlign()) {
     Outs << " SUBALIGN(";
     OutpuSectDescProlog.subAlign().dump(Outs);
@@ -231,6 +240,7 @@ void OutputSectDesc::setProlog(const Prolog &PProlog) {
   OutpuSectDescProlog.SectionConstraint = PProlog.SectionConstraint;
   OutpuSectDescProlog.ThisPlugin = PProlog.ThisPlugin;
   OutpuSectDescProlog.PluginCmd = PProlog.PluginCmd;
+  OutpuSectDescProlog.HasAlignWithInput = PProlog.HasAlignWithInput;
   if (OutpuSectDescProlog.OutputSectionVMA)
     OutpuSectDescProlog.OutputSectionVMA->setContextRecursively(getContext());
   if (OutpuSectDescProlog.OutputSectionLMA)

--- a/lib/ScriptParser/ScriptParser.cpp
+++ b/lib/ScriptParser/ScriptParser.cpp
@@ -741,6 +741,13 @@ OutputSectDesc::Prolog ScriptParser::readOutputSectDescPrologue() {
     Prologue.OutputSectionLMA = readParenExpr(/*setParen=*/false);
   if (consume("ALIGN"))
     Prologue.Alignment = readParenExpr(/*setParen=*/false);
+  if (consume("ALIGN_WITH_INPUT"))
+    Prologue.HasAlignWithInput = true;
+
+  if (Prologue.Alignment && Prologue.HasAlignWithInput) {
+    setError("ALIGN_WITH_INPUT specified with explicit alignment ");
+  }
+
   if (consume("SUBALIGN"))
     Prologue.OutputSectionSubaAlign = readParenExpr(/*setParen=*/false);
 

--- a/test/Common/standalone/linkerscript/AlignWithInput/AlignWithInput.test
+++ b/test/Common/standalone/linkerscript/AlignWithInput/AlignWithInput.test
@@ -1,0 +1,17 @@
+#---AlignWithInput.test--------------------- Executable,LS------------------#
+#BEGIN_COMMENT
+# This tests that ALIGN_WITH_INPUT keyword in the output section description
+# aligns the physical address according to requirements of the output section.
+# This is default behavior so there is nothing to change
+#END_COMMENT
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -ffunction-sections
+RUN: %link %linkopts %t1.1.o -T %p/Inputs/script.t -Map %t2.map -o %t2.out 2>&1
+RUN: %filecheck %s -check-prefix=LMA < %t2.map
+RUN: %not %link %linkopts %t1.1.o -T %p/Inputs/scripterr.t -o %t2.out.2 2>&1 | %filecheck %s -check-prefix=ERR
+
+#CHECK: .foo    0x200   {{.*}} # Offset: {{.*}}, LMA: 0x200, Alignment: 0x200, Flags: SHF_ALLOC|SHF_EXECINSTR, Type: SHT_PROGBITS, Segments : [ A ], Memory : [MEMA, LMEMA]
+#CHECK: .bar    0x800   {{.*}} # Offset: {{.*}}, LMA: 0x400, Alignment: 0x200, Flags: SHF_ALLOC|SHF_EXECINSTR, Type: SHT_PROGBITS, Segments : [ B ], Memory : [MEMB, LMEMB]
+#CHECK: .baz    0xc00   {{.*}} # Offset: {{.*}}, LMA: 0x600, Alignment: 0x200, Flags: SHF_ALLOC|SHF_EXECINSTR, Type: SHT_PROGBITS, Segments : [ C ], Memory : [MEMC, LMEMC]
+
+#ERR: ALIGN_WITH_INPUT specified with explicit alignment
+

--- a/test/Common/standalone/linkerscript/AlignWithInput/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/AlignWithInput/Inputs/1.c
@@ -1,0 +1,3 @@
+__attribute__((aligned(512))) int foo() { return 0; }
+__attribute__((aligned(512))) int bar() { return 0; }
+__attribute__((aligned(512))) int baz() { return 0; }

--- a/test/Common/standalone/linkerscript/AlignWithInput/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/AlignWithInput/Inputs/script.t
@@ -1,0 +1,21 @@
+PHDRS {
+  A PT_LOAD;
+  B PT_LOAD;
+  C PT_LOAD;
+}
+
+MEMORY {
+  MEMA : ORIGIN = 0x100, LENGTH = 2000
+  MEMB : ORIGIN = 0x800, LENGTH = 2000
+  MEMC : ORIGIN = 0xc00, LENGTH = 2000
+  LMEMA : ORIGIN = 100, LENGTH = 2000
+  LMEMB : ORIGIN = 800, LENGTH = 2000
+  LMEMC : ORIGIN = 1500, LENGTH = 2000
+}
+
+SECTIONS {
+  .foo : ALIGN_WITH_INPUT  { *(.text.foo) } >MEMA AT>LMEMA :A
+  .bar : ALIGN_WITH_INPUT  { *(.text.bar) } >MEMB AT>LMEMB :B
+  .baz : ALIGN_WITH_INPUT { *(.text.baz) } >MEMC AT>LMEMC :C
+  /DISCARD/ : { *(.ARM.exidx*) }
+}

--- a/test/Common/standalone/linkerscript/AlignWithInput/Inputs/scripterr.t
+++ b/test/Common/standalone/linkerscript/AlignWithInput/Inputs/scripterr.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  .foo : ALIGN(0x20) ALIGN_WITH_INPUT  { *(.text.foo) }
+  .bar : ALIGN(0x20) ALIGN_WITH_INPUT  { *(.text.bar) }
+  .baz : ALIGN(0x20) ALIGN_WITH_INPUT { *(.text.baz) }
+  /DISCARD/ : { *(.ARM.exidx*) }
+}


### PR DESCRIPTION
You can enforce that the difference between the VMA and LMA remains intact throughout this output section with the ALIGN_WITH_INPUT attribute.

This behavior is default and so there is nothing to do here.

Added a test that the behavior is consistent with expectations.

Also updated documentation.

Closes #52

Change-Id: Ic5c1e57542a9064b595fcffb63c781e2b71a4a4f