### PR TITLE
[LSParser] Fix seek to prev feature to correctly work with INCLUDEs

### DIFF
--- a/include/eld/ScriptParser/ScriptLexer.h
+++ b/include/eld/ScriptParser/ScriptLexer.h
@@ -13,6 +13,7 @@
 #ifndef ELD_SCRIPTPARSER_SCRIPTLEXER_H
 #define ELD_SCRIPTPARSER_SCRIPTLEXER_H
 
+#include "eld/Input/InputFile.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -112,6 +113,10 @@ protected:
   // Get current memory buffer
   llvm::MemoryBufferRef getCurrentMB() const;
 
+  llvm::MemoryBufferRef getAssociatedMB(llvm::StringRef S) const;
+
+  InputFile *getAssociatedIF(llvm::StringRef S) const;
+
   size_t getColumnNumber() const;
 
   size_t computeColumnWidth(llvm::StringRef s, llvm::StringRef e) const;
@@ -187,7 +192,7 @@ protected:
   bool Eof = false;
 
   // All the memory buffers that need to be parsed.
-  std::vector<llvm::MemoryBufferRef> MemoryBuffers;
+  std::vector<InputFile *> InputFileBuffers;
 
   ScriptFile &ThisScriptFile;
 

--- a/lib/ScriptParser/ScriptParser.cpp
+++ b/lib/ScriptParser/ScriptParser.cpp
@@ -1227,7 +1227,7 @@ bool ScriptParser::readInclude() {
     llvm::MemoryBufferRef MemRef = Input->getMemoryBufferRef();
     Buffers.push_back(CurBuf);
     CurBuf = Buffer(MemRef);
-    MemoryBuffers.push_back(MemRef);
+    InputFileBuffers.push_back(IF);
     if (!ActiveFilenames.insert(CurBuf.Filename).second)
       setError("there is a cycle in linker script INCLUDEs");
   }

--- a/test/Common/standalone/linkerscript/PrevOnTokenFromInclude/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/PrevOnTokenFromInclude/Inputs/1.c
@@ -1,0 +1,2 @@
+int foo() { return 0; }
+int bar() { return 0; }

--- a/test/Common/standalone/linkerscript/PrevOnTokenFromInclude/Inputs/f.t
+++ b/test/Common/standalone/linkerscript/PrevOnTokenFromInclude/Inputs/f.t
@@ -1,0 +1,2 @@
+*(.text.bar)
+__function__

--- a/test/Common/standalone/linkerscript/PrevOnTokenFromInclude/Inputs/i.t
+++ b/test/Common/standalone/linkerscript/PrevOnTokenFromInclude/Inputs/i.t
@@ -1,0 +1,5 @@
+.foo :
+{
+    INCLUDE f.t
+  . = ALIGN(4);
+}

--- a/test/Common/standalone/linkerscript/PrevOnTokenFromInclude/Inputs/script1.t
+++ b/test/Common/standalone/linkerscript/PrevOnTokenFromInclude/Inputs/script1.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  INCLUDE i.t
+  .RULE_MATCHING_BUG : {
+    *(.text.foo)
+  }
+}

--- a/test/Common/standalone/linkerscript/PrevOnTokenFromInclude/Inputs/script2.t
+++ b/test/Common/standalone/linkerscript/PrevOnTokenFromInclude/Inputs/script2.t
@@ -1,0 +1,5 @@
+SECTIONS {
+  .foo : {
+    INCLUDE f.t
+  }
+}

--- a/test/Common/standalone/linkerscript/PrevOnTokenFromInclude/PrevOnTokenFromInclude.test
+++ b/test/Common/standalone/linkerscript/PrevOnTokenFromInclude/PrevOnTokenFromInclude.test
@@ -1,0 +1,29 @@
+#---PrevOnTokenFromInclude.test------------------- Executable,LS------------------#
+#BEGIN_COMMENT
+# This test verifies that the linker script parser moving to the previous token
+# functionality works correctly when the previous token comes from an INCLUDE
+# file.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
+RUN: %link -MapStyle txt %linkopts -o %t1.s1.out -L %p/Inputs -T %p/Inputs/script1.t \
+RUN:   -Map %t1.s1.map.txt 2>&1 | %filecheck %s
+RUN: %filecheck %s --check-prefix S1MAP < %t1.s1.map.txt
+RUN: %link -MapStyle txt %linkopts -o %t1.s2.out -L %p/Inputs -T %p/Inputs/script2.t \
+RUN:   -Map %t1.s2.map.txt 2>&1 | %filecheck %s
+RUN: %filecheck %s --check-prefix S2MAP < %t1.s2.map.txt
+#END_TEST
+
+CHECK: Note: Rule __function__ in output section .foo does not have any sections specified
+CHECK-NOT: .RULE_MATCHING_BUG
+CHECK-NOT: does not have any sections specified
+
+S1MAP: .foo
+S1MAP: *(.text.bar) #Rule 1
+S1MAP: __function__(*) #Rule 2
+S1MAP: .RULE_MATCHING_BUG
+S1MAP: *(.text.foo)
+
+S2MAP: .foo
+S2MAP: *(.text.bar) #Rule 1
+S2MAP: __function__(*) #Rule 2


### PR DESCRIPTION
This commit fixes linker script parser seek to previous token
functionality so that it works correctly when the previous token and the
current token are from different input files.

Closes #230
