### PR TITLE
improve ci workflow by speeding up checkouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/checkout@v4
       with:
+        fetch-depth: 2
         repository: llvm/llvm-project
         path: pr-${{ env.PR_NUMBER }}/llvm-project
 
@@ -38,6 +39,7 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/checkout@v4
       with:
+        fetch-depth: 2
         repository: qualcomm/eld
         path: pr-${{ env.PR_NUMBER }}/llvm-project/llvm/tools/eld
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,6 +16,7 @@ jobs:
       - name: Checkout llvm-project
         uses: actions/checkout@v4
         with:
+          fetch-depth: 2
           repository: llvm/llvm-project
           path: llvm-project
           ref: main
@@ -23,6 +24,7 @@ jobs:
       - name: Checkout eld
         uses: actions/checkout@v4
         with:
+          fetch-depth: 2
           path: llvm-project/llvm/tools/eld
           ref: main
 


### PR DESCRIPTION
In Git, fetch-depth refers to how many commits deep Git should go when fetching or cloning a repository. It’s used to create a shallow clone, which limits the history you download—super handy when you don’t need the full commit log.