### PR TITLE
[LSParser] Ignore non-ascii unicode characters

### DIFF
--- a/include/eld/Diagnostics/DiagLDScript.inc
+++ b/include/eld/Diagnostics/DiagLDScript.inc
@@ -63,6 +63,7 @@ DIAG(no_pt_tls_segment, DiagnosticEngine::Error,
 DIAG(linker_script_var_used_before_define, DiagnosticEngine::Warning,
      "Symbol %0 used before being defined")
 DIAG(error_linker_script, DiagnosticEngine::Error, "%0")
+DIAG(note_linker_script, DiagnosticEngine::Note, "%0")
 DIAG(reading_dynamic_list, DiagnosticEngine::Verbose, "Dynamic List[%0] : %1")
 DIAG(reading_extern_list, DiagnosticEngine::Verbose, "Extern List[%0] : %1")
 DIAG(error_parsing_version_script, DiagnosticEngine::Error, "Error parsing version script %0")

--- a/include/eld/ScriptParser/ScriptLexer.h
+++ b/include/eld/ScriptParser/ScriptLexer.h
@@ -18,6 +18,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/MemoryBufferRef.h"
+#include <optional>
 #include <vector>
 
 namespace eld {
@@ -39,6 +40,9 @@ public:
 
   // Set error as needed
   void setError(const llvm::Twine &Msg);
+
+  void setNote(const llvm::Twine &msg,
+               std::optional<llvm::StringRef> columnTok = std::nullopt) const;
 
   void lex();
 
@@ -75,16 +79,16 @@ public:
   bool consumeLabel(llvm::StringRef Tok);
 
   // Check if s encloses t
-  bool encloses(llvm::StringRef S, llvm::StringRef T);
+  bool encloses(llvm::StringRef S, llvm::StringRef T) const;
 
   // Get current location of token including filename
-  std::string getCurrentLocation();
+  std::string getCurrentLocation() const;
 
   // Unquote string if quoted
   llvm::StringRef unquote(llvm::StringRef S);
 
   // Get Line and column information
-  llvm::StringRef getLine();
+  llvm::StringRef getLine() const;
 
   /// Returns true if there are no reported errors that should
   /// end the link abruptly.
@@ -98,15 +102,23 @@ public:
 
 protected:
   // Get current memory buffer
-  llvm::MemoryBufferRef getCurrentMB();
+  llvm::MemoryBufferRef getCurrentMB() const;
 
-  size_t getColumnNumber();
+  size_t getColumnNumber() const;
+
+  size_t computeColumnWidth(llvm::StringRef s, llvm::StringRef e) const;
 
 private:
   // Handle expression splits.
   void maybeSplitExpr();
 
-  // Check if there is an error
+  llvm::StringRef noteAndSkipNonASCIIUnicodeChars(llvm::StringRef s) const;
+
+  bool isNonASCIIUnicode(char c) const { return c & 0x80; }
+
+  bool isFirstByteOfMultiByteUnicode(char c) const {
+    return (c & 0xc0) == 0xc0;
+  }
 
 protected:
   struct Buffer {

--- a/test/Common/LinkerScriptParsing/Expressions/UnicodeCharacterWarning/Inputs/script.t
+++ b/test/Common/LinkerScriptParsing/Expressions/UnicodeCharacterWarning/Inputs/script.t
@@ -1,0 +1,8 @@
+SECTIONS {
+  foo :
+  {
+    . = ALIGN(4);
+  }
+   FOODATA_LMA_START = SIZEOF(foo);
+   FOODATA_LMA_END    = FOODATA_LMA_START + 10;
+}

--- a/test/Common/LinkerScriptParsing/Expressions/UnicodeCharacterWarning/UnicodeCharacterWarning.test
+++ b/test/Common/LinkerScriptParsing/Expressions/UnicodeCharacterWarning/UnicodeCharacterWarning.test
@@ -1,0 +1,12 @@
+#---UnicodeCharacterWarning.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+# This test checks that linker script parser gives note diagnostics for
+# non-ascii unicode characters.
+#END_COMMENT
+RUN: %lsparserverifier %lsparserverifier_opts %p/Inputs/script.t 2>&1 | %filecheck %s
+CHECK: Note: {{.*}}script.t:7: treating non-ascii unicode character as whitespace
+CHECK: >>>    FOODATA_LMA_END    = FOODATA_LMA_START + 10;
+CHECK: >>>                    ^
+CHECK: Note: {{.*}}script.t:7: treating non-ascii unicode character as whitespace
+CHECK: >>>    FOODATA_LMA_END    = FOODATA_LMA_START + 10;
+CHECK: >>>                      ^


### PR DESCRIPTION
This commit modifies linker script parser to ignore non-ascii unicode characters and report note diagnostics for the same.

Closes #62