### PR TITLE
Annotate autoloaded plugins in the text map-file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,7 @@ add_subdirectory(lib)
 add_subdirectory(tools)
 add_subdirectory(docs)
 add_subdirectory(test)
+add_subdirectory(Plugins)
 
 install(
   DIRECTORY templates/

--- a/Plugins/CMakeLists.txt
+++ b/Plugins/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(HelloWorldPlugin)

--- a/Plugins/HelloWorldPlugin/CMakeLists.txt
+++ b/Plugins/HelloWorldPlugin/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(SOURCES HelloWorldPlugin.cpp)
+
+if(NOT CYGWIN AND LLVM_ENABLE_PIC)
+  set(SHARED_LIB_SOURCES ${SOURCES})
+
+  set(bsl ${BUILD_SHARED_LIBS})
+
+  set(BUILD_SHARED_LIBS ON)
+
+  add_llvm_library(HelloWorldPlugin ${SHARED_LIB_SOURCES} LINK_LIBS LW)
+
+  set(BUILD_SHARED_LIBS ${bsl})
+endif()

--- a/Plugins/HelloWorldPlugin/HelloWorldPlugin.cpp
+++ b/Plugins/HelloWorldPlugin/HelloWorldPlugin.cpp
@@ -1,0 +1,32 @@
+//===- HelloWorldPlugin.h--------------------------------------------------===//
+// Part of the eld Project, under the BSD License
+// See https://github.com/qualcomm/eld/LICENSE.txt for license information.
+// SPDX-License-Identifier: BSD-3-Clause
+//===----------------------------------------------------------------------===//
+
+#include "Defines.h"
+#include "PluginBase.h"
+#include "PluginVersion.h"
+#include "LinkerPlugin.h"
+#include <iostream>
+
+class DLL_A_EXPORT HelloWorldPlugin : public eld::plugin::LinkerPlugin {
+public:
+  HelloWorldPlugin() : eld::plugin::LinkerPlugin("HelloWorldPlugin") {}
+
+  void Init(const std::string &options) override {}
+
+  void VisitSections(eld::plugin::InputFile IF) override {}
+
+  void ActBeforeRuleMatching() override {}
+
+  void ActBeforeSectionMerging() override {}
+
+  void ActBeforePerformingLayout() override {}
+
+  void ActBeforeWritingOutput() override {}
+
+  void Destroy() override {}
+};
+
+ELD_REGISTER_PLUGIN(HelloWorldPlugin)

--- a/Plugins/HelloWorldPlugin/HelloWorldPlugin.yaml
+++ b/Plugins/HelloWorldPlugin/HelloWorldPlugin.yaml
@@ -1,0 +1,4 @@
+GlobalPlugins:
+  - Type: LinkerPlugin
+    Name: HelloWorldPlugin
+    Library: HelloWorldPlugin

--- a/include/eld/Core/LinkerScript.h
+++ b/include/eld/Core/LinkerScript.h
@@ -146,7 +146,7 @@ public:
   // ---------------- Plugin Support ------------------------------
   Plugin *addPlugin(plugin::PluginBase::Type T, std::string Name,
                     std::string PluginRegisterType, std::string PluginOpts,
-                    bool S, Module &Module);
+                    bool S, bool IsDefaultPlugin, Module &Module);
 
   void addPlugin(Plugin *, Module &Module);
 

--- a/include/eld/Core/Module.h
+++ b/include/eld/Core/Module.h
@@ -629,7 +629,7 @@ private:
   bool verifyInvariantsForCreatingSectionsState() const;
 
   // Read one plugin config file
-  bool readOnePluginConfig(llvm::StringRef Cfg);
+  bool readOnePluginConfig(llvm::StringRef Cfg, bool IsDefaultConfig);
 
 private:
   LinkerScript &UserLinkerScript;

--- a/include/eld/Script/Plugin.h
+++ b/include/eld/Script/Plugin.h
@@ -26,7 +26,8 @@ class Module;
 class Plugin {
 public:
   explicit Plugin(plugin::Plugin::Type T, std::string Name, std::string R,
-                  std::string O, bool Stats, Module &Module);
+                  std::string O, bool Stats, bool DefaultPlugin,
+                  Module &Module);
 
   ~Plugin();
 
@@ -213,6 +214,8 @@ public:
   /// Calls ActBeforeRuleMatching hook handler.
   void callActBeforeRuleMatchingHook();
 
+  bool isDefaultPlugin() const { return IsDefaultPlugin; }
+
 private:
   bool check();
 
@@ -244,6 +247,7 @@ private:
   UnbalancedFragmentMoves PluginUnbalancedFragmentMoves;
   std::vector<void *> LibraryHandles;
   std::vector<CommandLineOptionSpec> PluginCommandLineOptions;
