### PR TITLE
Initialize Expression::result as an empty optional object

### DIFF
--- a/include/eld/Script/Expression.h
+++ b/include/eld/Script/Expression.h
@@ -241,6 +241,13 @@ public:
   virtual void dump(llvm::raw_ostream &Outs, bool ShowValues = true) const = 0;
 
   uint64_t result() const;
+
+  bool hasResult() const {
+    return MResult.has_value();
+  }
+
+  uint64_t resultOrZero() const;
+
   const std::string &name() const { return Name; }
   Type type() const { return ThisType; }
   Type getType() const { return ThisType; }

--- a/lib/Script/Assignment.cpp
+++ b/lib/Script/Assignment.cpp
@@ -143,7 +143,7 @@ void Assignment::dumpMap(llvm::raw_ostream &Ostream, bool Color,
     Ostream << Name;
     if (WithValues) {
       Ostream << "(0x";
-      Ostream.write_hex(ExpressionToEvaluate->result());
+      Ostream.write_hex(ExpressionToEvaluate->resultOrZero());
       Ostream << ")";
     }
     Ostream << " " << ExpressionToEvaluate->getAssignStr() << " ";

--- a/lib/Script/Expression.cpp
+++ b/lib/Script/Expression.cpp
@@ -15,13 +15,14 @@
 #include "eld/Target/ELFSegment.h"
 #include "eld/Target/GNULDBackend.h"
 #include "llvm/Support/MathExtras.h"
+#include <optional>
 
 using namespace eld;
 
 Expression::Expression(std::string Name, Type Type, Module &Module,
                        GNULDBackend &Backend, uint64_t Value)
     : Name(Name), ThisType(Type), ThisModule(Module), ThisBackend(Backend),
-      MResult(0), EvaluatedValue(Value) {}
+      MResult(std::nullopt), EvaluatedValue(Value) {}
 
 void Expression::setContext(const std::string &Context) {
   ASSERT(!Context.empty(), "Empty context for expression");
@@ -31,6 +32,12 @@ void Expression::setContext(const std::string &Context) {
 uint64_t Expression::result() const {
   ASSERT(MResult, "Expression result is not yet committed");
   return *MResult;
+}
+
+uint64_t Expression::resultOrZero() const {
+  if (hasResult())
+    return MResult.value();
+  return 0;
 }
 
 std::unique_ptr<plugin::DiagnosticEntry> Expression::addContextToDiagEntry(


### PR DESCRIPTION
This commit changes Expression::result initialization value from 0 to std::nullopt. Now, Expression::result is an empty object by default. The main motivation for this change is to make it possible to determine whether a linker script expression has been evaluated and to find cases where expression values were (incorrectly) used before evaluating the expression.

Closes #204