### PR TITLE
[RISCV] Implement Xqci Call Relaxations

### DIFF
--- a/lib/Target/RISCV/RISCVLDBackend.h
+++ b/lib/Target/RISCV/RISCVLDBackend.h
@@ -197,8 +197,8 @@ private:
 
   bool isGOTReloc(Relocation *reloc) const;
 
-  bool doRelaxationCall(Relocation *R, bool DoCompressed);
-  bool doRelaxationQCCall(Relocation *R, bool DoCompressed);
+  bool doRelaxationCall(Relocation *R);
+  bool doRelaxationQCCall(Relocation *R);
 
   bool doRelaxationLui(Relocation *R, Relocation::DWord G);
   bool doRelaxationQCLi(Relocation *R, Relocation::DWord G);

--- a/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_CJ/AUIPC_JALR_TO_CJ.test
+++ b/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_CJ/AUIPC_JALR_TO_CJ.test
@@ -22,8 +22,8 @@ VERBOSE_RELAX: RISCV_CALL_C : Deleting 6 bytes for symbol 'foo' in section .text
 DUMP_RELAX: b011         j 0x{{[0-9a-f]+}} <foo>
 
 ## The third jump is never compressed because it's too far
-VERBOSE_RELAX: RISCV_CALL_C : Cannot relax 2 bytes for symbol 'foo' in section .text+0xff6 file {{.*}}.o
 VERBOSE_RELAX: RISCV_CALL : Deleting 4 bytes for symbol 'foo' in section .text+0xffa file {{.*}}.o
+VERBOSE_RELAX: RISCV_CALL_C : Cannot relax 2 bytes for symbol 'foo' in section .text+0xff6 file {{.*}}.o
 DUMP_RELAX: 80aff06f   j 0x{{[0-9a-f]+}} <foo>
 
 RUN: %link %linkopts %t.o -o %t.2.out --verbose --no-relax 2>&1 | %filecheck %s --check-prefix=VERBOSE_NORELAX

--- a/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL/AUIPC_JALR_TO_JAL_RV32.test
+++ b/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL/AUIPC_JALR_TO_JAL_RV32.test
@@ -12,10 +12,10 @@ VERBOSE_RELAX_C: RISCV_CALL_JAL : relaxing instruction 0x00000097,000080e7 to co
 VERBOSE_RELAX_C: RISCV_CALL_C : Deleting 6 bytes for symbol 'f' in section .text+0x4 file {{.*}}.o
 VERBOSE_RELAX_C: RISCV_CALL_JAL : relaxing instruction 0x00000097,000080e7 to compressed instruction 0x2001 for symbol f in section .text+0x77A file {{.*}}.o
 VERBOSE_RELAX_C: RISCV_CALL_C : Deleting 6 bytes for symbol 'f' in section .text+0x77c file {{.*}}.o
-VERBOSE_RELAX_C: RISCV_CALL_C : Cannot relax 2 bytes for symbol 'f' in section .text+0x874 file {{.*}}.o
 VERBOSE_RELAX_C: RISCV_CALL : Deleting 4 bytes for symbol 'f' in section .text+0x878 file {{.*}}.o
-VERBOSE_RELAX_C: RISCV_CALL_C : Cannot relax 2 bytes for symbol 'f' in section .text+0xffef0 file {{.*}}.o
+VERBOSE_RELAX_C: RISCV_CALL_C : Cannot relax 2 bytes for symbol 'f' in section .text+0x874 file {{.*}}.o
 VERBOSE_RELAX_C: RISCV_CALL : Deleting 4 bytes for symbol 'f' in section .text+0xffef4 file {{.*}}.o
+VERBOSE_RELAX_C: RISCV_CALL_C : Cannot relax 2 bytes for symbol 'f' in section .text+0xffef0 file {{.*}}.o
 VERBOSE_RELAX_C: RISCV_CALL : Cannot relax 6 bytes for symbol 'f' in section .text+0x1000ec file {{.*}}.o
 
 RUN: %objdump -d %t.1.out 2>&1 | %filecheck %s --check-prefix=DUMP_RELAX_C