+  bool IsDefaultPlugin = false;
 };
 } // namespace eld
 

--- a/lib/Core/LinkerScript.cpp
+++ b/lib/Core/LinkerScript.cpp
@@ -78,9 +78,9 @@ void LinkerScript::insertPhdrSpec(const PhdrSpec &PhdrsSpec) {
 Plugin *LinkerScript::addPlugin(plugin::PluginBase::Type T, std::string Name,
                                 std::string PluginRegisterType,
                                 std::string PluginOpts, bool Stats,
-                                Module &Module) {
-  Plugin *P =
-      make<Plugin>(T, Name, PluginRegisterType, PluginOpts, Stats, Module);
+                                bool IsDefaultPlugin, Module &Module) {
+  Plugin *P = make<Plugin>(T, Name, PluginRegisterType, PluginOpts, Stats,
+                           IsDefaultPlugin, Module);
   addPlugin(P, Module);
   return P;
 }

--- a/lib/LayoutMap/TextLayoutPrinter.cpp
+++ b/lib/LayoutMap/TextLayoutPrinter.cpp
@@ -313,72 +313,62 @@ void TextLayoutPrinter::printGlobalPluginInfo(Module &M, bool UseColor) {
   if (UseColor)
     outputStream().resetColor();
 
+  auto PrintPlugin = [this](const Plugin &P) {
+    std::string features;
+    if (P.isDefaultPlugin())
+      features += "[autoloaded]";
+    outputStream() << "\t" << "\t" << P.getName() << "\t"
+                   << P.getLibraryName() << "\t" << P.getPluginType() << "\t"
+                   << P.getPluginOptions() << features << "\n";
+  };
+
   if (UniversalPlugins.size()) {
     outputStream() << "\t";
     outputStream() << "Linker Plugins" << "\n";
     for (auto &P : UniversalPlugins)
-      outputStream() << "\t" << "\t" << P->getName() << "\t"
-                     << P->getLibraryName() << "\t" << P->getPluginType()
-                     << "\t" << P->getPluginOptions() << "\n";
+      PrintPlugin(*P);
   }
   if (PluginListForSectionMatcher.size()) {
     outputStream() << "\t";
     outputStream() << "SectionMatcher Plugins"
                    << "\n";
     for (auto &P : PluginListForSectionMatcher)
-      outputStream() << "\t"
-                     << "\t" << P->getName() << "\t" << P->getLibraryName()
-                     << "\t" << P->getPluginType() << "\t"
-                     << P->getPluginOptions() << "\n";
+      PrintPlugin(*P);
   }
   if (PluginListForSectionIterator.size()) {
     outputStream() << "\t";
     outputStream() << "SectionIterator Plugins"
                    << "\n";
     for (auto &P : PluginListForSectionIterator)
-      outputStream() << "\t"
-                     << "\t" << P->getName() << "\t" << P->getLibraryName()
-                     << "\t" << P->getPluginType() << "\t"
-                     << P->getPluginOptions() << "\n";
+      PrintPlugin(*P);
   }
   if (PluginListForOutputSectionIterator.size()) {
     outputStream() << "\t";
     outputStream() << "Output SectionIterator Plugins"
                    << "\n";
     for (auto &P : PluginListForOutputSectionIterator)
-      outputStream() << "\t"
-                     << "\t" << P->getName() << "\t" << P->getLibraryName()
-                     << "\t" << P->getPluginType() << "\t"
-                     << P->getPluginOptions() << "\n";
+      PrintPlugin(*P);
   }
   if (PluginListForMemorySize.size()) {
     outputStream() << "\t";
     outputStream() << "Memory Size Plugin(s)"
                    << "\n";
     for (auto &P : PluginListForMemorySize)
-      outputStream() << "\t"
-                     << "\t" << P->getName() << "\t" << P->getLibraryName()
-                     << "\t" << P->getPluginType() << "\t"
-                     << P->getPluginOptions() << "\n";
+      PrintPlugin(*P);
   }
   if (PluginListForFileSize.size()) {
     outputStream() << "\t";
     outputStream() << "File Size Plugin(s)"
                    << "\n";
     for (auto &P : PluginListForFileSize)
-      outputStream() << "\t"
-                     << "\t" << P->getName() << "\t" << P->getLibraryName()
-                     << "\t" << P->getPluginType() << "\t"
-                     << P->getPluginOptions() << "\n";
+      PrintPlugin(*P);
   }
   outputStream() << "Linker Plugin Run Information"
                  << "\n";
   int Index = 0;
   for (auto &P : M.getScript().getPluginRunList()) {
     outputStream() << "#" << ++Index << "\t";
-    outputStream() << P->getName() << "\t" << P->getLibraryName() << "\t"
-                   << P->getPluginType() << "\t" << P->getPluginOptions()
-                   << "\n";
+    PrintPlugin(*P);
   }
 }
 

--- a/lib/Script/Plugin.cpp
+++ b/lib/Script/Plugin.cpp
@@ -40,13 +40,14 @@ private:
 };
 
 Plugin::Plugin(plugin::Plugin::Type T, std::string LibraryName,
-               std::string PluginName, std::string O, bool Stats,
-               Module &Module)
+               std::string PluginName, std::string O,
+               bool Stats, bool DefaultPlugin, Module &Module)
     : ThisType(T), CurID(0), Name(LibraryName), PluginType(PluginName),
       PluginOptions(O), PluginLibraryHandle(nullptr),
       PluginRegisterFunction(nullptr), GetPluginFunction(nullptr),
       UserPluginHandle(nullptr), PluginCleanupFunction(nullptr), Stats(Stats),
