### PR TITLE
Fix reproduce crash when input is passed through linkerscript

### DIFF
--- a/include/eld/Script/ScriptFile.h
+++ b/include/eld/Script/ScriptFile.h
@@ -95,6 +95,8 @@ public:
 
   size_t size() const { return LinkerScriptCommandQueue.size(); }
 
+  InputToken *findResolvedFilename(InputToken * Input);
+
   std::string findIncludeFile(const std::string &Filename, bool &Result,
                               bool State);
 

--- a/lib/Script/GroupCmd.cpp
+++ b/lib/Script/GroupCmd.cpp
@@ -61,6 +61,7 @@ eld::Expected<void> GroupCmd::activate(Module &CurModule) {
 
   for (auto &S : ThisStringList) {
     InputToken *Token = llvm::cast<InputToken>(S);
+    Token = ThisScriptFile.findResolvedFilename(Token);
     if (Token->asNeeded())
       ThisBuilder.getAttributes().setAsNeeded();
     else

--- a/lib/Script/InputCmd.cpp
+++ b/lib/Script/InputCmd.cpp
@@ -58,6 +58,7 @@ void InputCmd::dump(llvm::raw_ostream &Outs) const {
 eld::Expected<void> InputCmd::activate(Module &CurModule) {
   for (auto &S : ThisStringList) {
     InputToken *Token = llvm::cast<InputToken>(S);
+    Token = ThisScriptFile.findResolvedFilename(Token);
     if (Token->asNeeded())
       ThisBuilder.getAttributes().setAsNeeded();
     else

--- a/lib/Script/ScriptFile.cpp
+++ b/lib/Script/ScriptFile.cpp
@@ -150,6 +150,21 @@ inline bool searchIncludeFile(llvm::StringRef Name, llvm::StringRef FileName,
 
 } // namespace
 
+InputToken* ScriptFile::findResolvedFilename(InputToken *input) {
+  LinkerConfig &Config = ThisModule.getConfig();
+  if (Config.options().hasMappingFile()) {
+    std::string ResolvedFilename =
+        ThisModule.getConfig().getHashFromFile(input->name());
+    if (llvm::sys::fs::exists(ResolvedFilename)) {
+      if(llvm::isa<eld::NameSpec>(input))
+      return createNameSpecToken(ResolvedFilename, input->asNeeded());
+    else
+      return createFileToken(ResolvedFilename, input->asNeeded());
+    }
+  }
+  return input;
+}
+
 std::string ScriptFile::findIncludeFile(const std::string &Filename,
                                         bool &Result, bool State) {
   LinkerConfig &Config = ThisModule.getConfig();

--- a/test/Common/standalone/linkerscript/ReproduceInputCommand/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/ReproduceInputCommand/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() {return 1;}

--- a/test/Common/standalone/linkerscript/ReproduceInputCommand/ReproduceInputCommand.test
+++ b/test/Common/standalone/linkerscript/ReproduceInputCommand/ReproduceInputCommand.test
@@ -1,0 +1,7 @@
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
+RUN: echo "INPUT(%t1.1.o)" > %t1.script1.t
+RUN: %link %linkopts -o %t1.1.out -T %t1.script1.t --reproduce %t1.1.reproduce.tar
+RUN: %mkdir %t1.1.reproduce
+RUN: %tar %gnutaropts -xvf %t1.1.reproduce.tar -C %t1.1.reproduce
+RUN: cd %t1.1.reproduce
+RUN: %link @%t1.1.reproduce/response.txt -o %t1.1.rep.out


### PR DESCRIPTION
This patch aims to fix the reproduce crash when the input file is passed through the linkerscript.

Resolved #205 