### PR TITLE
[LinkerScript] Parse symbol assignment inside PROVIDE in LexState::Expr

### DIFF
--- a/lib/ScriptParser/ScriptParser.cpp
+++ b/lib/ScriptParser/ScriptParser.cpp
@@ -538,6 +538,7 @@ void ScriptParser::readProvideHidden(StringRef Tok) {
   else
     llvm_unreachable("Expected PROVIDE/HIDDEN/PROVIDE_HIDDEN assignments!");
   expect("(");
+  llvm::SaveAndRestore SaveLexState(LexState, LexState::Expr);
   Tok = next();
   if (peek() != "=") {
     setError("= expected, but got " + next());

--- a/test/Common/standalone/linkerscript/ProvideSymbolNoSpaceAroundEqualTo/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/ProvideSymbolNoSpaceAroundEqualTo/Inputs/script.t
@@ -1,0 +1,8 @@
+SECTIONS {
+  . = 0x11;
+  PROVIDE(foo=.);
+  OUT: {
+    PROVIDE(bar=foo);
+  }
+}
+PROVIDE(baz=bar);

--- a/test/Common/standalone/linkerscript/ProvideSymbolNoSpaceAroundEqualTo/ProvideSymbolNoSpaceAroundEqualTo.test
+++ b/test/Common/standalone/linkerscript/ProvideSymbolNoSpaceAroundEqualTo/ProvideSymbolNoSpaceAroundEqualTo.test
@@ -1,0 +1,11 @@
+#---ProvideSymbolNoSpaceAroundEqualTo.test--------------------- Executable,LS------------------#
+#BEGIN_COMMENT
+# This test checks that the linker correctly parses PROVIDE(var=value) expression.
+#END_COMMENT
+RUN: %touch %t1.1.o
+RUN: %link %linkopts -o %t1.a.out %t1.1.o -T %p/Inputs/script.t -u foo -u bar -u baz
+RUN: %readelf -s %t1.a.out | %filecheck %s
+
+CHECK: 11 {{.*}} ABS bar
+CHECK: 11 {{.*}} ABS baz
+CHECK: 11 {{.*}} ABS foo


### PR DESCRIPTION
This commit fixes unexpected error when parsing symbol assignment inside PROVIDE statement when the symbol assignment does not contain whitespaces around the equal-to operator.

Closes #82