--- a/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL/AUIPC_JALR_TO_JAL_RV64.test
+++ b/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL/AUIPC_JALR_TO_JAL_RV64.test
@@ -12,7 +12,7 @@ VERBOSE_RELAX_C: RISCV_CALL : Deleting 4 bytes for symbol 'f' in section .text+0
 VERBOSE_RELAX_C: RISCV_CALL : Deleting 4 bytes for symbol 'f' in section .text+0x780 file {{.*}}.o
 VERBOSE_RELAX_C: RISCV_CALL : Deleting 4 bytes for symbol 'f' in section .text+0x87c file {{.*}}.o
 VERBOSE_RELAX_C: RISCV_CALL : Deleting 4 bytes for symbol 'f' in section .text+0xffef8 file {{.*}}.o
-VERBOSE_RELAX_C: RISCV_CALL : Cannot relax 4 bytes for symbol 'f' in section .text+0x1000f0 file {{.*}}.o
+VERBOSE_RELAX_C: RISCV_CALL : Cannot relax 6 bytes for symbol 'f' in section .text+0x1000f0 file {{.*}}.o
 VERBOSE_RELAX_C-NOT: Cannot relax
 
 RUN: %objdump -d %t.1.out 2>&1 | %filecheck %s --check-prefix=DUMP_RELAX_C
@@ -26,25 +26,27 @@ DUMP_RELAX_C: f10080e7  jalr
 RUN: %filecheck %s --input-file=%t.1.map --check-prefix=MAP_RELAX_C
 MAP_RELAX_C: # LinkStats Begin
 MAP_RELAX_C: # RelaxationBytesDeleted : 16
-MAP_RELAX_C: # RelaxationBytesMissed : 4
+MAP_RELAX_C: # RelaxationBytesMissed : 14
 MAP_RELAX_C: # LinkStats End
 
 MAP_RELAX_C: .text {{.+}}, Alignment: 0x2, Flags: SHF_ALLOC|SHF_EXECINSTR, Type: SHT_PROGBITS
 MAP_RELAX_C: # RelaxationBytesDeleted : 16
-MAP_RELAX_C: # RelaxationBytesMissed : 4
+MAP_RELAX_C: # RelaxationBytesMissed : 14
 MAP_RELAX_C: .text {{.+}}.o     #SHT_PROGBITS,SHF_ALLOC|SHF_EXECINSTR,2
 
 # Only non-compressed relaxations are enabled.
 RUN: %link %linkopts --no-relax-c %t.o -o %t.2.out -MapStyle txt -Map %t.2.map --verbose 2>&1 | %filecheck %s --check-prefix=VERBOSE_RELAX
-VERBOSE_RELAX: RISCV_CALL : Cannot relax 4 bytes for symbol 'f' in section .text+0x1000f0 file {{.*}}.o
+VERBOSE_RELAX: RISCV_CALL : Cannot relax 6 bytes for symbol 'f' in section .text+0x1000f0 file {{.*}}.o
 
 RUN: %filecheck %s --input-file=%t.2.map --check-prefix=MAP_RELAX
 MAP_RELAX: # LinkStats Begin
-MAP_RELAX: # RelaxationBytesMissed : 4
+MAP_RELAX: # RelaxationBytesDeleted : 16
+MAP_RELAX: # RelaxationBytesMissed : 14
 MAP_RELAX: # LinkStats End
 
 MAP_RELAX: .text {{.+}}, Alignment: 0x2, Flags: SHF_ALLOC|SHF_EXECINSTR, Type: SHT_PROGBITS
-MAP_RELAX: # RelaxationBytesMissed : 4
+MAP_RELAX: # RelaxationBytesDeleted : 16
+MAP_RELAX: # RelaxationBytesMissed : 14
 MAP_RELAX: .text {{.+}}.o     #SHT_PROGBITS,SHF_ALLOC|SHF_EXECINSTR,2
 
 ### Relaxations are disabled.
@@ -52,9 +54,9 @@ RUN: %link %linkopts --no-relax %t.o -o %t.3.out -MapStyle txt -Map %t.3.map
 
 RUN: %filecheck %s --input-file=%t.3.map --check-prefix=MAP_NORELAX
 MAP_NORELAX: # LinkStats Begin
-MAP_NORELAX: # RelaxationBytesMissed : 20
+MAP_NORELAX: # RelaxationBytesMissed : 30
 MAP_NORELAX: # LinkStats End
 
 MAP_NORELAX: .text {{.+}}, Alignment: 0x2, Flags: SHF_ALLOC|SHF_EXECINSTR, Type: SHT_PROGBITS
-MAP_NORELAX: # RelaxationBytesMissed : 20
+MAP_NORELAX: # RelaxationBytesMissed : 30
 MAP_NORELAX: .text {{.+}}.o     #SHT_PROGBITS,SHF_ALLOC|SHF_EXECINSTR,2

