### PR TITLE
Fix evaluation of expressions containing forward references

### DIFF
--- a/include/eld/Diagnostics/DiagVerbose.inc
+++ b/include/eld/Diagnostics/DiagVerbose.inc
@@ -163,3 +163,9 @@ DIAG(verbose_linker_script_output_file, DiagnosticEngine::Verbose,
      "Using output file name '%0' specified in the linker script '%1'")
 DIAG(verbose_rule_matching_cache_func_hash, DiagnosticEngine::Verbose,
      "Rule-matching cache-functionailty hash: %0")
+DIAG(verbose_performing_layout_iteration, DiagnosticEngine::Verbose,
+     "Performing layout iteration %0")
+DIAG(verbose_eval_pending_assignments, DiagnosticEngine::Verbose,
+     "Evaluating pending assignments")
+DIAG(verbose_reset_tracked_assignment, DiagnosticEngine::Verbose,
+     "Resetting tracked assignments")

--- a/include/eld/Diagnostics/DiagnosticPrinter.h
+++ b/include/eld/Diagnostics/DiagnosticPrinter.h
@@ -47,6 +47,7 @@ public:
     TraceMergeStrings = 0x8000,
     TraceLinkerScript = 0x10000,
     TraceSymDef = 0x100000,
+    TracePendingAssignments = 0x200000
   };
 
   enum Verbose : uint16_t { None = 0x0, Default = 0x1 };
@@ -67,6 +68,8 @@ public:
   bool traceTrampolines() { return Trace & TraceTrampolines; }
 
   bool traceAssignments() { return Trace & TraceAssignments; }
+
+  bool tracePendingAssignments() { return Trace & TracePendingAssignments; }
 
   bool traceFiles() { return Trace & TraceFiles; }
 

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -658,7 +658,8 @@ defm trace
           "\t\t\t --trace=trampolines : trace trampolines\n"
           "\t\t\t --trace=wrap-symbols : trace symbol wrap options\n"
           "\t\t\t --trace=symdef : trace symbol resolution from symdef files\n"
-          "\t\t\t --trace=dynamic-linking : trace dynamic linking">,
+          "\t\t\t --trace=dynamic-linking : trace dynamic linking\n"
+          "\t\t\t --trace=pending-assignments : trace pending symbol assignments evaluation">,
       MetaVarName<"<trace-type>">,
       Group<grp_diagopts>;
 defm trace_symbol : smDashTwoWithOpt<"y", "trace-symbol", "trace_symbol",

--- a/include/eld/Script/Assignment.h
+++ b/include/eld/Script/Assignment.h
@@ -73,20 +73,26 @@ public:
 
   bool isDot() const;
 
-  // Does the assignment have any dot usage ?
+  // Does the assignment has any dot usage ?
   bool hasDot() const;
 
   static bool classof(const ScriptCommand *LinkerScriptCommand) {
     return LinkerScriptCommand->getKind() == ScriptCommand::ASSIGNMENT;
   }
 
+  /// Sets the expression context (location in the linker script)
+  /// and the assignment level.
   eld::Expected<void> activate(Module &CurModule) override;
 
   /// assign - evaluate the rhs and assign the result to lhs.
-  bool assign(Module &CurModule, const ELFSection *Section);
+  bool assign(Module &CurModule, const ELFSection *Section,
+              bool EvaluatePendingOnly);
 
   LDSymbol *symbol() const { return ThisSymbol; }
 
+  /// Returns all the symbols that might be referenced by the rhs of this
+  /// assignment No expression evaluation is performed. Hence, this may return
+  /// more symbols than what is actually referenced at runtime.
   void getSymbols(std::vector<ResolveInfo *> &Symbols) const;
 
   /// Query functions on Assignment Kinds.
@@ -117,7 +123,9 @@ public:
 
   bool isAssert() const { return ThisType == ASSERT; }
 
-  // Retrieve the symbol names referred by the assignment expression
+  /// Returns the symbol names that might be referenced by the rhs of this
+  /// assignment. No expression evaluation is performed. Hence, this may return
+  /// names of more symbols than what is actually referenced at runtime.
   std::unordered_set<std::string> getSymbolNames() const;
 
   // Add all undefined references from assignmnent expressions
