### PR TITLE
Fix crash on parsing ':ALIGN' in linker script

### DIFF
--- a/include/eld/Diagnostics/DiagLDScript.inc
+++ b/include/eld/Diagnostics/DiagLDScript.inc
@@ -128,3 +128,5 @@ DIAG(warn_memory_region_has_zero_size, DiagnosticEngine::Warning,
      "%0: Memory region '%1' has zero size")
 DIAG(error_empty_pt_tls_segment, DiagnosticEngine::Error,
       "TLS segments are empty")
+DIAG(internal_error_null_expression, DiagnosticEngine::InternalError,
+     "Trying to evaluate null expression")

--- a/include/eld/Script/Expression.h
+++ b/include/eld/Script/Expression.h
@@ -78,7 +78,8 @@ public:
     LOGICAL_AND,
     LOGICAL_OR,
     ORIGIN,
-    LENGTH
+    LENGTH,
+    NULLEXPR
   };
 
   Expression(std::string Name, Type Type, Module &Module, GNULDBackend &Backend,
@@ -182,6 +183,8 @@ public:
   bool isOrigin() const { return (ThisType == ORIGIN); }
 
   bool isLength() const { return (ThisType == LENGTH); }
+
+  bool isNullExpr() const { return ThisType == Expression::Type::NULLEXPR; }
 
   /// evaluateAndReturnError
   /// \brief Evaluate the expression, commit and return the value when
@@ -1503,6 +1506,25 @@ inline void alignAddress(uint64_t &PAddr, uint64_t AlignConstraint) {
   if (AlignConstraint != 0)
     PAddr = (PAddr + AlignConstraint - 1) & ~(AlignConstraint - 1);
 }
+
+/// NullExpression represents an invalid expression. It is used as a sentinel
+/// expression when the linker script parser fails to parse an expression.
+class NullExpression : public Expression {
+public:
+  NullExpression(Module &Module, GNULDBackend &Backend);
+
+  // Casting support
+  static bool classof(const Expression *Exp) { return Exp->isNullExpr(); }
+
+private:
+  bool hasDot() const override { return false; }
+  void dump(llvm::raw_ostream &Outs, bool WithValues = true) const override;
+  eld::Expected<uint64_t> evalImpl() override;
+  void getSymbols(std::vector<ResolveInfo *> &Symbols) override;
+  void getSymbolNames(std::unordered_set<std::string> &SymbolTokens) override;
+  Expression *getLeftExpression() const override { return nullptr; }
+  Expression *getRightExpression() const override { return nullptr; }
+};
 
 } // namespace eld
 

--- a/lib/Script/Expression.cpp
+++ b/lib/Script/Expression.cpp
@@ -5,6 +5,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "eld/Script/Expression.h"
+#include "DiagnosticEntry.h"
 #include "eld/Core/LinkerScript.h"
 #include "eld/Core/Module.h"
 #include "eld/Readers/ELFSection.h"
@@ -1748,4 +1749,24 @@ eld::Expected<uint64_t> QueryMemory::evalImpl() {
 void QueryMemory::getSymbols(std::vector<ResolveInfo *> &Symbols) {}
 
 void QueryMemory::getSymbolNames(
+    std::unordered_set<std::string> &SymbolTokens) {}
+
+//===----------------------------------------------------------------------===//
+/// NullExpression support
+NullExpression::NullExpression(Module &Module,
+                         GNULDBackend &Backend)
+    : Expression("[NULL]", Expression::Type::NULLEXPR, Module, Backend) {}
+
+void NullExpression::dump(llvm::raw_ostream &Outs, bool WithValues) const {
+  Outs << Name;
+}
+
+eld::Expected<uint64_t> NullExpression::evalImpl() {
+  return std::make_unique<plugin::DiagnosticEntry>(
+      Diag::internal_error_null_expression, std::vector<std::string>{});
+}
+
+void NullExpression::getSymbols(std::vector<ResolveInfo *> &Symbols) {}
+
+void NullExpression::getSymbolNames(
     std::unordered_set<std::string> &SymbolTokens) {}

--- a/lib/ScriptParser/ScriptParser.cpp
+++ b/lib/ScriptParser/ScriptParser.cpp
@@ -155,6 +155,17 @@ void ScriptParser::readEntry() {
 }
 
 eld::Expression *ScriptParser::readExpr() {
+  if (atEOF()) {
+    Module &Module = ThisScriptFile.module();
+    GNULDBackend &Backend = ThisScriptFile.backend();
+    // We do not return nullptr here because the returned expression is
+    // dereferenced at many places. We can add a null-pointer check everywhere,
+    // but that would impose issues if we want to extend the parser to continue
+    // parsing despite errors (the way we do with --no-inhibit-exec for overall
+    // linking). Adding checks everywhere would also violate the parser design
+    // to be able to continue parsing even after errors have occurred.
+    return make<NullExpression>(Module, Backend);
+  }
   // Our lexer is context-aware. Set the in-expression bit so that
   // they apply different tokenization rules.
   enum LexState Orig = LexState;

--- a/test/Common/standalone/linkerscript/ColonAlignWithoutSpaceError/ColonErrorWithoutSpaceError.test
+++ b/test/Common/standalone/linkerscript/ColonAlignWithoutSpaceError/ColonErrorWithoutSpaceError.test
@@ -1,0 +1,14 @@
+#---ColonErrorWithoutSpaceError.test----------------- Executable----------------#
+#BEGIN_COMMENT
+# Verify that the linker properly reports error on parsing ":ALIGN" in
+# an ouput section description.
+#END_COMMENT
+#START_TEST
+RUN: %touch %t1.1.o
+RUN: %not %link %linkopts %t1.1.o -T %p/Inputs/script.t 2>&1 | %filecheck %s --match-full-lines --strict-whitespace
+#END_TEST
+
+CHECK:Error: {{.*}}script.t:3: malformed number: :
+CHECK:>>>   S :ALIGN(4096) {}
+CHECK:>>>     ^
+

--- a/test/Common/standalone/linkerscript/ColonAlignWithoutSpaceError/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/ColonAlignWithoutSpaceError/Inputs/script.t
@@ -1,0 +1,4 @@
+SECTIONS
+{
+  S :ALIGN(4096) {}
+}


### PR DESCRIPTION
The linker was crashing due to stack overflow when parsing ':ALIGN' in an output section description. This commit fixes the linker script parser so that the crash does not happen.

The root cause of the stack overflow is how we parse expressions (readExpr) in linker script and the behavior of ScriptLexer::expect(...) utility. ScriptLexer::expect does not do anything if errors have already been encountered during linker script parsing. In particular, it never increments the current token position in the script file, even if the current token is the same as the expected token. This causes an infinite call cycle on parsing an expression such as '(4096)' when an error has already been encountered.

readExpr() calls readPrimary()
readPrimary() calls readParenExpr()

readParenExpr():

  expect("("); // no-op, current token still points to '('
  Expression *E = readExpr(); // The cycle continues...

Closes #202