### PR TITLE
Correctly set hasOutputSection property of output section plugin cmd

### DIFF
--- a/lib/ScriptParser/ScriptParser.cpp
+++ b/lib/ScriptParser/ScriptParser.cpp
@@ -743,6 +743,8 @@ OutputSectDesc::Prolog ScriptParser::readOutputSectDescPrologue() {
 
     if (!Prologue.PluginCmd)
       Prologue.PluginCmd = readOutputSectionPluginDirective();
+    if (Prologue.PluginCmd)
+      Prologue.PluginCmd->setHasOutputSection();
   }
 
   expect(":");

--- a/test/Common/Plugin/BasicLinkerScriptGenerator/BasicLinkerScriptGenerator.test
+++ b/test/Common/Plugin/BasicLinkerScriptGenerator/BasicLinkerScriptGenerator.test
@@ -6,6 +6,7 @@
 #START_TEST
 RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
 RUN: %link %linkopts -o %t1.1.out %t1.1.o -L%libsdir/test -T %p/Inputs/script.t 2>&1 | %filecheck %s
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -L%libsdir/test -T %p/Inputs/script.OutputSectionPlugin.t 2>&1 | %filecheck %s --check-prefix OUTSECT_PLUGIN
 #END_TEST
 #CHECK: SECTIONS {
 #CHECK:   .foo : {
@@ -26,3 +27,17 @@ RUN: %link %linkopts -o %t1.1.out %t1.1.o -L%libsdir/test -T %p/Inputs/script.t 
 #CHECK:     SQUAD (0xefef)
 #CHECK:   }
 #CHECK: }
+
+OUTSECT_PLUGIN: SECTIONS {
+OUTSECT_PLUGIN:   .foo PLUGIN_CONTROL_MEMSZ("copy", "COPYBLOCKS", "G0") : {
+OUTSECT_PLUGIN:     *(*foo*)
+OUTSECT_PLUGIN:   }
+OUTSECT_PLUGIN:   .bar : {
+OUTSECT_PLUGIN:     *(*bar*)
+OUTSECT_PLUGIN:   }
+OUTSECT_PLUGIN:   .baz : {
+OUTSECT_PLUGIN:     *(*baz*)
+OUTSECT_PLUGIN:   }
+OUTSECT_PLUGIN: }
+OUTSECT_PLUGIN: LINKER_PLUGIN("BasicLinkerScriptGenerator", "BasicLinkerScriptGenerator");
+OUTSECT_PLUGIN-NOT: PLUGIN_CONTROL_MEMSZ

--- a/test/Common/Plugin/BasicLinkerScriptGenerator/Inputs/script.OutputSectionPlugin.t
+++ b/test/Common/Plugin/BasicLinkerScriptGenerator/Inputs/script.OutputSectionPlugin.t
@@ -1,0 +1,7 @@
+SECTIONS {
+  .foo PLUGIN_CONTROL_MEMSZ("copy","COPYBLOCKS", "G0") : { *(*foo*) }
+  .bar : { *(*bar*) }
+  .baz : { *(*baz*) }
+}
+
+LINKER_PLUGIN("BasicLinkerScriptGenerator", "BasicLinkerScriptGenerator")


### PR DESCRIPTION
This commit sets the hasOutputSection property for output section plugin commands. Previously, this property was not being set and it was causing non-top level commands being returned from
`plugin::LinkerScript::getLinkerScriptCommands`.

Closes #186