### PR TITLE
Fix linker crash when invalid section is used with 'ALIGNOF' linker script command.

### DIFF
--- a/include/eld/Diagnostics/DiagLDScript.inc
+++ b/include/eld/Diagnostics/DiagLDScript.inc
@@ -29,6 +29,8 @@ DIAG(promoting_bss_to_progbits, DiagnosticEngine::Note,
      "Section %0(%1) is before %2(%3), Promoting %0 to PROGBITS")
 DIAG(undefined_symbol_in_linker_script, DiagnosticEngine::Fatal,
      "%0: Error: undefined symbol '%1' referenced in expression")
+DIAG(error_sect_invalid, DiagnosticEngine::Error,
+     "%0: Invalid section '%1'")
 DIAG(warn_section_no_segment, DiagnosticEngine::Warning,
      "Section %0 does not have segment assignment in linker script.")
 DIAG(fatal_segment_not_defined_ldscript, DiagnosticEngine::Fatal,

--- a/lib/Script/Expression.cpp
+++ b/lib/Script/Expression.cpp
@@ -726,7 +726,10 @@ eld::Expected<uint64_t> AlignOf::evalImpl() {
   // sections are known only after all the assignments are complete
   if (ThisSection == nullptr)
     ThisSection = ThisModule.getScript().sectionMap().find(Name);
-  assert(ThisSection != nullptr);
+  if (!ThisSection) {
+    return std::make_unique<plugin::DiagnosticEntry>(
+        Diag::error_sect_invalid, std::vector<std::string>{Name});
+  }
   // evaluate sub expressions
   return ThisSection->getAddrAlign();
 }

--- a/test/Common/standalone/linkerscript/AlignOfInvalidSection/AlignOfInvalidSection.test
+++ b/test/Common/standalone/linkerscript/AlignOfInvalidSection/AlignOfInvalidSection.test
@@ -1,0 +1,13 @@
+#---AlignOfInvalidSection.test--------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# This test checks whether the linker errors out when an invalid section
+# is passed to the ALIGNOF command supported by the linkerscript.
+#END_COMMENT
+#START_TEST
+
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o -ffunction-sections
+RUN: %not %link %linkopts -T %p/Inputs/script.t %t1.o -o %t2.out 2>&1 | %filecheck %s -check-prefix=ERR
+
+#ERR: Error: {{[ -\(\)_A-Za-z0-9.\\/:]+}}script.t: Invalid section 'NON_EXISTENT_SECTION'
+#ERR: Fatal: Linking had errors.
+#END_TEST

--- a/test/Common/standalone/linkerscript/AlignOfInvalidSection/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/AlignOfInvalidSection/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/Common/standalone/linkerscript/AlignOfInvalidSection/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/AlignOfInvalidSection/Inputs/script.t
@@ -1,0 +1,9 @@
+SECTIONS {
+TEXT :
+
+{ *(*text*) }
+. = ALIGN(ALIGNOF(NON_EXISTENT_SECTION));
+DATA :
+
+{ *(*data*) }
+}


### PR DESCRIPTION

This patch fixes the linker scrash that occurs when an invalid section is used with the 'ALIGNOF' linker script command.

Resolves #239 