### PR TITLE
make autoplugin test unsupported

### DIFF
--- a/test/Common/Plugin/AutoloadPlugins/AutoloadPlugins.test
+++ b/test/Common/Plugin/AutoloadPlugins/AutoloadPlugins.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: true
 #---AutoloadPlugins.test----------------------- Executable,LS --------------------#
 #BEGIN_COMMENT
 # This tests checks the autoloading of plugins from the


### PR DESCRIPTION
it appears there is a race condition when the test runs, and there is an attempt to remove the config file