### PR TITLE
Fix DEFINED(...) function evaluation for undef but referenced symbols

### DIFF
--- a/lib/Script/Expression.cpp
+++ b/lib/Script/Expression.cpp
@@ -1389,7 +1389,7 @@ eld::Expected<uint64_t> Defined::evalImpl() {
       return 1;
     return 0;
   }
-  return 1;
+  return !Symbol->resolveInfo()->isUndef();
 }
 
 void Defined::getSymbols(std::vector<ResolveInfo *> &Symbols) {}

--- a/test/Common/standalone/Expressions/Inputs/defined-with-undef-sym.t
+++ b/test/Common/standalone/Expressions/Inputs/defined-with-undef-sym.t
@@ -1,0 +1,4 @@
+SECTIONS {
+  u = 0x1 ? 0x0 : undef_fn;
+  A = DEFINED(undef_fn);
+}

--- a/test/Common/standalone/Expressions/defined.test
+++ b/test/Common/standalone/Expressions/defined.test
@@ -5,8 +5,13 @@
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o
 RUN: %link %linkopts %t1.o -T %p/Inputs/defined.t 2>&1 | %filecheck --allow-empty %s
+RUN: %link %linkopts -o %t1.1.out %t1.o -T %p/Inputs/defined-with-undef-sym.t
+RUN: %readelf -s %t1.1.out | %filecheck %s --check-prefix READELF
+#END_TEST
+
 CHECK-NOT: undefined symbol 'B' referenced in expression
 CHECK-NOT: Symbol D used before being defined
 CHECK-NOT: Assertion failed.
 CHECK-NOT: Linking had errors.
-#END_TEST
+
+READELF: {{0+}} 0 NOTYPE {{.*}} ABS A


### PR DESCRIPTION
This commit fixes DEFINED(...) function evaluation for undefined but referenced symbols. This function was returning true instead of false for undefined but referenced symbols.

Closes #209