@@ -127,6 +135,9 @@ public:
   void setUsed(bool Used) { IsUsed = Used; }
 
   bool isUsed() const { return IsUsed; }
+
+  /// Reset the assignment value and the expression node.
+  void reset();
 
 private:
   bool checkLinkerScript(Module &CurModule);

--- a/lib/Config/GeneralOptions.cpp
+++ b/lib/Config/GeneralOptions.cpp
@@ -230,6 +230,8 @@ eld::Expected<void> GeneralOptions::setTrace(const char *PTraceType) {
                   DiagEngine->getPrinter()->TraceDynamicLinking)
             .Case("linker-script", DiagEngine->getPrinter()->TraceLinkerScript)
             .Case("symdef", DiagEngine->getPrinter()->TraceSymDef)
+            .Case("pending-assignments",
+                  DiagEngine->getPrinter()->TracePendingAssignments)
             .Default(std::nullopt);
   }
   // Warn if trace category is unknown.

--- a/lib/LinkerWrapper/LinkerWrapper.cpp
+++ b/lib/LinkerWrapper/LinkerWrapper.cpp
@@ -217,7 +217,9 @@ eld::Expected<void> LinkerWrapper::finishAssignOutputSections() {
 eld::Expected<void> LinkerWrapper::reassignVirtualAddresses() {
   if (getState() != State::CreatingSegments)
     RETURN_INVALID_LINK_STATE_ERR("CreatingSegments");
-  m_Module.getBackend().createScriptProgramHdrs();
+  auto &Backend = m_Module.getBackend();
+  Backend.createScriptProgramHdrs();
+  Backend.evaluatePendingAssignments();
   return {};
 }
 

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -892,7 +892,10 @@ bool ObjectLinker::createOutputSection(ObjectBuilder &Builder,
 
   // force input alignment from ldscript if any
   if (Output->prolog().hasSubAlign()) {
-    Output->prolog().subAlign().eval();
+    // FIXME: eval() is an implementation function, it should not be
+    // used outside the component. Instead, evaluateAndReturnError and
+    // evaluateAndRaiseError should be used.
+    Output->prolog().subAlign().eval(/*EvaluatePendingOnly=*/false);
     Output->prolog().subAlign().commit();
     InAlign = Output->prolog().subAlign().result();
     HasSubAlign = true;

--- a/lib/Target/CreateProgramHeaders.hpp
+++ b/lib/Target/CreateProgramHeaders.hpp
@@ -168,9 +168,14 @@ bool GNULDBackend::createProgramHdrs() {
     noLoadSections.clear();
     resetNewSectionsAddedToLayout();
     enable_RELRO = true;
+    resetTrackedAssignments();
+    restoreLSSymbolsUsingSnapshot();
+    restorePartiallyEvalAssignsAndSymbolsUsingSnapshot();
   };
 
   reset_state();
+
+  llvm::SaveAndRestore saved(TrackAssignments, true);
 
   if (load_ehdr)
     setNeedEhdr();

--- a/lib/Target/CreateScriptProgramHeaders.hpp
+++ b/lib/Target/CreateScriptProgramHeaders.hpp
@@ -81,9 +81,13 @@ bool GNULDBackend::createScriptProgramHdrs() {
     m_ImageStartVMA = vma;
     // Set initial dot symbol value.
     dotSymbol->setValue(vma);
+    resetTrackedAssignments();
+    restoreLSSymbolsUsingSnapshot();
+    restorePartiallyEvalAssignsAndSymbolsUsingSnapshot();
   };
 
   reset_state();
+  llvm::SaveAndRestore saved(TrackAssignments, true);
 
   while (out != outEnd) {
     bool useSetLMA = false;

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/ForwardReference.test
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/ForwardReference.test
@@ -1,0 +1,16 @@
+#---ForwardReference.test----------------------- Executable,LS --------------------#
+#BEGIN_COMMENT
+# This test checks that the linker performs correct expression evaluation
+# when the expression contains a forward-reference.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts  -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.ForwardReference.t
+RUN: %readelf -s %t1.1.out 2>&1 | %filecheck %s
+RUN: %link %linkopts -o %t1.1.phdr.out %t1.1.o -T %p/Inputs/script.ForwardReference.phdr.t
+RUN: %readelf -s %t1.1.phdr.out 2>&1 | %filecheck %s
+#END_TEST
+
+CHECK-DAG: [[VALUE:[0-9a-f]+]] {{.*}} ABS u
+CHECK-DAG: [[VALUE]] {{.*}} ABS v
+

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/ForwardReferenceProvideSymbol.test
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/ForwardReferenceProvideSymbol.test
@@ -1,0 +1,20 @@
+#---ForwardReferenceProvideSymbol.test----------------------- Executable,LS --------------------#
+#BEGIN_COMMENT
+# This test checks that the linker performs correct expression evaluation
+# when the expression contains a forward-reference of a PROVIDE symbol.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
+RUN: %link %linkopts -o %t1.1.out %t1.1.o \
+RUN:   -T %p/Inputs/script.ForwardReferenceProvideSymbol.t
+RUN: %readelf -s %t1.1.out 2>&1 | %filecheck %s
+RUN: %link %linkopts -o %t1.1.phdr.out %t1.1.o \
+RUN:   -T %p/Inputs/script.ForwardReferenceProvideSymbol.phdr.t
+RUN: %readelf -s %t1.1.phdr.out 2>&1 | %filecheck %s
+#END_TEST
+
+CHECK-DAG: : [[#%x, START:]] {{.*}} start
+CHECK-DAG: : [[#%x, END:]] {{.*}} end
+CHECK-DAG: : {{0+}}[[#%x, V: END - START]] {{.*}} ABS v
+CHECK-DAG: : {{0+}}[[#%x, V + 0x10]] {{.*}} ABS u
+

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/2.c
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/2.c
@@ -1,0 +1,11 @@
+int fn();
+
+int foo() { return 11; }
+
+int bar() { return 13; }
+
+int baz() { return fn(); }
+
+int main() {
+  return baz();
+}

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.ForwardReference.phdr.t
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.ForwardReference.phdr.t
@@ -1,0 +1,13 @@
+PHDRS {
+  A PT_LOAD;
+}
+
+SECTIONS {
+  u = v;
+  FOO (0x1000): {
+    start = .;
+    *(.text.foo)
+    end = .;
+  } :A
+  v = end - start;
+}

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.ForwardReference.t
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.ForwardReference.t
@@ -1,0 +1,9 @@
+SECTIONS {
+  u = v;
+  FOO (0x1000): {
+    start = .;
+    *(.text.foo)
+    end = .;
+  }
+  v = end - start;
+}

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.ForwardReferenceProvideSymbol.phdr.t
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.ForwardReferenceProvideSymbol.phdr.t
@@ -1,0 +1,13 @@
+PHDRS {
+  A PT_LOAD;
+}
+
+SECTIONS {
+  u = v ? v + 0x10 : 0x20;
+  FOO (0x1000): {
+    start = .;
+    *(.text.foo)
+    end = .;
+  } :A
+  PROVIDE(v = end - start);
+}

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.ForwardReferenceProvideSymbol.t
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.ForwardReferenceProvideSymbol.t
@@ -1,0 +1,9 @@
+SECTIONS {
+  u = v ? v + 0x10 : 0x20;
+  FOO (0x1000): {
+    start = .;
+    *(.text.foo)
+    end = .;
+  }
+  PROVIDE(v = end - start);
+}

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.LayoutReset.phdr.t
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.LayoutReset.phdr.t
@@ -1,0 +1,24 @@
+PHDRS {
+  A PT_LOAD;
+  B PT_LOAD;
+}
+
+SECTIONS {
+  FOO (0x1000): {
+    fn = u;
+    u = bar;
+    *(.text.foo)
+  } :A
+
+  BAR : {
+    u = baz;
+    *(.text.bar)
+  } :B
+
+  BAZ : {
+    u = main;
+    *(.text.baz)
+  } :B
+
+  u = foo;
+}

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.LayoutReset.t
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.LayoutReset.t
@@ -1,0 +1,19 @@
+SECTIONS {
+  FOO (0x1000): {
+    fn = u;
+    u = bar;
+    *(.text.foo)
+  }
+
+  BAR : {
+    u = baz;
+    *(.text.bar)
+  }
+
+  BAZ : {
+    u = main;
+    *(.text.baz)
+  }
+
+  u = foo;
+}

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.RecursivePendingEvaluation.phdr.t
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.RecursivePendingEvaluation.phdr.t
@@ -1,0 +1,17 @@
+PHDRS {
+  A PT_LOAD;
+}
+
+SECTIONS {
+  FOO (0x1000) : {
+    fn = u;
+    u = v1;
+    *(.text.foo)
+  } :A
+  v1 = v2;
+  v2 = v3;
+  v3 = v4;
+  v4 = v5;
+  v5 = v6;
+  v6 = foo;
+}

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.RecursivePendingEvaluation.t
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.RecursivePendingEvaluation.t
@@ -1,0 +1,13 @@
+SECTIONS {
+  FOO (0x1000) : {
+    fn = u;
+    u = v1;
+    *(.text.foo)
+  }
+  v1 = v2;
+  v2 = v3;
+  v3 = v4;
+  v4 = v5;
+  v5 = v6;
+  v6 = foo;
+}

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/LayoutResetForwardReference.test
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/LayoutResetForwardReference.test
@@ -1,0 +1,25 @@
+#---LayoutResetForwardReference.test----------------------- Executable,LS --------------------#
+#BEGIN_COMMENT
+# This test checks that the linker performs correct expression evaluation
+# when the expression contains a forward-reference, and the layout reset
+# during the layout may cause incorrect expression evaluation by incorrectly
+# providing intermediate values to pending assignments.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts  -o %t1.2.o %p/Inputs/2.c -c -ffunction-sections
+RUN: %link %linkopts -o %t1.2.out %t1.2.o -T %p/Inputs/script.LayoutReset.t \
+RUN:   --trace=pending-assignments --verbose 2>&1 | %filecheck %s
+RUN: %readelf -s %t1.2.out 2>&1 | %filecheck %s --check-prefix READELF
+RUN: %link %linkopts -o %t1.2.phdr.out %t1.2.o -T %p/Inputs/script.LayoutReset.phdr.t \
+RUN:   --trace=pending-assignments --verbose 2>&1 | %filecheck %s
+RUN: %readelf -s %t1.2.phdr.out 2>&1 | %filecheck %s --check-prefix READELF
+#END_TEST
+
+CHECK-DAG: Verbose: Performing layout iteration 0
+CHECK-DAG: Verbose: Evaluating pending assignments
+CHECK-DAG:     INSIDE_OUTPUT_SECTION    >>  fn(4096) = u(0x1000);
+
+READELF-DAG: {{0+}}1000 {{.*}} u
+READELF-DAG: {{0+}}1000 {{.*}} foo
+READELF-DAG: {{0+}}1000 {{.*}} fn
+

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/RecursivePendingEvaluation.test
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/RecursivePendingEvaluation.test
@@ -1,0 +1,59 @@
+#---RecursivePendingEvaluation.test----------------------- Executable,LS --------------------#
+#BEGIN_COMMENT
+# This test checks that the linker performs correct expression evaluation
+# when there is a chain of forward reference expression such that
+# the pending assignments evaluation rounds needs several iterations
+# to resolve all the pending assignments.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts  -o %t1.2.o %p/Inputs/2.c -c -ffunction-sections
+RUN: %link %linkopts -o %t1.2.out %t1.2.o \
+RUN:   -T %p/Inputs/script.RecursivePendingEvaluation.t \
+RUN:  --trace=pending-assignments --verbose 2>&1 | %filecheck %s
+RUN: %readelf -s %t1.2.out 2>&1 | %filecheck %s --check-prefix READELF
+RUN: %link %linkopts -o %t1.2.phdr.out %t1.2.o \
+RUN:   -T %p/Inputs/script.RecursivePendingEvaluation.phdr.t \
+RUN:  --trace=pending-assignments --verbose 2>&1 | %filecheck %s
+RUN: %readelf -s %t1.2.phdr.out 2>&1 | %filecheck %s --check-prefix READELF
+#END_TEST
+
+CHECK-DAG: Verbose: Performing layout iteration 0
+CHECK: INSIDE_OUTPUT_SECTION    >>  fn(0) = u(0x0);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  u(0) = v1(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v1(0) = v2(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v2(0) = v3(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v3(0) = v4(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v4(0) = v5(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v5(4096) = v6(0x1000);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  fn(0) = u(0x0);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  u(0) = v1(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v1(0) = v2(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v2(0) = v3(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v3(0) = v4(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v4(4096) = v5(0x1000);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  fn(0) = u(0x0);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  u(0) = v1(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v1(0) = v2(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v2(0) = v3(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v3(4096) = v4(0x1000);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  fn(0) = u(0x0);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  u(0) = v1(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v1(0) = v2(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v2(4096) = v3(0x1000);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  fn(0) = u(0x0);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  u(0) = v1(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v1(4096) = v2(0x1000);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  fn(0) = u(0x0);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  u(4096) = v1(0x1000);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  fn(4096) = u(0x1000);
+
+READELF-DAG: {{0+}}1000 {{.*}} u
+READELF-DAG: {{0+}}1000 {{.*}} foo
+READELF-DAG: {{0+}}1000 {{.*}} fn
+READELF-DAG: {{0+}}1000 {{.*}} v1
+READELF-DAG: {{0+}}1000 {{.*}} v2
+READELF-DAG: {{0+}}1000 {{.*}} v3
+READELF-DAG: {{0+}}1000 {{.*}} v4
+READELF-DAG: {{0+}}1000 {{.*}} v5
+READELF-DAG: {{0+}}1000 {{.*}} v6
+


### PR DESCRIPTION
This commit fixes evaluation of expressions containing forward
references. At a high-level, eld evaluates assignments in sequence
and consequently the expressions containing forward references needs to
be reevaluated when the forward reference value is computed for the correct
computation results. For example:

```
  u = v1;    // Assignment 1
  v1 = v2;   // Assignment 2
  v2 = 0xa;  // Assignment 3
```

eld evaluates the assignments in order, that is, the evaluation happens
as: [Assignment 1, Assignment 2, Assignment 3]. If we follow this
evaluation order, the symbols `u` and `v1` will have incorrect values
because the value of `v2` is unknown when the assignments of `u` and
`v1` are evaluated.

This commit fixes evaluation of expressions containing forward
references by making the below two changes:

1) Assignments which cannot be completely evaluated during the
   sequential evaluation of expressions are marked as pending
   assignments. After the layout is done, but before the relaxation,
   these pending assignments are recursively reevaluated until there
   is no improvement in pending assignments or a MaxIteration limit is
   reached.

2) During a layout iteration, assignments may get evaluated multiple times
   as layout needs to reset itself based on a few conditions
   (new segment needs to be created, and so on...). It is important to reset
   the assignments and the symbol values if a layout gets reset. Let's
   see why it is important with the help of an example:

```
   SECTIONS {
     FOO : {
       u = v; // Assignment 1
       v = 0xa; // Assignment 2
       *(.text.foo)
     }
     BAR : {
       v = 0xb; // Assignment 3
     }
     v = 0xc; // Assignment 4
  }
```

  The sequential assignment evaluation order is: [A1, A2, A3, A4]. When
  A1 is evaluated, `v` is not defined, hence we mark A1 as pending
  assignment. However, if the layout gets reset after evaluating A2,
  then A1 will be evaluated again, but this time, `v` is defined (from
  assignment 2 evaluation) and thus A1 can be completely evaluated.
  This is wrong because A1 should get the value from the assignment 4
  instead of assignment 2!

  We fix this issue by resetting the assignments and the symbol values
  whenever a layout is reset.

  The same issue happens when the layout needs to be recomputed after a
  relaxation pass. And the same solution of resetting the assignments and
  the symbol values works for this case as well.

This commit also adds a new trace category 'pending-assignments' for
tracing pending assignment evaluation.

Closes https://github.com/qualcomm/eld/issues/169