### PR TITLE
Move LinkerWrapper::State to Module

### DIFF
--- a/lib/Core/Linker.cpp
+++ b/lib/Core/Linker.cpp
@@ -675,7 +675,7 @@ bool Linker::layout() {
     eld::RegisterTimer T("AfterLayout OutputSection Iterator", "Perform Layout",
                          ThisConfig->options().printTimingStats("plugin"));
     // Run the output section iterator plugin after all the layout is done.
-    ThisModule->setState(plugin::LinkerWrapper::AfterLayout);
+    ThisModule->setLinkState(Module::LinkState::AfterLayout);
     Backend->finalizeLayout();
 
     {

--- a/lib/LinkerWrapper/CheckLinkState.h
+++ b/lib/LinkerWrapper/CheckLinkState.h
@@ -1,0 +1,57 @@
+//===- CheckLinkState.h---------------------------------------------------===//
+// Part of the eld Project, under the BSD License
+// See https://github.com/qualcomm/eld/LICENSE.txt for license information.
+// SPDX-License-Identifier: BSD-3-Clause
+//===----------------------------------------------------------------------===//
+#ifndef LINKER_WRAPPER_CHECK_LINK_STATE_H
+#define LINKER_WRAPPER_CHECK_LINK_STATE_H
+
+#include "LinkerWrapper.h"
+#include "eld/Diagnostics/MsgHandler.h"
+#include <initializer_list>
+#include <string>
+
+#define RETURN_INVALID_LINK_STATE_ERR(LW, validStates)                         \
+  return std::make_unique<DiagnosticEntry>(                                    \
+      Diag::error_invalid_link_state,                                          \
+      std::vector<std::string>{std::string(LW.getCurrentLinkStateAsStr()),     \
+                               std::string(LLVM_PRETTY_FUNCTION),              \
+                               std::string(validStates)});
+
+#define CHECK_LINK_STATE(LW, ...)                                              \
+  if (!isValidLinkState(LW, {__VA_ARGS__}))                                    \
+    RETURN_INVALID_LINK_STATE_ERR((LW), joinStrings({__VA_ARGS__}));
+
+static inline bool
+isValidLinkState(const eld::plugin::LinkerWrapper &LW,
+                 std::initializer_list<std::string_view> ValidLinkStates) {
+  for (const auto &S : ValidLinkStates) {
+    bool b = S == "Initializing" || S == "BeforeLayout" ||
+             S == "CreatingSections" || S == "CreatingSegments" ||
+             S == "AfterLayout";
+    ASSERT(b, "Invalid link state: " + std::string(S));
+    if (S == "Initializing" && LW.isLinkStateInitializing())
+      return true;
+    if (S == "BeforeLayout" && LW.isLinkStateBeforeLayout())
+      return true;
+    if (S == "CreatingSections" && LW.isLinkStateCreatingSections())
+      return true;
+    if (S == "CreatingSegments" && LW.isLinkStateCreatingSegments())
+      return true;
+    if (S == "AfterLayout" && LW.isLinkStateAfterLayout())
+      return true;
+  }
+  return false;
+}
+
+static inline std::string
+joinStrings(std::initializer_list<std::string_view> Names) {
+  std::string S;
+  for (auto it = Names.begin(), e = Names.end(); it != e; ++it) {
+    S += *it;
+    if (it != e - 1)
+      S += ", ";
+  }
+  return S;
+}
+#endif

--- a/lib/Object/ObjectBuilder.cpp
+++ b/lib/Object/ObjectBuilder.cpp
@@ -470,7 +470,7 @@ void ObjectBuilder::assignOutputSections(std::vector<eld::InputFile *> Inputs,
   bool HasSectionsCommand =
       ThisModule.getScript().linkerScriptHasSectionsCommand();
 
-  ThisModule.setState(plugin::LinkerWrapper::BeforeLayout);
+  ThisModule.setLinkState(Module::LinkState::BeforeLayout);
 
   std::sort(Inputs.begin(), Inputs.end(), [](InputFile *A, InputFile *B) {
     return A->getNumSections() > B->getNumSections();

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -1099,8 +1099,7 @@ bool ObjectLinker::runOutputSectionIteratorPlugin() {
   }
   // Fragment movement verification is only done for CreatingSections link state
   // because fragments cannot be moved in any other link state.
-  if (ThisModule->getState() ==
-      plugin::LinkerWrapper::State::CreatingSections) {
+  if (ThisModule->isLinkStateCreatingSections()) {
     for (auto *P : PluginList) {
       auto ExpVerifyFragmentMoves = P->verifyFragmentMovements();
       if (!ExpVerifyFragmentMoves) {
@@ -1172,7 +1171,7 @@ bool ObjectLinker::mergeSections() {
   OutBegin = ThisModule->getScript().sectionMap().begin();
   OutEnd = ThisModule->getScript().sectionMap().end();
 
-  ThisModule->setState(plugin::LinkerWrapper::CreatingSections);
+  ThisModule->setLinkState(Module::LinkState::CreatingSections);
   if (!ThisConfig.getDiagEngine()->diagnose())
     return false;
 

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -4517,7 +4517,7 @@ void GNULDBackend::resolveTargetDefinedSymbols() {
 void GNULDBackend::doPostLayout() {
   resolveTargetDefinedSymbols();
 
-  m_Module.setState(plugin::LinkerWrapper::CreatingSegments);
+  m_Module.setLinkState(Module::LinkState::CreatingSegments);
   if (!m_Module.getLinker()
            ->getObjectLinker()
            ->runOutputSectionIteratorPlugin()) {

--- a/test/Common/Plugin/AddedSectionOverrides/AddedSectionOverrides.cpp
+++ b/test/Common/Plugin/AddedSectionOverrides/AddedSectionOverrides.cpp
@@ -17,7 +17,7 @@ public:
   void processOutputSection(OutputSection S) override { return; }
 
   Status Run(bool Trace) override {
-    if (getLinker()->getState() != LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return Status::SUCCESS;
     eld::Expected<eld::plugin::OutputSection> expO =
         getLinker()->getOutputSection(".data");

--- a/test/Common/Plugin/BasicChunkMover/BasicChunkMover.cpp
+++ b/test/Common/Plugin/BasicChunkMover/BasicChunkMover.cpp
@@ -14,7 +14,7 @@ public:
   void Init(std::string options) override {}
 
   void processOutputSection(eld::plugin::OutputSection O) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return;
     if (O.getName() == "foo")
       m_Foo = O;
@@ -23,7 +23,7 @@ public:
   }
 
   Status Run(bool trace) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return Status::SUCCESS;
     assert(m_Foo && m_Bar && "foo and bar output sections must be present!");
     auto fooRules = m_Foo.getLinkerScriptRules();

--- a/test/Common/Plugin/ChunkMovesInInvalidLinkStates/ChunkMovesInInvalidLinkStates.cpp
+++ b/test/Common/Plugin/ChunkMovesInInvalidLinkStates/ChunkMovesInInvalidLinkStates.cpp
@@ -65,7 +65,7 @@ public:
   void Init(std::string options) override {}
 
   void processOutputSection(eld::plugin::OutputSection O) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return;
     if (O.getName() == "FOO")
       m_Foo = O;
@@ -74,12 +74,12 @@ public:
   }
 
   Status Run(bool trace) override {
-    if (getLinker()->getState() == eld::plugin::LinkerWrapper::CreatingSections) {
+    if (getLinker()->isLinkStateCreatingSections()) {
       auto barRules = m_Bar.getLinkerScriptRules();
       m_BarChunk = barRules.front().getChunks().front();
       return Status::SUCCESS;
     }
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::AfterLayout)
+    if (!getLinker()->isLinkStateAfterLayout())
       return Status::SUCCESS;
 
     assert(m_Foo && m_Bar && "foo and bar output sections must be present!");

--- a/test/Common/Plugin/FindConfigFile/findconfig.cpp
+++ b/test/Common/Plugin/FindConfigFile/findconfig.cpp
@@ -13,7 +13,7 @@ public:
 
   // Perform any initialization here
   void Init(std::string Options) override {
-    if (getLinker()->getState() != LinkerWrapper::AfterLayout)
+    if (!getLinker()->isLinkStateAfterLayout())
      return;
     auto E = getLinker()->findConfigFile(Options);
     ELDEXP_REPORT_AND_RETURN_VOID_IF_ERROR(getLinker(), E);

--- a/test/Common/Plugin/LayoutWrapperTests/APIsForBinaryMapTest/APIsForBinaryMapTest.cpp
+++ b/test/Common/Plugin/LayoutWrapperTests/APIsForBinaryMapTest/APIsForBinaryMapTest.cpp
@@ -14,7 +14,7 @@ public:
   // Perform any initialization here
   void Init(std::string Options) override {
     auto linker = getLinker();
-    if (linker->getState() != LinkerWrapper::AfterLayout)
+    if (!getLinker()->isLinkStateAfterLayout())
       return;
     std::cout << "\nMap File: " << linker->getLinkerConfig().getMapFileName();
     auto Sym = linker->getSymbol("foo").value();

--- a/test/Common/Plugin/LayoutWrapperTests/LayoutHeaderTest/LayoutHeaderTest.cpp
+++ b/test/Common/Plugin/LayoutWrapperTests/LayoutHeaderTest/LayoutHeaderTest.cpp
@@ -13,7 +13,7 @@ public:
   // Perform any initialization here
   void Init(std::string Options) override {
     auto linker = getLinker();
-    if (linker->getState() != LinkerWrapper::AfterLayout)
+    if (!linker->isLinkStateAfterLayout())
       return;
 
     std::unique_ptr<LayoutWrapper> layout =

--- a/test/Common/Plugin/MultithreadedDiagnostics/TestMultithreadedDiagnostics.cpp
+++ b/test/Common/Plugin/MultithreadedDiagnostics/TestMultithreadedDiagnostics.cpp
@@ -53,7 +53,7 @@ public:
   void processOutputSection(OutputSection S) override { return; }
 
   Status Run(bool Trace) override {
-    if (getLinker()->getState() != LinkerWrapper::State::BeforeLayout)
+    if (!getLinker()->isLinkStateBeforeLayout())
       return Plugin::Status::SUCCESS;
 
     std::vector<std::size_t> concurrencies = {1, 2, 4, 8, 16, 32, 64, 128};
@@ -96,7 +96,7 @@ public:
   void processOutputSection(OutputSection S) override { return; }
 
   Status Run(bool Trace) override {
-    if (getLinker()->getState() != LinkerWrapper::State::BeforeLayout)
+    if (!getLinker()->isLinkStateBeforeLayout())
       return Plugin::Status::SUCCESS;
 
     std::vector<std::size_t> concurrencies = {1, 2, 4, 8, 16, 32, 64, 128};

--- a/test/Common/Plugin/NoSectionOverrides/nosectionoverrides.cpp
+++ b/test/Common/Plugin/NoSectionOverrides/nosectionoverrides.cpp
@@ -22,7 +22,7 @@ public:
   void processOutputSection(OutputSection S) override { return; }
 
   Status Run(bool Trace) override {
-    if (getLinker()->getState() == LinkerWrapper::State::BeforeLayout) {
+    if (getLinker()->isLinkStateBeforeLayout()) {
       eld::Expected<void> expFinishAssign =
           getLinker()->finishAssignOutputSections();
       ELDEXP_REPORT_AND_RETURN_ERROR_IF_ERROR(getLinker(), expFinishAssign);

--- a/test/Common/Plugin/OrderChunks/OrderChunks.cpp
+++ b/test/Common/Plugin/OrderChunks/OrderChunks.cpp
@@ -26,7 +26,7 @@ public:
 
   // This function will be called whenever the linker processes a OutputSection.
   void processOutputSection(OutputSection O) override {
-    if (getLinker()->getState() != LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return;
     if (O.getName() != ".reordersection")
       return;
@@ -36,7 +36,7 @@ public:
   // After the linker lays out the image, but before it creates the elf file,
   // it will call this run function.
   Status Run(bool Trace) override {
-    if (getLinker()->getState() != LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return Plugin::Status::SUCCESS;
 
     if (!ReorderOutputSection.getOutputSection())

--- a/test/Common/Plugin/OutputChunkIterator/outputchunkiterator.cpp
+++ b/test/Common/Plugin/OutputChunkIterator/outputchunkiterator.cpp
@@ -18,7 +18,7 @@ public:
   void Init(std::string Options) override {}
 
   void processOutputSection(OutputSection O) override {
-    if (getLinker()->getState() != LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return;
 
     if (O.getName() == ".foo")
@@ -26,12 +26,12 @@ public:
   }
 
   Status Run(bool Trace) override {
-    if (getLinker()->getState() == LinkerWrapper::AfterLayout) {
+    if (getLinker()->isLinkStateAfterLayout()) {
       std::cout << FirstChunk.getName() << "\t" << std::hex
                 << FirstChunk.getAddress() << "\n";
     }
 
-    if (getLinker()->getState() != LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return eld::plugin::Plugin::Status::SUCCESS;
 
     std::vector<eld::plugin::LinkerScriptRule> Rules;

--- a/test/Common/Plugin/OutputChunkIteratorMoveBetweenSections/outputchunkiteratormovebetweensections.cpp
+++ b/test/Common/Plugin/OutputChunkIteratorMoveBetweenSections/outputchunkiteratormovebetweensections.cpp
@@ -19,7 +19,7 @@ public:
   void Init(std::string Options) override {}
 
   void processOutputSection(OutputSection O) override {
-    if (getLinker()->getState() != LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return;
 
     if (O.getName() == ".foo")
@@ -27,7 +27,7 @@ public:
   }
 
   Status Run(bool Trace) override {
-    if (getLinker()->getState() != LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return eld::plugin::Plugin::Status::SUCCESS;
 
     std::vector<eld::plugin::LinkerScriptRule> Rules;

--- a/test/Common/Plugin/OutputChunkIteratorSymbols/outputchunkiteratorsymbols.cpp
+++ b/test/Common/Plugin/OutputChunkIteratorSymbols/outputchunkiteratorsymbols.cpp
@@ -19,7 +19,7 @@ public:
   void Init(std::string Options) override {}
 
   void processOutputSection(OutputSection O) override {
-    if (getLinker()->getState() != LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return;
     if (O.getName() == ".foo")
       OutputSections.push_back(O);
@@ -56,7 +56,7 @@ public:
   }
 
   Status Run(bool Trace) override {
-    if (getLinker()->getState() != LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return eld::plugin::Plugin::Status::SUCCESS;
 
     std::vector<eld::plugin::LinkerScriptRule> Rules;

--- a/test/Common/Plugin/OutputSectionAddRules/outputsectionaddrules.cpp
+++ b/test/Common/Plugin/OutputSectionAddRules/outputsectionaddrules.cpp
@@ -19,7 +19,7 @@ public:
   void Init(std::string Options) override {}
 
   void processOutputSection(OutputSection O) override {
-    if (getLinker()->getState() == LinkerWrapper::CreatingSections) {
+    if (getLinker()->isLinkStateCreatingSections()) {
       std::cout << "\n" << O.getName();
       if (!O.getLinkerScriptRules().size())
         return;

--- a/test/Common/Plugin/PartialPendingSectionOverrides/TestPartialPendingSectionOverrides.cpp
+++ b/test/Common/Plugin/PartialPendingSectionOverrides/TestPartialPendingSectionOverrides.cpp
@@ -22,8 +22,8 @@ public:
   void processOutputSection(OutputSection S) override { return; }
 
   Status Run(bool Trace) override {
-    if (getLinker()->getState() == LinkerWrapper::AfterLayout ||
-        getLinker()->getState() == LinkerWrapper::CreatingSections)
+    if (getLinker()->isLinkStateAfterLayout() ||
+        getLinker()->isLinkStateCreatingSections())
       return Status::SUCCESS;
     eld::Expected<OutputSection> expO =
         getLinker()->getOutputSection(".data");
@@ -59,8 +59,8 @@ public:
   void processOutputSection(OutputSection S) override { return; }
 
   Status Run(bool Trace) override {
-    if (getLinker()->getState() == LinkerWrapper::AfterLayout ||
-        getLinker()->getState() == LinkerWrapper::CreatingSections)
+    if (getLinker()->isLinkStateAfterLayout() ||
+        getLinker()->isLinkStateCreatingSections())
       return Status::SUCCESS;
     eld::Expected<OutputSection> expO =
         getLinker()->getOutputSection(".data");

--- a/test/Common/Plugin/PendingAndNoSectionOverrides/TestPendingAndNoSectionOverrides.cpp
+++ b/test/Common/Plugin/PendingAndNoSectionOverrides/TestPendingAndNoSectionOverrides.cpp
@@ -22,8 +22,8 @@ public:
   void processOutputSection(OutputSection S) override { return; }
 
   Status Run(bool Trace) override {
-    if (getLinker()->getState() == LinkerWrapper::AfterLayout ||
-        getLinker()->getState() == LinkerWrapper::CreatingSections)
+    if (getLinker()->isLinkStateAfterLayout() ||
+        getLinker()->isLinkStateCreatingSections())
       return Status::SUCCESS;
     eld::Expected<eld::plugin::OutputSection> expO =
         getLinker()->getOutputSection(".data");
@@ -57,8 +57,8 @@ public:
   void processOutputSection(OutputSection S) override { return; }
 
   Status Run(bool Trace) override {
-    if (getLinker()->getState() == LinkerWrapper::AfterLayout ||
-        getLinker()->getState() == LinkerWrapper::CreatingSections)
+    if (getLinker()->isLinkStateAfterLayout() ||
+        getLinker()->isLinkStateCreatingSections())
       return Status::SUCCESS;
     eld::Expected<void> expFinishAssign =
         getLinker()->finishAssignOutputSections();

--- a/test/Common/Plugin/PendingRuleInsertions/CreateRules.cpp
+++ b/test/Common/Plugin/PendingRuleInsertions/CreateRules.cpp
@@ -13,7 +13,7 @@ public:
   void Init(std::string options) override {}
 
   void processOutputSection(eld::plugin::OutputSection O) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return;
     if (O.getName() == "foo")
       m_Foo = O;
@@ -22,7 +22,7 @@ public:
   }
 
   Status Run(bool trace) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return Status::SUCCESS;
     assert(m_Foo && m_Bar && "foo and bar output sections must be present!");
     eld::Expected<eld::plugin::LinkerScriptRule> expNewFooRule =

--- a/test/Common/Plugin/PendingSectionOverrides/pendingsectionoverrides.cpp
+++ b/test/Common/Plugin/PendingSectionOverrides/pendingsectionoverrides.cpp
@@ -22,8 +22,8 @@ public:
   void processOutputSection(OutputSection S) override { return; }
 
   Status Run(bool Trace) override {
-    if (getLinker()->getState() == LinkerWrapper::AfterLayout ||
-        getLinker()->getState() == LinkerWrapper::CreatingSections)
+    if (getLinker()->isLinkStateAfterLayout() ||
+        getLinker()->isLinkStateCreatingSections())
       return Status::SUCCESS;
     eld::Expected<OutputSection> expO = getLinker()->getOutputSection(".data");
     ELDEXP_REPORT_AND_RETURN_ERROR_IF_ERROR(getLinker(), expO);
@@ -59,8 +59,8 @@ public:
   void processOutputSection(OutputSection S) override { return; }
 
   Status Run(bool Trace) override {
-    if (getLinker()->getState() == LinkerWrapper::AfterLayout ||
-        getLinker()->getState() == LinkerWrapper::CreatingSections)
+    if (getLinker()->isLinkStateAfterLayout() ||
+        getLinker()->isLinkStateCreatingSections())
       return Status::SUCCESS;
     eld::Expected<OutputSection> expO =
         getLinker()->getOutputSection(".data");

--- a/test/Common/Plugin/RemoveChunks/RemoveChunks.cpp
+++ b/test/Common/Plugin/RemoveChunks/RemoveChunks.cpp
@@ -18,7 +18,7 @@ public:
   void Init(std::string Options) override {}
 
   void processOutputSection(OutputSection O) override {
-    if (getLinker()->getState() != LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return;
 
     if (O.getName() == ".foobar")
@@ -28,9 +28,9 @@ public:
   // After the linker lays out the image, but before it creates the elf file,
   // it will call this run function.
   Status Run(bool Trace) override {
-    if (getLinker()->getState() == LinkerWrapper::AfterLayout)
+    if (getLinker()->isLinkStateAfterLayout())
       return eld::plugin::Plugin::Status::SUCCESS;
-    if (getLinker()->getState() != LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return eld::plugin::Plugin::Status::SUCCESS;
 
     auto linkerscriptRuleVec = FooBar.getLinkerScriptRules();

--- a/test/Common/Plugin/ReproducerWithFindConfigFile/ReproducerWithFindConfigFile.cpp
+++ b/test/Common/Plugin/ReproducerWithFindConfigFile/ReproducerWithFindConfigFile.cpp
@@ -15,7 +15,7 @@ public:
 
   // Perform any initialization here
   void Init(std::string Options) override {
-    if (getLinker()->getState() != LinkerWrapper::AfterLayout)
+    if (!getLinker()->isLinkStateAfterLayout())
      return;
     auto E = getLinker()->findConfigFile("some-file.txt");
     ELDEXP_REPORT_AND_RETURN_VOID_IF_ERROR(getLinker(), E);

--- a/test/Common/Plugin/TarWriterTests/TarWriterNotNullTerminatedTest/TarWriterNotNullTerminatedTest.cpp
+++ b/test/Common/Plugin/TarWriterTests/TarWriterNotNullTerminatedTest/TarWriterNotNullTerminatedTest.cpp
@@ -14,7 +14,7 @@ public:
 
   // Perform any initialization here
   void Init(std::string Options) override {
-    if (getLinker()->getState() != LinkerWrapper::AfterLayout)
+    if (!getLinker()->isLinkStateAfterLayout())
       return;
 
     // Create tar file and add files to it.

--- a/test/Common/Plugin/TarWriterTests/TarWriterOverwriteTest/TarWriterOverwriteTest.cpp
+++ b/test/Common/Plugin/TarWriterTests/TarWriterOverwriteTest/TarWriterOverwriteTest.cpp
@@ -14,7 +14,7 @@ public:
 
   // Perform any initialization here
   void Init(std::string Options) override {
-    if (getLinker()->getState() != LinkerWrapper::AfterLayout)
+    if (!getLinker()->isLinkStateAfterLayout())
       return;
 
     // Create tar file.

--- a/test/Common/Plugin/TarWriterTests/TarWriterReadOnlyTest/TarWriterReadOnlyTest.cpp
+++ b/test/Common/Plugin/TarWriterTests/TarWriterReadOnlyTest/TarWriterReadOnlyTest.cpp
@@ -13,7 +13,7 @@ public:
 
   // Perform any initialization here
   void Init(std::string Options) override {
-    if (getLinker()->getState() != LinkerWrapper::AfterLayout)
+    if (!getLinker()->isLinkStateAfterLayout())
       return;
 
     std::string FileName = "Inputs/testTar.tar";

--- a/test/Common/Plugin/TarWriterTests/TarWriterTest/TarWriterTest.cpp
+++ b/test/Common/Plugin/TarWriterTests/TarWriterTest/TarWriterTest.cpp
@@ -11,7 +11,7 @@ public:
 
   // Perform any initialization here
   void Init(std::string Options) override {
-    if (getLinker()->getState() != LinkerWrapper::AfterLayout)
+    if (!getLinker()->isLinkStateAfterLayout())
       return;
 
     // Create tar file and add files to it.

--- a/test/Common/Plugin/TarWriterTests/TarWriterUnwritablePathTest/TarWriterUnwritablePathTest.cpp
+++ b/test/Common/Plugin/TarWriterTests/TarWriterUnwritablePathTest/TarWriterUnwritablePathTest.cpp
@@ -13,7 +13,7 @@ public:
 
   // Perform any initialization here
   void Init(std::string Options) override {
-    if (getLinker()->getState() != LinkerWrapper::AfterLayout)
+    if (!getLinker()->isLinkStateAfterLayout())
       return;
 
     // Create tar file in "/"

--- a/test/Common/Plugin/UnbalancedChunkMoves/UnbalancedChunkMoves.cpp
+++ b/test/Common/Plugin/UnbalancedChunkMoves/UnbalancedChunkMoves.cpp
@@ -16,7 +16,7 @@ public:
   void Init(std::string options) override {}
 
   void processOutputSection(eld::plugin::OutputSection O) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return;
     if (O.getName() == "FOO")
       m_Foo = O;
@@ -25,7 +25,7 @@ public:
   }
 
   Status Run(bool trace) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return Status::SUCCESS;
     assert(m_Foo && m_Bar && "foo and bar output sections must be present!");
     auto barRules = m_Bar.getLinkerScriptRules();
@@ -46,7 +46,7 @@ public:
   std::string GetLastErrorAsString() override { return "Success"; }
 
   void Destroy() override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return;
     auto unbalancedAdds = getLinker()->getUnbalancedChunkAdds();
     assert(unbalancedAdds.empty() && "No unbalanced adds expected");
@@ -81,7 +81,7 @@ public:
   void Init(std::string options) override {}
 
   void processOutputSection(eld::plugin::OutputSection O) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return;
     if (O.getName() == "FOO")
       m_Foo = O;
@@ -90,7 +90,7 @@ public:
   }
 
   Status Run(bool trace) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return Status::SUCCESS;
     assert(m_Foo && m_Bar && "foo and bar output sections must be present!");
     auto barRules = m_Bar.getLinkerScriptRules();
@@ -111,7 +111,7 @@ public:
   std::string GetLastErrorAsString() override { return "Success"; }
 
   void Destroy() override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return;
     [[maybe_unused]] const auto &unbalancedChunkRemoves =
         getLinker()->getUnbalancedChunkRemoves();

--- a/test/Common/Plugin/VerifyChunkMoves/VerifyChunkMoves.cpp
+++ b/test/Common/Plugin/VerifyChunkMoves/VerifyChunkMoves.cpp
@@ -16,7 +16,7 @@ public:
   void Init(std::string options) override {}
 
   void processOutputSection(eld::plugin::OutputSection O) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return;
     if (O.getName() == "FOO")
       m_Foo = O;
@@ -25,7 +25,7 @@ public:
   }
 
   Status Run(bool trace) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return Status::SUCCESS;
     assert(m_Foo && m_Bar && "foo and bar output sections must be present!");
     auto fooRules = m_Foo.getLinkerScriptRules();
@@ -64,7 +64,7 @@ public:
   void Init(std::string options) override {}
 
   void processOutputSection(eld::plugin::OutputSection O) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return;
     if (O.getName() == "FOO")
       m_Foo = O;
@@ -73,7 +73,7 @@ public:
   }
 
   Status Run(bool trace) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return Status::SUCCESS;
     assert(m_Foo && m_Bar && "foo and bar output sections must be present!");
     auto fooRules = m_Foo.getLinkerScriptRules();
@@ -107,7 +107,7 @@ public:
   void Init(std::string options) override {}
 
   void processOutputSection(eld::plugin::OutputSection O) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return;
     if (O.getName() == "FOO")
       m_Foo = O;
@@ -116,7 +116,7 @@ public:
   }
 
   Status Run(bool trace) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return Status::SUCCESS;
     assert(m_Foo && m_Bar && "foo and bar output sections must be present!");
     auto fooRules = m_Foo.getLinkerScriptRules();
@@ -157,7 +157,7 @@ public:
   void Init(std::string options) override {}
 
   void processOutputSection(eld::plugin::OutputSection O) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return;
     if (O.getName() == "FOO")
       m_Foo = O;
@@ -166,7 +166,7 @@ public:
   }
 
   Status Run(bool trace) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return Status::SUCCESS;
     assert(m_Foo && m_Bar && "foo and bar output sections must be present!");
     auto fooRules = m_Foo.getLinkerScriptRules();

--- a/test/Common/standalone/SymbolResolutionReport/PluginSymbols/PluginSymbols.cpp
+++ b/test/Common/standalone/SymbolResolutionReport/PluginSymbols/PluginSymbols.cpp
@@ -16,7 +16,7 @@ public:
   }
 
   Status Run(bool Trace) override {
-    if (getLinker()->getState() != LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return eld::plugin::Plugin::Status::SUCCESS;
 
     eld::Expected<eld::plugin::OutputSection> expFooSect =

--- a/test/Hexagon/Plugin/AllOutSectAddresses/AllOutSectAddresses.test
+++ b/test/Hexagon/Plugin/AllOutSectAddresses/AllOutSectAddresses.test
@@ -18,5 +18,5 @@ RUN: %not %link %linkopts -o %t1.1.out %t1.1.o -L%libsdir/test -T %p/Inputs/scri
 #CHECK: Output section: .comment
 #CHECK: Virtual address: {{.*}}
 #CHECK: Physical address: 0
-#INVALID_STATE: InvalidStateFindOutSectAddresses:Error: Link state 'BeforeLayout' is invalid for the API '{{(eld::plugin::OutputSection::)?}}getVirtualAddress'. Valid link states: ['CreatingSegments, AfterLayout']
-#INVALID_STATE: InvalidStateFindOutSectAddresses:Error: Link state 'BeforeLayout' is invalid for the API '{{.*}}eld::plugin::LinkerWrapper::getAllOutputSections({{.*}}) const'. Valid link states: [CreatingSegments, AfterLayout, CreatingSections]
+#INVALID_STATE: InvalidStateFindOutSectAddresses:Error: Link state 'BeforeLayout' is invalid for the API '{{.*}}getVirtualAddress{{.*}}'. Valid link states: [CreatingSegments, AfterLayout]
+#INVALID_STATE: InvalidStateFindOutSectAddresses:Error: Link state 'BeforeLayout' is invalid for the API '{{.*}}eld::plugin::LinkerWrapper::getAllOutputSections({{.*}}) const'. Valid link states: [CreatingSections, CreatingSegments, AfterLayout]

--- a/test/Hexagon/Plugin/AllOutSectAddresses/FindOutSectAddresses.cpp
+++ b/test/Hexagon/Plugin/AllOutSectAddresses/FindOutSectAddresses.cpp
@@ -16,7 +16,7 @@ public:
   void processOutputSection(OutputSection S) override { return; }
 
   Status Run(bool Trace) override {
-    if (getLinker()->getState() != LinkerWrapper::AfterLayout)
+    if (!getLinker()->isLinkStateAfterLayout())
       return Status::SUCCESS;
     eld::Expected<std::vector<eld::plugin::OutputSection>> expOutSects =
         getLinker()->getAllOutputSections();
@@ -55,7 +55,7 @@ public:
   void Init(std::string Options) override {}
 
   void processOutputSection(OutputSection S) override {
-    if (getLinker()->getState() != LinkerWrapper::BeforeLayout)
+    if (!getLinker()->isLinkStateBeforeLayout())
       return;
     if (S.getName() == "foo") {
       eld::Expected<uint64_t> expVirtualAddress =
@@ -67,7 +67,7 @@ public:
   }
 
   Status Run(bool Trace) override {
-    if (getLinker()->getState() != LinkerWrapper::BeforeLayout)
+    if (!getLinker()->isLinkStateBeforeLayout())
       return Status::SUCCESS;
     eld::Expected<std::vector<eld::plugin::OutputSection>> expOutSects =
         getLinker()->getAllOutputSections();

--- a/test/Hexagon/Plugin/ChangeSymbol/ChangeSymbol.cpp
+++ b/test/Hexagon/Plugin/ChangeSymbol/ChangeSymbol.cpp
@@ -20,22 +20,22 @@ public:
   void Init(std::string Options) override {}
 
   void processOutputSection(OutputSection O) override {
-    if (getLinker()->getState() == LinkerWrapper::BeforeLayout)
+    if (getLinker()->isLinkStateBeforeLayout())
       return;
 
-    if (getLinker()->getState() == LinkerWrapper::CreatingSections)
+    if (getLinker()->isLinkStateCreatingSections())
       return;
 
-    if (getLinker()->getState() == LinkerWrapper::AfterLayout)
+    if (getLinker()->isLinkStateAfterLayout())
       return;
   }
 
   // After the linker lays out the image, but before it creates the elf file,
   // it will call this run function.
   Status Run(bool Trace) override {
-    if (getLinker()->getState() == LinkerWrapper::BeforeLayout)
+    if (getLinker()->isLinkStateBeforeLayout())
       return eld::plugin::Plugin::Status::SUCCESS;
-    if (getLinker()->getState() == LinkerWrapper::AfterLayout) {
+    if (getLinker()->isLinkStateAfterLayout()) {
       eld::Expected<uint32_t> expChecksum =
           getLinker()->getImageLayoutChecksum();
       ELDEXP_REPORT_AND_RETURN_ERROR_IF_ERROR(getLinker(), expChecksum);
@@ -57,7 +57,7 @@ public:
                 << "\n";
       return eld::plugin::Plugin::Status::SUCCESS;
     }
-    if (getLinker()->getState() == LinkerWrapper::CreatingSections) {
+    if (getLinker()->isLinkStateCreatingSections()) {
       for (auto &Section : m_SectionToChunks) {
         for (auto &C : Section.second) {
           addChunkToSection(Section.first, C);

--- a/test/Hexagon/Plugin/CreateChunk/CreateChunk.cpp
+++ b/test/Hexagon/Plugin/CreateChunk/CreateChunk.cpp
@@ -20,7 +20,7 @@ public:
   std::string GetName() override { return PluginName; }
 
   Status Run(bool Trace) override {
-    if (getLinker()->getState() == eld::plugin::LinkerWrapper::CreatingSections) {
+    if (getLinker()->isLinkStateCreatingSections()) {
       size_t Align = sizeof(uint32_t);
 
       const unsigned char NOPBytes[] = {0x00, 0xc0, 0x00, 0x7f};

--- a/test/Hexagon/Plugin/GetAllSymbols/GetAllSymbols.cpp
+++ b/test/Hexagon/Plugin/GetAllSymbols/GetAllSymbols.cpp
@@ -23,7 +23,7 @@ public:
   // After the linker lays out the image, but before it creates the elf file,
   // it will call this run function.
   Status Run(bool Trace) override {
-    if (getLinker()->getState() != LinkerWrapper::AfterLayout)
+    if (!getLinker()->isLinkStateAfterLayout())
       return SUCCESS;
     eld::Expected<std::vector<eld::plugin::Symbol>> expAllSyms =
         getLinker()->getAllSymbols();

--- a/test/Hexagon/Plugin/LayoutWrapperTest/PaddingTest/PaddingTest.cpp
+++ b/test/Hexagon/Plugin/LayoutWrapperTest/PaddingTest/PaddingTest.cpp
@@ -13,7 +13,7 @@ public:
   // Perform any initialization here
   void Init(std::string Options) override {
     auto linker = getLinker();
-    if (linker->getState() != LinkerWrapper::AfterLayout)
+    if (!linker->isLinkStateAfterLayout())
       return;
     std::unique_ptr<LayoutWrapper> layout =
         std::make_unique<LayoutWrapper>(*linker);

--- a/test/Hexagon/Plugin/MergeStringChunk/MergeStringChunk.cpp
+++ b/test/Hexagon/Plugin/MergeStringChunk/MergeStringChunk.cpp
@@ -16,14 +16,14 @@ public:
   void Init(std::string options) override {}
 
   void processOutputSection(eld::plugin::OutputSection O) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return;
     if (O.getName() == ".rodata")
       Rodata = O;
   }
 
   Status Run(bool trace) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return Status::SUCCESS;
 
     auto Rules = Rodata.getLinkerScriptRules();

--- a/test/Hexagon/Plugin/MoveChunksFromOutputSection/MoveChunksFromOutputSection.cpp
+++ b/test/Hexagon/Plugin/MoveChunksFromOutputSection/MoveChunksFromOutputSection.cpp
@@ -28,11 +28,11 @@ public:
   void Init(std::string Options) override {}
 
   void processOutputSection(OutputSection O) override {
-    if (getLinker()->getState() == LinkerWrapper::AfterLayout) {
+    if (getLinker()->isLinkStateAfterLayout()) {
       std::cout << "Size of " << O.getName() << "\t" << O.getSize() << "\n";
       return;
     }
-    if (getLinker()->getState() != LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return;
 
     if (O.getName() == ".redistribute")
@@ -65,9 +65,9 @@ public:
   // After the linker lays out the image, but before it creates the elf file,
   // it will call this run function.
   Status Run(bool Trace) override {
-    if (getLinker()->getState() == LinkerWrapper::AfterLayout)
+    if (getLinker()->isLinkStateAfterLayout())
       return eld::plugin::Plugin::Status::SUCCESS;
-    if (getLinker()->getState() != LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return eld::plugin::Plugin::Status::SUCCESS;
 
     eld::plugin::LinkerScriptRule HotRule = Hot.getLinkerScriptRules().front();

--- a/test/Hexagon/Plugin/MoveChunksFromOutputSectionForTrampolines/MoveChunksFromOutputSectionForTrampolines.cpp
+++ b/test/Hexagon/Plugin/MoveChunksFromOutputSectionForTrampolines/MoveChunksFromOutputSectionForTrampolines.cpp
@@ -22,7 +22,7 @@ public:
   void Init(std::string Options) override {}
 
   void processOutputSection(OutputSection O) override {
-    if (getLinker()->getState() != LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return;
 
     if (O.getName() == ".redistribute")
@@ -41,9 +41,9 @@ public:
   // After the linker lays out the image, but before it creates the elf file,
   // it will call this run function.
   Status Run(bool Trace) override {
-    if (getLinker()->getState() == LinkerWrapper::AfterLayout)
+    if (getLinker()->isLinkStateAfterLayout())
       return eld::plugin::Plugin::Status::SUCCESS;
-    if (getLinker()->getState() != LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return eld::plugin::Plugin::Status::SUCCESS;
 
     eld::plugin::LinkerScriptRule HotRule = Hot.getLinkerScriptRules().front();

--- a/test/Hexagon/Plugin/OutputSectionContents/OutputSectionContents.cpp
+++ b/test/Hexagon/Plugin/OutputSectionContents/OutputSectionContents.cpp
@@ -16,7 +16,7 @@ public:
   void Init(std::string Options) override {}
 
   void processOutputSection(OutputSection O) override {
-    if (getLinker()->getState() != LinkerWrapper::AfterLayout)
+    if (!getLinker()->isLinkStateAfterLayout())
       return;
     if (O.getName() == ".rodata" || O.getName() == ".buffer")
       Sections.push_back(O);
@@ -25,7 +25,7 @@ public:
   // After the linker lays out the image, but before it creates the elf file,
   // it will call this run function.
   Status Run(bool Trace) override {
-    if (getLinker()->getState() != LinkerWrapper::AfterLayout)
+    if (!getLinker()->isLinkStateAfterLayout())
       return {};
     for (OutputSection &O : Sections) {
       auto ExpContents = getLinker()->getOutputSectionContents(O);

--- a/test/Hexagon/Plugin/OutputSectionIteratorWithConfig/OutputSectionIteratorWithConfig.cpp
+++ b/test/Hexagon/Plugin/OutputSectionIteratorWithConfig/OutputSectionIteratorWithConfig.cpp
@@ -52,24 +52,24 @@ public:
   }
 
   void processOutputSection(OutputSection O) override {
-    if (getLinker()->getState() == LinkerWrapper::BeforeLayout)
+    if (getLinker()->isLinkStateBeforeLayout())
       return;
 
-    if (getLinker()->getState() == LinkerWrapper::CreatingSections)
+    if (getLinker()->isLinkStateCreatingSections())
       return;
 
-    if (getLinker()->getState() == LinkerWrapper::AfterLayout)
+    if (getLinker()->isLinkStateAfterLayout())
       return;
   }
 
   // After the linker lays out the image, but before it creates the elf file,
   // it will call this run function.
   Status Run(bool Trace) override {
-    if (getLinker()->getState() == LinkerWrapper::BeforeLayout)
+    if (getLinker()->isLinkStateBeforeLayout())
       return eld::plugin::Plugin::Status::SUCCESS;
-    if (getLinker()->getState() == LinkerWrapper::AfterLayout)
+    if (getLinker()->isLinkStateAfterLayout())
       return eld::plugin::Plugin::Status::SUCCESS;
-    if (getLinker()->getState() == LinkerWrapper::CreatingSections)
+    if (getLinker()->isLinkStateCreatingSections())
       return eld::plugin::Plugin::Status::SUCCESS;
     return Plugin::Status::SUCCESS;
   }

--- a/test/Hexagon/Plugin/SegmentInfo/segmentinfo.cpp
+++ b/test/Hexagon/Plugin/SegmentInfo/segmentinfo.cpp
@@ -18,14 +18,14 @@ public:
   void Init(std::string Options) override {}
 
   void processOutputSection(OutputSection O) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::AfterLayout)
+    if (!getLinker()->isLinkStateAfterLayout())
       return;
     if (O.getName() == ".dynamic")
       OutputSections.push_back(O);
   }
 
   Status Run(bool Trace) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::AfterLayout)
+    if (!getLinker()->isLinkStateAfterLayout())
       return eld::plugin::Plugin::Status::SUCCESS;
     for (OutputSection &O : OutputSections) {
       auto ExpSegments = O.getSegments(*getLinker());

--- a/test/Hexagon/Plugin/StringChunkMover/StringChunkMover.cpp
+++ b/test/Hexagon/Plugin/StringChunkMover/StringChunkMover.cpp
@@ -14,7 +14,7 @@ public:
   void Init(std::string Options) override {}
 
   void processOutputSection(eld::plugin::OutputSection O) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return;
     if (O.getName() == ".rodata")
       Rodata = O;
@@ -23,7 +23,7 @@ public:
   }
 
   Status Run(bool Trace) override {
-    if (getLinker()->getState() != eld::plugin::LinkerWrapper::CreatingSections)
+    if (!getLinker()->isLinkStateCreatingSections())
       return Status::SUCCESS;
     std::cout << "Plugin runs\n";
     assert(Text && Rodata);

--- a/test/Hexagon/Plugin/TargetChunkOffset/TargetChunkOffset.cpp
+++ b/test/Hexagon/Plugin/TargetChunkOffset/TargetChunkOffset.cpp
@@ -19,24 +19,24 @@ public:
   }
 
   void processOutputSection(OutputSection O) override {
-    if (getLinker()->getState() == LinkerWrapper::BeforeLayout)
+    if (getLinker()->isLinkStateBeforeLayout())
       return;
 
-    if (getLinker()->getState() == LinkerWrapper::CreatingSections)
+    if (getLinker()->isLinkStateCreatingSections())
       return;
 
-    if (getLinker()->getState() == LinkerWrapper::AfterLayout)
+    if (getLinker()->isLinkStateAfterLayout())
       return;
   }
 
   // After the linker lays out the image, but before it creates the elf file,
   // it will call this run function.
   Status Run(bool Trace) override {
-    if (getLinker()->getState() == LinkerWrapper::BeforeLayout)
+    if (getLinker()->isLinkStateBeforeLayout())
       return eld::plugin::Plugin::Status::SUCCESS;
-    if (getLinker()->getState() == LinkerWrapper::AfterLayout)
+    if (getLinker()->isLinkStateAfterLayout())
       return eld::plugin::Plugin::Status::SUCCESS;
-    if (getLinker()->getState() == LinkerWrapper::CreatingSections)
+    if (getLinker()->isLinkStateCreatingSections())
       return eld::plugin::Plugin::Status::SUCCESS;
     return Plugin::Status::SUCCESS;
   }


### PR DESCRIPTION
This commit moves LinkerWrapper::State to Module::LinkState and adds LinkerWrapper member fucntions for the plugins to query the link state. The main motivation for this change is to increase the ABI-compatibility robustness of the plugin framework. Previously, Any modification to LinkerWrapper::State could result in ABI-incompatibility. Now link states can be added without affecting the ABI-compatibility.

An added additional benefit is that the new design forces users to specify the exact link state that they need instead of using the error-prone less-than/greater-than link state comparisons.

Closes #134