### PR TITLE
support omagic

### DIFF
--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -302,7 +302,7 @@ public:
   // -N, --omagic
   void setOMagic(bool PMagic = true) { BOMagic = PMagic; }
 
-  bool omagic() const { return BOMagic; }
+  bool isOMagic() const { return BOMagic; }
 
   // -S, --strip-debug
   void setStripDebug(bool PStripDebug = true) { BStripDebug = PStripDebug; }
@@ -1150,8 +1150,8 @@ private:
   bool BColor = true;             // --color[=true,false,auto]
   bool BCreateEhFrameHdr = false; // --eh-frame-hdr
   bool BCreateEhFrameHdrSet = false;
-  bool BNMagic = false;            // -n, --nmagic
   bool BOMagic = false;            // -N, --omagic
+  bool BNMagic = false;            // -n, --nmagic
   bool BStripDebug = false;        // -S, --strip-debug
   bool BExportDynamic = false;     //-E, --export-dynamic
   bool BWarnSharedTextrel = false; // --warn-shared-textrel

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -373,6 +373,24 @@ def nostdlib : Flag<["-"], "nostdlib">,
 def emit_relocs : Flag<["-", "--"], "emit-relocs">,
                   HelpText<"Make Emit relocs behave just like GNU.">,
                   Group<grp_main>;
+def omagic
+    : Flag<["--"], "omagic">,
+      HelpText<"Set the text and data sections to be readable and writable."
+               " Also, do not page-align the data segment, and"
+               " disable linking against shared libraries.">,
+      Group<grp_main>;
+def no_omagic
+    : Flag<["--"], "no-omagic">,
+      HelpText<"This option negates most of the effects of the -N option."
+               "Disable linking with shared libraries">,
+      Group<grp_main>;
+def omagic_alias
+    : Flag<["-"], "N">,
+      HelpText<"Set the text and data sections to be readable and writable."
+               " Also, do not page-align the data segment, and"
+               " disable linking against shared libraries.">,
+      Alias<omagic>,
+      Group<grp_main>;
 
 //===----------------------------------------------------------------------===//
 /// Dynamic Library/Executable Options
@@ -942,30 +960,12 @@ def nmagic : Flag<["--"], "nmagic">,
              HelpText<"Turn off page alignment of sections,"
                       " and disable linking against shared libraries">,
              Group<grp_compatorignoredopts>;
-def omagic
-    : Flag<["--"], "omagic">,
-      HelpText<"Set the text and data sections to be readable and writable."
-               " Also, do not page-align the data segment, and"
-               " disable linking against shared libraries.">,
-      Group<grp_compatorignoredopts>;
-def no_omagic
-    : Flag<["--"], "no-omagic">,
-      HelpText<"This option negates most of the effects of the -N option."
-               "Disable linking with shared libraries">,
-      Group<grp_compatorignoredopts>;
 // Compatible Aliases
 def nmagic_alias : Flag<["-"], "n">,
                    HelpText<"Turn off page alignment of sections,"
                             " and disable linking against shared libraries">,
                    Alias<nmagic>,
                    Group<grp_compatorignoredopts>;
-def omagic_alias
-    : Flag<["-"], "N">,
-      HelpText<"Set the text and data sections to be readable and writable."
-               " Also, do not page-align the data segment, and"
-               " disable linking against shared libraries.">,
-      Alias<omagic>,
-      Group<grp_compatorignoredopts>;
 def add_needed : Flag<["--"], "add-needed">,
                  Group<grp_compatorignoredopts>,
                  HelpText<"Deprecated">;

