### PR TITLE
Improve mapping utility functions

### DIFF
--- a/include/eld/Config/LinkerConfig.h
+++ b/include/eld/Config/LinkerConfig.h
@@ -200,17 +200,9 @@ public:
     PathToHash[Name] = Hash;
   }
 
-  // FIXME: parameter name is confusing here. Why the parameter name is filename
-  // in the function named 'getFileFromHash'. Shouldn't the parameter name be
-  // 'hash'?
-  // FIXME: const in return type is redundant and can inhibit optimizations.
-  const std::string getFileFromHash(const std::string &FileName) const;
+  std::string getFileFromHash(const std::string &Hash) const;
 
-  // FIXME: parameter name is confusing here. Why the parameter name is hash in
-  // the function named 'getHashFromFile'. Shouldn't the parameter name be
-  // 'filename' here?
-  // FIXME: const in return type is redundant and can inhibit optimizations.
-  const std::string getHashFromFile(const std::string &Hash) const;
+  std::string getHashFromFile(const std::string &FileName) const;
 
   bool hasMappingForFile(const std::string &FileName) const {
     return PathToHash.find(FileName) != PathToHash.end();

--- a/lib/Config/LinkerConfig.cpp
+++ b/lib/Config/LinkerConfig.cpp
@@ -145,17 +145,17 @@ void LinkerConfig::printOptions(llvm::raw_ostream &Outs,
 
 const char *LinkerConfig::version() { return eld::getELDVersion().data(); }
 
-const std::string LinkerConfig::getFileFromHash(const std::string &Hash) const {
+std::string LinkerConfig::getFileFromHash(const std::string &Hash) const {
   const auto F = HashToPath.find(Hash);
   if (F == HashToPath.end())
     return Hash;
   return F->second;
 }
 
-const std::string LinkerConfig::getHashFromFile(const std::string &File) const {
-  const auto H = PathToHash.find(File);
+std::string LinkerConfig::getHashFromFile(const std::string &FileName) const {
+  const auto H = PathToHash.find(FileName);
   if (H == PathToHash.end())
-    return File;
+    return FileName;
   return H->second;
 }
 


### PR DESCRIPTION
This patch aims to fix misleading parameter names in two mapping utility `LinkerConfig::getHashFromFile()` and `LinkerConfig::getFileFromHash` as well as remove an extra const attached to the return type of these functions which could have inhibited some optimizations.