### PR TITLE
Fix reproduce crash when input is passed through linkerscript

### DIFF
--- a/include/eld/Script/ScriptFile.h
+++ b/include/eld/Script/ScriptFile.h
@@ -94,6 +94,8 @@ public:
 
   size_t size() const { return LinkerScriptCommandQueue.size(); }
 
+  InputToken *findResolvedFilename(InputToken *Input);
+
   std::string findIncludeFile(const std::string &Filename, bool &Result,
                               bool State);
 

--- a/lib/Script/GroupCmd.cpp
+++ b/lib/Script/GroupCmd.cpp
@@ -61,6 +61,7 @@ eld::Expected<void> GroupCmd::activate(Module &CurModule) {
 
   for (auto &S : ThisStringList) {
     InputToken *Token = llvm::cast<InputToken>(S);
+    Token = ThisScriptFile.findResolvedFilename(Token);
     if (Token->asNeeded())
       ThisBuilder.getAttributes().setAsNeeded();
     else

--- a/lib/Script/InputCmd.cpp
+++ b/lib/Script/InputCmd.cpp
@@ -58,6 +58,7 @@ void InputCmd::dump(llvm::raw_ostream &Outs) const {
 eld::Expected<void> InputCmd::activate(Module &CurModule) {
   for (auto &S : ThisStringList) {
     InputToken *Token = llvm::cast<InputToken>(S);
+    Token = ThisScriptFile.findResolvedFilename(Token);
     if (Token->asNeeded())
       ThisBuilder.getAttributes().setAsNeeded();
     else

--- a/lib/Script/ScriptFile.cpp
+++ b/lib/Script/ScriptFile.cpp
@@ -150,6 +150,22 @@ inline bool searchIncludeFile(llvm::StringRef Name, llvm::StringRef FileName,
 
 } // namespace
 
+InputToken *ScriptFile::findResolvedFilename(InputToken *input) {
+  LinkerConfig &Config = ThisModule.getConfig();
+  if (!Config.options().hasMappingFile())
+    return input;
+  std::string ResolvedFilename =
+      ThisModule.getConfig().getHashFromFile(input->name());
+  if (llvm::sys::fs::exists(ResolvedFilename)) {
+    if (llvm::isa<eld::NameSpec>(input)) {
+      return createNameSpecToken(ResolvedFilename, input->asNeeded());
+    } else {
+      return createFileToken(ResolvedFilename, input->asNeeded());
+    }
+  }
+  return input;
+}
+
 std::string ScriptFile::findIncludeFile(const std::string &Filename,
                                         bool &Result, bool State) {
   LinkerConfig &Config = ThisModule.getConfig();

--- a/test/Common/standalone/linkerscript/ReproduceGrpCmd/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/ReproduceGrpCmd/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() {return bar();}

--- a/test/Common/standalone/linkerscript/ReproduceGrpCmd/Inputs/2.c
+++ b/test/Common/standalone/linkerscript/ReproduceGrpCmd/Inputs/2.c
@@ -1,0 +1,1 @@
+int bar() { return foo();}

--- a/test/Common/standalone/linkerscript/ReproduceGrpCmd/ReproduceGrpCmd.test
+++ b/test/Common/standalone/linkerscript/ReproduceGrpCmd/ReproduceGrpCmd.test
@@ -1,0 +1,21 @@
+#---ReproduceGrpCmd.test--------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# This test checks if linking works with reproduce option on running
+# the response.txt file when input object files are passed through the GROUP
+# command of the linkerscript.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.1.o
+RUN: %ar cr %aropts %t1.lib1.a %t.1.o
+RUN: %clang %clangopts -c %p/Inputs/2.c -o %t.2.o
+RUN: echo "GROUP(%t1.lib1.a)" > %t4.t
+RUN: %link %linkopts %t.2.o -o %t1.2.out -T %t4.t --reproduce %t1.2.reproduce.tar --dump-response-file %t1.2.response
+RUN: %mkdir %t1.2.reproduce
+RUN: %tar -xf %t1.2.reproduce.tar -C %t1.2.reproduce --strip-components 1
+RUN: cd %t1.2.reproduce
+RUN: %link @response.txt -Map %t1.1.map.txt -o %t1.2.reproduce.out
+RUN: %filecheck %s < %t1.1.map.txt
+
+#CHECK: foo
+#CHECK: bar
+#END_TEST

--- a/test/Common/standalone/linkerscript/ReproduceInputCmd/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/ReproduceInputCmd/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/Common/standalone/linkerscript/ReproduceInputCmd/ReproduceInputCmd.test
+++ b/test/Common/standalone/linkerscript/ReproduceInputCmd/ReproduceInputCmd.test
@@ -1,0 +1,18 @@
+#---ReproduceInputCmd.test--------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# This test checks if linking works with reproduce option on running
+# the response.txt file when input object file is passed through the INPUT
+# command of the linkerscript.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.1.o
+RUN: echo "INPUT(%t.1.o)" > %t4.t
+RUN: %link %linkopts -o %t1.2.out -T %t4.t --reproduce %t1.2.reproduce.tar --dump-response-file %t1.2.response
+RUN: %mkdir %t1.2.reproduce
+RUN: %tar -xf %t1.2.reproduce.tar -C %t1.2.reproduce --strip-components 1
+RUN: cd %t1.2.reproduce
+RUN: %link @response.txt -Map %t1.1.map.txt -o %t1.2.reproduce.out
+RUN: %filecheck %s < %t1.1.map.txt
+
+#CHECK: foo
+#END_TEST


### PR DESCRIPTION
This patch aims to fix the reproduce crash when the input file is passed through the linkerscript

Resolves: #205