### PR TITLE
Fix DT_NEEDED entry for shared libs without SO name

### DIFF
--- a/include/eld/Input/ELFDynObjectFile.h
+++ b/include/eld/Input/ELFDynObjectFile.h
@@ -33,6 +33,8 @@ public:
 
   virtual ~ELFDynObjectFile() {}
 
+  std::string getFallbackSOName() const;
+
 private:
   std::vector<ELFSection *> Sections;
 };

--- a/lib/Input/ELFDynObjectFile.cpp
+++ b/lib/Input/ELFDynObjectFile.cpp
@@ -20,3 +20,13 @@ bool ELFDynObjectFile::isELFNeeded() {
     return true;
   return isUsed();
 }
+
+std::string ELFDynObjectFile::getFallbackSOName() const {
+  Input *I = getInput();
+  if (!getInput()->isNamespec())
+    return I->getResolvedPath().native();
+  const auto &filename = I->getFileName();
+  if (filename[0] == ':')
+    return filename.substr(1);
+  return I->getResolvedPath().filename().native();
+}

--- a/lib/Readers/DynamicELFReader.cpp
+++ b/lib/Readers/DynamicELFReader.cpp
@@ -116,9 +116,7 @@ eld::Expected<bool> DynamicELFReader<ELFT>::readDynamic() {
 
   // if there is no SONAME in .dynamic, then set it from input path
   if (!hasSOName)
-    dynObjFile->setSOName(
-        this->m_InputFile.getInput()->getResolvedPath().filename().native());
-
+    dynObjFile->setSOName(dynObjFile->getFallbackSOName());
   return true;
 }
 

--- a/test/Common/standalone/DTNeededWithoutSOName/DTNeededWithoutSOName.test
+++ b/test/Common/standalone/DTNeededWithoutSOName/DTNeededWithoutSOName.test
@@ -1,0 +1,22 @@
+#---DTNeededWithoutSOName.test--------------------------- Executable,SharedLibrary ---#
+#BEGIN_COMMENT
+# This test checks that the DT_NEEDED entry is correct for the shared libraries
+# without SOName.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -fPIC
+RUN: %clang %clangopts -o %t1.main.o %p/Inputs/main.c -c
+RUN: %mkdir %t1/a/b
+RUN: %link %linkopts -o %t1/a/b/lib1.so %t1.1.o -shared
+RUN: %link %linkopts -o %t1.main.out -dy %t1.main.o %t1/a/b/lib1.so
+RUN: %readelf -d %t1.main.out | %filecheck %s --check-prefix ABSOLUTE
+RUN: %link %linkopts -o %t1.main.namespec.out -dy %t1.main.o -L %t1/a -l:b/lib1.so
+RUN: %readelf -d %t1.main.namespec.out | %filecheck %s --check-prefix NAMESPEC
+RUN: cd %t1/a
+RUN: %link %linkopts -o %t1.main.relative.out -dy %t1.main.o b/lib1.so
+RUN: %readelf -d %t1.main.relative.out | %filecheck %s --check-prefix RELATIVE
+#END_TEST
+
+ABSOLUTE: (NEEDED) Shared library: [{{.*}}a/b/lib1.so]
+NAMESPEC: (NEEDED) Shared library: [b/lib1.so]
+RELATIVE: (NEEDED) Shared library: [b/lib1.so]

--- a/test/Common/standalone/DTNeededWithoutSOName/Inputs/1.c
+++ b/test/Common/standalone/DTNeededWithoutSOName/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/Common/standalone/DTNeededWithoutSOName/Inputs/main.c
+++ b/test/Common/standalone/DTNeededWithoutSOName/Inputs/main.c
@@ -1,0 +1,5 @@
+int foo();
+
+int main() {
+  return foo();
+}


### PR DESCRIPTION
This commit fixes DT_NEEDED entry value for shared libs without SO name. We were emitting the shared library basename as DT_NEEDED entry when SO name was not available. We should instead emit the shared library path that is passed to the linker.

Closes #180
Closes #184 