### PR TITLE
Support 'archive: member' file-pattern in input section description

### DIFF
--- a/include/eld/Diagnostics/DiagLDScript.inc
+++ b/include/eld/Diagnostics/DiagLDScript.inc
@@ -123,3 +123,4 @@ DIAG(warn_non_power_of_2_value_to_align_builtin, DiagnosticEngine::Warning,
 DIAG(error_non_power_of_2_value_to_align_output_section, DiagnosticEngine::Error,
      "%0: non-power-of-2 value 0x%1 passed to ALIGN in '%2' output section description, value must "
      "be 0 or a power of 2")
+DIAG(warn_linker_script, DiagnosticEngine::Warning, "%0")

--- a/include/eld/ScriptParser/ScriptLexer.h
+++ b/include/eld/ScriptParser/ScriptLexer.h
@@ -44,6 +44,8 @@ public:
   void setNote(const llvm::Twine &msg,
                std::optional<llvm::StringRef> columnTok = std::nullopt) const;
 
+  void setWarn(const llvm::Twine &Msg);
+
   void lex();
 
   // Skip spaces
@@ -99,6 +101,12 @@ public:
   /// calls in between, does not change the cursor position. If there
   /// is no previous token, this function is no-op.
   void prev();
+
+  size_t computeLineNumber(llvm::StringRef tok);
+
+  size_t getCurrentLineNumber() {
+    return PrevTokLine;
+  }
 
 protected:
   // Get current memory buffer

--- a/lib/ScriptParser/ScriptParser.cpp
+++ b/lib/ScriptParser/ScriptParser.cpp
@@ -684,8 +684,17 @@ InputSectDesc::Spec ScriptParser::readInputSectionDescSpec(StringRef Tok) {
   else {
     std::pair<llvm::StringRef, llvm::StringRef> Split = Tok.split(':');
     FilePat = ThisScriptFile.createWildCardPattern(Split.first);
-    if (!Split.second.empty())
+    if (!Split.second.empty()) {
       ArchiveMem = ThisScriptFile.createWildCardPattern(Split.second);
+    }
+    llvm::StringRef peekTok = peek();
+    if (!atEOF() && peekTok != "(" &&
+        computeLineNumber(peekTok) == getCurrentLineNumber()) {
+      next();
+      if (ThisConfig.showLinkerScriptWarnings())
+        setWarn("Space between archive:member file pattern is deprecated");
+      ArchiveMem = ThisScriptFile.createWildCardPattern(peekTok);
+    }
     IsArchive = true;
   }
   StringList *WildcardSections = nullptr;

--- a/test/Common/standalone/linkerscript/ArchiveFilePatternWithSpace/ArchiveFilePatternWithSpace.test
+++ b/test/Common/standalone/linkerscript/ArchiveFilePatternWithSpace/ArchiveFilePatternWithSpace.test
@@ -1,0 +1,39 @@
+#---ArchiveFilePatternWithSpace.test--------------------- Executable ------------------#
+#BEGIN_COMMENT
+# This tests that checks that 'archive: file' pattern works for now and a
+# deprecated diagnostic is emitted for this usage.
+#END_COMMENT
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
+RUN: %clang %clangopts -o %t1.2.o %p/Inputs/2.c -c -ffunction-sections
+RUN: %ar cr %t1.lib12.a %t1.1.o %t1.2.o
+RUN: %link %linkopts -o %t1.a1.out --whole-archive %t1.lib12.a \
+RUN:   -T %p/Inputs/script.1.t -Map %t1.a1.map.txt -Wno-linker-script 2>&1 | %filecheck %s --allow-empty --check-prefix NO_WARN
+RUN: %link %linkopts -o %t1.a1.out --whole-archive %t1.lib12.a \
+RUN:   -T %p/Inputs/script.1.t -Map %t1.a1.map.txt -Wlinker-script 2>&1 | %filecheck %s --check-prefix WARN
+RUN: %filecheck %s --check-prefix MAP < %t1.a1.map.txt
+RUN: %link %linkopts -o %t1.a2.out --whole-archive %t1.lib12.a \
+RUN:   -T %p/Inputs/script.2.t -Map %t1.a2.map.txt
+RUN: %filecheck %s --check-prefix MEMBER_PATTERN_NEXT_LINE < %t1.a2.map.txt
+
+NO_WARN-NOT: Space between
+
+WARN: Warning: {{.*}}script.1.t:2: Space between archive:member file pattern is deprecated
+WARN: >>>   FOO: { *lib12.a: *1.o(*foo*) }
+WARN: >>>                    ^
+WARN: Warning: {{.*}}script.1.t:3: Space between archive:member file pattern is deprecated
+WARN: >>>   BAR: { *lib12.a: *(*bar*) }
+WARN: >>>
+
+MAP: FOO
+MAP: *lib12.a:*1.o(*foo*)
+MAP: .text.foo
+
+MAP: BAR
+MAP: *lib12.a:*(*bar*)
+MAP: .text.bar
+
+MEMBER_PATTERN_NEXT_LINE: WRONG_DATA
+MEMBER_PATTERN_NEXT_LINE: *lib12.a:(*)
+MEMBER_PATTERN_NEXT_LINE: .text.foo
+MEMBER_PATTERN_NEXT_LINE: .text.bar
+MEMBER_PATTERN_NEXT_LINE: *(*data*)

--- a/test/Common/standalone/linkerscript/ArchiveFilePatternWithSpace/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/ArchiveFilePatternWithSpace/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/Common/standalone/linkerscript/ArchiveFilePatternWithSpace/Inputs/2.c
+++ b/test/Common/standalone/linkerscript/ArchiveFilePatternWithSpace/Inputs/2.c
@@ -1,0 +1,1 @@
+int bar() { return 3; }

--- a/test/Common/standalone/linkerscript/ArchiveFilePatternWithSpace/Inputs/script.1.t
+++ b/test/Common/standalone/linkerscript/ArchiveFilePatternWithSpace/Inputs/script.1.t
@@ -1,0 +1,4 @@
+SECTIONS {
+  FOO: { *lib12.a: *1.o(*foo*) }
+  BAR: { *lib12.a: *(*bar*) }
+}

--- a/test/Common/standalone/linkerscript/ArchiveFilePatternWithSpace/Inputs/script.2.t
+++ b/test/Common/standalone/linkerscript/ArchiveFilePatternWithSpace/Inputs/script.2.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  WRONG_DATA: {
+    *lib12.a:
+      *(*data*)
+  }
+}


### PR DESCRIPTION
This commit adds support for 'archive: member' pattern in input section description. Generally, there should be no space between the 'archive:' and 'member'. However, it is a common mistake to put a space here. This commit makes this common use-case work as expected and reports a deprecated warning for the same.

Closes #67