### PR TITLE
Revert "[ci] improve checkin workflow"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,22 +1,13 @@
 name: CI
 
-# dont start the job if there are changes only to .md files or docs
-on:
-  push:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-  pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
+on: [pull_request]
 
 jobs:
   build:
     runs-on: self-hosted
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     permissions:
       contents: write
       statuses: write
@@ -115,3 +106,4 @@ jobs:
     - name: Cleanup build directory
       run: |
         rm -rf pr-${{ github.event.number }}
+


### PR DESCRIPTION
This reverts commit 44649bf370f6983b0b5741040fe8b1ea917f8402.

This is causing some intermittent yaml parsing issues with the ci workflow.