### PR TITLE
eld should report version information

### DIFF
--- a/include/eld/Driver/GnuLdDriver.h
+++ b/include/eld/Driver/GnuLdDriver.h
@@ -132,7 +132,13 @@ protected:
 
   bool hasZOption(llvm::opt::InputArgList &Args, llvm::StringRef Key) const;
   const char *getLtoStatus() const;
+
+  // print more information about the linker
+  void printAboutInfo() const;
+
+  // print version information
   void printVersionInfo() const;
+
   // Print repository revision information of both ELD and llvm-project.
   void printRepositoryVersion() const;
 

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -918,6 +918,11 @@ defm dump_response_file
                     "Dump response file to output file">,
                     MetaVarName<"<outputfilename>">,
       Group<grp_extendedopts>;
+def about :
+     Flag<["--"], "about">,
+      HelpText<"Emit detailed information about the linker">,
+      Group<grp_extendedopts>;
+
 
 //===----------------------------------------------------------------------===//
 /// Map file

--- a/lib/LinkerWrapper/ARMLinkDriver.cpp
+++ b/lib/LinkerWrapper/ARMLinkDriver.cpp
@@ -100,6 +100,11 @@ opt::OptTable *ARMLinkDriver::parseOptions(ArrayRef<const char *> Args,
     printVersionInfo();
     return nullptr;
   }
