### PR TITLE
[RISCV] Remove -riscv-asm-relax-branches Flag

### DIFF
--- a/test/RISCV/FromLLD/riscv-branch.s
+++ b/test/RISCV/FromLLD/riscv-branch.s
@@ -1,6 +1,6 @@
 
 # UNSUPPORTED: riscv64
-# RUN: %llvm-mc -filetype=obj -triple=riscv32-unknown-elf -mattr=-relax -riscv-asm-relax-branches=0 %s -o %t.rv32.o
+# RUN: %llvm-mc -filetype=obj -triple=riscv32-unknown-elf -mattr=-relax %s -o %t.rv32.o
 
 # RUN: %link %linkopts %t.rv32.o --defsym foo=_start+4 --defsym bar=_start -o %t.rv32
 # RUN: llvm-objdump -d %t.rv32 | FileCheck %s --check-prefix=CHECK-32
@@ -18,6 +18,8 @@
 
 # RUN: %link %linkopts %t.rv32.o --defsym foo=_start+1 --defsym bar=_start-1 -o %t.out 2>&1 | FileCheck --check-prefix=WARN-ALIGN %s
 # WARN-ALIGN: Relocation `R_RISCV_BRANCH' for symbol `foo' referred from `(Not Applicable)' and defined in `{{.*}}' has alignment 2 but is not aligned
+
+.option exact
 
 .global _start
 _start:


### PR DESCRIPTION
This is being removed from LLVM, as the same functionality is available using `.option exact`, and llvm/llvm-project#142855 makes the same change to this test.