### PR TITLE
Suppress relaxations for incomplete script symbols

### DIFF
--- a/include/eld/Readers/Relocation.h
+++ b/include/eld/Readers/Relocation.h
@@ -62,6 +62,7 @@ public:
   Type type() const { return m_Type; }
 
   /// symValue - S value - the symbol address
+  Address symValue(Module &M, bool &Uncertain) const;
   Address symValue(Module &M) const;
 
   /// symOffset - Offset of the symbol

--- a/include/eld/SymbolResolver/LDSymbol.h
+++ b/include/eld/SymbolResolver/LDSymbol.h
@@ -112,9 +112,12 @@ public:
 
   bool scriptValueDefined() const { return ThisSymbolHasScriptValue; }
 
-  void setScriptValueDefined(bool Value = true) {
-    ThisSymbolHasScriptValue = Value;
+  void setScriptValueDefined(bool Uncertain) {
+    ThisSymbolHasScriptValue = true;
+    ThisSymbolHasUncertainValue = Uncertain;
   }
+
+  bool isUncertain() const { return ThisSymbolHasUncertainValue; }
 
   const FragmentRef *fragRef() const { return ThisFragRef; }
 
@@ -166,6 +169,7 @@ protected:
   uint32_t ThisSymIdx;
   bool ThisSymbolsIsScriptDefined;
   bool ThisSymbolHasScriptValue;
+  bool ThisSymbolHasUncertainValue;
   // used for ignore garbage collected Common symbols
   bool ThisSymbolGarbageCollected;
 };

--- a/include/eld/Target/Relocator.h
+++ b/include/eld/Target/Relocator.h
@@ -143,6 +143,7 @@ public:
   bool doDeMangle() const;
 
   // Get the address for a relocation
+  Relocation::Address getSymValue(Relocation *R, bool &Uncertain);
   Relocation::Address getSymValue(Relocation *R);
 
 private:

--- a/lib/Script/Assignment.cpp
+++ b/lib/Script/Assignment.cpp
@@ -211,10 +211,10 @@ bool Assignment::assign(Module &CurModule, const ELFSection *Section) {
   }
 
   // evaluate, commit, then get the result of the expression
-  auto Result = ExpressionToEvaluate->evaluateAndRaiseError();
+  auto Result = ExpressionToEvaluate->evaluateUncertainAndRaiseError();
   if (!Result)
     return false;
-  ExpressionValue = *Result;
+  ExpressionValue = Result->value();
 
   if (!checkLinkerScript(CurModule))
     return false;