--- a/lib/Core/Linker.cpp
+++ b/lib/Core/Linker.cpp
@@ -267,6 +267,11 @@ bool Linker::activateInputs(std::vector<InputAction *> &Actions) {
 }
 
 bool Linker::initializeInputTree(std::vector<InputAction *> &Actions) {
+
+  // Prefer static libraries over dynamic libraries with omagic
+  if (ThisConfig->options().isOMagic())
+    IR->getInputBuilder().makeBStatic();
+
   {
     LinkerProgress->incrementAndDisplayProgress();
     eld::RegisterTimer T("Input Activation", "Initialize",

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -1148,6 +1148,14 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
   if (Args.hasArg(T::noDefaultPlugins))
     Config.options().setNoDefaultPlugins();
 
+  // --no-omagic, --omagic, -N support
+  if (Args.hasArg(T::no_omagic))
+    Config.options().setOMagic(false);
+  else if (Args.hasArg(T::omagic)) {
+    Config.options().setAlignSegments(false);
+    Config.options().setOMagic(true);
+  }
+
   Config.options().setUnknownOptions(Args.getAllArgValues(T::UNKNOWN));
   return true;
 }

--- a/lib/Target/CreateProgramHeaders.hpp
+++ b/lib/Target/CreateProgramHeaders.hpp
@@ -380,8 +380,11 @@ bool GNULDBackend::createProgramHdrs() {
                            ->getMemoryDescriptor();
 
     // If the user specifies the linker to create a separate rosegment, do that.
-    if (!config().options().rosegment())
+    if (!config().options().rosegment() || config().options().isOMagic())
       cur_flag = (cur_flag & ~llvm::ELF::PF_X);
+
+    if (config().options().isOMagic())
+      cur_flag = (cur_flag & ~llvm::ELF::PF_W);
 
     // getSegmentFlag returns 0 if the section is not allocatable.
     if ((cur_flag != prev_flag) && (isCurAlloc))

--- a/test/Common/standalone/omagic/Inputs/1.c
+++ b/test/Common/standalone/omagic/Inputs/1.c
@@ -1,0 +1,3 @@
+const int rodata[] = {1,2,3};
+int rwdata = 100;
+int foo() { return 0; }

--- a/test/Common/standalone/omagic/Inputs/2.c
+++ b/test/Common/standalone/omagic/Inputs/2.c
@@ -1,0 +1,1 @@
+int bar() { return 0; }

--- a/test/Common/standalone/omagic/Inputs/script.t
+++ b/test/Common/standalone/omagic/Inputs/script.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  .text : { *(.text*) }
+  .rodata : { *(.rodata*) }
+  .data : { *(.data*) }
+  /DISCARD/ : { *(.ARM.exidx*) }
+}

--- a/test/Common/standalone/omagic/omagic.test
+++ b/test/Common/standalone/omagic/omagic.test
@@ -1,0 +1,25 @@
+#--omagic.test------------------ Executable,LS----------------#
+#BEGIN_COMMENT
+#Verify that the linker is able to produce output that supports omagic
+#END_COMMENT
+#START_TEST
+
+# Compile required files
+RUN: %clang %clangg0opts -o %t1.1.o -c %p/Inputs/1.c -ffunction-sections
+RUN: %clang %clangg0opts -o %t1.2.o -c %p/Inputs/2.c -ffunction-sections
+# link with omagic switch
+RUN: %link %linkg0opts %t1.1.o %t1.2.o -o %t2.out.omagic --omagic
+RUN: %readelf -l -W %t2.out.omagic | %filecheck %s -check-prefix=OMAGIC
+# link with no-omagic switch
+RUN: %link %linkg0opts %t1.1.o %t1.2.o -o %t2.out.noomagic --omagic --no-omagic
+RUN: %readelf -l -W %t2.out.noomagic | %filecheck %s -check-prefix=NOOMAGIC
+# link with omagic switch and linker script
+RUN: %link %linkg0opts %t1.1.o %t1.2.o -T %p/Inputs/script.t -o %t2.out.omagic.ls --omagic
+RUN: %readelf -l -W %t2.out.omagic.ls | %filecheck %s -check-prefix=OMAGICLS
+
+#OMAGIC: .text .rodata {{.*.data}}
+#NOOMAGIC: .text .rodata
+#NOOMAGIC: .data
+#OMAGICLS: .text .rodata .data
+
+#END_TEST


### PR DESCRIPTION
Purpose:

--omagic is primarily used when you want to generate an executable with a specific memory layout and characteristics, particularly when memory space is limited or when demand paging is not desired.

Key features:

No page alignment: The data segment is not aligned to page boundaries, which can lead to more compact executables.

Readable and writable sections: Both the text and data sections are marked as readable and writable, allowing for modifications during execution.

Fixes (#98)

Change-Id: I46480d959c41c175a4898c89ec0ac286fde54bcb