### PR TITLE
Add `ELD_REGISTER_PLUGIN` macro

### DIFF
--- a/include/eld/PluginAPI/PluginBase.h.inc
+++ b/include/eld/PluginAPI/PluginBase.h.inc
@@ -164,4 +164,28 @@ typedef void *PluginCleanupFuncT();
 // LinkerPluginConfig
 typedef LinkerPluginConfig *PluginConfigFuncT(PluginType T);
 }
+
+/// A helper macro for registering a plugin.
+/// It simply provides good defaults for RegisterAll, getPlugin
+/// and Cleanup functions.
+/// \note It can be only be used once in a source file.
+#define ELD_REGISTER_PLUGIN(PluginType)                                        \
+  PluginType *ThisPlugin = nullptr;                                            \
+                                                                               \
+  extern "C" {                                                                 \
+  bool DLL_A_EXPORT RegisterAll() {                                            \
+    ThisPlugin = new PluginType();                                             \
+    return true;                                                               \
+  }                                                                            \
+                                                                               \
+  eld::plugin::PluginBase DLL_A_EXPORT *getPlugin(const char *T) {             \
+    return ThisPlugin;                                                         \
+  }                                                                            \
+                                                                               \
+  void DLL_A_EXPORT Cleanup() {                                                \
+    if (ThisPlugin)                                                            \
+      delete ThisPlugin;                                                       \
+    ThisPlugin = nullptr;                                                      \
+  }                                                                            \
+  }
 #endif

--- a/test/Common/Plugin/AddedSectionOverrides/AddedSectionOverrides.cpp
+++ b/test/Common/Plugin/AddedSectionOverrides/AddedSectionOverrides.cpp
@@ -44,20 +44,4 @@ public:
 };
 
 
-std::unordered_map<std::string, Plugin *> Plugins;
-
-extern "C" {
-bool DLL_A_EXPORT RegisterAll() {
-  Plugins["AddedSectionOverrides"] = new AddedSectionOverrides();
-  return true;
-}
-
-PluginBase DLL_A_EXPORT *getPlugin(const char *T) { return Plugins[T]; }
-void DLL_A_EXPORT Cleanup() {
-  for (auto &item : Plugins) {
-    if (item.second)
-      delete item.second;
-  }
-  Plugins.clear();
-}
-}
+ELD_REGISTER_PLUGIN(AddedSectionOverrides)

--- a/test/Common/Plugin/BasicChunkMover/BasicChunkMover.cpp
+++ b/test/Common/Plugin/BasicChunkMover/BasicChunkMover.cpp
@@ -3,6 +3,7 @@
 #include "LinkerWrapper.h"
 #include "OutputSectionIteratorPlugin.h"
 #include "PluginADT.h"
+#include "PluginBase.h"
 #include "PluginVersion.h"
 #include <cassert>
 
@@ -63,19 +64,4 @@ private:
   eld::plugin::OutputSection m_Bar{nullptr};
 };
 
-BasicChunkMover *ThisPlugin = nullptr;
-
-extern "C" {
-bool DLL_A_EXPORT RegisterAll() {
-  ThisPlugin = new BasicChunkMover();
-  return true;
-}
-
-eld::plugin::PluginBase DLL_A_EXPORT *getPlugin(const char *T) { return ThisPlugin; }
-
-void DLL_A_EXPORT Cleanup() {
-  if (ThisPlugin)
-    delete ThisPlugin;
-  ThisPlugin = nullptr;
-}
-}
+ELD_REGISTER_PLUGIN(BasicChunkMover)


### PR DESCRIPTION
Add `ELD_REGISTER_PLUGIN` macro

 This commit adds `ELD_REGISTER_PLUGIN` macro. This macro provides
 good defaults for RegisterAll, getPlugin and Cleanup functions.
 The goal is to make creating a plugin more convenient by reducing the
 necessary boilerplate code.

 Closes #108