### PR TITLE
[RISCV] Implement Relaxations for QC.E.J/QC.E.JAL

### DIFF
--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -870,6 +870,10 @@ public:
 
   bool getRISCVRelaxToC() const { return BRiscvRelaxToC; }
 
+  void setRISCVRelaxXqci(bool Value) { BRiscvRelaxXqci = Value; }
+
+  bool getRISCVRelaxXqci() const { return BRiscvRelaxXqci; }
+
   bool warnCommon() const { return BWarnCommon; }
 
   void setWarnCommon() { BWarnCommon = true; }
@@ -1225,6 +1229,7 @@ private:
   bool RiscvZeroRelax = true;             // Zero-page relaxation
   bool RiscvGPRelax = true;               // GP relaxation
   bool BRiscvRelaxToC = true; // enable riscv relax to compressed code
+  bool BRiscvRelaxXqci = false; // enable riscv relaxations for xqci
   bool AllowIncompatibleSectionsMix = false; // Allow incompatibleSections;
   bool ProgressBar = false;                  // Show progressbar.
   bool RecordInputFiles = false;             // --reproduce

--- a/include/eld/Driver/RISCVLinkerOptions.td
+++ b/include/eld/Driver/RISCVLinkerOptions.td
@@ -41,6 +41,15 @@ def no_riscv_relax_compressed
       HelpText<"Disable relaxation to compressed instructions">,
       Group<grp_riscv_linker>;
 
+def riscv_relax_xqci
+    : Flag<["--"], "relax-xqci">,
+      HelpText<"Enable relaxing to/from Xqci instructions">,
+      Group<grp_riscv_linker>;
+def no_riscv_relax_xqci
+    : Flag<["--"], "no-relax-xqci">,
+      HelpText<"Disable relaxing to/from Xqci instructions (default behavior)">,
+      Group<grp_riscv_linker>;
+
 def riscv_relax : Flag<["--"], "relax">,
                   HelpText<"Enable relaxation (default behavior)">,
                   Group<grp_riscv_linker>;