-      ThisModule(Module), ThisConfig(Module.getConfig()) {}
+      ThisModule(Module), ThisConfig(Module.getConfig()),
+      IsDefaultPlugin(DefaultPlugin) {}
 
 std::string Plugin::resolvePath(const LinkerConfig &PConfig) {
   // Library already loaded!

--- a/lib/Script/PluginCmd.cpp
+++ b/lib/Script/PluginCmd.cpp
@@ -19,8 +19,9 @@ eld::Expected<void> PluginCmd::activate(Module &CurModule) {
       CurModule.getConfig().options().printTimingStats("Plugin") ||
       CurModule.getConfig().options().printTimingStats(Name.c_str()) ||
       CurModule.getConfig().options().allUserPluginStatsRequested();
-  Plugin = CurModule.getScript().addPlugin(T, Name, R, Options,
-                                           PrintTimingStats, CurModule);
+  Plugin =
+      CurModule.getScript().addPlugin(T, Name, R, Options, PrintTimingStats,
+                                      /*IsDefaultPlugin=*/false, CurModule);
   return eld::Expected<void>();
 }
 

--- a/test/Common/Plugin/AutoloadPlugins/AutoloadPlugins.test
+++ b/test/Common/Plugin/AutoloadPlugins/AutoloadPlugins.test
@@ -1,0 +1,18 @@
+#---AutoloadPlugins.test----------------------- Executable,LS --------------------#
+#BEGIN_COMMENT
+# This tests checks the autoloading of plugins from the
+# ${ORIGIN}/../etc/ELD/Plugins/Default directory.
+#END_COMMENT
+#START_TEST
+RUN: %mkdir -p %llvmobjroot/etc/ELD/Plugins/Default/HelloWorldPlugin
+RUN: %cp %eldsrcroot/Plugins/HelloWorldPlugin/HelloWorldPlugin.yaml \
+RUN:   %llvmobjroot/etc/ELD/Plugins/Default/HelloWorldPlugin
+RUN: %touch %t1.1.o
+RUN: %link -MapStyle txt %linkopts -o %t1.1.out %t1.1.o -Map %t1.1.map.txt --trace=plugin 2>&1 | %filecheck %s
+RUN: %rm %llvmobjroot/etc/ELD/Plugins/Default/HelloWorldPlugin/HelloWorldPlugin.yaml
+RUN: %filecheck %s --check-prefix=MAP < %t1.1.map.txt
+#END_TEST
+
+CHECK: Trace: Calling HelloWorldPlugin::Init plugin hook
+
+MAP: HelloWorldPlugin HelloWorldPlugin [autoloaded]

--- a/test/Common/Plugin/CMakeLists.txt
+++ b/test/Common/Plugin/CMakeLists.txt
@@ -6,6 +6,9 @@ function(add_common_plugin pluginname)
   add_dependencies(CommonPluginUnitTests ${pluginname})
 endfunction()
 
+# Add HelloWorldPlugin as a test dependency!
+add_common_plugin(HelloWorldPlugin)
+
 add_subdirectory(ActBeforeRuleMatching)
 add_subdirectory(ActBeforeSectionMerging)
 add_subdirectory(AddedSectionOverrides)


### PR DESCRIPTION
This commit adds an annotation for autoloaded plugins in the text map-file. The main motivation for this map-file addition is to be able to easily tell which plugins were loaded automatically by the linker and which were loaded by the user.

This commit also adds a dummy HelloWorldPlugin. This serves two purpose: it provides a skeleton linker plugin for the users to start with and to provide a plugin for testing the autoload annotation in the map-file.

Closes #136