### PR TITLE
annotate not provided symbols in the map file

### DIFF
--- a/include/eld/Script/Assignment.h
+++ b/include/eld/Script/Assignment.h
@@ -123,6 +123,11 @@ public:
   // Add all undefined references from assignmnent expressions
   void processAssignment(Module &M, InputFile &I);
 
+  // set property to check if the assignment expression is used
+  void setUsed(bool Used) { IsUsed = Used; }
+
+  bool isUsed() const { return IsUsed; }
+
 private:
   bool checkLinkerScript(Module &CurModule);
 
@@ -133,6 +138,8 @@ private:
   std::string Name;
   Expression *ExpressionToEvaluate;
   LDSymbol *ThisSymbol;
+  /* Signifies if the assignment expression is evaluated */
+  bool IsUsed = false;
 };
 
 } // namespace eld

--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -83,11 +83,6 @@ public:
     uint64_t offset = 0;
   };
 
-  struct ProvideMapValueType {
-    const Assignment *provideCmd = nullptr;
-    bool isUsed = false;
-  };
-
   typedef std::tuple<ResolveInfo::Type, uint64_t, InputFile *, bool> SymDefInfo;
 
   // Based on Kind in LDFileFormat to define basic section orders for ELF,
@@ -630,7 +625,7 @@ public:
   void addProvideSymbol(llvm::StringRef symName, Assignment *provideCmd) {
     ASSERT(!ProvideMap.count(symName),
            "Provide symbol of the same name already exists!");
-    ProvideMap[symName] = {provideCmd, /*isUsed=*/false};
+    ProvideMap[symName] = provideCmd;
   }
 
   bool isSymInProvideMap(llvm::StringRef symName) {
@@ -1113,7 +1108,7 @@ protected:
   std::unordered_map<const ResolveInfo *, VersionSymbol *> SymbolScopes;
   std::vector<ELFSection *> noLoadSections;
   // All provide symbols that may need to be defined.
-  llvm::StringMap<ProvideMapValueType> ProvideMap;
+  llvm::StringMap<Assignment *> ProvideMap;
 
   // All sym def provide symbols that may need to be defined.
   llvm::StringMap<SymDefInfo> m_SymDefProvideMap;

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -1695,6 +1695,7 @@ bool ObjectLinker::addScriptSymbols() {
                     Vis, true /*PostLTOPhase*/);
       LLVM_FALLTHROUGH;
     case Assignment::ASSERT:
+      AssignCmd->setUsed(true);
       break;
     }
     case Assignment::PROVIDE_HIDDEN:

--- a/lib/Script/Assignment.cpp
+++ b/lib/Script/Assignment.cpp
@@ -125,10 +125,14 @@ void Assignment::dumpMap(llvm::raw_ostream &Ostream, bool Color,
   bool CloseParen = false;
   switch (type()) {
   case PROVIDE:
+    if (!IsUsed && !WithValues)
+      Ostream << "!";
     Ostream << "PROVIDE(";
     CloseParen = true;
     break;
   case PROVIDE_HIDDEN:
+    if (!IsUsed && !WithValues)
+      Ostream << "!";
     Ostream << "PROVIDE_HIDDEN(";
     CloseParen = true;
     break;

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -4647,16 +4647,16 @@ LDSymbol *GNULDBackend::canProvideSymbol(llvm::StringRef symName) {
   bool isPSymDef = PSymDef != m_SymDefProvideMap.end();
   bool Patchable = false;
   if (P != ProvideMap.end()) {
-    if (P->getValue().provideCmd->isProvideHidden())
+    if (P->second->isProvideHidden())
       V = ResolveInfo::Hidden;
     resolverType = ResolveInfo::NoType;
-    file = P->second.provideCmd->getInputFileInContext();
+    file = P->second->getInputFileInContext();
     // FIXME: We ideally should not need this. It is added so that the link
     // does not fail if the provide command does not have input file context due
     // to any corner case.
     if (!file)
       file = m_Module.getInternalInput(Module::Script);
-    P->getValue().isUsed = true;
+    P->second->setUsed(true);
   } else if (isPSymDef) {
     resolverType = std::get<0>(PSymDef->second);
     symVal = std::get<1>(PSymDef->second);
@@ -4959,11 +4959,7 @@ bool GNULDBackend::assignMemoryRegions() {
 }
 
 bool GNULDBackend::isProvideSymBeingUsed(const Assignment *provideCmd) const {
-  llvm::StringRef symName = provideCmd->name();
-  auto it = ProvideMap.find(symName);
-  ASSERT(it != ProvideMap.end(), "Provide symbol not found!");
-  const ProvideMapValueType &val = it->getValue();
-  return val.provideCmd == provideCmd && val.isUsed;
+  return provideCmd->isUsed();
 }
 
 eld::Expected<void> GNULDBackend::printMemoryRegionsUsage() {

--- a/test/Common/standalone/Map/ProvideSymbols/Inputs/script.t
+++ b/test/Common/standalone/Map/ProvideSymbols/Inputs/script.t
@@ -1,0 +1,10 @@
+SECTIONS {
+  .text 0x1000 : AT(0x2000) {
+    PROVIDE(__text_start = .);
+    *(.text)
+    PROVIDE(__text_end = .);
+  }
+  PROVIDE(__text_size = __text_end - __text_start);
+  PROVIDE(__text_loadaddr = LOADADDR(.text));
+  PROVIDE(__other_end = __text_end);
+}

--- a/test/Common/standalone/Map/ProvideSymbols/Inputs/test.c
+++ b/test/Common/standalone/Map/ProvideSymbols/Inputs/test.c
@@ -1,0 +1,9 @@
+extern char *__text_start;
+extern char *__text_end;
+extern char *__text_size;
+
+int main(int argc, char *argv[]) {
+  char *start = __text_start;
+  char *end = __text_end;
+  char *size = __text_size;
+}

--- a/test/Common/standalone/Map/ProvideSymbols/ProvideSymbols.test
+++ b/test/Common/standalone/Map/ProvideSymbols/ProvideSymbols.test
@@ -1,0 +1,12 @@
+#---ProvideSymbols.test--------------------- Executable---------------------#
+#BEGIN_COMMENT
+# This tests that the Map file can show symbols that are not provided
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/test.c -ffunction-sections  -o %t1.1.o
+RUN: %link -MapStyle txt %linkopts %t1.1.o -Map %t2.map.1 -T %p/Inputs/script.t -o %t2.out.1
+RUN: %filecheck %s < %t2.map.1
+#END_TEST
+
+#CHECK: !PROVIDE(__text_loadaddr = LOADADDR(.text))
+#CHECK: !PROVIDE(__other_end = __text_end)


### PR DESCRIPTION
symbols that are not provided are annotate in the map file using !PROVIDE along with the PROVIDE expression.

Resolves #226