### PR TITLE
Add support for `--require-defined` option

### DIFF
--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -974,6 +974,13 @@ public:
 
   bool isReproduceOnFail() const { return RecordInputFilesOnFail; }
 
+  // --require-defined support
+  void addRequireDefinedSymbol(const std::string &S) { RequireDefinedSymbols.push_back(S); }
+
+  const std::vector<std::string> &getRequireDefinedSymbols() const {
+    return RequireDefinedSymbols;
+  }
+
   // -- enable relaxation on hexagon ----
   void enableRelaxation() { BRelaxation = true; }
 
@@ -1244,6 +1251,7 @@ private:
   bool ProgressBar = false;                  // Show progressbar.
   bool RecordInputFiles = false;             // --reproduce
   bool RecordInputFilesOnFail = false;       // --reproduce-on-fail
+  std::vector<std::string> RequireDefinedSymbols; // --require-defined
   // FIXME: Change the name to CompressReproduceTar
   bool CompressTar = false;         // --reproduce-compressed
   bool DisplaySummary = false;      // display linker run summary

--- a/include/eld/Diagnostics/DiagSymbolResolutions.inc
+++ b/include/eld/Diagnostics/DiagSymbolResolutions.inc
@@ -33,6 +33,8 @@ DIAG(symbol_undefined_by_user, DiagnosticEngine::Error,
      "Symbol %0 defined in %1 is undefined")
 DIAG(symbol_not_found, DiagnosticEngine::Fatal,
      "Malformed image: Symbol `%0' not found")
+DIAG(missing_required_symbol, DiagnosticEngine::Error,
+     "Required symbol `%0' not defined")
 DIAG(dynlist_symbol_undefined_by_user, DiagnosticEngine::Error,
      "Symbol %0 defined in Dynamic List  is undefined")
 DIAG(tls_non_tls_symbol_mismatch, DiagnosticEngine::Fatal, "%0")

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -601,6 +601,10 @@ def s : Flag<["-"], "s">,
 def no_demangle : Flag<["--"], "no-demangle">,
                   HelpText<"Dont demangle C++ symbols">,
                   Group<grp_symbolopts>;
+defm require_defined : mDashEq<"require-defined", "require_defined",
+                             "Require symbol to be defined in the final output">,
+                     MetaVarName<"<symbol>">,
+                     Group<grp_symbolopts>;
 def strip_debug : Flag<["--"], "strip-debug">,
                   HelpText<"Omit all debug information from output">,
                   Group<grp_symbolopts>;

--- a/include/eld/SymbolResolver/NamePool.h
+++ b/include/eld/SymbolResolver/NamePool.h
@@ -14,6 +14,7 @@
 #ifndef ELD_SYMBOLRESOLVER_NAMEPOOL_H
 #define ELD_SYMBOLRESOLVER_NAMEPOOL_H
 
+#include "eld/Input/ArchiveFile.h"
 #include "eld/Config/Config.h"
 #include "eld/Config/LinkerConfig.h"
 #include "eld/Script/Expression.h"
@@ -117,6 +118,24 @@ public:
 
   SymbolResolutionInfo &getSRI() { return SymbolResInfo; }
 
+  void addArchivedLibSymbol(ArchiveFile::Symbol *Sym) {
+    ArchivedLibsSymbols[Sym->Name] = Sym;
+  }
+
+  bool isSymbolPresent(std::string SymbolName) {
+    bool isSharedLibSymbol = false;
+    for (const auto& pair : SharedLibsSymbols) {
+      const ResolveInfo* info = pair.first;
+      if (info && info->name() == SymbolName) {
+        isSharedLibSymbol = true;
+        break;
+      }
+    }
+    return (GlobalSymbols.find(SymbolName) != GlobalSymbols.end() ||
+            ArchivedLibsSymbols.find(SymbolName) != ArchivedLibsSymbols.end() ||
+            isSharedLibSymbol);
+  }
+
   void addSharedLibSymbol(LDSymbol *Sym) {
     ASSERT(Sym->resolveInfo(), "symbol must have a resolveInfo!");
     SharedLibsSymbols[Sym->resolveInfo()] = Sym;
@@ -142,6 +161,7 @@ private:
   bool IsSymbolTracingRequested;
   SymbolResolutionInfo SymbolResInfo;
   std::map<const ResolveInfo *, LDSymbol *> SharedLibsSymbols;
+  llvm::StringMap<ArchiveFile::Symbol *> ArchivedLibsSymbols;
   PluginManager &PM;
 };
 

