### PR TITLE
Remove redundant TextLayoutPrinter::destroy function

### DIFF
--- a/include/eld/LayoutMap/TextLayoutPrinter.h
+++ b/include/eld/LayoutMap/TextLayoutPrinter.h
@@ -72,8 +72,6 @@ public:
 
   virtual ~TextLayoutPrinter();
 
-  void destroy();
-
   void clearInputRecords();
 
   void addLayoutMessage(std::string Msg) {

--- a/lib/LayoutMap/TextLayoutPrinter.cpp
+++ b/lib/LayoutMap/TextLayoutPrinter.cpp
@@ -1332,8 +1332,6 @@ TextLayoutPrinter::~TextLayoutPrinter() {
     (*LayoutFile) << Buffer->str();
 }
 
-void TextLayoutPrinter::destroy() {}
-
 void TextLayoutPrinter::clearInputRecords() {
   ThisLayoutPrinter->resetArchiveRecords();
   ThisLayoutPrinter->resetInputActions();

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -3418,7 +3418,6 @@ bool GNULDBackend::printLayout() {
   TextLayoutPrinter *printer = m_Module.getTextMapPrinter();
   if (printer) {
     printer->printMapFile(m_Module);
-    printer->destroy();
   }
   // print Cross Reference table, either on stdout
   // or in map file


### PR DESCRIPTION
This commit removes the TextLayoutPrinter::destroy function. The function definition was empty.

Closes #77