### PR TITLE
Do not check PHDR errors for partial link

### DIFF
--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -3142,7 +3142,7 @@ bool GNULDBackend::layout() {
     doPostLayout();
   }
 
-  if (m_Module.getScript().phdrsSpecified())
+  if (m_Module.getScript().phdrsSpecified() && !config().isLinkPartial())
     checkForLinkerScriptPhdrErrors();
 
   if (!config().getDiagEngine()->diagnose()) {

--- a/test/Common/standalone/linkerscript/PartialLinkWithPHDRS/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/PartialLinkWithPHDRS/Inputs/1.c
@@ -1,0 +1,3 @@
+int foo() { return 1; }
+
+int var = 3;

--- a/test/Common/standalone/linkerscript/PartialLinkWithPHDRS/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/PartialLinkWithPHDRS/Inputs/script.t
@@ -1,0 +1,9 @@
+PHDRS {
+  A PT_LOAD;
+  B PT_LOAD;
+}
+
+SECTIONS {
+  .text : { *(.text.*) } :B
+  .data : { *(.data.*) }
+}

--- a/test/Common/standalone/linkerscript/PartialLinkWithPHDRS/PartialLinkWithPHDRS.test
+++ b/test/Common/standalone/linkerscript/PartialLinkWithPHDRS/PartialLinkWithPHDRS.test
@@ -1,0 +1,11 @@
+#---PartialLinkWithPHDRS.test--------------------------- Executable,LS,PHDRS -----------------#
+#BEGIN_COMMENT
+# This tests that the linker does not report any error when PHDRS is
+# specified with partial link.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t | %filecheck %s --allow-empty
+#END_TEST
+
+CHECK-NOT: error


### PR DESCRIPTION
This commit fixes the incorrect PHDR-related linker error when doing partial link. The linker should ignore the PHDRS specified in the linker script when doing partial link.

Closes #118