@@ -223,7 +223,7 @@ bool Assignment::assign(Module &CurModule, const ELFSection *Section) {
   if (Sym != nullptr) {
     ThisSymbol = Sym;
     ThisSymbol->setValue(ExpressionValue);
-    ThisSymbol->setScriptValueDefined();
+    ThisSymbol->setScriptValueDefined(Result->isUncertain());
   }
 
   if (CurModule.getPrinter()->traceAssignments())

--- a/lib/Script/Expression.cpp
+++ b/lib/Script/Expression.cpp
@@ -68,10 +68,10 @@ eld::Expected<uint64_t> Expression::evaluateAndReturnError() {
   if (!Result)
     return addContextToDiagEntry(std::move(Result.error()), MContext);
   commit();
-  return Result;
+  return Result->value();
 }
 
-std::optional<uint64_t> Expression::evaluateAndRaiseError() {
+std::optional<UncertainValue> Expression::evaluateUncertainAndRaiseError() {
   ASSERT(!MContext.empty(), "Context not set for expression");
   auto Result = eval();
   if (!Result) {
@@ -86,10 +86,17 @@ std::optional<uint64_t> Expression::evaluateAndRaiseError() {
   return Result.value();
 }
 
-eld::Expected<uint64_t> Expression::eval() {
+std::optional<uint64_t> Expression::evaluateAndRaiseError() {
+  auto Result = evaluateUncertainAndRaiseError();
+  if (!Result)
+    return {};
+  return Result->value();
+}
+
+eld::Expected<UncertainValue> Expression::eval() {
   auto V = evalImpl();
   if (V)
-    EvaluatedValue = V.value();
+    EvaluatedValue = V->value();
   return V;
 }
 
@@ -122,7 +129,7 @@ bool Symbol::hasDot() const {
   return ThisSymbol == ThisModule.getDotSymbol();
 }
 
-eld::Expected<uint64_t> Symbol::evalImpl() {
+eld::Expected<UncertainValue> Symbol::evalImpl() {
 
   if (!ThisSymbol)
     ThisSymbol = ThisModule.getNamePool().findSymbol(Name);
@@ -174,7 +181,7 @@ void Integer::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> Integer::evalImpl() { return ExpressionValue; }
+eld::Expected<UncertainValue> Integer::evalImpl() { return ExpressionValue; }
 void Integer::getSymbols(std::vector<ResolveInfo *> &Symbols) {}
 
 void Integer::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {}
@@ -198,7 +205,7 @@ void Add::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> Add::evalImpl() {
+eld::Expected<UncertainValue> Add::evalImpl() {
   // evaluate sub expressions
   auto Left = LeftExpression.eval();
   if (!Left)
@@ -251,7 +258,7 @@ void Subtract::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> Subtract::evalImpl() {
+eld::Expected<UncertainValue> Subtract::evalImpl() {
   // evaluate sub expressions
   auto Left = LeftExpression.eval();
   if (!Left)
@@ -291,7 +298,7 @@ void Modulo::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> Modulo::evalImpl() {
+eld::Expected<UncertainValue> Modulo::evalImpl() {
   // evaluate sub expressions
   auto Left = LeftExpression.eval();
   if (!Left)
@@ -299,7 +306,7 @@ eld::Expected<uint64_t> Modulo::evalImpl() {
   auto Right = RightExpression.eval();
   if (!Right)
     return Right;
-  if (Right.value() == 0) {
+  if (Right->value() == 0) {
     std::string ErrorString;
     llvm::raw_string_ostream ErrorStringStream(ErrorString);
     dump(ErrorStringStream);
@@ -342,7 +349,7 @@ void Multiply::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> Multiply::evalImpl() {
+eld::Expected<UncertainValue> Multiply::evalImpl() {
   // evaluate sub expressions
   auto Left = LeftExpression.eval();
   if (!Left)
@@ -385,7 +392,7 @@ void Divide::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> Divide::evalImpl() {
+eld::Expected<UncertainValue> Divide::evalImpl() {
   // evaluate sub expressions
   auto Left = LeftExpression.eval();
   if (!Left)
@@ -393,7 +400,7 @@ eld::Expected<uint64_t> Divide::evalImpl() {
   auto Right = RightExpression.eval();
   if (!Right)
     return Right;
-  if (Right.value() == 0) {
+  if (Right->value() == 0) {
     std::string ErrorString;
     llvm::raw_string_ostream ErrorStringStream(ErrorString);
     dump(ErrorStringStream);
@@ -430,7 +437,7 @@ void SizeOf::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   }
   Outs << ")";
 }
-eld::Expected<uint64_t> SizeOf::evalImpl() {
+eld::Expected<UncertainValue> SizeOf::evalImpl() {
 
   if (Name.size() && Name[0] == ':') {
     // If the name is a segment and we don't have PHDR's. SIZEOF on segment will
@@ -497,7 +504,7 @@ void SizeOfHeaders::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   }
 }
 
-eld::Expected<uint64_t> SizeOfHeaders::evalImpl() {
+eld::Expected<UncertainValue> SizeOfHeaders::evalImpl() {
   uint64_t Offset = 0;
   std::vector<ELFSection *> Sections;
   if (!ThisBackend.isEhdrNeeded())
@@ -527,7 +534,7 @@ void Addr::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   }
   Outs << "\")";
 }
-eld::Expected<uint64_t> Addr::evalImpl() {
+eld::Expected<UncertainValue> Addr::evalImpl() {
   // As the section table is populated only during PostLayout, we have to
   // go the other way around to access the section. This is because size of
   // empty
@@ -542,7 +549,7 @@ eld::Expected<uint64_t> Addr::evalImpl() {
     ThisModule.getConfig().raise(Diag::warn_forward_reference)
         << MContext << Name;
   // evaluate sub expression
-  return ThisSection->addr();
+  return UncertainValue(ThisSection->addr(), !ThisSection->hasVMA());
 }
 
 void Addr::getSymbols(std::vector<ResolveInfo *> &Symbols) {}
@@ -565,7 +572,7 @@ void LoadAddr::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   }
   Outs << ")";
 }
-eld::Expected<uint64_t> LoadAddr::evalImpl() {
+eld::Expected<UncertainValue> LoadAddr::evalImpl() {
   // As the section table is populated only during PostLayout, we have to
   // go the other way around to access the section. This is because size of
   // empty
@@ -594,7 +601,7 @@ void OffsetOf::dump(llvm::raw_ostream &Outs, bool WithValues) const {
     Outs.write_hex(*MResult);
   }
 }
-eld::Expected<uint64_t> OffsetOf::evalImpl() {
+eld::Expected<UncertainValue> OffsetOf::evalImpl() {
   // As the section table is populated only during PostLayout, we have to
   // go the other way around to access the section. This is because size of
   // empty
@@ -605,7 +612,7 @@ eld::Expected<uint64_t> OffsetOf::evalImpl() {
   // evaluate sub expression
   if (ThisSection->hasOffset())
     return ThisSection->offset();
-  return 0;
+  return UncertainValue(0, true);
 }
 void OffsetOf::getSymbols(std::vector<ResolveInfo *> &Symbols) {}
 
@@ -630,11 +637,14 @@ void Ternary::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> Ternary::evalImpl() {
+eld::Expected<UncertainValue> Ternary::evalImpl() {
   auto Cond = ConditionExpression.eval();
   if (!Cond)
     return Cond;
-  return Cond.value() ? LeftExpression.eval() : RightExpression.eval();
+  auto Left = LeftExpression.eval();
+  auto Right = RightExpression.eval();
+  return UncertainValue(Cond->value() ? Left->value() : Right->value(), *Cond,
+                        *Left, *Right);
 }
 void Ternary::getSymbols(std::vector<ResolveInfo *> &Symbols) {
   ConditionExpression.getSymbols(Symbols);
@@ -676,7 +686,7 @@ void AlignExpr::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   AlignmentExpression.dump(Outs, WithValues);
   Outs << ")";
 }
-eld::Expected<uint64_t> AlignExpr::evalImpl() {
+eld::Expected<UncertainValue> AlignExpr::evalImpl() {
   // evaluate sub expressions
   auto Expr = ExpressionToEvaluate.eval();
   if (!Expr)
@@ -684,8 +694,8 @@ eld::Expected<uint64_t> AlignExpr::evalImpl() {
   auto Align = AlignmentExpression.eval();
   if (!Align)
     return Align;
-  uint64_t Value = Expr.value();
-  uint64_t AlignValue = Align.value();
+  uint64_t Value = Expr->value();
+  uint64_t AlignValue = Align->value();
   if (!AlignValue)
     return Value;
   if (ThisModule.getConfig().showLinkerScriptWarnings() &&
@@ -693,7 +703,7 @@ eld::Expected<uint64_t> AlignExpr::evalImpl() {
     ThisModule.getConfig().raise(
         Diag::warn_non_power_of_2_value_to_align_builtin)
         << getContext() << utility::toHex(AlignValue);
-  return llvm::alignTo(Value, AlignValue);
+  return UncertainValue(llvm::alignTo(Value, AlignValue), *Expr, *Align);
 }
 
 void AlignExpr::getSymbols(std::vector<ResolveInfo *> &Symbols) {
@@ -719,7 +729,7 @@ void AlignOf::getSymbols(std::vector<ResolveInfo *> &Symbols) {}
 
 void AlignOf::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {}
 
-eld::Expected<uint64_t> AlignOf::evalImpl() {
+eld::Expected<UncertainValue> AlignOf::evalImpl() {
   // As the section table is populated only during PostLayout, we have to
   // go the other way around to access the section. This is because size of
   // empty
@@ -743,7 +753,7 @@ void Absolute::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   ExpressionToEvaluate.dump(Outs, WithValues);
   Outs << ")";
 }
-eld::Expected<uint64_t> Absolute::evalImpl() {
+eld::Expected<UncertainValue> Absolute::evalImpl() {
   return ExpressionToEvaluate.eval();
 }
 void Absolute::getSymbols(std::vector<ResolveInfo *> &Symbols) {
@@ -773,7 +783,7 @@ void ConditionGT::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> ConditionGT::evalImpl() {
+eld::Expected<UncertainValue> ConditionGT::evalImpl() {
   auto Left = LeftExpression.eval();
   if (!Left)
     return Left;
@@ -814,7 +824,7 @@ void ConditionLT::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> ConditionLT::evalImpl() {
+eld::Expected<UncertainValue> ConditionLT::evalImpl() {
   // evaluate sub expressions
   auto Left = LeftExpression.eval();
   if (!Left)
@@ -856,7 +866,7 @@ void ConditionEQ::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> ConditionEQ::evalImpl() {
+eld::Expected<UncertainValue> ConditionEQ::evalImpl() {
   // evaluate sub expressions
   auto Left = LeftExpression.eval();
   if (!Left)
@@ -898,7 +908,7 @@ void ConditionGTE::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> ConditionGTE::evalImpl() {
+eld::Expected<UncertainValue> ConditionGTE::evalImpl() {
   // evaluate sub expressions
   auto Left = LeftExpression.eval();
   if (!Left)
@@ -940,7 +950,7 @@ void ConditionLTE::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> ConditionLTE::evalImpl() {
+eld::Expected<UncertainValue> ConditionLTE::evalImpl() {
   // evaluate sub expressions
   auto Left = LeftExpression.eval();
   if (!Left)
@@ -982,7 +992,7 @@ void ConditionNEQ::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> ConditionNEQ::evalImpl() {
+eld::Expected<UncertainValue> ConditionNEQ::evalImpl() {
   // evaluate sub expressions
   auto Left = LeftExpression.eval();
   if (!Left)
@@ -1018,7 +1028,7 @@ void Complement::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   Outs << Name;
   ExpressionToEvaluate.dump(Outs, WithValues);
 }
-eld::Expected<uint64_t> Complement::evalImpl() {
+eld::Expected<UncertainValue> Complement::evalImpl() {
   // evaluate sub expressions
   auto Expr = ExpressionToEvaluate.eval();
   if (!Expr)
@@ -1046,7 +1056,7 @@ void UnaryPlus::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   Outs << Name;
   ExpressionToEvaluate.dump(Outs, WithValues);
 }
-eld::Expected<uint64_t> UnaryPlus::evalImpl() {
+eld::Expected<UncertainValue> UnaryPlus::evalImpl() {
   return ExpressionToEvaluate.eval();
 }
 void UnaryPlus::getSymbols(std::vector<ResolveInfo *> &Symbols) {
@@ -1069,7 +1079,7 @@ void UnaryMinus::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   Outs << "-";
   ExpressionToEvaluate.dump(Outs, WithValues);
 }
-eld::Expected<uint64_t> UnaryMinus::evalImpl() {
+eld::Expected<UncertainValue> UnaryMinus::evalImpl() {
   // evaluate sub expressions
   auto Expr = ExpressionToEvaluate.eval();
   if (!Expr)
@@ -1096,7 +1106,7 @@ void UnaryNot::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   Outs << Name;
   ExpressionToEvaluate.dump(Outs, WithValues);
 }
-eld::Expected<uint64_t> UnaryNot::evalImpl() {
+eld::Expected<UncertainValue> UnaryNot::evalImpl() {
   // evaluate sub expressions
   auto Expr = ExpressionToEvaluate.eval();
   if (!Expr)
@@ -1118,7 +1128,7 @@ void Constant::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   // format output for operator
   Outs << "CONSTANT(" << Name << ")";
 }
-eld::Expected<uint64_t> Constant::evalImpl() {
+eld::Expected<UncertainValue> Constant::evalImpl() {
   // evaluate sub expressions
   switch (type()) {
   case Expression::MAXPAGESIZE:
@@ -1128,7 +1138,7 @@ eld::Expected<uint64_t> Constant::evalImpl() {
   default:
     // this can't happen because all constants are part of the syntax
     ASSERT(0, "Unexpected constant");
-    return {};
+    return 0;
   }
 }
 void Constant::getSymbols(std::vector<ResolveInfo *> &Symbols) {}
@@ -1147,7 +1157,7 @@ void SegmentStart::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   ExpressionToEvaluate.dump(Outs, WithValues);
   Outs << ")";
 }
-eld::Expected<uint64_t> SegmentStart::evalImpl() {
+eld::Expected<UncertainValue> SegmentStart::evalImpl() {
   GeneralOptions::AddressMapType &AddressMap =
       ThisModule.getConfig().options().addressMap();
   GeneralOptions::AddressMapType::const_iterator Addr;
@@ -1196,7 +1206,7 @@ void AssertCmd::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   ExpressionToEvaluate.dump(Outs, WithValues);
   Outs << ", \"" << AssertionMessage << "\")";
 }
-eld::Expected<uint64_t> AssertCmd::evalImpl() {
+eld::Expected<UncertainValue> AssertCmd::evalImpl() {
   auto Expr = ExpressionToEvaluate.eval();
   if (!Expr)
     return Expr;
@@ -1231,7 +1241,7 @@ void RightShift::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> RightShift::evalImpl() {
+eld::Expected<UncertainValue> RightShift::evalImpl() {
   // evaluate sub expressions
   auto Left = LeftExpression.eval();
   if (!Left)
@@ -1275,7 +1285,7 @@ void LeftShift::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> LeftShift::evalImpl() {
+eld::Expected<UncertainValue> LeftShift::evalImpl() {
   // evaluate sub expressions
   auto Left = LeftExpression.eval();
   if (!Left)
@@ -1318,7 +1328,7 @@ void BitwiseOr::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> BitwiseOr::evalImpl() {
+eld::Expected<UncertainValue> BitwiseOr::evalImpl() {
   // evaluate sub expressions
   auto Left = LeftExpression.eval();
   if (!Left)
@@ -1361,7 +1371,7 @@ void BitwiseAnd::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> BitwiseAnd::evalImpl() {
+eld::Expected<UncertainValue> BitwiseAnd::evalImpl() {
   // evaluate sub expressions
   auto Left = LeftExpression.eval();
   if (!Left)
@@ -1391,7 +1401,7 @@ void Defined::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   // format output for operator
   Outs << "DEFINED(" << Name << ")";
 }
-eld::Expected<uint64_t> Defined::evalImpl() {
+eld::Expected<UncertainValue> Defined::evalImpl() {
   const LDSymbol *Symbol = ThisModule.getNamePool().findSymbol(Name);
   if (Symbol == nullptr)
     return 0;
@@ -1428,7 +1438,7 @@ void DataSegmentAlign::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   CommonPageSize.dump(Outs, WithValues);
   Outs << ")";
 }
-eld::Expected<uint64_t> DataSegmentAlign::evalImpl() {
+eld::Expected<UncertainValue> DataSegmentAlign::evalImpl() {
   auto MaxPageSize = this->MaxPageSize.eval();
   if (!MaxPageSize)
     return MaxPageSize;
@@ -1436,18 +1446,13 @@ eld::Expected<uint64_t> DataSegmentAlign::evalImpl() {
   if (!CommonPageSize)
     return CommonPageSize;
   uint64_t Dot = ThisModule.getDotSymbol()->value();
-  uint64_t Form1 = 0, Form2 = 0;
-
   uint64_t DotAligned = Dot;
+  alignAddress(DotAligned, MaxPageSize->value());
 
-  alignAddress(DotAligned, MaxPageSize.value());
-
-  Form1 = DotAligned + (Dot & (MaxPageSize.value() - 1));
-  Form2 = DotAligned + (Dot & (MaxPageSize.value() - CommonPageSize.value()));
-
-  if (Form1 <= Form2)
-    return Form1;
-  return Form2;
+  uint64_t Form1 = DotAligned + (Dot & (MaxPageSize->value() - 1));
+  uint64_t Form2 =
+      DotAligned + (Dot & (MaxPageSize->value() - CommonPageSize->value()));
+  return UncertainValue(std::min(Form1, Form2), *MaxPageSize, *CommonPageSize);
 }
 void DataSegmentAlign::getSymbols(std::vector<ResolveInfo *> &Symbols) {}
 
@@ -1470,7 +1475,7 @@ void DataSegmentRelRoEnd::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   RightExpression.dump(Outs, WithValues);
   Outs << ")";
 }
-eld::Expected<uint64_t> DataSegmentRelRoEnd::evalImpl() {
+eld::Expected<UncertainValue> DataSegmentRelRoEnd::evalImpl() {
   auto CommonPageSize = this->CommonPageSize.eval();
   if (!CommonPageSize)
     return CommonPageSize;
@@ -1480,8 +1485,8 @@ eld::Expected<uint64_t> DataSegmentRelRoEnd::evalImpl() {
   auto Expr2 = RightExpression.eval();
   if (!Expr2)
     return Expr2;
-  uint64_t Value = Expr1.value() + Expr2.value();
-  alignAddress(Value, CommonPageSize.value());
+  auto Value = Expr1.value() + Expr2.value();
+  alignAddress(Value.value(), CommonPageSize->value());
   return Value;
 }
 void DataSegmentRelRoEnd::getSymbols(std::vector<ResolveInfo *> &Symbols) {
@@ -1511,7 +1516,7 @@ void DataSegmentEnd::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   ExpressionToEvaluate.dump(Outs, WithValues);
   Outs << ")";
 }
-eld::Expected<uint64_t> DataSegmentEnd::evalImpl() {
+eld::Expected<UncertainValue> DataSegmentEnd::evalImpl() {
   // evaluate sub expressions
   auto Expr = ExpressionToEvaluate.eval();
   if (!Expr)
@@ -1548,7 +1553,7 @@ void Max::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> Max::evalImpl() {
+eld::Expected<UncertainValue> Max::evalImpl() {
   // evaluate sub expressions
   auto Left = LeftExpression.eval();
   if (!Left)
@@ -1557,7 +1562,9 @@ eld::Expected<uint64_t> Max::evalImpl() {
   if (!Right)
     return Right;
 
-  return Left.value() > Right.value() ? Left.value() : Right.value();
+  return UncertainValue(Left->value() > Right->value() ? Left->value()
+                                                       : Right->value(),
+                        *Left, *Right);
 }
 void Max::getSymbols(std::vector<ResolveInfo *> &Symbols) {
   LeftExpression.getSymbols(Symbols);
@@ -1590,7 +1597,7 @@ void Min::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> Min::evalImpl() {
+eld::Expected<UncertainValue> Min::evalImpl() {
   // evaluate sub expressions
   auto Left = LeftExpression.eval();
   if (!Left)
@@ -1598,7 +1605,9 @@ eld::Expected<uint64_t> Min::evalImpl() {
   auto Right = RightExpression.eval();
   if (!Right)
     return Right;
-  return Left.value() < Right.value() ? Left.value() : Right.value();
+  return UncertainValue(Left->value() < Right->value() ? Left->value()
+                                                       : Right->value(),
+                        *Left, *Right);
 }
 void Min::getSymbols(std::vector<ResolveInfo *> &Symbols) {
   LeftExpression.getSymbols(Symbols);
@@ -1625,7 +1634,9 @@ void Fill::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   ExpressionToEvaluate.dump(Outs, WithValues);
   Outs << ")";
 }
-eld::Expected<uint64_t> Fill::evalImpl() { return ExpressionToEvaluate.eval(); }
+eld::Expected<UncertainValue> Fill::evalImpl() {
+  return ExpressionToEvaluate.eval();
+}
 
 void Fill::getSymbols(std::vector<ResolveInfo *> &Symbols) {
   ExpressionToEvaluate.getSymbols(Symbols);
@@ -1651,11 +1662,12 @@ void Log2Ceil::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   Outs << ")";
 }
 
-eld::Expected<uint64_t> Log2Ceil::evalImpl() {
+eld::Expected<UncertainValue> Log2Ceil::evalImpl() {
   auto Val = ExpressionToEvaluate.eval();
   if (!Val)
     return Val;
-  return llvm::Log2_64_Ceil(std::max(Val.value(), UINT64_C(1)));
+  return UncertainValue(llvm::Log2_64_Ceil(std::max(Val->value(), UINT64_C(1))),
+                        *Val);
 }
 
 void Log2Ceil::getSymbols(std::vector<ResolveInfo *> &Symbols) {
@@ -1695,7 +1707,7 @@ void LogicalOp::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> LogicalOp::evalImpl() {
+eld::Expected<UncertainValue> LogicalOp::evalImpl() {
   // evaluate sub expressions
   auto Left = LeftExpression.eval();
   if (!Left)
@@ -1737,13 +1749,12 @@ void QueryMemory::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   Outs << ")";
 }
 
-eld::Expected<uint64_t> QueryMemory::evalImpl() {
+eld::Expected<UncertainValue> QueryMemory::evalImpl() {
   auto Region = ThisModule.getScript().getMemoryRegion(Name);
   if (!Region)
     return std::move(Region.error());
-  if (isOrigin())
-    return Region.value()->getOrigin();
-  return Region.value()->getLength();
+  return UncertainValue(isOrigin() ? *Region.value()->getOrigin()
+                                   : *Region.value()->getLength());
 }
 
 void QueryMemory::getSymbols(std::vector<ResolveInfo *> &Symbols) {}
@@ -1761,7 +1772,7 @@ void NullExpression::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   Outs << Name;
 }
 
-eld::Expected<uint64_t> NullExpression::evalImpl() {
+eld::Expected<UncertainValue> NullExpression::evalImpl() {
   return std::make_unique<plugin::DiagnosticEntry>(
       Diag::internal_error_null_expression, std::vector<std::string>{});
 }

--- a/lib/SymbolResolver/LDSymbol.cpp
+++ b/lib/SymbolResolver/LDSymbol.cpp
@@ -32,7 +32,7 @@ static LDSymbol GNullSymbol;
 LDSymbol::LDSymbol(ResolveInfo *R, bool IsGc)
     : ThisResolveInfo(R), ThisFragRef(nullptr), ThisShndx(0), ThisSymIdx(0),
       ThisSymbolsIsScriptDefined(false), ThisSymbolHasScriptValue(false),
-      ThisSymbolGarbageCollected(IsGc) {}
+      ThisSymbolHasUncertainValue(false), ThisSymbolGarbageCollected(IsGc) {}
 
 LDSymbol::~LDSymbol() {}
 

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -61,15 +61,25 @@ Relocator *RISCVLDBackend::getRelocator() const {
   return m_pRelocator;
 }
 
-Relocation::Address RISCVLDBackend::getSymbolValuePLT(Relocation &R) {
+Relocation::Address RISCVLDBackend::getSymbolValuePLT(Relocation &R,
+                                                      bool &Uncertain) {
   ResolveInfo *rsym = R.symInfo();
   if (rsym && (rsym->reserved() & Relocator::ReservePLT)) {
-    if (const Fragment *S = findEntryInPLT(rsym))
+    if (const Fragment *S = findEntryInPLT(rsym)) {
+      Uncertain = false;
       return S->getAddr(config().getDiagEngine());
-    if (const ResolveInfo *S = findAbsolutePLT(rsym))
+    }
+    if (const ResolveInfo *S = findAbsolutePLT(rsym)) {
+      Uncertain = false;
       return S->value();
+    }
   }
-  return getRelocator()->getSymValue(&R);
+  return getRelocator()->getSymValue(&R, Uncertain);
+}
+
+Relocation::Address RISCVLDBackend::getSymbolValuePLT(Relocation &R) {
+  bool Ignored;
+  return getSymbolValuePLT(R, Ignored);
 }
 
 Relocation::Type RISCVLDBackend::getCopyRelType() const {
@@ -241,11 +251,13 @@ bool RISCVLDBackend::doRelaxationCall(Relocation *reloc, bool DoCompressed) {
   bool canCompress = (rd == 0 || (rd == 1 && config().targets().is32Bits()));
 
   // test if it can fall into 21bits
-  Relocator::DWord S = getSymbolValuePLT(*reloc);
+  bool Uncertain;
+  Relocator::DWord S = getSymbolValuePLT(*reloc, Uncertain);
   Relocator::DWord A = reloc->addend();
   Relocator::DWord P = reloc->place(m_Module);
   Relocator::DWord X = S + A - P;
-  bool canRelax = config().options().getRISCVRelax() && llvm::isInt<21>(X);
+  bool canRelax =
+      config().options().getRISCVRelax() && llvm::isInt<21>(X) && !Uncertain;
 
   if (!canRelax) {
     reportMissedRelaxation("RISCV_CALL", *region, offset, canCompress ? 6 : 4,
@@ -313,15 +325,16 @@ bool RISCVLDBackend::doRelaxationQCCall(Relocation *reloc, bool DoCompressed) {
   uint64_t qc_e_jump = reloc->target() & 0xffffffffffff;
   bool isTailCall = (qc_e_jump & 0xf1f07f) == 0x00401f;
 
-  Relocator::DWord S = getSymbolValuePLT(*reloc);
+  bool Uncertain;
+  Relocator::DWord S = getSymbolValuePLT(*reloc, Uncertain);
   Relocator::DWord A = reloc->addend();
   Relocator::DWord P = reloc->place(m_Module);
   Relocator::DWord X = S + A - P;
 
-  bool canRelaxXqci =
-      config().targets().is32Bits() && config().options().getRISCVRelaxXqci();
-  bool canRelax =
-      config().options().getRISCVRelax() && canRelaxXqci && llvm::isInt<21>(X);
+  bool canRelax = config().options().getRISCVRelax() &&
+                  config().options().getRISCVRelaxXqci() &&
+                  config().targets().is32Bits() && llvm::isInt<21>(X) &&
+                  !Uncertain;
   bool canCompress = DoCompressed && llvm::isInt<12>(X);
 
   if (!canRelax) {
@@ -382,20 +395,17 @@ bool RISCVLDBackend::doRelaxationLui(Relocation *reloc, Relocator::DWord G) {
     return false;
 
   size_t SymbolSize = reloc->symInfo()->outSymbol()->size();
-  Relocator::DWord S = getSymbolValuePLT(*reloc);
+  bool Uncertain;
+  Relocator::DWord S = getSymbolValuePLT(*reloc, Uncertain);
   Relocator::DWord A = reloc->addend();
   Relocator::DWord Value = S + A;
   uint64_t offset = reloc->targetRef()->offset();
   Relocation::Type type = reloc->type();
 
-  // Do not relax complete zeroes because they can be mistaken for
-  // not-yet-assigned values. This applies to both zero-page relaxation and GP
-  // relaxation when GP is close to zero.
-
   // First, try zero-page relaxation. It's the cheapest and does not need GP.
   bool canRelaxZero = config().options().getRISCVRelax() &&
                       config().options().getRISCVZeroRelax() &&
-                      llvm::isInt<12>(Value) && S != 0;
+                      llvm::isInt<12>(Value) && !Uncertain;
 
   // HI will be deleted, LO will be converted to use GP as base.
   // GP must be available and relocation must fit in 12 bits relative to GP.
@@ -404,7 +414,7 @@ bool RISCVLDBackend::doRelaxationLui(Relocation *reloc, Relocator::DWord G) {
       config().options().getRISCVRelax() &&
       config().options().getRISCVGPRelax() && !config().isCodeIndep() &&
       G != 0 && fitsInGP(G, Value, frag, reloc->targetSection(), SymbolSize) &&
-      S != 0;
+      !Uncertain;
 
   if (type == llvm::ELF::R_RISCV_HI20) {
 
@@ -644,12 +654,7 @@ bool RISCVLDBackend::doRelaxationPC(Relocation *reloc, Relocator::DWord G) {
   if (!region)
     return false;
 
-  // Test if the symbol with size can fall in 12 bits.
-  size_t SymbolSize = reloc->symInfo()->outSymbol()->size();
-  Relocator::DWord S = getSymbolValuePLT(*reloc);
-  Relocator::DWord A = reloc->addend();
-
-  Relocation::Type new_type = 0x0;
+  std::optional<Relocation::Type> new_type;
   Relocation::Type type = reloc->type();
   switch (type) {
   case llvm::ELF::R_RISCV_PCREL_LO12_I:
@@ -662,6 +667,7 @@ bool RISCVLDBackend::doRelaxationPC(Relocation *reloc, Relocator::DWord G) {
     break;
   }
 
+  Relocation *SymbolReloc = reloc;
   if (new_type) {
     // Lookup reloc to get actual addend of HI.
     Relocation *HIReloc = m_PairedRelocs[reloc];
@@ -671,15 +677,21 @@ bool RISCVLDBackend::doRelaxationPC(Relocation *reloc, Relocator::DWord G) {
       return false;
     if (!HIReloc)
       ASSERT(0, "HIReloc not found! Internal Error!");
-    S = getSymbolValuePLT(*HIReloc);
-    A = HIReloc->addend();
-    SymbolSize = HIReloc->symInfo()->outSymbol()->size();
+    SymbolReloc = HIReloc;
   }
 
+  // Test if the symbol with size can fall in 12 bits.
+  size_t SymbolSize = SymbolReloc->symInfo()->outSymbol()->size();
+  bool Uncertain;
+  Relocator::DWord S = getSymbolValuePLT(*SymbolReloc, Uncertain);
+  Relocator::DWord A = SymbolReloc->addend();
+
   uint64_t offset = reloc->targetRef()->offset();
-  bool canRelax = config().options().getRISCVRelax() &&
-                  config().options().getRISCVGPRelax() && G != 0 &&
-                  fitsInGP(G, S + A, frag, reloc->targetSection(), SymbolSize);
+  bool canRelax =
+      config().options().getRISCVRelax() &&
+      config().options().getRISCVGPRelax() && G != 0 &&
+      fitsInGP(G, S + A, frag, reloc->targetSection(), SymbolSize) &&
+      !Uncertain;
 
   // HI will be deleted, Low will be converted to use gp as base.
   if (type == llvm::ELF::R_RISCV_PCREL_HI20) {
@@ -701,7 +713,7 @@ bool RISCVLDBackend::doRelaxationPC(Relocation *reloc, Relocator::DWord G) {
   uint64_t instr = reloc->target();
   uint64_t mask = 0x1F << 15;
   instr = (instr & ~mask) | (0x3 << 15);
-  reloc->setType(new_type);
+  reloc->setType(*new_type);
   reloc->setTargetData(instr);
   reloc->setAddend(A);
   return true;

--- a/lib/Target/RISCV/RISCVLDBackend.h
+++ b/lib/Target/RISCV/RISCVLDBackend.h
@@ -176,6 +176,7 @@ public:
   }
 
   // Get the value of the symbol, using the PLT slot if one exists.
+  Relocation::Address getSymbolValuePLT(Relocation &R, bool &Uncertain);
   Relocation::Address getSymbolValuePLT(Relocation &R);
 
 private:

--- a/lib/Target/Relocator.cpp
+++ b/lib/Target/Relocator.cpp
@@ -289,8 +289,15 @@ bool Relocator::doDeMangle() const {
   return m_Config.options().shouldDemangle();
 }
 
-Relocation::Address Relocator::getSymValue(Relocation *R) {
-  if (R->symInfo() && R->symInfo()->isThreadLocal())
+Relocation::Address Relocator::getSymValue(Relocation *R, bool &Uncertain) {
+  if (R->symInfo() && R->symInfo()->isThreadLocal()) {
+    Uncertain = false;
     return getTarget().finalizeTLSSymbol(R->symInfo()->outSymbol());
-  return R->symValue(m_Module);
+  }
+  return R->symValue(m_Module, Uncertain);
+}
+
+Relocation::Address Relocator::getSymValue(Relocation *R) {
+  bool Ignored;
+  return getSymValue(R, Ignored);
 }


### PR DESCRIPTION
A symbol may be defined in a script referencing a section address. Such symbols get their values after section layout is complete. At the relaxation time such symbols do not have the correct value. The current logic uses a value of zero as an indicator that the symbol value is unknown and prevents some relaxations with them. However, this logic produces both false positives and false negatives because 1) incomplete symbol values may be used in expressions that produce a nonzero value and 2) some symbols having a zero value are valid and can be relaxed.

In this change, symbols that reference unknows section addresses are detected and the corresponding relaxations are not performed.