### PR TITLE
Add support for asciidoc documentation.

### DIFF
--- a/cmake/modules/BuildASCIIDOCTarget.cmake
+++ b/cmake/modules/BuildASCIIDOCTarget.cmake
@@ -1,0 +1,27 @@
+if(ELD_ENABLE_ASCIIDOC)
+  find_package(Python3 REQUIRED)
+endif()
+
+# Convert asciidoc documentation to html
+function(build_adoc_to_html adoc_source_dir)
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html/adoc/)
+  file(GLOB ADOC_FILES "${adoc_source_dir}/*")
+  foreach(ADOC_FILE ${ADOC_FILES})
+    get_filename_component(ADOC_FILE_NAME ${ADOC_FILE} NAME)
+    add_custom_target(
+      eld-asciidocs
+      COMMAND
+        ${Python3_EXECUTABLE} -m asciidoc -o
+        ${CMAKE_CURRENT_BINARY_DIR}/html/adoc/${ADOC_FILE_NAME}.html
+        ${ADOC_FILE}
+      COMMAND
+        tree -H "${CMAKE_CURRENT_BINARY_DIR}/html/adoc/" -L 1 -T
+        "ADOC Documentation"--noreport -I "index.html" -o
+        ${CMAKE_CURRENT_BINARY_DIR}/html/adoc/index.html
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html/adoc/
+      DEPENDS ${Python3_EXECUTABLE}
+      COMMENT
+        "Generating ASCIIDOC documentation in ${CMAKE_CURRENT_BINARY_DIR}/html/adoc/"
+    )
+  endforeach()
+endfunction()

--- a/docs/userguide/CMakeLists.txt
+++ b/docs/userguide/CMakeLists.txt
@@ -73,3 +73,15 @@ if(LLVM_ENABLE_SPHINX)
 
   add_custom_target(eld-docs DEPENDS ${target_name})
 endif()
+
+if(ELD_ENABLE_ASCIIDOC)
+  message(STATUS "ASCIIDOC Documentation Enabled")
+  # Convert asciidoc to html documentation.
+  include(${ELD_SOURCE_DIR}/cmake/modules/BuildASCIIDOCTarget.cmake)
+  build_adoc_to_html(${ELD_SOURCE_DIR}/docs/userguide/documentation/asciidoc/)
+
+  # Build asciidocs with eld-docs
+  if(LLVM_ENABLE_SPHINX)
+    add_dependencies(eld-docs eld-asciidocs)
+  endif()
+endif()

--- a/docs/userguide/documentation/asciidoc/sample.adoc
+++ b/docs/userguide/documentation/asciidoc/sample.adoc
@@ -1,0 +1,8 @@
+= Sample Doc!
+
+This is a sample asciidoc document.
+
+== Section Title
+
+* Sample list
+


### PR DESCRIPTION
This patch adds support to generates HTML documentation from asciidoc source using asciidoc python module.

"eld-asciidocs" target is added to build this documentation. ELD_ENABLE_ASCIIDOC flag must be turned ON to enable this target. The asciidoc documentation will also be generated if "eld-docs" is built.

An index page is also generated to list all the asciidoc documentation and can be accessed at "<eld-documentation-index-dir>/adoc/index.html".