### PR TITLE
fix dllexport

### DIFF
--- a/test/Common/Plugin/FindConfigFile/CMakeLists.txt
+++ b/test/Common/Plugin/FindConfigFile/CMakeLists.txt
@@ -10,8 +10,6 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   add_llvm_library(findconfig ${SHARED_LIB_SOURCES} LINK_LIBS
                    LW)
 
-  target_compile_definitions(findconfig PRIVATE IN_DLL)
-
   set(BUILD_SHARED_LIBS ${bsl})
 
 endif()

--- a/test/Common/Plugin/MissingINIFile/CMakeLists.txt
+++ b/test/Common/Plugin/MissingINIFile/CMakeLists.txt
@@ -9,8 +9,6 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
   add_llvm_library(missinginifile ${SHARED_LIB_SOURCES} LINK_LIBS LW)
 
-  target_compile_definitions(missinginifile PRIVATE IN_DLL)
-
   set(BUILD_SHARED_LIBS ${bsl})
 
 endif()

--- a/test/Common/Plugin/MissingINIFile/MissingINIFile.cpp
+++ b/test/Common/Plugin/MissingINIFile/MissingINIFile.cpp
@@ -4,15 +4,9 @@
 #include "PluginVersion.h"
 #include <string>
 
-#ifdef _WIN32
-#define DLL_EXPORT __declspec(dllexport)
-#else
-#define DLL_EXPORT
-#endif
-
 using namespace eld::plugin;
 
-class DLL_EXPORT MissingINIFile : public OutputSectionIteratorPlugin {
+class DLL_A_EXPORT MissingINIFile : public OutputSectionIteratorPlugin {
 
 public:
   MissingINIFile() : OutputSectionIteratorPlugin("MissingINIFile") {}
@@ -59,14 +53,14 @@ public:
 MissingINIFile *ThisPlugin = nullptr;
 
 extern "C" {
-bool DLL_EXPORT RegisterAll() {
+bool DLL_A_EXPORT RegisterAll() {
   ThisPlugin = new MissingINIFile();
   return true;
 }
 
-Plugin DLL_EXPORT *getPlugin(const char *T) { return ThisPlugin; }
+Plugin DLL_A_EXPORT *getPlugin(const char *T) { return ThisPlugin; }
 
-void DLL_EXPORT Cleanup() {
+void DLL_A_EXPORT Cleanup() {
   if (ThisPlugin)
     delete ThisPlugin;
 }


### PR DESCRIPTION
windows builds fails because of inconsistent dll linkage.

Change-Id: Ife7fdfaec77fb5b49ce388c8934ebea66901d40d