### PR TITLE
Fix incorrect call to `Linker::emit()` with `-emit-timing-stats-in-output` flag

### DIFF
--- a/lib/Core/Linker.cpp
+++ b/lib/Core/Linker.cpp
@@ -207,7 +207,6 @@ bool Linker::link() {
     eld::RegisterTimer F("Emit output file", "Link Summary",
                          ThisConfig->options().printTimingStats());
     if (ThisConfig->options().getInsertTimingStats()) {
-      emit();
       TimingSectionTimer->stopTimer();
       uint64_t DurationMicro =
           TimingSectionTimer->getTotalTime().getWallTime() * 1000000;


### PR DESCRIPTION
This patch aims to fix an extra incorrect call to `Linker::emit()` when the `emit-timing-stats-in-output` flag is used.

Resolves #75