### PR TITLE
Emit empty segment warning only if linker-script warnings are enabled

### DIFF
--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -5178,7 +5178,7 @@ bool GNULDBackend::allocateHeaders() {
 bool GNULDBackend::verifySegments() const {
   const auto &SegTable = elfSegmentTable();
   for (const auto &S : SegTable.segments()) {
-    if (S->empty())
+    if (S->empty() && config().showLinkerScriptWarnings())
       config().raise(Diag::warn_empty_segment) << S->name();
   }
   return true;

--- a/test/Common/standalone/linkerscript/WarnEmptySegment/WarnEmptySegment.test
+++ b/test/Common/standalone/linkerscript/WarnEmptySegment/WarnEmptySegment.test
@@ -1,10 +1,13 @@
 #---WarnEmptySegments.test--------------------- Executable,LS------------------#
 #BEGIN_COMMENT
-# This tests checks that the linker emits a warning for empty segments.
+# This test checks that the linker emits a warning for empty segments
+# only when -Wlinker-script is specified.
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -o %t1.1.o -c %p/Inputs/1.c
-RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t 2>&1 | %filecheck %s
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t -Wlinker-script 2>&1 | %filecheck %s
+RUN: %link %linkopts -o %t1.2.out %t1.1.o -T %p/Inputs/script.t -Wno-linker-script 2>&1 | %filecheck %s --check-prefix=NO_LS_WARN --allow-empty
 #END_TEST
 
 CHECK:  Warning: Empty segment: 'A'
+NO_LS_WARN-NOT: Warning: Empty segment


### PR DESCRIPTION
Emit empty segment warning only if linker-script warnings are enabled

With this change, the empty segment warning is only emitted when
linker-script warning category is enabled.

Closes #227