### PR TITLE
Renamed `LayoutPrinter` to `LayoutInfo`

### DIFF
--- a/include/eld/Core/LinkerScript.h
+++ b/include/eld/Core/LinkerScript.h
@@ -45,7 +45,7 @@ class ChangeOutputSectionOp;
 class DiagnosticEngine;
 class ELFSection;
 class GeneralOptions;
-class LayoutPrinter;
+class LayoutInfo;
 class LDSymbol;
 class OutputTarWriter;
 class RuleContainer;
@@ -96,7 +96,7 @@ public:
   PhdrSpecList &phdrList() { return PhdrList; }
 
   void createSectionMap(LinkerScript &L, const LinkerConfig &Config,
-                        LayoutPrinter *LayoutPrinter);
+                        LayoutInfo *LayoutInfo);
 
   SectionMap &sectionMap() const { return *OutputSectionMap; }
 

--- a/include/eld/Core/Module.h
+++ b/include/eld/Core/Module.h
@@ -20,7 +20,7 @@
 #include "eld/Config/GeneralOptions.h"
 #include "eld/Core/Linker.h"
 #include "eld/Input/InputFile.h"
-#include "eld/LayoutMap/LayoutPrinter.h"
+#include "eld/LayoutMap/LayoutInfo.h"
 #include "eld/Plugin/PluginManager.h"
 #include "eld/PluginAPI/LinkerWrapper.h"
 #include "eld/Script/StrToken.h"
@@ -140,10 +140,10 @@ public:
 
 public:
   explicit Module(LinkerScript &CurScript, LinkerConfig &Config,
-                  LayoutPrinter *LayoutPrinter);
+                  LayoutInfo *LayoutInfo);
 
   Module(const std::string &Name, LinkerScript &CurScript, LinkerConfig &Config,
-         LayoutPrinter *LayoutPrinter);
+         LayoutInfo *LayoutInfo);
 
   ~Module();
 
@@ -319,7 +319,7 @@ public:
                                              std::string Name, uint32_t Type,
                                              uint32_t PFlag, uint32_t PAlign);
 
