### PR TITLE
Fix x86_64 default image base

### DIFF
--- a/lib/Target/x86_64/x86_64StandaloneInfo.h
+++ b/lib/Target/x86_64/x86_64StandaloneInfo.h
@@ -19,7 +19,7 @@ public:
 
   uint64_t startAddr(bool linkerScriptHasSectionsCmd, bool isDynExec,
                      bool loadPhdr) const override {
-    return 0;
+    return 0x400000;
   }
   void initializeAttributes(InputBuilder &pBuilder) override {
     pBuilder.makeBStatic();

--- a/test/x86_64/linux/DefaultImageBase/DefaultImageBase.test
+++ b/test/x86_64/linux/DefaultImageBase/DefaultImageBase.test
@@ -1,0 +1,18 @@
+#---DefaultImageBase.test-----Executable--------#
+
+BEGIN_COMMENT
+# Test x86_64 default image address
+# This test verifies that eld uses the correct default image base (0x400000)
+# without requiring manual --image-base=0x400000 flag.
+#END_COMMENT
+
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.1.o
+RUN: %link %linkopts -o %t.1.out %t.1.o
+RUN: %t.1.out; echo $? > %t.code
+RUN: %filecheck --input-file=%t.code %s --check-prefix=EXITCODE
+RUN: readelf -l %t.1.out | grep LOAD | head -1 > %t.load
+RUN: %filecheck --input-file=%t.load %s --check-prefix=IMAGEBASE
+EXITCODE: 7
+IMAGEBASE: {{.*}}400000{{.*}}
+#END_TEST

--- a/test/x86_64/linux/DefaultImageBase/Inputs/1.c
+++ b/test/x86_64/linux/DefaultImageBase/Inputs/1.c
@@ -1,0 +1,11 @@
+void _start() {
+  long u = 7;
+  asm (
+    "movq $60, %%rax\n"
+    "movq %0, %%rdi\n"
+    "syscall\n"
+    :
+    : "r" (u)
+    : "%rax", "%rdi"
+  );
+}


### PR DESCRIPTION
Change the default image base from 0x0 to 0x400000 for x86_64 as x86_64 cannot load executables at address 0x0.
Add test case to verify the default image base is 0x400000 now.