--- a/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_XQCI/AUIPC_JALR_TO_XQCI.test
+++ b/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_XQCI/AUIPC_JALR_TO_XQCI.test
@@ -1,0 +1,101 @@
+#----------AUIPC_JALR_TO_XQCI.test----------------- Executable------------------#
+#BEGIN_COMMENT
+# Do relaxation based from AUIPC/JALR to Xqci QC.E.JAL/QC.E.J (rv32 only)
+#END_COMMENT
+#--------------------------------------------------------------------
+# REQUIRES: riscv32
+RUN: %clang %clangopts -c %p/Inputs/x.s -o %t.o -march=rv32gc_xqcilb0p2 -menable-experimental-extensions
+
+# Xqci Relaxations are enabled
+RUN: %link %linkopts --relax-xqci %t.o -o %t.1.out -MapStyle txt -Map %t.1.map --verbose 2>&1 | %filecheck %s --check-prefix=VERBOSE
+VERBOSE: RISCV_CALL_JAL : relaxing instruction 0x00000097,000080e7 to compressed instruction 0x2001 for symbol f in section .text+0x2 file {{.*}}.o
+VERBOSE: RISCV_CALL_C : Deleting 6 bytes for symbol 'f' in section .text+0x4 file {{.*}}.o
+VERBOSE: RISCV_CALL_J : relaxing instruction 0x00000317,00030067 to compressed instruction 0xa001 for symbol f in section .text+0x4 file {{.*}}.o
+VERBOSE: RISCV_CALL_C : Deleting 6 bytes for symbol 'f' in section .text+0x6 file {{.*}}.o
+VERBOSE: RISCV_CALL_JAL : relaxing instruction 0x00000097,000080e7 to compressed instruction 0x2001 for symbol f in section .text+0x774 file {{.*}}.o
+VERBOSE: RISCV_CALL_C : Deleting 6 bytes for symbol 'f' in section .text+0x776 file {{.*}}.o
+VERBOSE: RISCV_CALL_J : relaxing instruction 0x00000317,00030067 to compressed instruction 0xa001 for symbol f in section .text+0x776 file {{.*}}.o
+VERBOSE: RISCV_CALL_C : Deleting 6 bytes for symbol 'f' in section .text+0x778 file {{.*}}.o
+VERBOSE: RISCV_CALL : Deleting 4 bytes for symbol 'f' in section .text+0x86c file {{.*}}.o
+VERBOSE: RISCV_CALL_C : Cannot relax 2 bytes for symbol 'f' in section .text+0x868 file {{.*}}.o
+VERBOSE: RISCV_CALL : Deleting 4 bytes for symbol 'f' in section .text+0x870 file {{.*}}.o
+VERBOSE: RISCV_CALL_C : Cannot relax 2 bytes for symbol 'f' in section .text+0x86c file {{.*}}.o
+VERBOSE: RISCV_CALL : Deleting 4 bytes for symbol 'f' in section .text+0xffee4 file {{.*}}.o
+VERBOSE: RISCV_CALL_C : Cannot relax 2 bytes for symbol 'f' in section .text+0xffee0 file {{.*}}.o
+VERBOSE: RISCV_CALL : Deleting 4 bytes for symbol 'f' in section .text+0xffee8 file {{.*}}.o
+VERBOSE: RISCV_CALL_C : Cannot relax 2 bytes for symbol 'f' in section .text+0xffee4 file {{.*}}.o
+VERBOSE: R_RISCV_CALL_QC_E_JAL : Deleting 2 bytes for symbol 'f' in section .text+0x1000de file {{.*}}.o
+VERBOSE: R_RISCV_CALL_QC_E_JAL : Cannot relax 4 bytes for symbol 'f' in section .text+0x1000d8 file {{.*}}.o
+VERBOSE: R_RISCV_CALL_QC_E_J : Deleting 2 bytes for symbol 'f' in section .text+0x1000e4 file {{.*}}.o
+VERBOSE: R_RISCV_CALL_QC_E_J : Cannot relax 4 bytes for symbol 'f' in section .text+0x1000de file {{.*}}.o
+
+RUN: %objdump -d %t.1.out -M no-aliases 2>&1 | %filecheck %s --check-prefix=DUMP
+DUMP: 3ffd c.jal 0x74 <f>
+DUMP: bff5 c.j 0x74 <f>
+DUMP: 3071 c.jal 0x74 <f>
+DUMP: b069 c.j 0x74 <f>
+DUMP: f98ff0ef jal ra, 0x74 <f>
+DUMP: f94ff06f jal zero, 0x74 <f>
+DUMP: 920000ef jal ra, 0x74 <f>
+DUMP: 91c0006f jal zero, 0x74 <f>
+DUMP: c49f f20e ffef qc.e.jal 0x74 <f>
+DUMP: 419f f20e ffef qc.e.j 0x74 <f>
+
+RUN: %filecheck %s --input-file=%t.1.map --check-prefix=MAP
+
+MAP: # LinkStats Begin
+MAP: # RelaxationBytesDeleted : 44
+MAP: # RelaxationBytesMissed : 16
+MAP: # LinkStats End
+
+MAP: .text {{.+}}, Alignment: 0x2, Flags: SHF_ALLOC|SHF_EXECINSTR, Type: SHT_PROGBITS
+MAP: # RelaxationBytesDeleted : 44
+MAP: # RelaxationBytesMissed : 16
+MAP: .text {{.+}}.o     #SHT_PROGBITS,SHF_ALLOC|SHF_EXECINSTR,2
+
+# Xqci relaxations are disabled
+RUN: %link %linkopts --no-relax-xqci %t.o -o %t.2.out -MapStyle txt -Map %t.2.map --verbose 2>&1 | %filecheck %s --check-prefix=VERBOSE_NOXQCI
+VERBOSE_NOXQCI: RISCV_CALL_JAL : relaxing instruction 0x00000097,000080e7 to compressed instruction 0x2001 for symbol f in section .text+0x2 file {{.*}}.o
+VERBOSE_NOXQCI: RISCV_CALL_C : Deleting 6 bytes for symbol 'f' in section .text+0x4 file {{.*}}.o
+VERBOSE_NOXQCI: RISCV_CALL_J : relaxing instruction 0x00000317,00030067 to compressed instruction 0xa001 for symbol f in section .text+0x4 file {{.*}}.o
+VERBOSE_NOXQCI: RISCV_CALL_C : Deleting 6 bytes for symbol 'f' in section .text+0x6 file {{.*}}.o
+VERBOSE_NOXQCI: RISCV_CALL_JAL : relaxing instruction 0x00000097,000080e7 to compressed instruction 0x2001 for symbol f in section .text+0x774 file {{.*}}.o
+VERBOSE_NOXQCI: RISCV_CALL_C : Deleting 6 bytes for symbol 'f' in section .text+0x776 file {{.*}}.o
+VERBOSE_NOXQCI: RISCV_CALL_J : relaxing instruction 0x00000317,00030067 to compressed instruction 0xa001 for symbol f in section .text+0x776 file {{.*}}.o
+VERBOSE_NOXQCI: RISCV_CALL_C : Deleting 6 bytes for symbol 'f' in section .text+0x778 file {{.*}}.o
+VERBOSE_NOXQCI: RISCV_CALL : Deleting 4 bytes for symbol 'f' in section .text+0x86c file {{.*}}.o
+VERBOSE_NOXQCI: RISCV_CALL_C : Cannot relax 2 bytes for symbol 'f' in section .text+0x868 file {{.*}}.o
+VERBOSE_NOXQCI: RISCV_CALL : Deleting 4 bytes for symbol 'f' in section .text+0x870 file {{.*}}.o
+VERBOSE_NOXQCI: RISCV_CALL_C : Cannot relax 2 bytes for symbol 'f' in section .text+0x86c file {{.*}}.o
+VERBOSE_NOXQCI: RISCV_CALL : Deleting 4 bytes for symbol 'f' in section .text+0xffee4 file {{.*}}.o
+VERBOSE_NOXQCI: RISCV_CALL_C : Cannot relax 2 bytes for symbol 'f' in section .text+0xffee0 file {{.*}}.o
+VERBOSE_NOXQCI: RISCV_CALL : Deleting 4 bytes for symbol 'f' in section .text+0xffee8 file {{.*}}.o
+VERBOSE_NOXQCI: RISCV_CALL_C : Cannot relax 2 bytes for symbol 'f' in section .text+0xffee4 file {{.*}}.o
+VERBOSE_NOXQCI: RISCV_CALL : Cannot relax 6 bytes for symbol 'f' in section .text+0x1000d8 file {{.*}}.o
+VERBOSE_NOXQCI: RISCV_CALL : Cannot relax 6 bytes for symbol 'f' in section .text+0x1000e0 file {{.*}}.o
+
+RUN: %objdump -d %t.2.out -M no-aliases 2>&1 | %filecheck %s --check-prefix=DUMP_NOXQCI
+DUMP_NOXQCI: 3ffd c.jal 0x74 <f>
+DUMP_NOXQCI: bff5 c.j 0x74 <f>
+DUMP_NOXQCI: 3071 c.jal 0x74 <f>
+DUMP_NOXQCI: b069 c.j 0x74 <f>
+DUMP_NOXQCI: f98ff0ef jal ra, 0x74 <f>
+DUMP_NOXQCI: f94ff06f jal zero, 0x74 <f>
+DUMP_NOXQCI: 920000ef jal ra, 0x74 <f>
+DUMP_NOXQCI: 91c0006f jal zero, 0x74 <f>
+DUMP_NOXQCI: fff00097 auipc ra, 0xfff00
+DUMP_NOXQCI: f28080e7 jalr ra, -0xd8(ra)
+DUMP_NOXQCI: fff00317 auipc t1, 0xfff00
+DUMP_NOXQCI: f2030067 jalr zero, -0xe0(t1)
+
+RUN: %filecheck %s --input-file=%t.2.map --check-prefix=MAP_NOXQCI
+
+MAP_NOXQCI: # LinkStats Begin
+MAP_NOXQCI: # RelaxationBytesDeleted : 40
+MAP_NOXQCI: # RelaxationBytesMissed : 20
+MAP_NOXQCI: # LinkStats End
+
+MAP_NOXQCI: .text {{.+}}, Alignment: 0x2, Flags: SHF_ALLOC|SHF_EXECINSTR, Type: SHT_PROGBITS
+MAP_NOXQCI: # RelaxationBytesDeleted : 40
+MAP_NOXQCI: # RelaxationBytesMissed : 20
+MAP_NOXQCI: .text {{.+}}.o     #SHT_PROGBITS,SHF_ALLOC|SHF_EXECINSTR,2

