### PR TITLE
bump tls align

### DIFF
--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -1004,6 +1004,9 @@ private:
   // header when loaded assign a proper virtual address
   bool allocateHeaders();
 
+  // Setup TLS alignment and check for any layout issues
+  bool setupTLS();
+
 protected:
   Module &m_Module;
 

--- a/test/Common/standalone/linkerscript/TLS/TDataTBSSAlign/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/TLS/TDataTBSSAlign/Inputs/script.t
@@ -1,0 +1,12 @@
+MEMORY {
+  mem : ORIGIN = 0x1000, LENGTH = 0x1000
+}
+
+SECTIONS {
+  .text : {
+    *(.text*)
+    . += 4;
+  } > mem
+  .tdata : { *(.tdata*) } > mem
+  .tbss : { *(.tbss*) } > mem
+}

--- a/test/Common/standalone/linkerscript/TLS/TDataTBSSAlign/Inputs/scriptphdrs.t
+++ b/test/Common/standalone/linkerscript/TLS/TDataTBSSAlign/Inputs/scriptphdrs.t
@@ -1,0 +1,17 @@
+PHDRS {
+  A PT_LOAD;
+  B PT_LOAD;
+  C PT_TLS;
+}
+MEMORY {
+  mem : ORIGIN = 0x1000, LENGTH = 0x1000
+}
+
+SECTIONS {
+  .text : {
+    *(.text*)
+    . += 4;
+  } > mem :A
+  .tdata : { *(.tdata*) } > mem :B :C
+  .tbss : { *(.tbss*) } > mem :B :C
+}

--- a/test/Common/standalone/linkerscript/TLS/TDataTBSSAlign/Inputs/tls.c
+++ b/test/Common/standalone/linkerscript/TLS/TDataTBSSAlign/Inputs/tls.c
@@ -1,0 +1,4 @@
+__thread int a = 1;
+__attribute__((aligned(256))) __thread long long b;
+
+int main(int argc, char *argv[]) { return 0; }

--- a/test/Common/standalone/linkerscript/TLS/TDataTBSSAlign/TDataTBSSAlign.test
+++ b/test/Common/standalone/linkerscript/TLS/TDataTBSSAlign/TDataTBSSAlign.test
@@ -1,0 +1,11 @@
+UNSUPPORTED:arm
+#---TDataTBSSAlign.test--------------------- Executable,LS------------------#
+#BEGIN_COMMENT
+# This tests that the linker is able to bump the alignment for tdata section
+#END_COMMENT
+RUN: %clang %clangopts -c %p/Inputs/tls.c  -o %t1.1.o -ffunction-sections -fdata-sections
+RUN: %link -MapStyle txt %linkopts %t1.1.o -T %p/Inputs/script.t -o %t2.out.1 -Map %t2.map.out.1
+RUN: %readelf -S -W %t2.out.1 | %filecheck %s -check-prefix=SECTIONS
+RUN: %link -MapStyle txt %linkopts %t1.1.o -T %p/Inputs/scriptphdrs.t -o %t2.out.2 -Map %t2.map.out.2
+RUN: %readelf -S -W %t2.out.2 | %filecheck %s -check-prefix=SECTIONS
+#SECTIONS: .tdata {{.*}} 256


### PR DESCRIPTION
emulate bfd behavior to bump tdata alignment with the max alignment of all sections that have SHF_TLS flag set (TLS sections).

Resolves #193