### PR TITLE
ThinLTO cache commit

### DIFF
--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -2980,6 +2980,8 @@ bool ObjectLinker::doLto(llvm::lto::LTO &LTO) {
       report_fatal_error(Twine("unable to add memory buffer: ") +
                          toString(S.takeError()));
     *(*S)->OS << MB->getBuffer();
+    if (Error Err = (*S)->commit())
+      report_fatal_error(std::move(Err));
   };
 
   llvm::FileCache ThinLTOCache;

--- a/test/Common/LTO/ThinLTOCaching/Inputs/1.c
+++ b/test/Common/LTO/ThinLTOCaching/Inputs/1.c
@@ -1,0 +1,6 @@
+extern void globalfunc(void);
+
+int _start() {
+  globalfunc();
+  return 0;
+}

--- a/test/Common/LTO/ThinLTOCaching/Inputs/2.c
+++ b/test/Common/LTO/ThinLTOCaching/Inputs/2.c
@@ -1,0 +1,1 @@
+void globalfunc() {}

--- a/test/Common/LTO/ThinLTOCaching/ThinLTOCaching.test
+++ b/test/Common/LTO/ThinLTOCaching/ThinLTOCaching.test
@@ -1,0 +1,16 @@
+## A basic test for thin LTO cache
+
+RUN: %clang %clangopts -flto=thin -O2 -c %p/Inputs/1.c -o %t.1.bc
+RUN: %clang %clangopts -flto=thin -O2 -c %p/Inputs/2.c -o %t.2.bc
+
+## Test --save-temps with thin LTO cache
+RUN: rm -rf %t.cache
+RUN: mkdir -p %t.t
+RUN: %link %linkopts -flto-options=cache=%t.cache --save-temps=%t.t -e _start -o out %t.2.bc %t.1.bc -M 2>&1 | FileCheck %s --check-prefix=MAP
+MAP: .text {{.*}} {{.*}}out.llvm-lto.[[#]].o
+
+RUN: ls %t.t | FileCheck %s --check-prefix=OUT
+OUT-DAG: out.llvm-lto.[[#]].o
+OUT-DAG: out.llvm-lto.[[#]].[[#]].preopt.bc
+
+RUN: ls %t.cache | count 2


### PR DESCRIPTION
As a result of upstream LLVM PR #136121, users of CacheFileStream must call its commit() function before deleting the stream.