### PR TITLE
Use -G0 for Map/ProvideSymbols test

### DIFF
--- a/test/Common/standalone/Map/ProvideSymbols/ProvideSymbols.test
+++ b/test/Common/standalone/Map/ProvideSymbols/ProvideSymbols.test
@@ -3,8 +3,8 @@
 # This tests that the Map file can show symbols that are not provided
 #END_COMMENT
 #START_TEST
-RUN: %clang %clangopts -c %p/Inputs/test.c -ffunction-sections  -o %t1.1.o
-RUN: %link -MapStyle txt %linkopts %t1.1.o -Map %t2.map.1 -T %p/Inputs/script.t -o %t2.out.1
+RUN: %clang %clangg0opts -c %p/Inputs/test.c -ffunction-sections  -o %t1.1.o
+RUN: %link -MapStyle txt %linkg0opts %t1.1.o -Map %t2.map.1 -T %p/Inputs/script.t -o %t2.out.1
 RUN: %filecheck %s < %t2.map.1
 #END_TEST
 


### PR DESCRIPTION
This commit modifies the Map/ProvideSymbols test to use -G0 option for compiling and linking. This is required to fix test failures when the compiler is built with small-data option ON as default.
