### PR TITLE
[RISCV] Fix QC Relocation Tests

### DIFF
--- a/test/RISCV/standalone/Relocs/R_RISCV_QC_ABS20_U/Inputs/1.s
+++ b/test/RISCV/standalone/Relocs/R_RISCV_QC_ABS20_U/Inputs/1.s
@@ -2,6 +2,8 @@
   .text
   .p2align 1
 
+  .option exact
+
   .set test_zero, 0
   .set test_hi, 524287
   .set test_lo, -524288

--- a/test/RISCV/standalone/Relocs/R_RISCV_QC_E_32/Inputs/1.s
+++ b/test/RISCV/standalone/Relocs/R_RISCV_QC_E_32/Inputs/1.s
@@ -2,6 +2,8 @@
   .text
   .p2align 1
 
+  .option exact
+
   .set test_zero, 0
   .set test_ffff, 0xffffffff
   .set test_distinct, 0x89abcdef

--- a/test/RISCV/standalone/Relocs/R_RISCV_QC_E_BRANCH/Inputs/1.s
+++ b/test/RISCV/standalone/Relocs/R_RISCV_QC_E_BRANCH/Inputs/1.s
@@ -2,6 +2,8 @@
   .text
   .p2align 1
 
+  .option exact
+
 QUALCOMM:
 
 test_before_4kib:

--- a/test/RISCV/standalone/Relocs/R_RISCV_QC_E_BRANCH/Inputs/1.s
+++ b/test/RISCV/standalone/Relocs/R_RISCV_QC_E_BRANCH/Inputs/1.s
@@ -26,7 +26,7 @@ test3:
 
   .space 0xa4, 0x0
 test_distinct:
-  nop
+  c.nop
 
 test4:
   qc.e.bltui x5, 65535, 0x0
@@ -36,4 +36,4 @@ test4:
   /* 6 bytes per qc.e.b<cmp>i, PC-relative offset is measured from start of instruction */
   .space 0x100 - 6, 0x00
 test_after_4kib:
-  nop
+  c.nop

--- a/test/RISCV/standalone/Relocs/R_RISCV_QC_E_JUMP_PLT/Inputs/1.s
+++ b/test/RISCV/standalone/Relocs/R_RISCV_QC_E_JUMP_PLT/Inputs/1.s
@@ -2,6 +2,8 @@
   .text
   .p2align 1
 
+  .option exact
+
   .set test_zero, 0x0
   .set test_distinct, 0xabcdef78
   .set test_fffe, 0xfffffffe


### PR DESCRIPTION
The instructions to be relocated were being compressed, due to new compression patterns in 04cb2b3164cb401a4aa36d3c192c59c036b47858.

This uses exact mode to turn off compression and branch relaxation.