### PR TITLE
Fix dot counter handling for non-alloc sections

### DIFF
--- a/test/Common/standalone/linkerscript/NonAllocSectionSymbolAssignment/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/NonAllocSectionSymbolAssignment/Inputs/1.c
@@ -1,0 +1,3 @@
+int foo() { return 1; }
+int bar() { return 3; }
+int baz() { return 5; }

--- a/test/Common/standalone/linkerscript/NonAllocSectionSymbolAssignment/Inputs/script.2.t
+++ b/test/Common/standalone/linkerscript/NonAllocSectionSymbolAssignment/Inputs/script.2.t
@@ -1,0 +1,12 @@
+SECTIONS {
+  .foo : { *(*foo*) }
+  . = . + 0x100;
+  my_start = .;
+    .debug_info : {
+    start = .;
+    (.debug_info)
+    end = . ;
+  }
+  my_end = .;
+  mytext : { *(*text*) }
+}

--- a/test/Common/standalone/linkerscript/NonAllocSectionSymbolAssignment/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/NonAllocSectionSymbolAssignment/Inputs/script.t
@@ -1,0 +1,9 @@
+SECTIONS {
+  .foo : { *(*foo*) }
+  debug_info : {
+    start = .;
+    *(.debug_info*)
+    end = .;
+  }
+  TEXT : { *(*text*) }
+}

--- a/test/Common/standalone/linkerscript/NonAllocSectionSymbolAssignment/NonAllocSectionSymbolAssignment.test
+++ b/test/Common/standalone/linkerscript/NonAllocSectionSymbolAssignment/NonAllocSectionSymbolAssignment.test
@@ -1,0 +1,27 @@
+#---NonAllocSectionSymbolAssignment.test--------------------------- Executable,LS --------------------#
+#BEGIN_COMMENT
+# This test checks that the linker properly evaluates symbol assignments in
+# non-alloc sections and that the layout is correct when non-alloc sections
+# contain symbol assignments.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections -g
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t
+RUN: (%readelf -sS %t1.1.out && %readelf -S %t1.1.out) | %filecheck %s -check-prefix=READELF1
+
+RUN: %link %linkopts -o %t1.1.2.out %t1.1.o -T %p/Inputs/script.2.t
+RUN: %readelf -sS %t1.1.2.out | %filecheck %s -check-prefix=READELF2
+
+READELF1: .foo PROGBITS [[#%x,FOO_ADDRESS:]] [[#%x,FOO_OFFSET:]] [[#%x,FOO_SIZE:]] {{.*}} AX 0 0 [[#%u,FOO_ALIGNMENT:]]
+READELF1: debug_info PROGBITS {{[a-z0-9]+}} {{[a-z0-9]+}} [[#%x,DEBUG_INFO_SIZE:]]
+READELF1: TEXT PROGBITS {{0+}}[[#%x,FOO_ADDRESS+max(FOO_SIZE,FOO_ALIGNMENT)]] {{0+}}[[#%x,FOO_OFFSET+max(FOO_SIZE,FOO_ALIGNMENT)]] [[#%x,TEXTSIZE:]]
+READELF1: {{.*}}: [[#%x,START_VALUE:]] {{.*}} start
+READELF1: {{.*}}: {{0+}}[[#%x,START_VALUE+DEBUG_INFO_SIZE]] {{.*}} end
+READELF1: debug_info PROGBITS {{[a-z0-9]+}} {{0+}}[[#%x,FOO_OFFSET+max(FOO_SIZE,FOO_ALIGNMENT)+TEXTSIZE]]
+
+READELF2: .foo PROGBITS [[#%x,FOO_ADDRESS:]] {{[a-z0-9]+}} [[#%x,FOO_SIZE:]] {{.*}} AX 0 0 [[#%u,FOO_ALIGNMENT:]]
+READELF2: mytext PROGBITS {{0+}}[[#%x,FOO_ADDRESS+max(FOO_SIZE,FOO_ALIGNMENT)+0x100]]
+READELF2-DAG: {{.*}}: {{0+}}[[#%x,MY_START_VALUE:FOO_ADDRESS+FOO_SIZE+0x100]] {{.*}} my_start
+READELF2-DAG: {{.*}}: {{0+}}[[#%x,MY_START_VALUE]] {{.*}} my_end
+
+#END_TEST


### PR DESCRIPTION
Until now, we were not properly handling dot counter in non-alloc sections and this was leading to incorrect symbol assignment evaluations in non-alloc sections and non-alloc sections size incorrectly being set to 0. This commit fixes the dot counter handling in non-alloc sections. Now dot counter is moved around as usual in non-alloc sections but is restored to its original value after performing symbol evaluations and updating the output section size.

Closes #91