### PR TITLE
Add support and test case for x86_64 emulation via -m elf_x86_64 and -m elf_amd64

### DIFF
--- a/include/eld/Driver/x86_64LinkDriver.h
+++ b/include/eld/Driver/x86_64LinkDriver.h
@@ -40,6 +40,8 @@ public:
 
   virtual ~x86_64LinkDriver() {}
 
+  static bool isValidEmulation(llvm::StringRef Emulation );
+
   // Main entry point.
   int link(llvm::ArrayRef<const char *> Args,
            llvm::ArrayRef<llvm::StringRef> ELDFlagsArgs) override;

--- a/lib/LinkerWrapper/Driver.cpp
+++ b/lib/LinkerWrapper/Driver.cpp
@@ -10,6 +10,7 @@
 #include "eld/Driver/ARMLinkDriver.h"
 #include "eld/Driver/GnuLdDriver.h"
 #include "eld/Driver/HexagonLinkDriver.h"
+#include "eld/Driver/x86_64LinkDriver.h"
 #include "eld/Driver/RISCVLinkDriver.h"
 #include "eld/PluginAPI/DiagnosticEntry.h"
 #include "eld/Support/Memory.h"
@@ -183,6 +184,10 @@ Driver::getFlavorAndTripleFromLinkCommand(llvm::ArrayRef<const char *> Args) {
         F = Flavor::AArch64;
     }
 #endif
+#if defined(ELD_ENABLE_TARGET_X86_64)
+    if (x86_64LinkDriver::isValidEmulation(Emulation))
+      F = Flavor::x86_64;
+#endif 
     if (F == Flavor::Invalid)
       return std::make_unique<eld::DiagnosticEntry>(
           eld::Diag::fatal_unsupported_emulation,

--- a/lib/LinkerWrapper/x86_64LinkDriver.cpp
+++ b/lib/LinkerWrapper/x86_64LinkDriver.cpp
@@ -161,3 +161,8 @@ template <class T>
 bool x86_64LinkDriver::processLLVMOptions(llvm::opt::InputArgList &Args) {
   return GnuLdDriver::processLLVMOptions<T>(Args);
 }
+
+
+bool x86_64LinkDriver::isValidEmulation(llvm::StringRef Emulation){
+  return Emulation == "elf_x86_64" || Emulation == "elf_amd64";
+}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -277,11 +277,11 @@ if config.test_target == 'Hexagon':
 
 if config.test_target == 'X86':
     config.march = ''
-    clang = 'clang'
+    clang = 'clang -target x86_64-linux-gnu'
     clangxx = 'clang++'
     llvmmc = 'llvm-mc'
     readelf = 'llvm-readelf'
-    link = 'x86_64-link'
+    link = 'ld.eld -m elf_x86_64'
     ar = 'llvm-ar'
     nm = 'llvm-nm'
     objdump = 'llvm-objdump'

--- a/test/x86_64/linux/EmulationSupport/EmulationOption.test
+++ b/test/x86_64/linux/EmulationSupport/EmulationOption.test
@@ -1,0 +1,16 @@
+#---CommonsGnuHash.test----------------- Executable --------------------#
+
+BEGIN_COMMENT
+# Test x86_64 emulation support in eld
+# This test verifies that eld correctly handles the -m elf_x86_64 emulation flag.
+# It compiles a minimal C program with a custom _start() that performs a syscall
+# to exit with code 5. The program is linked using eld with --image-base.
+#The test uses CheckExitCode.sh to run the output binary and validate that it exits 
+#with the expected return code. 
+#END_COMMENT
+
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.1.o
+RUN: %link %linkopts -o %t.1.out %t.1.o --image-base=0x400000
+RUN: %p/Inputs/CheckExitCode.sh %t.1.out 5
+#END_TEST

--- a/test/x86_64/linux/EmulationSupport/Inputs/1.c
+++ b/test/x86_64/linux/EmulationSupport/Inputs/1.c
@@ -1,0 +1,11 @@
+void _start() {
+  long u = 5;
+  asm (
+    "movq $60, %%rax\n"
+    "movq %0, %%rdi\n"
+    "syscall\n"
+    :
+    : "r" (u)
+    : "%rax", "%rdi"
+  );
+}

--- a/test/x86_64/linux/EmulationSupport/Inputs/CheckExitCode.sh
+++ b/test/x86_64/linux/EmulationSupport/Inputs/CheckExitCode.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+eval "$1"
+return_code=$?
+if [[ return_code -eq "$2" ]]; then
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
Implemented emulation detection.
A test case is added that compiles and links a minimal program with a custom _start() function that performs a syscall to exit with code 5. The test uses a shell script to validate the exit code and requires --image-base for correct execution.

Fixes #105