### PR TITLE
Unconditionally create internal RISCV AttributeFragment

### DIFF
--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -678,6 +678,7 @@ bool ObjectLinker::mayBeSortSections(std::vector<Section *> &Sections) {
                      ELFSection *B = llvm::dyn_cast<ELFSection>(BSection);
                      if (A == nullptr or B == nullptr)
                        return false;
+                     // FIXME: Redundant checks. All files have original input.
                      if (!A->originalInput())
                        return false;
                      if (!B->originalInput())
@@ -965,7 +966,6 @@ bool ObjectLinker::createOutputSection(ObjectBuilder &Builder,
       OutSect->setWanted(true);
     ThisModule->addOutputSectionToTable(OutSect);
   }
-
   return true;
 }
 

--- a/test/RISCV/standalone/AttributesWithLTO/AttributesWithLTO.test
+++ b/test/RISCV/standalone/AttributesWithLTO/AttributesWithLTO.test
@@ -1,0 +1,15 @@
+#------AttributesWithLTO.test-----------Executable,LS---------------#
+#BEGIN_COMMENT
+# This test verifies that the linker emits .riscv.attributes output section
+# when the input contains bitcode files and a linker script.
+#--------------------------------------------------------------------
+#END_COMMENT
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -flto
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t
+RUN: %readelf -S %t1.1.out 2>&1 | %filecheck %s
+RUN: %touch %t1.empty.o
+RUN: %link %linkopts -o %t1.2.out %t1.empty.o
+RUN: %readelf -S %t1.2.out 2>&1 | %filecheck %s --check-prefix=EMPTY
+
+CHECK: .riscv.attributes RISCV_ATTRIBUTES
+EMPTY-NOT: .riscv.attributes

--- a/test/RISCV/standalone/AttributesWithLTO/Inputs/1.c
+++ b/test/RISCV/standalone/AttributesWithLTO/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/RISCV/standalone/AttributesWithLTO/Inputs/script.t
+++ b/test/RISCV/standalone/AttributesWithLTO/Inputs/script.t
@@ -1,0 +1,4 @@
+SECTIONS {
+  .text : { *(*text*) }
+  .riscv.attributes 0 : { *(.riscv.attributes) }
+}


### PR DESCRIPTION
Until now, we only created internal RISCV AttributeFragment if there
was an input file that contained .riscv.attributes section. This commit
changes this behavior by unconditionally creating the internal RISCV
AttributeFragment.

This change fixes the issue of the missing .riscv.attributes output
section when LTO inputs are used with linker scripts. The root cause
of the issue was that we were moving the content of the empty internal RISCV
AttributeSection into the output section due to the order of input sections
after section sorting and delayed creation of internal RISCV AttributeFragment.