### PR TITLE
Add warn diagnostics for zero-sized memory regions

### DIFF
--- a/include/eld/Diagnostics/DiagLDScript.inc
+++ b/include/eld/Diagnostics/DiagLDScript.inc
@@ -124,3 +124,5 @@ DIAG(error_non_power_of_2_value_to_align_output_section, DiagnosticEngine::Error
      "%0: non-power-of-2 value 0x%1 passed to ALIGN in '%2' output section description, value must "
      "be 0 or a power of 2")
 DIAG(warn_linker_script, DiagnosticEngine::Warning, "%0")
+DIAG(warn_memory_region_has_zero_size, DiagnosticEngine::Warning,
+     "%0: Memory region '%1' has zero size")

--- a/lib/Object/ScriptMemoryRegion.cpp
+++ b/lib/Object/ScriptMemoryRegion.cpp
@@ -36,6 +36,13 @@ void ScriptMemoryRegion::addOutputSection(const OutputSectionEntry *O) {
 
 eld::Expected<void>
 ScriptMemoryRegion::verifyMemoryUsage(LinkerConfig &Config) {
+  auto ExpLen = getLength();
+  if (ExpLen && !ExpLen.value() && Config.showLinkerScriptWarnings()) {
+    MemorySpec *Spec = MMemoryDesc->getMemorySpec();
+    Expression *Length = Spec->getLength();
+    Config.raise(Diag::warn_memory_region_has_zero_size)
+        << Length->getContext() << getName();
+  }
   if (FirstOutputSectionExceededLimit)
     return std::make_unique<plugin::DiagnosticEntry>(plugin::DiagnosticEntry(
         Diag::error_memory_region_exceeded_limit,

--- a/test/Common/standalone/linkerscript/ZeroSizedMemoryRegionWarn/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/ZeroSizedMemoryRegionWarn/Inputs/script.t
@@ -1,0 +1,4 @@
+MEMORY {
+  A (ARX) : ORIGIN = 0x1000, LENGTH = 0x1 - 0x1
+  B (AW) : ORIGIN = 0x2000, LENGTH = 0x1000
+}

--- a/test/Common/standalone/linkerscript/ZeroSizedMemoryRegionWarn/ZeroSizedMemoryRegionWarn.test
+++ b/test/Common/standalone/linkerscript/ZeroSizedMemoryRegionWarn/ZeroSizedMemoryRegionWarn.test
@@ -1,0 +1,14 @@
+#---ZeroSizedMemoryRegionWarn.test--------------------- Executable,LS------------------#
+#BEGIN_COMMENT
+# This test verifies that the linker emits a warning for zero sized memory
+# regions
+#END_COMMENT
+#START_TEST
+RUN: %touch %t1.1.o
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t -Wlinker-script 2>&1 | %filecheck %s
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t -Wno-linker-script 2>&1 | %filecheck %s --allow-empty --check-prefix NOWARNLS
+#END_TEST
+
+CHECK: Warning: {{.*}}script.t: Memory region 'A' has zero size
+
+NOWARNLS-NOT: has zero size


### PR DESCRIPTION
This commit improves linker script diagnostics by adding a warning diagnostic for zero-sized memory regions.

Closes #114