### PR TITLE
Explicitly disable copying/moving GeneralOptions and export GnuLdDriver

### DIFF
--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -116,6 +116,10 @@ public:
   GeneralOptions(DiagnosticEngine *);
   ~GeneralOptions();
 
+  GeneralOptions() = delete;
+  GeneralOptions(const GeneralOptions&) = delete;
+  GeneralOptions(GeneralOptions&&) = delete;
+
   /// stats
   void setStats(llvm::StringRef Stats);
 

--- a/include/eld/Driver/GnuLdDriver.h
+++ b/include/eld/Driver/GnuLdDriver.h
@@ -49,7 +49,7 @@ public:
   OPT_GnuLdOptTable();
 };
 
-class GnuLdDriver {
+class DLL_A_EXPORT GnuLdDriver {
 public:
   static GnuLdDriver *Create(eld::LinkerConfig &C, Flavor F,
                              std::string Triple);


### PR DESCRIPTION
This commit explicitly disables copying/moving of GeneralOptions class. For some reason, MSVC compiler was moving/copying GeneralOptions and was causing compilation failure.

Exporting GnuLdDriver class is required because we now use GnuLdDriver function in the main function (eld.cpp).