--- a/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_XQCI/Inputs/x.s
+++ b/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_XQCI/Inputs/x.s
@@ -1,0 +1,31 @@
+  .text
+  .p2align 1
+  .type f, @function
+f:
+  ret
+  .size f, .-f
+
+  .p2align 1
+  .globl main
+  .type main, @function
+main:
+  call f
+  tail f
+
+  .org 0x780
+  call f
+  tail f
+
+  .org 0x880
+  call f
+  tail f
+
+  .org 0xfff00
+  call f
+  tail f
+
+  .org 0x100100
+  call f
+  tail f
+
+  .size main, .-main

--- a/test/RISCV/standalone/Relaxation/HI20_LO12_I_TO_GP/HI20_LO12_I_TO_GP.test
+++ b/test/RISCV/standalone/Relaxation/HI20_LO12_I_TO_GP/HI20_LO12_I_TO_GP.test
@@ -16,10 +16,8 @@ CHECK: lw      a{{.*}}, 0(gp)
 RUN: %filecheck %s --input-file=%t.1.map --check-prefix=MAP
 MAP: # LinkStats Begin
 MAP: # RelaxationBytesDeleted : {{18|16}}
-MAP-NOT: # RelaxationBytesMissed
 MAP: # LinkStats End
 
 MAP: .text {{.+}}, Alignment: 0x2, Flags: SHF_ALLOC|SHF_EXECINSTR, Type: SHT_PROGBITS
 MAP: # RelaxationBytesDeleted : {{18|16}}
-MAP-NOT: # RelaxationBytesMissed
 MAP: .text {{.+}}.o     #SHT_PROGBITS,SHF_ALLOC|SHF_EXECINSTR,2


### PR DESCRIPTION
These relaxations are implemented as part of
RISCVLDBackend::doRelaxationCall as they apply to the same relocation/instructions.

The relaxations are:
- `AUIPC; JALR ra`   -> `QC.E.JAL`
- `AUIPC; JALR zero` -> `QC.E.J`

These respect the existing command-line switches which prevent these being applied when relaxations (or xqci relaxations) are disabled. This is particularly important in this case as standard instructions are replaced by custom Xqci instructions, which will fail to execute on most RISC-V implementations.

These relaxations are described in
http://github.com/quic/riscv-elf-psabi-quic-extensions/releases/latest

This continues the implementation of #147.

I also took the time to refactor `doRelaxationCall` to make the priority between relaxations clearer, and the verbose "relaxation missed" messages be emitted later, once we're surer the relaxation has been missed.