### PR TITLE
[RISCV] Fix ANDES Vendor Issue

### DIFF
--- a/lib/Target/RISCV/RISCVRelocationInternal.h
+++ b/lib/Target/RISCV/RISCVRelocationInternal.h
@@ -74,6 +74,9 @@ enum : uint32_t {
   QUALCOMMVendorRelocationOffset =
       FirstQUALCOMMVendorRelocation - FirstNonstandardRelocation,
 
+  /* We don't support ANDES vendor relocations */
+  ANDESVendorRelocationOffset = 0,
+
 #define ELF_RISCV_NONSTANDARD_RELOC(vendor_symbol, name, value)                \
   name = value + vendor_symbol##VendorRelocationOffset,
 #include "llvm/BinaryFormat/ELFRelocs/RISCV_nonstandard.def"


### PR DESCRIPTION
Upstream landed llvm/llvm-project#137748 (commit
a05393a879b2950fccca66ff0e1b6c70c39838e4) which added more vendor relocations, this time for ANDES.

ELD does not support ANDES vendor relocations, so this just adds the offset member used by the ELF_RISCV_NONSTANDARD_RELOC macro until I can land the refactors to make each vendor's relocations opt-in.