--- a/lib/LinkerWrapper/RISCVLinkDriver.cpp
+++ b/lib/LinkerWrapper/RISCVLinkDriver.cpp
@@ -121,6 +121,11 @@ opt::OptTable *RISCVLinkDriver::parseOptions(ArrayRef<const char *> Args,
   if (ArgList.hasArg(OPT_RISCVLinkOptTable::no_riscv_relax_compressed))
     Config.options().setRISCVRelaxToC(false);
 
+  // --relax-xqci, --no-relax-xqci  (default)
+  Config.options().setRISCVRelaxXqci(
+      ArgList.hasFlag(OPT_RISCVLinkOptTable::riscv_relax_xqci,
+                      OPT_RISCVLinkOptTable::no_riscv_relax_xqci, false));
+
   // --enable-bss-mixing
   if (ArgList.hasArg(OPT_RISCVLinkOptTable::enable_bss_mixing))
     Config.options().setAllowBSSMixing(true);

--- a/lib/Target/RISCV/RISCVLDBackend.h
+++ b/lib/Target/RISCV/RISCVLDBackend.h
@@ -198,6 +198,7 @@ private:
   bool isGOTReloc(Relocation *reloc) const;
 
   bool doRelaxationCall(Relocation *R, bool DoCompressed);
+  bool doRelaxationQCCall(Relocation *R, bool DoCompressed);
 
   bool doRelaxationLui(Relocation *R, Relocation::DWord G);
 

--- a/test/RISCV/standalone/Relaxation/QC_E_CALL_TO_JAL/Inputs/shared.s
+++ b/test/RISCV/standalone/Relaxation/QC_E_CALL_TO_JAL/Inputs/shared.s
@@ -1,0 +1,9 @@
+	.text
+	.global f
+f:
+	/* exact+relax needed while llvm/llvm-project#142702 is not yet fixed/landed */
+	.option exact
+	.option relax
+
+	qc.e.jal	f
+	qc.e.j	f

--- a/test/RISCV/standalone/Relaxation/QC_E_CALL_TO_JAL/Inputs/x.s
+++ b/test/RISCV/standalone/Relaxation/QC_E_CALL_TO_JAL/Inputs/x.s
@@ -1,0 +1,35 @@
+	/* exact+relax needed while llvm/llvm-project#142702 is not yet fixed/landed */
+	.option exact
+	.option relax
+
+	.text
+	.align	1
+	.type	f, @function
+f:
+	ret
+	.size	f, .-f
+
+	.align	1
+	.globl	main
+	.type	main, @function
+main:
+	qc.e.jal	f
+	qc.e.j	f
+
+	.org	0x780
+	qc.e.jal	f
+	qc.e.j	f
+
+	.org	0x880
+	qc.e.jal	f
+	qc.e.j	f
+
+	.org	0xfff00
+	qc.e.jal	f
+	qc.e.j	f
+
+	.org	0x100100
+	qc.e.jal	f
+	qc.e.j	f
+
+	.size	main, .-main

--- a/test/RISCV/standalone/Relaxation/QC_E_CALL_TO_JAL/QC_E_CALL_TO_JAL.test
+++ b/test/RISCV/standalone/Relaxation/QC_E_CALL_TO_JAL/QC_E_CALL_TO_JAL.test
@@ -1,0 +1,116 @@
+#----------QC_E_CALL_TO_JAL.test----------------- Executable------------------#
+#BEGIN_COMMENT
+# Do relaxation from QC.E.J and QC.E.JAL to JAL or C.J/C.JAL
+#END_COMMENT
+#--------------------------------------------------------------------
+REQUIRES: riscv32
+RUN: %clang %clangopts -c %p/Inputs/x.s -o %t.o -menable-experimental-extensions -march=rv32gc_xqcilb0p2
+
+# Relaxations are enabled, including compressed ones.
+RUN: %link %linkopts --relax-xqci %t.o -o %t.1.out -MapStyle txt -Map %t.1.map --verbose 2>&1 | %filecheck %s --check-prefix=VERBOSE_RELAX_C
+RUN: %link %linkopts --relax-xqci %t.o -o %t.1.so -shared -MapStyle txt -Map %t.1.so.map --verbose 2>&1 | %filecheck %s --check-prefix=VERBOSE_RELAX_C
+VERBOSE_RELAX_C: RISCV_QC_E_JAL_C : relaxing instruction 0x00000000c01f to compressed instruction 0x2001 for symbol f in section .text+0x4 file {{.*}}.o
+VERBOSE_RELAX_C: RISCV_QC_E_JAL_C : Deleting 4 bytes for symbol 'f' in section .text+0x6 file {{.*}}.o
+VERBOSE_RELAX_C: RISCV_QC_E_J_C : relaxing instruction 0x00000000401f to compressed instruction 0xa001 for symbol f in section .text+0x6 file {{.*}}.o
+VERBOSE_RELAX_C: RISCV_QC_E_J_C : Deleting 4 bytes for symbol 'f' in section .text+0x8 file {{.*}}.o
+VERBOSE_RELAX_C: RISCV_QC_E_JAL_C : relaxing instruction 0x00000000c01f to compressed instruction 0x2001 for symbol f in section .text+0x778 file {{.*}}.o
+VERBOSE_RELAX_C: RISCV_QC_E_JAL_C : Deleting 4 bytes for symbol 'f' in section .text+0x77a file {{.*}}.o
+VERBOSE_RELAX_C: RISCV_QC_E_J_C : relaxing instruction 0x00000000401f to compressed instruction 0xa001 for symbol f in section .text+0x77A file {{.*}}.o
+VERBOSE_RELAX_C: RISCV_QC_E_J_C : Deleting 4 bytes for symbol 'f' in section .text+0x77c file {{.*}}.o
+VERBOSE_RELAX_C: RISCV_QC_E_JAL : Deleting 2 bytes for symbol 'f' in section .text+0x874 file {{.*}}.o
+VERBOSE_RELAX_C: RISCV_QC_E_J : Deleting 2 bytes for symbol 'f' in section .text+0x878 file {{.*}}.o
+VERBOSE_RELAX_C: RISCV_QC_E_JAL : Deleting 2 bytes for symbol 'f' in section .text+0xffef0 file {{.*}}.o
+VERBOSE_RELAX_C: RISCV_QC_E_J : Deleting 2 bytes for symbol 'f' in section .text+0xffef4 file {{.*}}.o
+VERBOSE_RELAX_C: RISCV_QC_E_CALL : Cannot relax 2 bytes for symbol 'f' in section .text+0x1000e8 file {{.*}}.o
+VERBOSE_RELAX_C: RISCV_QC_E_CALL : Cannot relax 2 bytes for symbol 'f' in section .text+0x1000ee file {{.*}}.o
+
+RUN: %objdump -d %t.1.out 2>&1 | %filecheck %s --check-prefix=DUMP_RELAX_C
+RUN: %objdump -d %t.1.so 2>&1 | %filecheck %s --check-prefix=DUMP_RELAX_C
+DUMP_RELAX_C: 3ff5        jal 0x{{[[:xdigit:]]+}} <f>
+DUMP_RELAX_C: bfed        j 0x{{[[:xdigit:]]+}} <f>
+DUMP_RELAX_C: 3061        jal 0x{{[[:xdigit:]]+}} <f>
+DUMP_RELAX_C: b059        j 0x{{[[:xdigit:]]+}} <f>
+DUMP_RELAX_C: f90ff0ef  jal 0x{{[[:xdigit:]]+}} <f>
+DUMP_RELAX_C: f8cff06f  j 0x{{[[:xdigit:]]+}} <f>
+DUMP_RELAX_C: 914000ef  jal 0x{{[[:xdigit:]]+}} <f>
+DUMP_RELAX_C: 9100006f  j 0x{{[[:xdigit:]]+}} <f>
+DUMP_RELAX_C: cc9f f00e ffef  qc.e.jal 0x{{[[:xdigit:]]+}} <f>
+DUMP_RELAX_C: 499f f00e ffef  qc.e.j 0x{{[[:xdigit:]]+}} <f>
+
+RUN: %filecheck %s --input-file=%t.1.map --check-prefix=MAP_RELAX_C
+RUN: %filecheck %s --input-file=%t.1.so.map --check-prefix=MAP_RELAX_C
+MAP_RELAX_C: # LinkStats Begin
+MAP_RELAX_C: # RelaxationBytesDeleted : 24
+MAP_RELAX_C: # RelaxationBytesMissed : 4
+MAP_RELAX_C: # LinkStats End
+
+MAP_RELAX_C: .text {{.+}}, Alignment: 0x2, Flags: SHF_ALLOC|SHF_EXECINSTR, Type: SHT_PROGBITS
+MAP_RELAX_C: # RelaxationBytesDeleted : 24
+MAP_RELAX_C: # RelaxationBytesMissed : 4
+MAP_RELAX_C: .text {{.+}}.o     #SHT_PROGBITS,SHF_ALLOC|SHF_EXECINSTR,2
+
+# Only non-compressed relaxations are enabled.
+RUN: %link %linkopts --relax-xqci --no-relax-c %t.o -o %t.2.out -MapStyle txt -Map %t.2.map --verbose 2>&1 | %filecheck %s --check-prefix=VERBOSE_RELAX
+RUN: %link %linkopts --relax-xqci --no-relax-c %t.o -o %t.2.so -shared -MapStyle txt -Map %t.2.so.map --verbose 2>&1 | %filecheck %s --check-prefix=VERBOSE_RELAX
+VERBOSE_RELAX: RISCV_QC_E_JAL : Deleting 2 bytes for symbol 'f' in section .text+0x8 file {{.*}}.o
+VERBOSE_RELAX: RISCV_QC_E_J : Deleting 2 bytes for symbol 'f' in section .text+0xc file {{.*}}.o
+VERBOSE_RELAX: RISCV_QC_E_JAL : Deleting 2 bytes for symbol 'f' in section .text+0x780 file {{.*}}.o
+VERBOSE_RELAX: RISCV_QC_E_J : Deleting 2 bytes for symbol 'f' in section .text+0x784 file {{.*}}.o
+VERBOSE_RELAX: RISCV_QC_E_JAL : Deleting 2 bytes for symbol 'f' in section .text+0x87c file {{.*}}.o
+VERBOSE_RELAX: RISCV_QC_E_J : Deleting 2 bytes for symbol 'f' in section .text+0x880 file {{.*}}.o
+VERBOSE_RELAX: RISCV_QC_E_JAL : Deleting 2 bytes for symbol 'f' in section .text+0xffef8 file {{.*}}.o
+VERBOSE_RELAX: RISCV_QC_E_J : Deleting 2 bytes for symbol 'f' in section .text+0xffefc file {{.*}}.o
+VERBOSE_RELAX: RISCV_QC_E_CALL : Cannot relax 2 bytes for symbol 'f' in section .text+0x1000f0 file {{.*}}.o
+VERBOSE_RELAX: RISCV_QC_E_CALL : Cannot relax 2 bytes for symbol 'f' in section .text+0x1000f6 file {{.*}}.o
+
+RUN: %objdump -d %t.2.out 2>&1 | %filecheck %s --check-prefix=DUMP_RELAX
+RUN: %objdump -d %t.2.so 2>&1 | %filecheck %s --check-prefix=DUMP_RELAX
+DUMP_RELAX: ffdff0ef  jal 0x{{[[:xdigit:]]+}} <f>
+DUMP_RELAX: ff9ff06f  j 0x{{[[:xdigit:]]+}} <f>
+DUMP_RELAX: 885ff0ef  jal 0x{{[[:xdigit:]]+}} <f>
+DUMP_RELAX: 881ff06f  j 0x{{[[:xdigit:]]+}} <f>
+DUMP_RELAX: f88ff0ef  jal 0x{{[[:xdigit:]]+}} <f>
+DUMP_RELAX: f84ff06f  j 0x{{[[:xdigit:]]+}} <f>
+DUMP_RELAX: 90c000ef  jal 0x{{[[:xdigit:]]+}} <f>
+DUMP_RELAX: 9080006f  j 0x{{[[:xdigit:]]+}} <f>
+DUMP_RELAX: c89f f00e ffef  qc.e.jal 0x{{[[:xdigit:]]+}} <f>
+DUMP_RELAX: 459f f00e ffef  qc.e.j 0x{{[[:xdigit:]]+}} <f>
+
+RUN: %filecheck %s --input-file=%t.2.map --check-prefix=MAP_RELAX
+RUN: %filecheck %s --input-file=%t.2.so.map --check-prefix=MAP_RELAX
+MAP_RELAX: # LinkStats Begin
+MAP_RELAX: # RelaxationBytesDeleted : 16
+MAP_RELAX: # LinkStats End
+
+MAP_RELAX: .text {{.+}}, Alignment: 0x2, Flags: SHF_ALLOC|SHF_EXECINSTR, Type: SHT_PROGBITS
+MAP_RELAX: # RelaxationBytesDeleted : 16
+MAP_RELAX: .text {{.+}}.o     #SHT_PROGBITS,SHF_ALLOC|SHF_EXECINSTR,2
+
+### Relaxations are disabled.
+RUN: %link %linkopts --no-relax-xqci --no-relax %t.o -o %t.3.out -MapStyle txt -Map %t.3.map --verbose 2>&1 | %filecheck %s --check-prefix=VERBOSE_NORELAX
+RUN: %link %linkopts --no-relax-xqci --no-relax %t.o -o %t.3.so -shared -MapStyle txt -Map %t.3.so.map --verbose 2>&1 | %filecheck %s --check-prefix=VERBOSE_NORELAX
+VERBOSE_NORELAX-COUNT-10: RISCV_QC_E_CALL : Cannot relax
+VERBOSE_NORELAX-NOT: Deleting
+
+RUN: %objdump -d %t.3.out 2>&1 | %filecheck %s --check-prefix=DUMP_NORELAX
+RUN: %objdump -d %t.3.so 2>&1 | %filecheck %s --check-prefix=DUMP_NORELAX
+DUMP_NORELAX: qc.e.jal
+DUMP_NORELAX: qc.e.j
+DUMP_NORELAX: qc.e.jal
+DUMP_NORELAX: qc.e.j
+DUMP_NORELAX: qc.e.jal
+DUMP_NORELAX: qc.e.j
+DUMP_NORELAX: qc.e.jal
+DUMP_NORELAX: qc.e.j
+DUMP_NORELAX: qc.e.jal
+DUMP_NORELAX: qc.e.j
+
+RUN: %filecheck %s --input-file=%t.3.map --check-prefix=MAP_NORELAX
+RUN: %filecheck %s --input-file=%t.3.so.map --check-prefix=MAP_NORELAX
+MAP_NORELAX: # LinkStats Begin
+MAP_NORELAX-NOT: # RelaxationBytesDeleted
+MAP_NORELAX: # LinkStats End
+
+MAP_NORELAX: .text {{.+}}, Alignment: 0x2, Flags: SHF_ALLOC|SHF_EXECINSTR, Type: SHT_PROGBITS
+MAP_NORELAX-NOT: # RelaxationBytesDeleted
+MAP_NORELAX: .text {{.+}}.o     #SHT_PROGBITS,SHF_ALLOC|SHF_EXECINSTR,2

--- a/test/RISCV/standalone/Relaxation/QC_E_CALL_TO_JAL/QC_E_CALL_TO_JAL_PLT.test
+++ b/test/RISCV/standalone/Relaxation/QC_E_CALL_TO_JAL/QC_E_CALL_TO_JAL_PLT.test
@@ -1,0 +1,14 @@
+#----------QC_E_CALL_TO_JAL_PLT.test-------------------------------#
+#BEGIN_COMMENT
+# Check that offset to PLT is used when relaxing.
+#END_COMMENT
+#--------------------------------------------------------------------
+REQUIRES: riscv32
+RUN: %clang %clangopts -c %p/Inputs/shared.s -o %t.shared.o -menable-experimental-extensions -march=rv32gc_xqcilb0p2
+RUN: %link %linkopts --relax-xqci -shared %t.shared.o -o %t.so --section-start=.text=0x1000 --section-start=.plt=0x20000
+RUN: %objdump -d %t.so 2>&1 | %filecheck %s
+
+CHECK: {{0+}}20000 <.plt>:
+CHECK: {{0+}}01000 <f>:
+    1000: 0201f0ef      jal     0x20020 <.plt+0x20>
+    1004: 01c1f06f      j       0x20020 <.plt+0x20>


### PR DESCRIPTION
These relaxations are like call relaxations, so they are done in the same phase as call relaxations.

The Relaxations are:
- QC.E.J to C.J or JAL X0
- QC.E.JAL to C.JAL or JAL X1

This change also adds a command-line switch for turning off all the xqci relaxations.

These relaxations are described in http://github.com/quic/riscv-elf-psabi-quic-extensions/releases/latest

This is the first commit to implement #147 so includes adding the flag as well.