--- a/lib/Core/Linker.cpp
+++ b/lib/Core/Linker.cpp
@@ -429,6 +429,18 @@ bool Linker::resolve() {
     return false;
   }
 
+  // Making sure that all of the required symbols from --require-defined are defined.
+  std::vector<std::string> UndefRequiredSymbols;
+  for (const std::string &S : ThisConfig->options().getRequireDefinedSymbols())
+    if (!ThisModule->getNamePool().isSymbolPresent(S))
+      UndefRequiredSymbols.push_back(S);
+  if (!UndefRequiredSymbols.empty()) {
+    for (const std::string &UndefSymbol : UndefRequiredSymbols)
+      ThisConfig->raise(Diag::missing_required_symbol) << UndefSymbol;
+    ThisModule->setFailure(true);
+    return false;
+  }
+
   {
     LinkerProgress->incrementAndDisplayProgress();
     eld::RegisterTimer T("Allocate Common Symbols", "Common Symbols",

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -1034,6 +1034,10 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
     reproduceFileName = arg->getValue();
   }
 
+  // --require-defined
+  for (const auto *Arg : Args.filtered(T::require_defined))
+    Config.options().addRequireDefinedSymbol(Arg->getValue());
+
   if (reproduceFileName)
     Config.options().setTarFile(*reproduceFileName);
 

--- a/lib/Readers/ArchiveParser.cpp
+++ b/lib/Readers/ArchiveParser.cpp
@@ -117,6 +117,7 @@ eld::Expected<uint32_t> ArchiveParser::parseFile(InputFile &inputFile) const {
       ArchiveFile::Symbol &symbol = *(archiveFile->getSymbolTable()[idx]);
       ArchiveFile::Symbol::SymbolStatus status =
           shouldIncludeSymbol(symbol, &referredSite);
+      m_Module.getNamePool().addArchivedLibSymbol(&symbol);
       if (ArchiveFile::Symbol::Include == status) {
         // include the object member from the given offset
         Input *I =

--- a/test/ld/RequireDefined/ArchivedSymbol.test
+++ b/test/ld/RequireDefined/ArchivedSymbol.test
@@ -1,0 +1,10 @@
+#---ArchivedSymbol.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+# Check that --require-defined does not ignore archived symbols
+#--------------------------------------------------------------------
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
+RUN: %ar rcs %t1.1.a %t1.1.o
+RUN: %link %linkopts --require-defined foo -o %t1.1.out %t1.1.a
+#END_TEST

--- a/test/ld/RequireDefined/GarbageCollectedSymbol.test
+++ b/test/ld/RequireDefined/GarbageCollectedSymbol.test
@@ -1,0 +1,11 @@
+#---GarbageCollectedSymbol.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+# Check that --require-defined prevents symbol from being garbage collected
+#--------------------------------------------------------------------
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
+RUN: %link %linkopts -T %p/script.t --gc-sections --require-defined foo -o %t1.1.out %t1.1.o
+RUN: %objdump -t %t1.1.out | %filecheck %s
+CHECK: foo
+#END_TEST

--- a/test/ld/RequireDefined/Inputs/1.c
+++ b/test/ld/RequireDefined/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 0; }

--- a/test/ld/RequireDefined/SharedLibrary.test
+++ b/test/ld/RequireDefined/SharedLibrary.test
@@ -1,0 +1,10 @@
+#---SharedLibrary.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+# Check that --require-defined does not ignore shared library symbols
+#--------------------------------------------------------------------
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c -fpic -o %t1.1.o %p/Inputs/1.c
+RUN: %link %linkopts -shared -o %t1.1.so %t1.1.o
+RUN: %link %linkopts --require-defined foo -o %t1.1.out -Bdynamic %t1.1.so
+#END_TEST

--- a/test/ld/RequireDefined/StaticLinking.test
+++ b/test/ld/RequireDefined/StaticLinking.test
@@ -1,0 +1,10 @@
+#---StaticLinking.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+# Check that --require-defined works for static linking
+#--------------------------------------------------------------------
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
+RUN: not %link %linkopts --require-defined bar -o %t1.1.out %t1.1.o 2>&1 | %filecheck %s
+CHECK: Error: Required symbol `bar' not defined
+#END_TEST

--- a/test/ld/RequireDefined/script.t
+++ b/test/ld/RequireDefined/script.t
@@ -1,0 +1,1 @@
+PROVIDE(unused = foo);


### PR DESCRIPTION
Implement the `--require-defined` command-line option for improved GNU LD compatibility. Error if the specified symbol is not defined in the output.

Closes #72