+  // --about
+  if (ArgList.hasArg(OPT_ARMLinkOptTable::about)) {
+    printAboutInfo();
+    return nullptr;
+  }
   // -repository-version
   if (ArgList.hasArg(OPT_ARMLinkOptTable::repository_version)) {
     printRepositoryVersion();
@@ -190,6 +195,7 @@ int ARMLinkDriver::link(llvm::ArrayRef<const char *> Args,
     if (ArgList.hasArg(OPT_ARMLinkOptTable::help) ||
         ArgList.hasArg(OPT_ARMLinkOptTable::help_hidden) ||
         ArgList.hasArg(OPT_ARMLinkOptTable::version) ||
+        ArgList.hasArg(OPT_ARMLinkOptTable::about) ||
         ArgList.hasArg(OPT_ARMLinkOptTable::repository_version)) {
       return LINK_SUCCESS;
     }

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -133,7 +133,7 @@ bool GnuLdDriver::checkAndRaiseTraceDiagEntry(eld::Expected<void> E) const {
 
 const char *GnuLdDriver::getLtoStatus() const { return "Enabled"; }
 
-void GnuLdDriver::printVersionInfo() const {
+void GnuLdDriver::printAboutInfo() const {
   outs() << "Supported Targets: ";
   for (const auto &x : m_SupportedTargets)
     outs() << x << " ";
@@ -148,6 +148,15 @@ void GnuLdDriver::printVersionInfo() const {
          << LINKER_PLUGIN_API_MAJOR_VERSION << "."
          << LINKER_PLUGIN_API_MINOR_VERSION << "\n";
   outs() << "LTO Support " << getLtoStatus() << "\n";
+}
+
+void GnuLdDriver::printVersionInfo() const {
+  outs() << "eld " << eld::getELDVersion() << " (GNU Compatible linker)"
+         << "\n";
+  outs() << "Supported Targets: ";
+  for (const auto &x : m_SupportedTargets)
+    outs() << x << " ";
+  outs() << "\n";
 }
 
 // Some command line options or some combinations of them are not allowed.

--- a/lib/LinkerWrapper/HexagonLinkDriver.cpp
+++ b/lib/LinkerWrapper/HexagonLinkDriver.cpp
@@ -85,6 +85,11 @@ HexagonLinkDriver::parseOptions(ArrayRef<const char *> Args,
     printVersionInfo();
     return nullptr;
   }
+  // --about
+  if (ArgList.hasArg(OPT_HexagonLinkOptTable::about)) {
+    printAboutInfo();
+    return nullptr;
+  }
   // -repository-version
   if (ArgList.hasArg(OPT_HexagonLinkOptTable::repository_version)) {
     printRepositoryVersion();
@@ -125,6 +130,7 @@ int HexagonLinkDriver::link(llvm::ArrayRef<const char *> Args,
     if (ArgList.hasArg(OPT_HexagonLinkOptTable::help) ||
         ArgList.hasArg(OPT_HexagonLinkOptTable::help_hidden) ||
         ArgList.hasArg(OPT_HexagonLinkOptTable::version) ||
+        ArgList.hasArg(OPT_HexagonLinkOptTable::about) ||
         ArgList.hasArg(OPT_HexagonLinkOptTable::repository_version)) {
       return LINK_SUCCESS;
     }

--- a/lib/LinkerWrapper/RISCVLinkDriver.cpp
+++ b/lib/LinkerWrapper/RISCVLinkDriver.cpp
@@ -94,6 +94,11 @@ opt::OptTable *RISCVLinkDriver::parseOptions(ArrayRef<const char *> Args,
     printVersionInfo();
     return nullptr;
   }
+  // --about
+  if (ArgList.hasArg(OPT_RISCVLinkOptTable::about)) {
+    printAboutInfo();
+    return nullptr;
+  }
   // -repository-version
   if (ArgList.hasArg(OPT_RISCVLinkOptTable::repository_version)) {
     printRepositoryVersion();
@@ -174,6 +179,7 @@ int RISCVLinkDriver::link(llvm::ArrayRef<const char *> Args,
     if (ArgList.hasArg(OPT_RISCVLinkOptTable::help) ||
         ArgList.hasArg(OPT_RISCVLinkOptTable::help_hidden) ||
         ArgList.hasArg(OPT_RISCVLinkOptTable::version) ||
+        ArgList.hasArg(OPT_RISCVLinkOptTable::about) ||
         ArgList.hasArg(OPT_RISCVLinkOptTable::repository_version)) {
       return LINK_SUCCESS;
     }

--- a/lib/LinkerWrapper/x86_64LinkDriver.cpp
+++ b/lib/LinkerWrapper/x86_64LinkDriver.cpp
@@ -74,6 +74,11 @@ x86_64LinkDriver::parseOptions(ArrayRef<const char *> Args,
     printVersionInfo();
     return nullptr;
   }
+  // --about
+  if (ArgList.hasArg(OPT_x86_64LinkOptTable::about)) {
+    printAboutInfo();
+    return nullptr;
+  }
   // -repository-version
   if (ArgList.hasArg(OPT_x86_64LinkOptTable::repository_version)) {
     printRepositoryVersion();
@@ -113,6 +118,7 @@ int x86_64LinkDriver::link(llvm::ArrayRef<const char *> Args,
     if (ArgList.hasArg(OPT_x86_64LinkOptTable::help) ||
         ArgList.hasArg(OPT_x86_64LinkOptTable::help_hidden) ||
         ArgList.hasArg(OPT_x86_64LinkOptTable::version) ||
+        ArgList.hasArg(OPT_x86_64LinkOptTable::about) ||
         ArgList.hasArg(OPT_x86_64LinkOptTable::repository_version)) {
       return LINK_SUCCESS;
     }

--- a/test/Common/standalone/printVersion/printVersion.test
+++ b/test/Common/standalone/printVersion/printVersion.test
@@ -4,6 +4,7 @@
 #END_COMMENT
 
 RUN: %link --version 2>&1 | %filecheck %s
+RUN: %link --about 2>&1 | %filecheck %s -check-prefix=ABOUT
 
-CHECK: Supported Targets:
-CHECK: Linker Plugin Interface Version {{[[:xdigit:]]+}}.{{[[:xdigit:]]+}}
+#CHECK: eld {{.*}} (GNU Compatible linker)
+#ABOUT: Linker Plugin Interface Version {{[[:xdigit:]]+}}.{{[[:xdigit:]]+}}


### PR DESCRIPTION
add information in version dump that a build system can identify if eld is being used.

Also add --about option that can add additional details beyond just version information.

Fixes (#138)