-  LayoutPrinter *getLayoutPrinter() { return ThisLayoutPrinter; }
+  LayoutInfo *getLayoutInfo() { return ThisLayoutInfo; }
 
   // Section symbols and all other symbols that live in the output.
   void recordSectionSymbol(ELFSection *S, ResolveInfo *R) {
@@ -660,7 +660,7 @@ private:
   LDSymbol *DotSymbol = nullptr;
   Linker *Linker = nullptr;
   GNULDBackend *Backend = nullptr;
-  LayoutPrinter *ThisLayoutPrinter = nullptr;
+  LayoutInfo *ThisLayoutInfo = nullptr;
   bool Failure = false;
   bool UsesLto = false;
   plugin::LinkerWrapper::State State = plugin::LinkerWrapper::Unknown;

--- a/include/eld/LayoutMap/LayoutInfo.h
+++ b/include/eld/LayoutMap/LayoutInfo.h
@@ -1,4 +1,4 @@
-//===- LayoutPrinter.h-----------------------------------------------------===//
+//===- LayoutInfo.h-----------------------------------------------------===//
 // Part of the eld Project, under the BSD License
 // See https://github.com/qualcomm/eld/LICENSE.txt for license information.
 // SPDX-License-Identifier: BSD-3-Clause
@@ -69,7 +69,7 @@ struct LayoutFragmentInfo {
   std::vector<LDSymbol *> Symbols;
 };
 
-class LayoutPrinter {
+class LayoutInfo {
   static uint32_t LayoutDetail;
 
 public:
@@ -182,7 +182,7 @@ public:
 
   // -------------------End Typedefs ---------------------------------
 
-  LayoutPrinter(LinkerConfig &PConfig);
+  LayoutInfo(LinkerConfig &PConfig);
 
   bool showStrings() const { return LayoutDetail & ShowStrings; }
 
@@ -230,7 +230,7 @@ public:
   void recordOutputFileSize(uint32_t Sz) { LinkStats.OutputFileSize = Sz; }
 
   // FIXME: Destructor is redundant here.
-  ~LayoutPrinter() { destroy(); }
+  ~LayoutInfo() { destroy(); }
 
   // FIXME: This function is not required.
   void destroy() {
@@ -450,7 +450,7 @@ private:
   LinkerConfig &ThisConfig;
   /// It is required to compute relative path when -MapDetail
   /// 'show-relative-path=...' is used.
-  // It needs to be 'static' because LayoutPrinter::setLayoutDetail member
+  // It needs to be 'static' because LayoutInfo::setLayoutDetail member
   // function is static.
   static std::optional<std::string> ThisBasepath;
   std::optional<uint32_t> OutputFileSize;

--- a/include/eld/LayoutMap/TextLayoutPrinter.h
+++ b/include/eld/LayoutMap/TextLayoutPrinter.h
@@ -8,7 +8,7 @@
 #define ELD_LAYOUTMAP_TEXTLAYOUTPRINTER_H
 #include "eld/Diagnostics/DiagnosticPrinter.h"
 #include "eld/Input/Input.h"
-#include "eld/LayoutMap/LayoutPrinter.h"
+#include "eld/LayoutMap/LayoutInfo.h"
 #include "eld/Readers/ELFSection.h"
 #include "eld/Support/MemoryArea.h"
 #include "eld/Support/MemoryRegion.h"
@@ -25,7 +25,7 @@ class LinkerConfig;
 
 class TextLayoutPrinter {
 public:
-  TextLayoutPrinter(LayoutPrinter *ThisLayoutPrinter);
+  TextLayoutPrinter(LayoutInfo *ThisLayoutInfo);
 
   eld::Expected<void> init();
 
@@ -115,7 +115,7 @@ private:
                               int64_t FillValue, bool IsAlign,
                               bool UseColor = false) const;
 
-  void printStats(LayoutPrinter::Stats &L, const Module &Module);
+  void printStats(LayoutInfo::Stats &L, const Module &Module);
 
   void printStat(llvm::StringRef S, uint64_t Stats);
 
@@ -160,7 +160,7 @@ private:
   std::string Storage;
   std::unique_ptr<llvm::raw_string_ostream> Buffer = nullptr;
   std::unique_ptr<llvm::raw_fd_ostream> LayoutFile = nullptr;
-  LayoutPrinter *ThisLayoutPrinter = nullptr;
+  LayoutInfo *ThisLayoutInfo = nullptr;
 };
 
 } // namespace eld

--- a/include/eld/LayoutMap/YamlLayoutPrinter.h
+++ b/include/eld/LayoutMap/YamlLayoutPrinter.h
@@ -8,7 +8,7 @@
 #define ELD_LAYOUTMAP_YAMLLAYOUTPRINTER_H
 
 #include "eld/LayoutMap/LDYAML.h"
-#include "eld/LayoutMap/LayoutPrinter.h"
+#include "eld/LayoutMap/LayoutInfo.h"
 #include "eld/Support/MemoryArea.h"
 #include "eld/Support/MemoryRegion.h"
 #include "eld/Target/GNULDBackend.h"
@@ -26,7 +26,7 @@ struct CommandLineDefault {
 class YamlLayoutPrinter {
 
 public:
-  YamlLayoutPrinter(LayoutPrinter *P);
+  YamlLayoutPrinter(LayoutInfo *layoutInfo);
 
   eld::Expected<void> init();
 
@@ -50,7 +50,7 @@ public:
 
   eld::LDYAML::LinkStats addStat(std::string S, uint64_t Count);
 
-  void addStats(LayoutPrinter::Stats &L,
+  void addStats(LayoutInfo::Stats &L,
                 std::vector<eld::LDYAML::LinkStats> &S);
 
   void insertCommons(std::vector<eld::LDYAML::Common> &Commons,
@@ -64,7 +64,7 @@ private:
   std::string CommandLine;
   llvm::raw_fd_ostream *LayoutFile;
   llvm::raw_fd_ostream *TrampolineLayoutFile;
-  LayoutPrinter *ThisLayoutPrinter = nullptr;
+  LayoutInfo *ThisLayoutInfo = nullptr;
 };
 
 } // namespace eld

--- a/include/eld/Object/SectionMap.h
+++ b/include/eld/Object/SectionMap.h
@@ -25,7 +25,7 @@
 namespace eld {
 
 class ELFSection;
-class LayoutPrinter;
+class LayoutInfo;
 class LinkerScript;
 class LinkerConfig;
 class EhFrameHdrSection;
@@ -48,7 +48,7 @@ public:
 
 public:
   SectionMap(LinkerScript &L, const LinkerConfig &Config,
-             LayoutPrinter *LayoutPrinter);
+             LayoutInfo *LayoutInfo);
 
   ~SectionMap();
 
@@ -182,7 +182,7 @@ private:
       SpecialSections;
   std::vector<ELFSection *> MEntrySections;
   const DiagnosticPrinter *MPrinter;
-  LayoutPrinter *MLayoutPrinter = nullptr;
+  LayoutInfo *MLayoutInfo = nullptr;
 };
 
 } // namespace eld

--- a/include/eld/SymbolResolver/IRBuilder.h
+++ b/include/eld/SymbolResolver/IRBuilder.h
@@ -33,7 +33,7 @@ class Module;
 class LinkerConfig;
 class InputTree;
 class InputFile;
-class LayoutPrinter;
+class LayoutInfo;
 
 class IRBuilder {
 public:

--- a/include/eld/SymbolResolver/NamePool.h
+++ b/include/eld/SymbolResolver/NamePool.h
@@ -29,7 +29,7 @@
 
 namespace eld {
 
-class LayoutPrinter;
+class LayoutInfo;
 class LDSymbol;
 class Module;
 class PluginManager;
@@ -84,7 +84,7 @@ public:
 
   LDSymbol *createPluginSymbol(InputFile *Input, std::string SymbolName,
                                Fragment *CurFragment, uint64_t Val,
-                               LayoutPrinter *LP);
+                               LayoutInfo *layoutInfo);
 
   size_t getNumGlobalSize() const { return GlobalSymbols.size(); }
 

--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -13,7 +13,7 @@
 #ifndef ELD_TARGET_GNULDBACKEND_H
 #define ELD_TARGET_GNULDBACKEND_H
 #include "eld/GarbageCollection/GarbageCollection.h"
-#include "eld/LayoutMap/LayoutPrinter.h"
+#include "eld/LayoutMap/LayoutInfo.h"
 #include "eld/Object/ObjectBuilder.h"
 #include "eld/Readers/CommonELFSection.h"
 #include "eld/Readers/ELFExecObjParser.h"

--- a/lib/BranchIsland/BranchIslandFactory.cpp
+++ b/lib/BranchIsland/BranchIslandFactory.cpp
@@ -15,7 +15,7 @@
 #include "eld/Config/LinkerConfig.h"
 #include "eld/Core/Module.h"
 #include "eld/Fragment/Fragment.h"
-#include "eld/LayoutMap/LayoutPrinter.h"
+#include "eld/LayoutMap/LayoutInfo.h"
 #include "eld/Object/ObjectLinker.h"
 #include "eld/Readers/ELFSection.h"
 #include "eld/Support/Memory.h"
@@ -83,7 +83,7 @@ BranchIslandFactory::createBranchIsland(Relocation &PReloc, Stub *S,
                                         eld::IRBuilder &PBuilder,
                                         const Relocator *PRelocator) {
   Module &PModule = PBuilder.getModule();
-  LayoutPrinter *LayoutPrinter = PBuilder.getModule().getLayoutPrinter();
+  LayoutInfo *LayoutInfo = PBuilder.getModule().getLayoutInfo();
 
   bool CloneFrag = false;
 
@@ -331,12 +331,12 @@ BranchIslandFactory::createBranchIsland(Relocation &PReloc, Stub *S,
     MatchedSection->splice(CurNodeIter, ToBeInsertedFrags);
     Symbol->resolveInfo()->setResolvedOrigin(TrampolineInput);
 
-    if (LayoutPrinter && !LayoutPrinter->showOnlyLayout()) {
+    if (LayoutInfo && !LayoutInfo->showOnlyLayout()) {
       std::lock_guard<std::mutex> Guard(Mutex);
-      LayoutPrinter->recordFragment(TrampolineInput, TrampolineInputSection,
+      LayoutInfo->recordFragment(TrampolineInput, TrampolineInputSection,
                                     Clone);
-      LayoutPrinter->recordSymbol(Clone, Symbol);
-      LayoutPrinter->recordTrampolines();
+      LayoutInfo->recordSymbol(Clone, Symbol);
+      LayoutInfo->recordTrampolines();
     }
 
     OutputElfSection->getOutputSection()->addBranchIsland(PReloc.symInfo(),

--- a/lib/Fragment/MergeStringFragment.cpp
+++ b/lib/Fragment/MergeStringFragment.cpp
@@ -8,7 +8,7 @@
 #include "eld/Fragment/MergeStringFragment.h"
 #include "eld/Config/LinkerConfig.h"
 #include "eld/Core/Module.h"
-#include "eld/LayoutMap/LayoutPrinter.h"
+#include "eld/LayoutMap/LayoutInfo.h"
 #include "eld/Readers/ELFSection.h"
 
 using namespace eld;

--- a/lib/GarbageCollection/GarbageCollection.cpp
+++ b/lib/GarbageCollection/GarbageCollection.cpp
@@ -710,7 +710,7 @@ void GarbageCollection::stripSections(SectionSetTy &S,
 
   std::vector<std::pair<ELFSection *, LDFileFormat::Kind>> IgnoredSections;
 
-  LayoutPrinter *Printer = ThisModule.getLayoutPrinter();
+  LayoutInfo *layoutInfo = ThisModule.getLayoutInfo();
   bool ShouldDemangle = ThisConfig.options().shouldDemangle();
 
   for (Obj = ThisModule.objBegin(); Obj != ObjEnd; ++Obj) {
@@ -761,8 +761,8 @@ void GarbageCollection::stripSections(SectionSetTy &S,
         if (CommonSectionsOnly && !IsCommonSection)
           IgnoredSections.push_back(
               std::make_pair(Section, Section->getKind()));
-        else if (Printer)
-          Printer->recordGC(Section);
+        else if (layoutInfo)
+          layoutInfo->recordGC(Section);
         Section->setKind(LDFileFormat::Ignore);
       }
     }
@@ -838,8 +838,8 @@ void GarbageCollection::addRetainSections(SectionSetTy &EntrySections) {
       ELFSection *S = llvm::dyn_cast<ELFSection>(Sect);
       if (S && S->isRetain()) {
         EntrySections.insert(S);
-        if (ThisModule.getLayoutPrinter())
-          ThisModule.getLayoutPrinter()->recordRetainedSections();
+        if (ThisModule.getLayoutInfo())
+          ThisModule.getLayoutInfo()->recordRetainedSections();
         if (ThisModule.getPrinter()->isVerbose() ||
             ThisConfig.options().traceSection(S->name().str()))
           ThisConfig.raise(Diag::retaining_section)

--- a/lib/LayoutMap/CMakeLists.txt
+++ b/lib/LayoutMap/CMakeLists.txt
@@ -1,4 +1,4 @@
-llvm_add_library(ELDLayout STATIC LayoutPrinter.cpp LDYAML.cpp
+llvm_add_library(ELDLayout STATIC LayoutInfo.cpp LDYAML.cpp
                  TextLayoutPrinter.cpp YamlLayoutPrinter.cpp)
 
 target_link_libraries(

--- a/lib/LayoutMap/YamlLayoutPrinter.cpp
+++ b/lib/LayoutMap/YamlLayoutPrinter.cpp
@@ -26,21 +26,21 @@
 using namespace eld;
 using namespace llvm;
 
-YamlLayoutPrinter::YamlLayoutPrinter(LayoutPrinter *P)
-    : LayoutFile(nullptr), TrampolineLayoutFile(nullptr), ThisLayoutPrinter(P) {
+YamlLayoutPrinter::YamlLayoutPrinter(LayoutInfo *layoutInfo)
+    : LayoutFile(nullptr), TrampolineLayoutFile(nullptr), ThisLayoutInfo(layoutInfo) {
 }
 
 eld::Expected<void> YamlLayoutPrinter::init() {
-  if (ThisLayoutPrinter->getConfig().options().printMap())
+  if (ThisLayoutInfo->getConfig().options().printMap())
     return {};
   std::string SuffixExtension = "";
-  if (!ThisLayoutPrinter->getConfig().options().isDefaultMapStyleYAML())
+  if (!ThisLayoutInfo->getConfig().options().isDefaultMapStyleYAML())
     SuffixExtension = ".yaml";
-  if (!ThisLayoutPrinter->getConfig().options().layoutFile().empty()) {
+  if (!ThisLayoutInfo->getConfig().options().layoutFile().empty()) {
     std::string LayoutFileName =
-        ThisLayoutPrinter->getConfig().options().layoutFile();
+        ThisLayoutInfo->getConfig().options().layoutFile();
     if (!SuffixExtension.empty())
-      LayoutFileName = ThisLayoutPrinter->getConfig().options().layoutFile() +
+      LayoutFileName = ThisLayoutInfo->getConfig().options().layoutFile() +
                        SuffixExtension;
     std::error_code Error;
     LayoutFile =
@@ -52,21 +52,21 @@ eld::Expected<void> YamlLayoutPrinter::init() {
     }
     Defaults.push_back(
         {"NoVerify",
-         std::to_string(ThisLayoutPrinter->getConfig().options().verifyLink()),
+         std::to_string(ThisLayoutInfo->getConfig().options().verifyLink()),
          "Enable Linker verification"});
     Defaults.push_back(
         {"MaxGPSize",
-         std::to_string(ThisLayoutPrinter->getConfig().options().getGPSize()),
+         std::to_string(ThisLayoutInfo->getConfig().options().getGPSize()),
          "GP Size value for Small Data"});
     char const *Separator = "";
-    for (const auto *Arg : ThisLayoutPrinter->getConfig().options().args()) {
+    for (const auto *Arg : ThisLayoutInfo->getConfig().options().args()) {
       CommandLine.append(Separator);
       Separator = " ";
       if (Arg)
         CommandLine.append(std::string(Arg));
     }
   }
-  ThisLayoutPrinter->getConfig().options().setBuildCRef();
+  ThisLayoutInfo->getConfig().options().setBuildCRef();
   return {};
 }
 
@@ -83,11 +83,11 @@ void YamlLayoutPrinter::insertCommons(std::vector<eld::LDYAML::Common> &Commons,
   for (auto &I : Infos) {
     eld::LDYAML::Common Common;
     Common.Name =
-        ThisLayoutPrinter->showSymbolName(StringRef(I->name(), I->nameSize()));
+        ThisLayoutInfo->showSymbolName(StringRef(I->name(), I->nameSize()));
     Common.Size = I->size();
     InputFile *Input = I->resolvedOrigin();
     if (Input != nullptr)
-      Common.InputPath = ThisLayoutPrinter->getPath(Input->getInput());
+      Common.InputPath = ThisLayoutInfo->getPath(Input->getInput());
     if (Input->getInput()->isArchiveMember() > 0)
       Common.InputName = Input->getInput()->getName();
     Commons.push_back(Common);
@@ -110,7 +110,7 @@ void YamlLayoutPrinter::addInputs(
     if (!InpFile)
       continue;
     if (InpFile->isArchive()) {
-      A.Name = ThisLayoutPrinter->getPath(Inp);
+      A.Name = ThisLayoutInfo->getPath(Inp);
       A.Used = InpFile->isUsed();
       for (auto &M :
            llvm::dyn_cast<eld::ArchiveFile>(InpFile)->getAllMembers()) {
@@ -122,7 +122,7 @@ void YamlLayoutPrinter::addInputs(
       Inputs.push_back(std::make_shared<eld::LDYAML::Archive>(std::move(A)));
       continue;
     }
-    I.Name = ThisLayoutPrinter->getPath(Inp);
+    I.Name = ThisLayoutInfo->getPath(Inp);
     I.Used = InpFile->isUsed();
     Inputs.push_back(std::make_shared<eld::LDYAML::RegularInput>(std::move(I)));
   }
@@ -136,7 +136,7 @@ eld::LDYAML::LinkStats YamlLayoutPrinter::addStat(std::string S,
   return L;
 }
 
-void YamlLayoutPrinter::addStats(LayoutPrinter::Stats &L,
+void YamlLayoutPrinter::addStats(LayoutInfo::Stats &L,
                                  std::vector<eld::LDYAML::LinkStats> &S) {
   S.push_back(addStat("ObjectFiles", L.NumElfObjectFiles));
   S.push_back(addStat("LinkerScripts", L.NumLinkerScripts));
@@ -181,27 +181,27 @@ eld::YamlLayoutPrinter::buildYaml(eld::Module &Module,
   Result.ModuleVersion.VendorVersion = eld::getVendorVersion().str();
   Result.ModuleVersion.ELDVersion = eld::getELDVersion().str();
 
-  for (auto &I : ThisLayoutPrinter->getArchiveRecords()) {
+  for (auto &I : ThisLayoutInfo->getArchiveRecords()) {
     std::pair<std::string, std::string> Ret =
-        ThisLayoutPrinter->getArchiveRecord(I);
+        ThisLayoutInfo->getArchiveRecord(I);
     Result.ArchiveRecords.push_back({Ret.first, Ret.second});
   }
   insertCommons(Result.Commons,
-                ThisLayoutPrinter->getAllocatedCommonSymbols(Module));
-  addStats(ThisLayoutPrinter->getLinkStats(), Result.Stats);
-  Result.Features = ThisLayoutPrinter->getFeatures();
+                ThisLayoutInfo->getAllocatedCommonSymbols(Module));
+  addStats(ThisLayoutInfo->getLinkStats(), Result.Stats);
+  Result.Features = ThisLayoutInfo->getFeatures();
   addInputs(Result.InputFileInfo, Module);
-  for (auto &I : ThisLayoutPrinter->getInputActions()) {
-    std::string Action = ThisLayoutPrinter->getStringFromLoadSequence(I);
+  for (auto &I : ThisLayoutInfo->getInputActions()) {
+    std::string Action = ThisLayoutInfo->getStringFromLoadSequence(I);
     Result.InputActions.push_back(Action);
   }
-  for (auto &Script : ThisLayoutPrinter->getLinkerScripts()) {
+  for (auto &Script : ThisLayoutInfo->getLinkerScripts()) {
     std::string Indent = "";
     for (uint32_t I = 0; I < Script.Depth; ++I)
       Indent += "\t";
     std::string LinkerScriptName = Script.Include;
-    if (ThisLayoutPrinter->getConfig().options().hasMappingFile())
-      LinkerScriptName = ThisLayoutPrinter->getPath(LinkerScriptName) + "(" +
+    if (ThisLayoutInfo->getConfig().options().hasMappingFile())
+      LinkerScriptName = ThisLayoutInfo->getPath(LinkerScriptName) + "(" +
                          LinkerScriptName + ")";
     if (!Script.Found)
       LinkerScriptName += "(NOTFOUND)";
@@ -213,7 +213,7 @@ eld::YamlLayoutPrinter::buildYaml(eld::Module &Module,
   Result.EntryAddress = getEntryAddress(Module, Backend);
   for (auto *I : Module.getScript().sectionMap()) {
     auto *Section = I->getSection();
-    if (!(ThisLayoutPrinter->showHeaderDetails() &&
+    if (!(ThisLayoutInfo->showHeaderDetails() &&
           (Section->name() == "__ehdr__" || Section->name() == "__pHdr__")) &&
         (Section->isNullType() || (!HasSectionsCmd && !I->size() &&
                                    !Section->isWanted() && !Section->size())))
@@ -273,8 +273,8 @@ eld::YamlLayoutPrinter::buildYaml(eld::Module &Module,
             Value.Inputs.push_back(
                 std::make_shared<eld::LDYAML::Padding>(std::move(Padding)));
           }
-          auto Existing = ThisLayoutPrinter->getFragmentInfoMap().find(Frag);
-          if (Existing != ThisLayoutPrinter->getFragmentInfoMap().end()) {
+          auto Existing = ThisLayoutInfo->getFragmentInfoMap().find(Frag);
+          if (Existing != ThisLayoutInfo->getFragmentInfoMap().end()) {
             eld::LDYAML::InputSection Input;
             eld::LDYAML::InputBitcodeSection BCInput;
             eld::LDYAML::InputSection *ELFInputSection = &Input;
@@ -319,27 +319,27 @@ eld::YamlLayoutPrinter::buildYaml(eld::Module &Module,
             if (IsBitcode)
               BCInput.BitcodeOrigin =
                   Info->section()->getOldInputFile()->getInput()->decoratedPath(
-                      ThisLayoutPrinter->showAbsolutePath());
-            ThisLayoutPrinter->sortFragmentSymbols(Info);
+                      ThisLayoutInfo->showAbsolutePath());
+            ThisLayoutInfo->sortFragmentSymbols(Info);
             for (auto *K : Info->Symbols) {
               eld::InputFile *RO = K->resolveInfo()
                                        ? K->resolveInfo()->resolvedOrigin()
                                        : nullptr;
               if (!RO->isBitcode() &&
                   (RO->getInput()->decoratedPath(
-                       ThisLayoutPrinter->showAbsolutePath()) !=
+                       ThisLayoutInfo->showAbsolutePath()) !=
                    Info->getResolvedPath()))
                 continue;
               if (IsBitcode) {
                 BCInput.Symbols.push_back(
                     {K->name(), K->type(), K->binding(), K->size(),
-                     (llvm::yaml::Hex64)ThisLayoutPrinter->calculateSymbolValue(
+                     (llvm::yaml::Hex64)ThisLayoutInfo->calculateSymbolValue(
                          K, Module)});
                 continue;
               }
               ELFInputSection->Symbols.push_back(
                   {K->name(), K->type(), K->binding(), K->size(),
-                   (llvm::yaml::Hex64)ThisLayoutPrinter->calculateSymbolValue(
+                   (llvm::yaml::Hex64)ThisLayoutInfo->calculateSymbolValue(
                        K, Module)});
             }
             if (IsBitcode && !BCInput.Symbols.empty())
@@ -408,8 +408,8 @@ eld::YamlLayoutPrinter::buildYaml(eld::Module &Module,
       if (!Section->isIgnore() && !Section->isDiscard())
         continue;
       if (!Section->hasSectionData()) {
-        auto Existing = ThisLayoutPrinter->getSectionInfoMap().find(Section);
-        if (Existing == ThisLayoutPrinter->getSectionInfoMap().end())
+        auto Existing = ThisLayoutInfo->getSectionInfoMap().find(Section);
+        if (Existing == ThisLayoutInfo->getSectionInfoMap().end())
           continue;
         eld::LDYAML::DiscardedSection DS;
         eld::LDYAML::DiscardedSection *ELFDiscardedSection = &DS;
@@ -418,7 +418,7 @@ eld::YamlLayoutPrinter::buildYaml(eld::Module &Module,
         ELFDiscardedSection->Type = Section->getType();
         ELFDiscardedSection->Origin =
             Existing->second->getInput()->decoratedPath(
-                ThisLayoutPrinter->showAbsolutePath());
+                ThisLayoutInfo->showAbsolutePath());
         ELFDiscardedSection->Alignment = Section->getAddrAlign();
         ELFDiscardedSection->InputPermissions = Section->getFlags();
         Result.DiscardedSectionGroups.emplace_back(
@@ -426,8 +426,8 @@ eld::YamlLayoutPrinter::buildYaml(eld::Module &Module,
         continue;
       }
       for (auto &F : Section->getFragmentList()) {
-        auto Existing = ThisLayoutPrinter->getFragmentInfoMap().find(F);
-        if (Existing == ThisLayoutPrinter->getFragmentInfoMap().end())
+        auto Existing = ThisLayoutInfo->getFragmentInfoMap().find(F);
+        if (Existing == ThisLayoutInfo->getFragmentInfoMap().end())
           continue;
         eld::LDYAML::DiscardedSection DS;
         eld::LDYAML::DiscardedSection *ELFDiscardedSection = &DS;
@@ -438,7 +438,7 @@ eld::YamlLayoutPrinter::buildYaml(eld::Module &Module,
         ELFDiscardedSection->Origin = Info->getResolvedPath();
         ELFDiscardedSection->Alignment = F->alignment();
         ELFDiscardedSection->InputPermissions = Info->flag();
-        ThisLayoutPrinter->sortFragmentSymbols(Info);
+        ThisLayoutInfo->sortFragmentSymbols(Info);
         for (auto *K : Info->Symbols)
           ELFDiscardedSection->Symbols.push_back(
               {K->name(), K->type(), K->binding(), K->size(), 0});
@@ -451,11 +451,11 @@ eld::YamlLayoutPrinter::buildYaml(eld::Module &Module,
     ResolveInfo *Info = G.getValue();
     if (Info->isCommon() && (Info->outSymbol()->shouldIgnore())) {
       eld::LDYAML::Common S;
-      S.Name = ThisLayoutPrinter->showSymbolName(Info->name());
+      S.Name = ThisLayoutInfo->showSymbolName(Info->name());
       S.Size = Info->size();
       InputFile *Input = Info->resolvedOrigin();
       if (Input != nullptr)
-        S.InputPath = ThisLayoutPrinter->getPath(Input->getInput());
+        S.InputPath = ThisLayoutInfo->getPath(Input->getInput());
       if (Input->getInput()->isArchiveMember())
         S.InputName = Input->getInput()->getName();
       Result.DiscardedCommons.emplace_back(S);
@@ -483,7 +483,7 @@ eld::YamlLayoutPrinter::buildYaml(eld::Module &Module,
     Result.LoadRegions.push_back(L);
   }
   const GeneralOptions::CrefTableType &Table =
-      ThisLayoutPrinter->getConfig().options().crefTable();
+      ThisLayoutInfo->getConfig().options().crefTable();
   std::vector<const ResolveInfo *> SymVector;
   GeneralOptions::CrefTableType::const_iterator Itr = Table.begin(),
                                                 Ite = Table.end();
@@ -549,8 +549,8 @@ void eld::YamlLayoutPrinter::getTrampolineMap(
       Fragment *PatchFrag = OrigRelocation->targetRef()->frag();
       T.From = PatchFrag->getOwningSection()->name().str();
       {
-        auto Existing = ThisLayoutPrinter->getFragmentInfoMap().find(PatchFrag);
-        if (Existing != ThisLayoutPrinter->getFragmentInfoMap().end()) {
+        auto Existing = ThisLayoutInfo->getFragmentInfoMap().find(PatchFrag);
+        if (Existing != ThisLayoutInfo->getFragmentInfoMap().end()) {
           auto *Info = Existing->second;
           for (auto *K : Info->Symbols) {
             if (!K->isSection())
@@ -561,7 +561,7 @@ void eld::YamlLayoutPrinter::getTrampolineMap(
       T.FromFile = PatchFrag->getOwningSection()
                        ->getInputFile()
                        ->getInput()
-                       ->decoratedPath(ThisLayoutPrinter->showAbsolutePath());
+                       ->decoratedPath(ThisLayoutInfo->showAbsolutePath());
       T.To = (*Bi)->stub()->savedSymInfo()->name();
       if (!(*Bi)->stub()->savedSymInfo()->isAbsolute()) {
         T.ToSection = (*Bi)
@@ -581,14 +581,14 @@ void eld::YamlLayoutPrinter::getTrampolineMap(
                      ->savedSymInfo()
                      ->resolvedOrigin()
                      ->getInput()
-                     ->decoratedPath(ThisLayoutPrinter->showAbsolutePath());
+                     ->decoratedPath(ThisLayoutInfo->showAbsolutePath());
       T.Addend = (*Bi)->getAddend();
       {
         if ((*Bi)->stub()->savedSymInfo()->isLocal()) {
           Fragment *ToFrag =
               (*Bi)->stub()->savedSymInfo()->outSymbol()->fragRef()->frag();
-          auto Existing = ThisLayoutPrinter->getFragmentInfoMap().find(ToFrag);
-          if (Existing != ThisLayoutPrinter->getFragmentInfoMap().end()) {
+          auto Existing = ThisLayoutInfo->getFragmentInfoMap().find(ToFrag);
+          if (Existing != ThisLayoutInfo->getFragmentInfoMap().end()) {
             auto *Info = Existing->second;
             for (auto *K : Info->Symbols) {
               if (!K->isSection())
@@ -606,8 +606,8 @@ void eld::YamlLayoutPrinter::getTrampolineMap(
           continue;
         RSet.insert(F);
         R.From = F->getOwningSection()->name().str();
-        auto Existing = ThisLayoutPrinter->getFragmentInfoMap().find(F);
-        if (Existing != ThisLayoutPrinter->getFragmentInfoMap().end()) {
+        auto Existing = ThisLayoutInfo->getFragmentInfoMap().find(F);
+        if (Existing != ThisLayoutInfo->getFragmentInfoMap().end()) {
           auto *Info = Existing->second;
           for (auto *K : Info->Symbols) {
             if (!K->isSection())
@@ -616,7 +616,7 @@ void eld::YamlLayoutPrinter::getTrampolineMap(
         }
         R.FromFile =
             F->getOwningSection()->getInputFile()->getInput()->decoratedPath(
-                ThisLayoutPrinter->showAbsolutePath());
+                ThisLayoutInfo->showAbsolutePath());
         R.Addend = Reloc->addend();
         T.Uses.push_back(R);
       }
@@ -652,12 +652,12 @@ void YamlLayoutPrinter::printLayout(eld::Module &Module,
                                     GNULDBackend const &Backend) {
   DiagnosticEngine *DiagEngine = Backend.config().getDiagEngine();
   // Open Trampoline Map file.
-  if (!ThisLayoutPrinter->getConfig()
+  if (!ThisLayoutInfo->getConfig()
            .options()
            .getTrampolineMapFile()
            .empty()) {
     std::string File =
-        ThisLayoutPrinter->getConfig().options().getTrampolineMapFile().str();
+        ThisLayoutInfo->getConfig().options().getTrampolineMapFile().str();
     std::error_code Error;
     TrampolineLayoutFile =
         new llvm::raw_fd_ostream(File, Error, llvm::sys::fs::OF_None);
@@ -670,7 +670,7 @@ void YamlLayoutPrinter::printLayout(eld::Module &Module,
 
   auto Yaml = buildYaml(Module, Backend);
   llvm::ArrayRef<std::string> MapStyles =
-      ThisLayoutPrinter->getConfig().options().mapStyle();
+      ThisLayoutInfo->getConfig().options().mapStyle();
   if (std::find(MapStyles.begin(), MapStyles.end(), "compressed") ==
       MapStyles.end()) {
     yaml::Output Yout(outputStream());

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -479,7 +479,7 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
 
   // -MapDetail
   for (llvm::opt::Arg *arg : Args.filtered(T::MapDetail)) {
-    eld::Expected<void> E = eld::LayoutPrinter::setLayoutDetail(
+    eld::Expected<void> E = eld::LayoutInfo::setLayoutDetail(
         arg->getValue(), Config.getDiagEngine());
     if (!E) {
       Config.raiseDiagEntry(std::move(E.error()));
@@ -1585,10 +1585,10 @@ bool GnuLdDriver::doLink(llvm::opt::InputArgList &Args,
   std::unique_ptr<eld::ELDTargetMachine> target_machine(
       ELDTarget->createTargetMachine(Config.targets().triple().getTriple(),
                                      *LLVMTarget));
-  eld::LayoutPrinter *layoutPrinter = nullptr;
+  eld::LayoutInfo *layoutInfo = nullptr;
   if (!Config.options().layoutFile().empty() || Config.options().printMap())
-    layoutPrinter = eld::make<eld::LayoutPrinter>(Config);
-  ThisModule = eld::make<eld::Module>(m_Script, Config, layoutPrinter);
+    layoutInfo = eld::make<eld::LayoutInfo>(Config);
+  ThisModule = eld::make<eld::Module>(m_Script, Config, layoutInfo);
 
   // Handle Map Style and set default MapStyle
   llvm::ArrayRef<std::string> MapStyles = Config.options().mapStyle();
@@ -1596,7 +1596,7 @@ bool GnuLdDriver::doLink(llvm::opt::InputArgList &Args,
     Config.options().setDefaultMapStyle(MapStyles[0]);
     if (Config.options().checkAndUpdateMapStyleForPrintMap())
       MapStyles = Config.options().mapStyle();
-    // Create LayoutPrinters.
+    // Create LayoutInfos.
     Config.raise(Diag::mapstyles_used) << llvm::join(MapStyles, ",");
     for (auto &Style : MapStyles) {
       if (!ThisModule->createLayoutPrintersForMapStyle(Style))

--- a/lib/LinkerWrapper/LinkerWrapper.cpp
+++ b/lib/LinkerWrapper/LinkerWrapper.cpp
@@ -294,10 +294,10 @@ eld::Expected<void> LinkerWrapper::addChunkToOutput(Chunk C) {
   m_Module.getLinker()->getObjLinker()->createOutputSection(
       Builder, OutputSection.getOutputSection(), true);
 
-  if (auto *Printer = m_Module.getLayoutPrinter()) {
+  if (auto *layoutInfo = m_Module.getLayoutInfo()) {
     auto *Op = make<AddChunkPluginOp>(this, Rule.getRuleContainer(),
                                       C.getFragment(), "");
-    Printer->recordAddChunk(this, Op);
+    layoutInfo->recordAddChunk(this, Op);
   }
   return {};
 }
@@ -305,12 +305,12 @@ eld::Expected<void> LinkerWrapper::addChunkToOutput(Chunk C) {
 eld::Expected<void> LinkerWrapper::resetOffset(OutputSection O) {
   if (getState() < LinkerWrapper::AfterLayout)
     RETURN_INVALID_LINK_STATE_ERR("CreatingSegments, AfterLayout");
-  if (auto *Printer = m_Module.getLayoutPrinter()) {
+  if (auto *layoutInfo = m_Module.getLayoutInfo()) {
     auto OldOffset = O.getOffset();
     ELDEXP_RETURN_DIAGENTRY_IF_ERROR(OldOffset);
     auto *Op =
         eld::make<ResetOffsetPluginOp>(this, O.getOutputSection(), *OldOffset);
-    Printer->recordResetOffset(this, Op);
+    layoutInfo->recordResetOffset(this, Op);
   }
   O.getOutputSection()->getSection()->setNoOffset();
   return {};
@@ -825,7 +825,7 @@ eld::Expected<void> LinkerWrapper::setTargetDataForUse(Use &U, uint64_t Data) {
     return std::make_unique<DiagnosticEntry>(
         DiagnosticEntry(Diag::error_invalid_use));
   m_Module.setRelocationData(R, Data);
-  if (LayoutPrinter *printer = m_Module.getLayoutPrinter()) {
+  if (LayoutInfo *printer = m_Module.getLayoutInfo()) {
     auto *Op = eld::make<RelocationDataPluginOp>(this, R);
     printer->recordRelocationData(this, Op);
   }

--- a/lib/Object/GroupReader.cpp
+++ b/lib/Object/GroupReader.cpp
@@ -27,14 +27,14 @@ GroupReader::~GroupReader() {}
 bool GroupReader::readGroup(InputBuilder::InputIteratorT &CurNode,
                             InputBuilder &PBuilder, LinkerConfig &PConfig,
                             bool IsPostLtoPhase) {
-  LayoutPrinter *Printer = MModule.getLayoutPrinter();
+  LayoutInfo *layoutInfo = MModule.getLayoutInfo();
 
   Module::LibraryList &ArchiveLibraryList = MModule.getArchiveLibraryList();
   size_t ArchiveLibraryListSize = ArchiveLibraryList.size();
 
-  if (Printer) {
-    Printer->recordInputActions(LayoutPrinter::StartGroup, nullptr);
-    Printer->recordGroup();
+  if (layoutInfo) {
+    layoutInfo->recordInputActions(LayoutInfo::StartGroup, nullptr);
+    layoutInfo->recordGroup();
   }
 
   std::vector<ArchiveFile *> Archives;
@@ -86,12 +86,12 @@ bool GroupReader::readGroup(InputBuilder::InputIteratorT &CurNode,
       }
     }
     NewSize = MModule.getNamePool().getNumGlobalSize();
-    if (Printer)
-      Printer->recordGroup();
+    if (layoutInfo)
+      layoutInfo->recordGroup();
   } while (CurNamePoolSize != NewSize);
 
-  if (Printer)
-    Printer->recordInputActions(LayoutPrinter::EndGroup, nullptr);
+  if (layoutInfo)
+    layoutInfo->recordInputActions(LayoutInfo::EndGroup, nullptr);
 
   return true;
 }

--- a/lib/Object/ObjectBuilder.cpp
+++ b/lib/Object/ObjectBuilder.cpp
@@ -535,11 +535,11 @@ void ObjectBuilder::printStats() {
   if (!ThisModule.getScript().linkerScriptHasSectionsCommand())
     return;
   auto &SectionMap = ThisModule.getScript().sectionMap();
-  LayoutPrinter *LayoutPrinter = ThisModule.getLayoutPrinter();
+  LayoutInfo *LayoutInfo = ThisModule.getLayoutInfo();
   for (auto *Out : SectionMap) {
     for (auto *In : *Out) {
-      if (LayoutPrinter && !In->getMatchCount())
-        LayoutPrinter->recordNoLinkerScriptRuleMatch();
+      if (LayoutInfo && !In->getMatchCount())
+        LayoutInfo->recordNoLinkerScriptRuleMatch();
       if (!ThisModule.getPrinter()->allStats())
         continue;
       if (In->desc()) {

--- a/lib/Object/SectionMap.cpp
+++ b/lib/Object/SectionMap.cpp
@@ -39,10 +39,10 @@ using namespace eld;
 using namespace llvm;
 
 SectionMap::SectionMap(LinkerScript &L, const LinkerConfig &Config,
-                       LayoutPrinter *LayoutPrinter)
+                       LayoutInfo *LayoutInfo)
     : MLinkerScript(L), ThisConfig(Config),
       IsSectionTracingRequested(Config.options().isSectionTracingRequested()),
-      MLayoutPrinter(LayoutPrinter) {
+      MLayoutInfo(LayoutInfo) {
   insert("", "");
   MPrinter = Config.getPrinter();
 }

--- a/lib/Readers/BinaryFileParser.cpp
+++ b/lib/Readers/BinaryFileParser.cpp
@@ -18,9 +18,9 @@
 using namespace eld;
 
 eld::Expected<void> BinaryFileParser::parseFile(InputFile &inputFile) {
-  LayoutPrinter *printer = m_Module.getLayoutPrinter();
-  if (printer)
-    printer->recordInputActions(LayoutPrinter::Load, inputFile.getInput());
+  LayoutInfo *layoutInfo = m_Module.getLayoutInfo();
+  if (layoutInfo)
+    layoutInfo->recordInputActions(LayoutInfo::Load, inputFile.getInput());
   ELFSection *S = createDataSection(inputFile);
   ObjectFile *objFile = llvm::cast<ObjectFile>(&inputFile);
   objFile->addSection(S);

--- a/lib/Readers/BitcodeReader.cpp
+++ b/lib/Readers/BitcodeReader.cpp
@@ -94,11 +94,11 @@ BitcodeReader::~BitcodeReader() {}
 
 bool BitcodeReader::readInput(InputFile &InputFile,
                               plugin::LinkerPlugin *LTOPlugin) {
-  LayoutPrinter *printer = m_Builder.getModule().getLayoutPrinter();
-  if (printer) {
+  LayoutInfo *layoutInfo = m_Builder.getModule().getLayoutInfo();
+  if (layoutInfo) {
     std::string action =
         "LOAD " + InputFile.getInput()->decoratedPath() + " [Bitcode]";
-    printer->recordInputActions(LayoutPrinter::Load, InputFile.getInput());
+    layoutInfo->recordInputActions(LayoutInfo::Load, InputFile.getInput());
   }
 
   if (m_Builder.getModule().getPrinter()->traceFiles())

--- a/lib/Readers/ELFDynObjParser.cpp
+++ b/lib/Readers/ELFDynObjParser.cpp
@@ -28,12 +28,12 @@ eld::Expected<bool> ELFDynObjParser::parseFile(InputFile &inputFile) {
 
   // FIXME: Linker should give some error if checkFlags return false.
   if (expCheckFlags.has_value() && expCheckFlags.value()) {
-    LayoutPrinter *printer = m_Module.getLayoutPrinter();
-    if (printer) {
+    LayoutInfo *layoutInfo = m_Module.getLayoutInfo();
+    if (layoutInfo) {
       std::string flagStr = ELFReader->getFlagString();
       if (!flagStr.empty()) {
         std::string flag = "[" + std::string(flagStr) + "]";
-        printer->recordInputActions(LayoutPrinter::Load, inputFile.getInput(),
+        layoutInfo->recordInputActions(LayoutInfo::Load, inputFile.getInput(),
                                     flag);
       }
     }

--- a/lib/Readers/ELFReader.cpp
+++ b/lib/Readers/ELFReader.cpp
@@ -375,12 +375,12 @@ template <class ELFT> std::string ELFReader<ELFT>::getFlagString() const {
 
 template <class ELFT> void ELFReader<ELFT>::recordInputActions() const {
   ASSERT(m_LLVMELFFile, "m_LLVMELFFile must be initialized!");
-  LayoutPrinter *printer = m_Module.getLayoutPrinter();
-  if (printer) {
+  LayoutInfo *layoutInfo = m_Module.getLayoutInfo();
+  if (layoutInfo) {
     std::string flagStr = getFlagString();
     if (!flagStr.empty()) {
       flagStr = "[" + flagStr + "]";
-      printer->recordInputActions(LayoutPrinter::Load, m_InputFile.getInput(),
+      layoutInfo->recordInputActions(LayoutInfo::Load, m_InputFile.getInput(),
                                   flagStr);
     }
   }
@@ -537,9 +537,9 @@ eld::Expected<bool> ELFReader<ELFT>::readCompressedSection(ELFSection *S) {
   S->addFragment(frag);
 
   // Record stuff in the map file
-  LayoutPrinter *printer = this->m_Module.getLayoutPrinter();
-  if (printer)
-    printer->recordFragment(&this->m_InputFile, S, frag);
+  LayoutInfo *layoutInfo = this->m_Module.getLayoutInfo();
+  if (layoutInfo)
+    layoutInfo->recordFragment(&this->m_InputFile, S, frag);
 
   return true;
 }
@@ -554,9 +554,9 @@ eld::Expected<bool> ELFReader<ELFT>::readMergeStringSection(ELFSection *S) {
   if (!F->readStrings(config))
     return false;
   S->addFragment(F);
-  LayoutPrinter *printer = this->m_Module.getLayoutPrinter();
-  if (printer)
-    printer->recordFragment(&this->m_InputFile, S, F);
+  LayoutInfo *layoutInfo = this->m_Module.getLayoutInfo();
+  if (layoutInfo)
+    layoutInfo->recordFragment(&this->m_InputFile, S, F);
   return true;
 }
 

--- a/lib/Readers/ELFRelocObjParser.cpp
+++ b/lib/Readers/ELFRelocObjParser.cpp
@@ -209,7 +209,7 @@ ELFRelocObjParser::readLinkOnceSection(ELFReaderBase &ELFReader,
   GNULDBackend &backend = *m_Module.getBackend();
   bool isPostLTOPhase = m_Module.isPostLTOPhase();
   InputFile *inputFile = ELFReader.getInputFile();
-  LayoutPrinter *printer = m_Module.getLayoutPrinter();
+  LayoutInfo *layoutInfo = m_Module.getLayoutInfo();
   LinkerConfig &config = m_Module.getConfig();
 
   Module::GroupSignatureMap &signatures = m_Module.signatureMap();
@@ -232,8 +232,8 @@ ELFRelocObjParser::readLinkOnceSection(ELFReaderBase &ELFReader,
     oldSect->setKind(LDFileFormat::Ignore);
     signatureInfo->getInfo()->setResolvedOrigin(ELFReader.getInputFile());
     signatureInfo->setSection(S);
-    if (printer)
-      printer->recordSection(oldSect, inputFile);
+    if (layoutInfo)
+      layoutInfo->recordSection(oldSect, inputFile);
     exist = false;
   }
 
@@ -257,8 +257,8 @@ ELFRelocObjParser::readLinkOnceSection(ELFReaderBase &ELFReader,
       }
     }
   } else {
-    if (printer)
-      printer->recordSection(S, inputFile);
+    if (layoutInfo)
+      layoutInfo->recordSection(S, inputFile);
     S->setKind(LDFileFormat::Ignore);
   }
   return true;
@@ -312,7 +312,7 @@ ELFRelocObjParser::readGroupSection(ELFReaderBase &ELFReader, ELFSection *S) {
   }
 
   bool PartialLinking = m_Module.getConfig().isLinkPartial();
-  LayoutPrinter *printer = m_Module.getLayoutPrinter();
+  LayoutInfo *layoutInfo = m_Module.getLayoutInfo();
 
   eld::Expected<std::vector<uint32_t>> expIndices =
       ELFReader.getGroupMemberIndices(S);
@@ -327,8 +327,8 @@ ELFRelocObjParser::readGroupSection(ELFReaderBase &ELFReader, ELFSection *S) {
     // Discard member sections, if the group is preempted.
     if (alreadyExist) {
       groupMemberSect->setKind(LDFileFormat::Ignore);
-      if (printer)
-        printer->recordSection(groupMemberSect, EObj);
+      if (layoutInfo)
+        layoutInfo->recordSection(groupMemberSect, EObj);
     } else {
       // Otherwise, record group members, only if linking a relocatable.
       if (PartialLinking)

--- a/lib/Readers/RelocELFReader.cpp
+++ b/lib/Readers/RelocELFReader.cpp
@@ -229,9 +229,9 @@ eld::Expected<bool> RelocELFReader<ELFT>::readCompressedSection(ELFSection *S) {
   S->addFragment(frag);
 
   // Record stuff in the map file
-  LayoutPrinter *printer = this->m_Module.getLayoutPrinter();
-  if (printer)
-    printer->recordFragment(&this->m_InputFile, S, frag);
+  LayoutInfo *layoutInfo = this->m_Module.getLayoutInfo();
+  if (layoutInfo)
+    layoutInfo->recordFragment(&this->m_InputFile, S, frag);
 
   return true;
 }
@@ -247,9 +247,9 @@ RelocELFReader<ELFT>::readMergeStringSection(ELFSection *S) {
   if (!F->readStrings(config))
     return false;
   S->addFragment(F);
-  LayoutPrinter *printer = this->m_Module.getLayoutPrinter();
-  if (printer)
-    printer->recordFragment(&this->m_InputFile, S, F);
+  LayoutInfo *layoutInfo = this->m_Module.getLayoutInfo();
+  if (layoutInfo)
+    layoutInfo->recordFragment(&this->m_InputFile, S, F);
   return true;
 }
 

--- a/lib/Script/OutputSectData.cpp
+++ b/lib/Script/OutputSectData.cpp
@@ -11,7 +11,7 @@
 #include "eld/Fragment/FragmentRef.h"
 #include "eld/Fragment/OutputSectDataFragment.h"
 #include "eld/Fragment/RegionFragment.h"
-#include "eld/LayoutMap/LayoutPrinter.h"
+#include "eld/LayoutMap/LayoutInfo.h"
 #include "eld/Object/RuleContainer.h"
 #include "eld/Readers/ELFSection.h"
 #include "eld/Script/Expression.h"
@@ -105,9 +105,9 @@ ELFSection *OutputSectData::createOSDSection(Module &Module) {
       Module::InternalInputType::OutputSectData, LDFileFormat::OutputSectData,
       Name, DefaultSectionType, DefaultSectionFlags, /*alignment=*/1);
   Fragment *F = make<OutputSectDataFragment>(*this);
-  LayoutPrinter *Printer = Module.getLayoutPrinter();
-  if (Printer)
-    Printer->recordFragment(
+  LayoutInfo *layoutInfo = Module.getLayoutInfo();
+  if (layoutInfo)
+    layoutInfo->recordFragment(
         Module.getInternalInput(Module::InternalInputType::OutputSectData), S,
         F);
   S->addFragmentAndUpdateSize(F);

--- a/lib/Script/ScriptFile.cpp
+++ b/lib/Script/ScriptFile.cpp
@@ -421,13 +421,13 @@ void ScriptFile::addInputSectDesc(InputSectDesc::Policy PPolicy,
   assert(!LinkerScriptCommandQueue.empty());
   assert(ScriptStateInSectionsCommmand);
 
-  LayoutPrinter *Printer = ThisModule.getLayoutPrinter();
+  LayoutInfo *layoutInfo = ThisModule.getLayoutInfo();
 
   assert(!LinkerScriptSectionsCommand->empty() &&
          ScriptStateInsideOutputSection);
 
-  if (Printer)
-    Printer->recordLinkerScriptRule();
+  if (layoutInfo)
+    layoutInfo->recordLinkerScriptRule();
 
   InputSectDesc *Desc = nullptr;
 
@@ -650,9 +650,9 @@ void ScriptFile::addOutputSectData(OutputSectData::OSDKind DataKind,
                                    Expression *Expr) {
   assert(ScriptStateInSectionsCommmand);
 
-  LayoutPrinter *Printer = ThisModule.getLayoutPrinter();
-  if (Printer)
-    Printer->recordLinkerScriptRule();
+  LayoutInfo *layoutInfo = ThisModule.getLayoutInfo();
+  if (layoutInfo)
+    layoutInfo->recordLinkerScriptRule();
 
   ASSERT(Expr, "expr must not be null!");
 

--- a/lib/ScriptParser/ScriptLexer.cpp
+++ b/lib/ScriptParser/ScriptLexer.cpp
@@ -131,9 +131,9 @@ void ScriptLexer::lex() {
       ActiveFilenames.erase(CurBuf.Filename);
       ThisScriptFile.popScriptStack();
       CurBuf = Buffers.pop_back_val();
-      LayoutPrinter *LP = ThisScriptFile.module().getLayoutPrinter();
-      if (LP)
-        LP->closeLinkerScript();
+      LayoutInfo *layoutInfo = ThisScriptFile.module().getLayoutInfo();
+      if (layoutInfo)
+        layoutInfo->closeLinkerScript();
       continue;
     }
     CurTokLexState = LexState;

--- a/lib/ScriptParser/ScriptParser.cpp
+++ b/lib/ScriptParser/ScriptParser.cpp
@@ -1179,12 +1179,12 @@ bool ScriptParser::readInclude() {
   skip();
   bool IsOptionalInclude = Tok == "INCLUDE_OPTIONAL";
   llvm::StringRef FileName = unquote(next());
-  LayoutPrinter *LP = ThisScriptFile.module().getLayoutPrinter();
+  LayoutInfo *layoutInfo = ThisScriptFile.module().getLayoutInfo();
   bool Result = true;
   std::string ResolvedFileName = ThisScriptFile.findIncludeFile(
       FileName.str(), Result, /*state=*/!IsOptionalInclude);
-  if (LP)
-    LP->recordLinkerScript(ResolvedFileName, Result);
+  if (layoutInfo)
+    layoutInfo->recordLinkerScript(ResolvedFileName, Result);
   if (!Result && IsOptionalInclude)
     return true;
   ThisScriptFile.module().getScript().addToHash(ResolvedFileName);

--- a/lib/SymbolResolver/IRBuilder.cpp
+++ b/lib/SymbolResolver/IRBuilder.cpp
@@ -135,7 +135,7 @@ LDSymbol *IRBuilder::addSymbol(InputFile &Input, const std::string &SymbolName,
     }
   }
 
-  LayoutPrinter *Printer = ThisModule.getLayoutPrinter();
+  LayoutInfo *layoutInfo = ThisModule.getLayoutInfo();
 
   switch (Input.getKind()) {
   case InputFile::BinaryFileKind:
@@ -192,9 +192,9 @@ LDSymbol *IRBuilder::addSymbol(InputFile &Input, const std::string &SymbolName,
       return nullptr;
 
     // FIXME: Why don't we record symbol if there is no pSection?
-    if (Printer && CurSection) {
-      Printer->recordFragment(&Input, CurSection, FragRef->frag());
-      Printer->recordSymbol(FragRef->frag(), InputSym);
+    if (layoutInfo && CurSection) {
+      layoutInfo->recordFragment(&Input, CurSection, FragRef->frag());
+      layoutInfo->recordSymbol(FragRef->frag(), InputSym);
     }
     ObjFile->addSymbol(InputSym);
     if (CurSection && ThisConfig.options().isSectionTracingRequested() &&
@@ -261,8 +261,8 @@ LDSymbol *IRBuilder::addSymbolFromObject(
     return InputSym;
   }
 
-  if (ThisModule.getLayoutPrinter() &&
-      ThisModule.getLayoutPrinter()->showSymbolResolution())
+  if (ThisModule.getLayoutInfo() &&
+      ThisModule.getLayoutInfo()->showSymbolResolution())
     NP.getSRI().recordSymbolInfo(InputSym, SymInfo);
 
   bool S = NP.insertNonLocalSymbol(InputSymbolResolveInfo, *InputSym,
@@ -329,8 +329,8 @@ LDSymbol *IRBuilder::addSymbolFromDynObj(
   SymbolInfo SymInfo(&Input, Size, Binding, Type, Visibility, Desc,
                      /*isBitcode=*/false);
 
-  if (ThisModule.getLayoutPrinter() &&
-      ThisModule.getLayoutPrinter()->showSymbolResolution())
+  if (ThisModule.getLayoutInfo() &&
+      ThisModule.getLayoutInfo()->showSymbolResolution())
     ThisModule.getNamePool().getSRI().recordSymbolInfo(InputSym, SymInfo);
   // insert symbol and resolve it immediately
   Resolver::Result ResolvedResult = {nullptr, false, false};
@@ -539,8 +539,8 @@ LDSymbol *IRBuilder::addSymbol<IRBuilder::Force, IRBuilder::Unresolve>(
     OutputSym->setValue(Value, false);
   }
 
-  if (ThisModule.getLayoutPrinter() &&
-      ThisModule.getLayoutPrinter()->showSymbolResolution()) {
+  if (ThisModule.getLayoutInfo() &&
+      ThisModule.getLayoutInfo()->showSymbolResolution()) {
     SymbolResolutionInfo &SRI = ThisModule.getNamePool().getSRI();
     SRI.recordSymbolInfo(OutputSym,
                          SymbolInfo{Input, Size, Binding, Type, Visibility,

--- a/lib/SymbolResolver/NamePool.cpp
+++ b/lib/SymbolResolver/NamePool.cpp
@@ -15,7 +15,7 @@
 #include "eld/Diagnostics/DiagnosticPrinter.h"
 #include "eld/Fragment/FragmentRef.h"
 #include "eld/Input/InputFile.h"
-#include "eld/LayoutMap/LayoutPrinter.h"
+#include "eld/LayoutMap/LayoutInfo.h"
 #include "eld/Plugin/PluginManager.h"
 #include "eld/Support/Memory.h"
 #include "eld/Support/MsgHandling.h"
@@ -275,7 +275,7 @@ void NamePool::setupNullSymbol() {
 /// createSymbol - create a symbol
 LDSymbol *NamePool::createPluginSymbol(InputFile *Input, std::string SymbolName,
                                        Fragment *CurFragment, uint64_t Val,
-                                       LayoutPrinter *LP) {
+                                       LayoutInfo *layoutInfo) {
   llvm::StringRef SymName = Saver.save(SymbolName);
   ResolveInfo *Info = make<ResolveInfo>(SymName);
   Info->setIsSymbol(true);
@@ -293,7 +293,7 @@ LDSymbol *NamePool::createPluginSymbol(InputFile *Input, std::string SymbolName,
   Sym->setFragmentRef(make<FragmentRef>(*CurFragment, Val));
   Info->setOutSymbol(Sym);
   LocalSymbols.push_back(Info);
-  if (LP && LP->showSymbolResolution())
+  if (layoutInfo && layoutInfo->showSymbolResolution())
     getSRI().recordSymbolInfo(
         Sym, SymbolInfo{Input, Info->size(),
                         static_cast<ResolveInfo::Binding>(Info->binding()),

--- a/lib/Target/AArch64/AArch64ErrataIslandFactory.cpp
+++ b/lib/Target/AArch64/AArch64ErrataIslandFactory.cpp
@@ -8,7 +8,7 @@
 #include "AArch64InsnHelpers.h"
 #include "eld/Core/Module.h"
 #include "eld/Fragment/Fragment.h"
-#include "eld/LayoutMap/LayoutPrinter.h"
+#include "eld/LayoutMap/LayoutInfo.h"
 #include "eld/Readers/ELFSection.h"
 #include "eld/Support/Memory.h"
 #include "eld/Support/MsgHandling.h"
@@ -30,7 +30,7 @@ AArch64ErrataIslandFactory::~AArch64ErrataIslandFactory() {}
 /// createAArch64ErrataIsland - create a errata island
 BranchIsland *AArch64ErrataIslandFactory::createAArch64ErrataIsland(
     Fragment *frag, uint32_t pOffset, Stub *stub, eld::IRBuilder &pBuilder) {
-  LayoutPrinter *layoutPrinter = pBuilder.getModule().getLayoutPrinter();
+  LayoutInfo *layoutInfo = pBuilder.getModule().getLayoutInfo();
   DiagnosticEngine *DiagEngine =
       pBuilder.getModule().getConfig().getDiagEngine();
   ELFSection *outputELFSection = frag->getOutputELFSection();
@@ -185,11 +185,11 @@ BranchIsland *AArch64ErrataIslandFactory::createAArch64ErrataIsland(
   for (auto &F : toBeInsertedFrags)
     F->getOwningSection()->setMatchedLinkerScriptRule(MatchedRule);
 
-  if (layoutPrinter) {
-    layoutPrinter->recordFragment(trampolineInput, clone->getOutputELFSection(),
+  if (layoutInfo) {
+    layoutInfo->recordFragment(trampolineInput, clone->getOutputELFSection(),
                                   clone);
-    layoutPrinter->recordSymbol(clone, symbol);
-    layoutPrinter->recordTrampolines();
+    layoutInfo->recordSymbol(clone, symbol);
+    layoutInfo->recordTrampolines();
   }
 
   // FIXME : insert all trampolines and do this only once per iteration.

--- a/lib/Target/ARM/ARMLDBackend.cpp
+++ b/lib/Target/ARM/ARMLDBackend.cpp
@@ -374,7 +374,7 @@ void ARMGNULDBackend::doPreLayout() {
       }
     }
 
-    LayoutPrinter *printer = getModule().getLayoutPrinter();
+    LayoutInfo *layoutInfo = getModule().getLayoutInfo();
     if (!entry_reloc) {
       static const char raw_data[] = "\x00\x00\x00\x00\x01\x00\x00\x00";
       StringRef entry_data(raw_data, 8);
@@ -382,8 +382,8 @@ void ARMGNULDBackend::doPreLayout() {
       Fragment *frag =
           make<RegionFragment>(entry_data, Last, Fragment::Type::Region, align);
       Last->addFragmentAndUpdateSize(frag);
-      if (printer)
-        printer->recordFragment(Last->getInputFile(), Last, frag);
+      if (layoutInfo)
+        layoutInfo->recordFragment(Last->getInputFile(), Last, frag);
       // create the relocation against this entry
       entry_reloc = Relocation::Create(llvm::ELF::R_ARM_PREL31, 32,
                                        make<FragmentRef>(*frag, 0), 0);
@@ -495,13 +495,13 @@ bool ARMGNULDBackend::readSection(InputFile &pInput, ELFSection *S) {
   // We need break them down to individual entry
   if (auto *EXIDX = llvm::dyn_cast<ARMEXIDXSection>(S)) {
     uint32_t Offset = 0;
-    LayoutPrinter *printer = getModule().getLayoutPrinter();
+    LayoutInfo *layoutInfo = getModule().getLayoutInfo();
     for (uint32_t i = 0; i < S->size(); i += 8) {
       llvm::StringRef region = pInput.getSlice(S->offset() + i, 8);
       Fragment *frag = make<RegionFragment>(region, S, Fragment::Type::Region,
                                             S->getAddrAlign());
-      if (printer)
-        printer->recordFragment(&pInput, S, frag);
+      if (layoutInfo)
+        layoutInfo->recordFragment(&pInput, S, frag);
       EXIDX->addFragment(frag);
       EXIDX->addEntry({Offset, frag});
       Offset += 8;
@@ -514,9 +514,9 @@ bool ARMGNULDBackend::readSection(InputFile &pInput, ELFSection *S) {
       createAttributeSection(S->getFlags(), S->getAddrAlign());
       AttributeFragment = make<ARMAttributeFragment>(m_pARMAttributeSection);
       m_pARMAttributeSection->getFragmentList().push_back(AttributeFragment);
-      LayoutPrinter *printer = getModule().getLayoutPrinter();
-      if (printer)
-        printer->recordFragment(m_pARMAttributeSection->getInputFile(),
+      LayoutInfo *layoutInfo = getModule().getLayoutInfo();
+      if (layoutInfo)
+        layoutInfo->recordFragment(m_pARMAttributeSection->getInputFile(),
                                 m_pARMAttributeSection, AttributeFragment);
     }
     AttributeFragment->updateAttributes(
@@ -1183,9 +1183,9 @@ void ARMGNULDBackend::finishAssignOutputSections() {
   m_pRegionTableFragment =
       make<RegionTableFragment<llvm::object::ELF32LE>>(m_pRegionTableSection);
   m_pRegionTableSection->addFragmentAndUpdateSize(m_pRegionTableFragment);
-  LayoutPrinter *printer = getModule().getLayoutPrinter();
-  if (printer)
-    printer->recordFragment(m_pRegionTableSection->getInputFile(),
+  LayoutInfo *layoutInfo = getModule().getLayoutInfo();
+  if (layoutInfo)
+    layoutInfo->recordFragment(m_pRegionTableSection->getInputFile(),
                             m_pRegionTableSection, m_pRegionTableFragment);
 }
 

--- a/lib/Target/Hexagon/HexagonLDBackend.cpp
+++ b/lib/Target/Hexagon/HexagonLDBackend.cpp
@@ -22,7 +22,7 @@
 #include "eld/Fragment/RegionFragmentEx.h"
 #include "eld/Fragment/Stub.h"
 #include "eld/Input/ELFObjectFile.h"
-#include "eld/LayoutMap/LayoutPrinter.h"
+#include "eld/LayoutMap/LayoutInfo.h"
 #include "eld/Object/ObjectBuilder.h"
 #include "eld/Object/ObjectLinker.h"
 #include "eld/Readers/CommonELFSection.h"
@@ -245,8 +245,8 @@ void HexagonLDBackend::createAttributeSection() {
       ".hexagon.attributes", llvm::ELF::SHT_HEXAGON_ATTRIBUTES, 0, 1);
   AttributeFragment = make<HexagonAttributeFragment>(AttributeSection);
   AttributeSection->addFragment(AttributeFragment);
-  if (auto *Printer = getModule().getLayoutPrinter())
-    Printer->recordFragment(AttributeSection->getInputFile(), AttributeSection,
+  if (auto *layoutInfo = getModule().getLayoutInfo())
+    layoutInfo->recordFragment(AttributeSection->getInputFile(), AttributeSection,
                             AttributeFragment);
 }
 
@@ -1096,7 +1096,7 @@ bool HexagonLDBackend::readSection(InputFile &pInput, ELFSection *S) {
         createAttributeSection();
       AttributeFragment->update(*S, *getModule().getConfig().getDiagEngine(),
                                 *llvm::dyn_cast<ObjectFile>(&pInput),
-                                getModule().getLayoutPrinter());
+                                getModule().getLayoutInfo());
       return true;
     }
     break;
@@ -1109,13 +1109,13 @@ bool HexagonLDBackend::readSection(InputFile &pInput, ELFSection *S) {
     return GNULDBackend::readSection(pInput, S);
 
   // Create a optimal fragment.
-  eld::LayoutPrinter *P = m_Module.getLayoutPrinter();
+  eld::LayoutInfo *layoutInfo = m_Module.getLayoutInfo();
   const char *Buf = pInput.getCopyForWrite(S->offset(), S->size());
   eld::RegionFragmentEx *F =
       make<RegionFragmentEx>(Buf, S->size(), S, S->getAddrAlign());
   S->addFragment(F);
-  if (P)
-    P->recordFragment(&pInput, S, F);
+  if (layoutInfo)
+    layoutInfo->recordFragment(&pInput, S, F);
   return true;
 }
 

--- a/lib/Target/Hexagon/HexagonRelocator.cpp
+++ b/lib/Target/Hexagon/HexagonRelocator.cpp
@@ -626,7 +626,7 @@ void HexagonRelocator::defineSymbolforGuard(eld::IRBuilder &pBuilder,
   std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
   // Create a fragment containing jumpr r31.
   if (!m_Guard) {
-    LayoutPrinter *layoutPrinter = pBuilder.getModule().getLayoutPrinter();
+    LayoutInfo *layoutInfo = pBuilder.getModule().getLayoutInfo();
     ELFSection *guardSection = pTarget.getGuard();
     Fragment *frag = make<RegionFragment>(
         llvm::StringRef((const char *)jmprr31, sizeof(jmprr31)), guardSection,
@@ -641,8 +641,8 @@ void HexagonRelocator::defineSymbolforGuard(eld::IRBuilder &pBuilder,
     if (m_Module.getConfig().options().isSymbolTracingRequested() &&
         m_Module.getConfig().options().traceSymbol(SymbolName))
       config().raise(Diag::target_specific_symbol) << SymbolName;
-    if (layoutPrinter)
-      layoutPrinter->recordFragment(guardSection->getInputFile(), guardSection,
+    if (layoutInfo)
+      layoutInfo->recordFragment(guardSection->getInputFile(), guardSection,
                                     frag);
   }
   config().raise(Diag::resolve_undef_weak_guard)

--- a/lib/Target/Hexagon/HexagonTLSStub.cpp
+++ b/lib/Target/Hexagon/HexagonTLSStub.cpp
@@ -7,7 +7,7 @@
 #include "HexagonTLSStub.h"
 #include "eld/Core/Module.h"
 #include "eld/Diagnostics/DiagnosticEngine.h"
-#include "eld/LayoutMap/LayoutPrinter.h"
+#include "eld/LayoutMap/LayoutInfo.h"
 #include "eld/Support/Memory.h"
 #include "eld/Support/MsgHandling.h"
 #include "eld/SymbolResolver/IRBuilder.h"
@@ -60,10 +60,10 @@ HexagonTLSStub *HexagonGDIEStub::Create(Module &pModule, ELFSection *O) {
   symbol->setShouldIgnore(false);
   symbol->resolveInfo()->setResolvedOrigin(O->getInputFile());
   T->setSymInfo(symbol->resolveInfo());
-  LayoutPrinter *printer = pModule.getLayoutPrinter();
-  if (printer) {
-    printer->recordFragment(O->getInputFile(), O, T);
-    printer->recordSymbol(T, symbol);
+  LayoutInfo *layoutInfo = pModule.getLayoutInfo();
+  if (layoutInfo) {
+    layoutInfo->recordFragment(O->getInputFile(), O, T);
+    layoutInfo->recordSymbol(T, symbol);
   }
   return T;
 }
@@ -86,10 +86,10 @@ HexagonTLSStub *HexagonLDLEStub::Create(Module &pModule, ELFSection *O) {
   // GC is already complete, mark this stub as it is needed
   symbol->setShouldIgnore(false);
   T->setSymInfo(symbol->resolveInfo());
-  LayoutPrinter *printer = pModule.getLayoutPrinter();
-  if (printer) {
-    printer->recordFragment(O->getInputFile(), O, T);
-    printer->recordSymbol(T, symbol);
+  LayoutInfo *layoutInfo = pModule.getLayoutInfo();
+  if (layoutInfo) {
+    layoutInfo->recordFragment(O->getInputFile(), O, T);
+    layoutInfo->recordSymbol(T, symbol);
   }
   return T;
 }

--- a/test/UnitTests/SymbolResolutionTests/SymbolResolutionTest.cpp
+++ b/test/UnitTests/SymbolResolutionTests/SymbolResolutionTest.cpp
@@ -35,7 +35,7 @@ SymbolResolutionTest::SymbolResolutionTest() {
   m_DiagEngine = make<DiagnosticEngine>(/*useColor=*/false);
   m_Config = make<LinkerConfig>(m_DiagEngine);
   LinkerScript *LScript = make<LinkerScript>(m_DiagEngine);
-  m_Module = make<Module>(*LScript, *m_Config, /*layoutPrinter=*/nullptr);
+  m_Module = make<Module>(*LScript, *m_Config, /*layoutInfo=*/nullptr);
   m_IRBuilder = make<IRBuilder>(*m_Module, *m_Config);
 }
 

--- a/tools/LSParserVerifier/LSParserVerifier.cpp
+++ b/tools/LSParserVerifier/LSParserVerifier.cpp
@@ -87,7 +87,7 @@ public:
     m_DiagEngine.setInfoMap(std::move(diagInfo));
     m_LinkerScript = eld::make<eld::LinkerScript>(&m_DiagEngine);
     m_Module = eld::make<eld::Module>(*m_LinkerScript, *m_Config,
-                                      /*layoutPrinter=*/nullptr);
+                                      /*layoutInfo=*/nullptr);
     targetInfo = eld::make<CommonTargetInfo>(*m_Config);
     m_Backend = eld::make<CommonLDBackend>(*m_Module, targetInfo);
     m_Builder = eld::make<eld::IRBuilder>(*m_Module, *m_Config);


### PR DESCRIPTION
Renamed all `LayoutPrinter` related class to `LayoutInfo` to better match the class usage.

Closes #76 