### PR TITLE
 Add R_X86_64_PLT32 static relocation support

### DIFF
--- a/lib/Target/x86_64/x86_64RelocationFunctions.h
+++ b/lib/Target/x86_64/x86_64RelocationFunctions.h
@@ -21,6 +21,8 @@ x86_64Relocator::Result relocPCREL(Relocation &pEntry, x86_64Relocator &pParent,
                                    RelocationDescription &RelocDesc);
 x86_64Relocator::Result relocAbs(Relocation &pEntry, x86_64Relocator &pParent,
                                  RelocationDescription &RelocDesc);
+x86_64Relocator::Result relocPLT32(Relocation &pEntry, x86_64Relocator &pParent,
+                                   RelocationDescription &RelocDesc);
 x86_64Relocator::Result unsupport(Relocation &pEntry, x86_64Relocator &pParent,
                                   RelocationDescription &RelocDesc);
 
@@ -56,7 +58,7 @@ struct RelocationDescription x86RelocDesc[] = {
     {/*.func = */ none,
      /*.type = */ llvm::ELF::R_X86_64_GOT32,
      /*.forceVerify = */ false},
-    {/*.func = */ none,
+    {/*.func = */ &relocPLT32,
      /*.type = */ llvm::ELF::R_X86_64_PLT32,
      /*.forceVerify = */ false},
     {/*.func = */ none,

--- a/lib/Target/x86_64/x86_64Relocator.cpp
+++ b/lib/Target/x86_64/x86_64Relocator.cpp
@@ -346,6 +346,28 @@ Relocator::Result eld::relocPCREL(Relocation &pReloc, x86_64Relocator &pParent,
   return applyRel(pReloc, Result, pRelocDesc, DiagEngine, options);
 }
 
+Relocator::Result eld::relocPLT32(Relocation &pReloc, x86_64Relocator &pParent,
+                                  RelocationDescription &pRelocDesc) {
+
+  DiagnosticEngine *DiagEngine = pParent.config().getDiagEngine();
+  Relocator::Address S = pReloc.symValue(pParent.module());
+  Relocator::DWord A = pReloc.addend();
+  Relocator::DWord P = pReloc.place(pParent.module());
+  const GeneralOptions &options = pParent.config().options();
+
+  FragmentRef *target_fragref = pReloc.targetRef();
+  Fragment *target_frag = target_fragref->frag();
+  ELFSection *target_sect = target_frag->getOutputELFSection();
+
+  // Static Linking : PLT32 behaves as PC32
+  Relocator::Address Result = S + A - P;
+
+  if (!target_sect->isAlloc()) {
+    return applyRel(pReloc, Result, pRelocDesc, DiagEngine, options);
+  }
+  return applyRel(pReloc, Result, pRelocDesc, DiagEngine, options);
+}
+
 Relocator::Result eld::unsupport(Relocation &pReloc, x86_64Relocator &pParent,
                                  RelocationDescription &pRelocDesc) {
   return x86_64Relocator::Unsupport;

--- a/lib/Target/x86_64/x86_64StandaloneInfo.h
+++ b/lib/Target/x86_64/x86_64StandaloneInfo.h
@@ -19,7 +19,7 @@ public:
 
   uint64_t startAddr(bool linkerScriptHasSectionsCmd, bool isDynExec,
                      bool loadPhdr) const override {
-    return 0;
+    return 0x400000;
   }
   void initializeAttributes(InputBuilder &pBuilder) override {
     pBuilder.makeBStatic();

--- a/test/x86_64/linux/DefaultImageBase/DefaultImageBase.test
+++ b/test/x86_64/linux/DefaultImageBase/DefaultImageBase.test
@@ -1,0 +1,18 @@
+#---DefaultImageBase.test-----Executable--------#
+
+BEGIN_COMMENT
+# Test x86_64 default image address
+# This test verifies that eld uses the correct default image base (0x400000)
+# without requiring manual --image-base=0x400000 flag.
+#END_COMMENT
+
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.1.o
+RUN: %link %linkopts -o %t.1.out %t.1.o
+RUN: %t.1.out; echo $? > %t.code
+RUN: %filecheck --input-file=%t.code %s --check-prefix=EXITCODE
+RUN: readelf -l %t.1.out | grep LOAD | head -1 > %t.load
+RUN: %filecheck --input-file=%t.load %s --check-prefix=IMAGEBASE
+EXITCODE: 7
+IMAGEBASE: {{.*}}400000{{.*}}
+#END_TEST

--- a/test/x86_64/linux/DefaultImageBase/Inputs/1.c
+++ b/test/x86_64/linux/DefaultImageBase/Inputs/1.c
@@ -1,0 +1,11 @@
+void _start() {
+  long u = 7;
+  asm (
+    "movq $60, %%rax\n"
+    "movq %0, %%rdi\n"
+    "syscall\n"
+    :
+    : "r" (u)
+    : "%rax", "%rdi"
+  );
+}

--- a/test/x86_64/linux/relocPLT32Static/Inputs/relocPLT32_test.c
+++ b/test/x86_64/linux/relocPLT32Static/Inputs/relocPLT32_test.c
@@ -1,0 +1,15 @@
+int foo() { return 11; }
+
+int val = 2;
+
+void _start() {
+  long u = foo() + val;
+  asm (
+    "movq $60, %%rax\n"
+    "movq %0, %%rdi\n"
+    "syscall\n"
+    :
+    : "r" (u)
+    : "%rax", "%rdi"
+  );
+}

--- a/test/x86_64/linux/relocPLT32Static/relocPLT32Static.test
+++ b/test/x86_64/linux/relocPLT32Static/relocPLT32Static.test
@@ -1,0 +1,14 @@
+#--PLT32Static.test----------Executable--------#
+
+BEGIN_COMMENT
+# Test x86_64 R_X86_64_PLT32 relocation type support in static linking.
+#END_COMMENT
+
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/relocPLT32_test.c -o %t.relocPLT32_test.o
+RUN: %link %linkopts -o %t.relocPLT32_test.out %t.relocPLT32_test.o
+RUN: %t.relocPLT32_test.out; echo $? > %t.code
+RUN: cat %t.code
+RUN: %filecheck --input-file=%t.code %s --check-prefix=EXITCODE
+EXITCODE: 13
+#END_TEST


### PR DESCRIPTION
 Implement R_X86_64_PLT32 relocation handling for static linking using PC-relative calculations.
Add test case to verify correct working of the implementation.