### PR TITLE
[NFC] ObjectLinker should own creation of readers

### DIFF
--- a/include/eld/Core/Module.h
+++ b/include/eld/Core/Module.h
@@ -460,7 +460,7 @@ public:
                                                const char *Buf, size_t Size);
 
   // Get backend
-  GNULDBackend *getBackend() const;
+  GNULDBackend &getBackend() const;
 
   void replaceFragment(FragmentRef *F, const uint8_t *Data, size_t Sz);
 

--- a/include/eld/Object/ObjectLinker.h
+++ b/include/eld/Object/ObjectLinker.h
@@ -453,6 +453,16 @@ private:
   /// using each input section it contained.
   void finalizeOutputSectionFlags(OutputSectionEntry *OSE) const;
 
+  // -----  readers/writers  ----- //
+  ArchiveParser *createArchiveParser();
+  ELFRelocObjParser *createRelocObjParser();
+  ELFExecObjParser *createELFExecObjParser();
+  BinaryFileParser *createBinaryFileParser();
+  BitcodeReader *createBitcodeReader();
+  SymDefReader *createSymDefReader();
+  ELFDynObjParser *createDynObjReader();
+  ELFObjectWriter *createWriter();
+
 private:
   LinkerConfig &ThisConfig;
   Module *ThisModule;

--- a/include/eld/Readers/BitcodeReader.h
+++ b/include/eld/Readers/BitcodeReader.h
@@ -13,24 +13,19 @@ class LinkerPlugin;
 
 namespace eld {
 
-class IRBuilder;
-class GNULDBackend;
-class LinkerConfig;
+class Module;
 class InputFile;
 
 class BitcodeReader {
 
 public:
-  BitcodeReader(GNULDBackend &pBackend, eld::IRBuilder &pBuilder,
-                LinkerConfig &pConfig);
+  BitcodeReader(Module &);
   ~BitcodeReader();
 
   bool readInput(InputFile &pFile, plugin::LinkerPlugin *LTOPlugin);
 
 private:
-  GNULDBackend &m_Backend;
-  eld::IRBuilder &m_Builder;
-  LinkerConfig &m_Config;
+  Module &m_Module;
   bool m_TraceLTO;
 };
 

--- a/include/eld/Readers/ELFDynObjParser.h
+++ b/include/eld/Readers/ELFDynObjParser.h
@@ -20,7 +20,7 @@ class Module;
 /// process.
 class ELFDynObjParser {
 public:
-  ELFDynObjParser(Module &module);
+  ELFDynObjParser(Module &);
 
   ~ELFDynObjParser();
 

--- a/include/eld/Readers/ELFExecObjParser.h
+++ b/include/eld/Readers/ELFExecObjParser.h
@@ -15,7 +15,7 @@ class ELFExecutableFileReader;
 
 class ELFExecObjParser {
 public:
-  ELFExecObjParser(Module &module);
+  ELFExecObjParser(Module &);
 
   eld::Expected<bool> parseFile(InputFile &inputFile,
                                 bool &ELFOverriddenWithBC);

--- a/include/eld/Readers/ELFRelocObjParser.h
+++ b/include/eld/Readers/ELFRelocObjParser.h
@@ -20,7 +20,7 @@ class Module;
 /// process.
 class ELFRelocObjParser {
 public:
-  ELFRelocObjParser(Module &module);
+  ELFRelocObjParser(Module &);
 
   // clang-format off
   /// This function does one of the two things depending on the context:

--- a/include/eld/Readers/SymDefReader.h
+++ b/include/eld/Readers/SymDefReader.h
@@ -8,24 +8,18 @@
 #define ELD_READERS_SYMDEFREADER_H
 
 #include "eld/Readers/ObjectReader.h"
-#include "eld/SymbolResolver/LDSymbol.h"
 #include "eld/SymbolResolver/ResolveInfo.h"
-#include "llvm/ADT/StringRef.h"
-#include "llvm/ADT/StringSwitch.h"
 #include <tuple>
 
 namespace eld {
 
-class IRBuilder;
-class GNULDBackend;
-class LinkerConfig;
 class InputFile;
+class Module;
 
 class SymDefReader : public ObjectReader {
 
 public:
-  SymDefReader(GNULDBackend &pBackend, eld::IRBuilder &pBuilder,
-               LinkerConfig &pConfig);
+  SymDefReader(Module &);
   ~SymDefReader();
 
   /* read symdef header*/
@@ -41,8 +35,7 @@ private:
   readSymDefs(InputFile &pFile);
 
 private:
-  eld::IRBuilder &m_Builder;
-  LinkerConfig &m_Config;
+  Module &m_Module;
 };
 
 } // namespace eld

--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -144,16 +144,6 @@ public:
 
   virtual ~GNULDBackend();
 
-  // -----  readers/writers  ----- //
-  ArchiveParser *createArchiveParser();
-  ELFRelocObjParser *createRelocObjParser();
-  ELFExecObjParser *createELFExecObjParser();
-  BinaryFileParser *createBinaryFileParser();
-  BitcodeReader *createBitcodeReader();
-  SymDefReader *createSymDefReader();
-  ELFDynObjParser *createDynObjReader();
-  ELFObjectWriter *createWriter();
-
   // -----  output sections  ----- //
   /// initStdSections - initialize standard sections of the output file.
   virtual eld::Expected<void> initStdSections();
@@ -1004,15 +994,6 @@ private:
 
 protected:
   Module &m_Module;
-
-  BitcodeReader *m_pBitcodeReader = nullptr;
-  SymDefReader *m_pSymDefReader = nullptr;
-  ELFObjectWriter *m_pELFObjWriter = nullptr;
-  ELFDynObjParser *m_NewDynObjReader = nullptr;
-  ELFRelocObjParser *m_NewRelocObjParser = nullptr;
-  ArchiveParser *m_ArchiveParser = nullptr;
-  ELFExecObjParser *m_ELFExecObjParser = nullptr;
-  BinaryFileParser *m_BinaryFileParser = nullptr;
 
   ELFFileFormat *m_pFileFormat = nullptr;
 

--- a/include/eld/Writers/ELFObjectWriter.h
+++ b/include/eld/Writers/ELFObjectWriter.h
@@ -21,7 +21,6 @@ namespace eld {
 
 class Module;
 class LinkerConfig;
-class GNULDBackend;
 class FragmentLinker;
 class Relocation;
 class ELFSection;
@@ -34,67 +33,53 @@ class Output;
  */
 class ELFObjectWriter {
 public:
-  ELFObjectWriter(GNULDBackend &CurBackend, LinkerConfig &CurConfig);
+  ELFObjectWriter(Module &M);
 
   ~ELFObjectWriter();
 
-  std::error_code writeObject(Module &CurModule,
-                              llvm::FileOutputBuffer &CurOutput);
+  std::error_code writeObject(llvm::FileOutputBuffer &CurOutput);
 
   // write timing stats into .note.qc.timing when -emit-timing-stats-in-output
   // enabled
-  void writeLinkTimeStats(Module &CurModule, uint64_t BeginningOfTime,
-                          uint64_t Duration);
+  void writeLinkTimeStats(uint64_t BeginningOfTime, uint64_t Duration);
 
   // Helper function, also used by compression.
-  eld::Expected<void> writeRegion(Module &CurModule, ELFSection *Section,
-                                  MemoryRegion &Region);
+  eld::Expected<void> writeRegion(ELFSection *Section, MemoryRegion &Region);
 
-  template <typename ELFT> size_t getOutputSize(const Module &CurModule) const;
+  template <typename ELFT> size_t getOutputSize() const;
 
-  eld::Expected<void> writeSection(Module &CurModule,
-                                   llvm::FileOutputBuffer &CurOutput,
+  eld::Expected<void> writeSection(llvm::FileOutputBuffer &CurOutput,
                                    ELFSection *Section);
 
 private:
-  GNULDBackend &target() { return Backend; }
-
-  const GNULDBackend &target() const { return Backend; }
-
   // writeELFHeader - emit ElfXX_Ehdr
   template <typename ELFT>
-  void writeELFHeader(LinkerConfig &CurConfig, const Module &CurModule,
-                      llvm::FileOutputBuffer &CurOutput) const;
+  void writeELFHeader(llvm::FileOutputBuffer &CurOutput) const;
 
-  uint64_t getEntryPoint(LinkerConfig &CurConfig,
-                         const Module &CurModule) const;
+  uint64_t getEntryPoint() const;
 
   // emitSectionHeader - emit ElfXX_Shdr
   template <typename ELFT>
-  void emitSectionHeader(const Module &CurModule, LinkerConfig &CurConfig,
-                         llvm::FileOutputBuffer &CurOutput) const;
+  void emitSectionHeader(llvm::FileOutputBuffer &CurOutput) const;
 
   // emitProgramHeader - emit ElfXX_Phdr
   template <typename ELFT>
   void emitProgramHeader(llvm::FileOutputBuffer &CurOutput) const;
 
   // emitShStrTab - emit .shstrtab
-  void emitShStrTab(ELFSection *ShStrTab, const Module &CurModule,
-                    llvm::FileOutputBuffer &CurOutput);
+  void emitShStrTab(ELFSection *ShStrTab, llvm::FileOutputBuffer &CurOutput);
 
   template <typename ELFT>
-  void emitRelocation(Module &Module, ELFSection *CurSection,
-                      MemoryRegion &CurRegion, bool IsDyn) const;
+  void emitRelocation(ELFSection *CurSection, MemoryRegion &CurRegion,
+                      bool IsDyn) const;
 
   // emitRel - emit ElfXX_Rel
   template <typename ELFT>
-  void emitRel(Module &Module, ELFSection *S, MemoryRegion &CurRegion,
-               bool IsDyn) const;
+  void emitRel(ELFSection *S, MemoryRegion &CurRegion, bool IsDyn) const;
 
   // emitRela - emit ElfXX_Rela
   template <typename ELFT>
-  void emitRela(Module &Module, ELFSection *S, MemoryRegion &CurRegion,
-                bool IsDyn) const;
+  void emitRela(ELFSection *S, MemoryRegion &CurRegion, bool IsDyn) const;
 
   // getSectEntrySize - compute ElfXX_Shdr::sh_entsize
   template <typename ELFT> uint64_t getSectEntrySize(ELFSection *S) const;
@@ -105,8 +90,7 @@ private:
   // getSectInfo - compute ElfXX_Shdr::sh_info
   uint64_t getSectInfo(ELFSection *S) const;
 
-  template <typename ELFT>
-  uint64_t getLastStartOffset(const Module &CurModule) const;
+  template <typename ELFT> uint64_t getLastStartOffset() const;
 
   eld::Expected<void> emitSection(ELFSection *CurSection,
                                   MemoryRegion &CurRegion) const;
@@ -126,9 +110,7 @@ private:
                       int32_t CurAddend) const;
 
 private:
-  GNULDBackend &Backend;
-
-  LinkerConfig &Config;
+  Module &ThisModule;
 };
 
 } // namespace eld

--- a/lib/BranchIsland/BranchIslandFactory.cpp
+++ b/lib/BranchIsland/BranchIslandFactory.cpp
@@ -308,7 +308,7 @@ BranchIslandFactory::createBranchIsland(Relocation &PReloc, Stub *S,
           << Relocation::getFragmentPath(nullptr, TargetFrag, Config.options())
           << Relocation::getFragmentPath(nullptr, RelocFrag, Config.options())
           << std::string(
-                 PModule.getBackend()->getRelocator()->getName(PReloc.type()));
+                 PModule.getBackend().getRelocator()->getName(PReloc.type()));
       PBuilder.getModule().setFailure(true);
       return std::make_pair(nullptr, false);
     }

--- a/lib/Core/Linker.cpp
+++ b/lib/Core/Linker.cpp
@@ -210,7 +210,7 @@ bool Linker::link() {
       TimingSectionTimer->stopTimer();
       uint64_t DurationMicro =
           TimingSectionTimer->getTotalTime().getWallTime() * 1000000;
-      ObjLinker->getWriter()->writeLinkTimeStats(*ThisModule, BeginningOfTime,
+      ObjLinker->getWriter()->writeLinkTimeStats(BeginningOfTime,
                                                  DurationMicro);
       TimingSectionTimer->clear();
     }
@@ -727,12 +727,10 @@ bool Linker::emit() {
   size_t OutputFileSize = 0;
   if (ThisConfig->targets().is32Bits())
     OutputFileSize =
-        ObjLinker->getWriter()->getOutputSize<llvm::object::ELF32LE>(
-            *ThisModule);
+        ObjLinker->getWriter()->getOutputSize<llvm::object::ELF32LE>();
   else if (ThisConfig->targets().is64Bits())
     OutputFileSize =
-        ObjLinker->getWriter()->getOutputSize<llvm::object::ELF64LE>(
-            *ThisModule);
+        ObjLinker->getWriter()->getOutputSize<llvm::object::ELF64LE>();
   uint64_t MaxImageSize =
       (ThisConfig->targets().is32Bits() ? UINT32_MAX : INT64_MAX);
   if (OutputFileSize > MaxImageSize) {

--- a/lib/Core/LinkerScript.cpp
+++ b/lib/Core/LinkerScript.cpp
@@ -470,7 +470,7 @@ bool LinkerScript::loadPlugin(Plugin &P, Module &M) {
   if (!P.registerPlugin(Handle))
     return false;
   // Create the Bitvector.
-  P.createRelocationVector(M.getBackend()->getRelocator()->getNumRelocs());
+  P.createRelocationVector(M.getBackend().getRelocator()->getNumRelocs());
 
   plugin::LinkerWrapper *LW = eld::make<plugin::LinkerWrapper>(&P, M);
   P.getLinkerPlugin()->setLinkerWrapper(LW);

--- a/lib/Core/Module.cpp
+++ b/lib/Core/Module.cpp
@@ -252,7 +252,7 @@ bool Module::createInternalInputs() {
     InternalFiles[IType] = IF;
   }
 
-  getBackend()->createInternalInputs();
+  getBackend().createInternalInputs();
 
   // Add implicit dot symbol
   Resolver::Result ResolvedResult;
@@ -630,9 +630,9 @@ Module::createPluginFragmentWithCustomName(std::string Name, size_t SectType,
   return F;
 }
 
-GNULDBackend *Module::getBackend() const {
+GNULDBackend &Module::getBackend() const {
   ASSERT(Linker->getBackend(), "The value must be non-null.");
-  return Linker->getBackend();
+  return *Linker->getBackend();
 }
 
 void Module::replaceFragment(FragmentRef *F, const uint8_t *Data, size_t Sz) {

--- a/lib/LayoutMap/LayoutInfo.cpp
+++ b/lib/LayoutMap/LayoutInfo.cpp
@@ -419,7 +419,7 @@ void LayoutInfo::recordRemoveSymbol(plugin::LinkerWrapper *W,
 
 LayoutInfo::ResolveInfoVectorT
 LayoutInfo::getAllocatedCommonSymbols(Module &Module) {
-  GNULDBackend &Backend = *Module.getBackend();
+  GNULDBackend &Backend = Module.getBackend();
   ObjectFile *CommonInputFile =
       llvm::cast<ObjectFile>(Module.getCommonInternalInput());
   ResolveInfoVectorT CommonSymbols;
@@ -439,7 +439,7 @@ LayoutInfo::getAllocatedCommonSymbols(Module &Module) {
 
 LayoutInfo::ResolveInfoVectorT
 LayoutInfo::getCommonsGarbageCollected(Module &Module) {
-  GNULDBackend &Backend = *Module.getBackend();
+  GNULDBackend &Backend = Module.getBackend();
   ObjectFile *CommonInputFile =
       llvm::cast<ObjectFile>(Module.getCommonInternalInput());
   ResolveInfoVectorT CommonSymbols;

--- a/lib/LayoutMap/TextLayoutPrinter.cpp
+++ b/lib/LayoutMap/TextLayoutPrinter.cpp
@@ -140,7 +140,7 @@ void TextLayoutPrinter::printStat(llvm::StringRef S,
 void TextLayoutPrinter::printStats(LayoutInfo::Stats &L,
                                    const Module &Module) {
   const ObjectLinker &ObjLinker = *(Module.getLinker()->getObjectLinker());
-  const GNULDBackend &Backend = *Module.getBackend();
+  const GNULDBackend &Backend = Module.getBackend();
 
   if (!L.hasStats())
     return;
@@ -473,7 +473,7 @@ bool TextLayoutPrinter::printRelocationDataPluginOp(eld::Module &M,
     outputStream() << "\n";
   }
   outputStream() << "#\tType: "
-                 << M.getBackend()->getRelocator()->getName(R->type()) << "\n";
+                 << M.getBackend().getRelocator()->getName(R->type()) << "\n";
   outputStream() << "#\tOriginal: 0x";
   outputStream().write_hex(R->target());
   uint64_t RelocationData;
@@ -1030,7 +1030,7 @@ void TextLayoutPrinter::printVersionScripts(bool UseColor) {
 }
 
 void TextLayoutPrinter::printLinkerInsertedTimingStats(Module &CurModule) {
-  TimingFragment *F = CurModule.getBackend()->getTimingFragment();
+  TimingFragment *F = CurModule.getBackend().getTimingFragment();
   const TimingSlice *T = F->getTimingSlice();
   outputStream() << T->getModuleName() << " " << T->getDate() << " "
                  << T->getDurationSeconds() << "\n";
@@ -1148,7 +1148,7 @@ void TextLayoutPrinter::printScriptCommands(const LinkerScript &Script) {
 // color. Reset the colors to terminal defaults after writing.
 void TextLayoutPrinter::printMapFile(eld::Module &Module) {
   ThisLayoutInfo->buildMergedStringMap(Module);
-  GNULDBackend &Backend = *Module.getBackend();
+  GNULDBackend &Backend = Module.getBackend();
   bool UseColor = Backend.config().options().color() &&
                   Backend.config().options().colorMap();
   LinkerScript const &Script = Module.getScript();
@@ -1210,7 +1210,7 @@ void TextLayoutPrinter::printLayout(eld::Module &Module) {
   // Get start and end points from section map to iterate over each section.
   SectionMap::const_iterator Out, OutBegin, OutEnd;
   LinkerScript const &Script = Module.getScript();
-  GNULDBackend &Backend = *Module.getBackend();
+  GNULDBackend &Backend = Module.getBackend();
   bool UseColor = Backend.config().options().color() &&
                   Backend.config().options().colorMap();
 

--- a/lib/LinkerWrapper/LayoutWrapper.cpp
+++ b/lib/LinkerWrapper/LayoutWrapper.cpp
@@ -19,13 +19,13 @@ const MapHeader LayoutWrapper::getMapHeader() const {
 }
 
 uint32_t LayoutWrapper::getABIPageSize() const {
-  return Linker.getModule()->getBackend()->abiPageSize();
+  return Linker.getModule()->getBackend().abiPageSize();
 }
 
 std::string LayoutWrapper::getTargetEmulation() const {
   std::string flagString = "";
-  flagString = Linker.getModule()->getBackend()->getInfo().flagString(
-      Linker.getModule()->getBackend()->getInfo().flags());
+  flagString = Linker.getModule()->getBackend().getInfo().flagString(
+      Linker.getModule()->getBackend().getInfo().flags());
   return flagString;
 }
 
@@ -46,7 +46,7 @@ LayoutWrapper::getPaddings(eld::plugin::OutputSection &Section) {
   eld::OutputSectionEntry *entry = Section.getOutputSection();
   // padding at section start
   for (const eld::GNULDBackend::PaddingT &p :
-       Linker.getModule()->getBackend()->getPaddingBetweenFragments(
+       Linker.getModule()->getBackend().getPaddingBetweenFragments(
            entry->getSection(), nullptr, entry->getFirstFrag())) {
     if (!(p.endOffset - p.startOffset))
       continue;
@@ -78,7 +78,7 @@ LayoutWrapper::getPaddings(eld::plugin::OutputSection &Section) {
         (*it)->getNextRuleWithContent();
     if ((*it)->hasContent()) {
       for (const eld::GNULDBackend::PaddingT &p :
-           Linker.getModule()->getBackend()->getPaddingBetweenFragments(
+           Linker.getModule()->getBackend().getPaddingBetweenFragments(
                entry->getSection(), (*it)->getLastFrag(),
                NextRuleWithContent ? NextRuleWithContent->getFirstFrag()
                                    : nullptr)) {

--- a/lib/LinkerWrapper/LinkerWrapper.cpp
+++ b/lib/LinkerWrapper/LinkerWrapper.cpp
@@ -193,7 +193,7 @@ LinkerWrapper::getOutputSectionContents(OutputSection &O) const {
     }
   }
   // The section could have a fill expression
-  m_Module.getBackend()->maybeFillRegion(O.getOutputSection(), Region);
+  m_Module.getBackend().maybeFillRegion(O.getOutputSection(), Region);
   return std::move(Data);
 }
 
@@ -217,7 +217,7 @@ eld::Expected<void> LinkerWrapper::finishAssignOutputSections() {
 eld::Expected<void> LinkerWrapper::reassignVirtualAddresses() {
   if (getState() != State::CreatingSegments)
     RETURN_INVALID_LINK_STATE_ERR("CreatingSegments");
-  m_Module.getBackend()->createScriptProgramHdrs();
+  m_Module.getBackend().createScriptProgramHdrs();
   return {};
 }
 
@@ -229,7 +229,7 @@ eld::Expected<std::vector<Segment>> LinkerWrapper::getSegmentTable() const {
                                  LLVM_PRETTY_FUNCTION,
                                  "'CreatingSegments, AfterLayout'"});
   std::vector<Segment> Segments;
-  for (auto *S : m_Module.getBackend()->elfSegmentTable())
+  for (auto *S : m_Module.getBackend().elfSegmentTable())
     Segments.push_back(Segment(S));
   return Segments;
 }
@@ -358,8 +358,8 @@ eld::Expected<void> LinkerWrapper::linkSections(OutputSection A,
   if (getState() != LinkerWrapper::CreatingSections &&
       getState() != LinkerWrapper::CreatingSegments)
     RETURN_INVALID_LINK_STATE_ERR("CreatingSections, CreatingSegments");
-  m_Module.getBackend()->pluginLinkSections(A.getOutputSection(),
-                                            B.getOutputSection());
+  m_Module.getBackend().pluginLinkSections(A.getOutputSection(),
+                                           B.getOutputSection());
   return {};
 }
 
@@ -605,7 +605,7 @@ eld::Expected<void> LinkerWrapper::registerReloc(uint32_t RelocType,
 }
 
 RelocationHandler LinkerWrapper::getRelocationHandler() const {
-  return RelocationHandler(m_Module.getBackend()->getRelocator());
+  return RelocationHandler(m_Module.getBackend().getRelocator());
 }
 
 size_t LinkerWrapper::getPluginThreadCount() const {
@@ -816,7 +816,7 @@ eld::Expected<Use> LinkerWrapper::createAndAddUse(Chunk C, off_t Offset,
                                                   int64_t Addend) {
   Use ChunkUse(nullptr);
   eld::Relocation *relocation = m_Module.getIRBuilder()->createRelocation(
-      m_Module.getBackend()->getRelocator(), *C.getFragment(), RelocationType,
+      m_Module.getBackend().getRelocator(), *C.getFragment(), RelocationType,
       *S.getSymbol()->outSymbol(), Offset, Addend);
   C.getFragment()->getOwningSection()->addRelocation(relocation);
   return Use(relocation);
@@ -903,7 +903,7 @@ LinkerWrapper::insertBeforeRule(plugin::OutputSection O,
 }
 
 void LinkerWrapper::removeSymbolTableEntry(plugin::Symbol S) {
-  m_Module.getBackend()->markSymbolForRemoval(S.getSymbol());
+  m_Module.getBackend().markSymbolForRemoval(S.getSymbol());
   m_Module.getScript().removeSymbolOp(this, &m_Module, S.getSymbol());
 }
 
@@ -1008,7 +1008,7 @@ LinkerWrapper::getSegmentsForOutputSection(const OutputSection &O) const {
                                  "'CreatingSections, AfterLayout'"});
   std::vector<Segment> Segments;
   for (auto *S :
-       m_Module.getBackend()->getSegmentsForSection(O.getOutputSection()))
+       m_Module.getBackend().getSegmentsForSection(O.getOutputSection()))
     Segments.push_back(Segment(S));
   return Segments;
 }
@@ -1158,7 +1158,7 @@ LinkerWrapper::getRuleMatchingSectionName(Section S) {
 }
 
 eld::Expected<uint64_t> LinkerWrapper::getOutputSymbolIndex(plugin::Symbol S) {
-  GNULDBackend &backend = *m_Module.getBackend();
+  GNULDBackend &backend = m_Module.getBackend();
   return backend.getSymbolIdx(S.getSymbol()->outSymbol());
 }
 

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -36,6 +36,7 @@
 #include "eld/Readers/BitcodeReader.h"
 #include "eld/Readers/CommonELFSection.h"
 #include "eld/Readers/ELFDynObjParser.h"
+#include "eld/Readers/ELFExecObjParser.h"
 #include "eld/Readers/ELFRelocObjParser.h"
 #include "eld/Readers/ELFSection.h"
 #include "eld/Readers/EhFrameHdrSection.h"
@@ -130,18 +131,18 @@ bool ObjectLinker::initialize(eld::Module &PModule, eld::IRBuilder &PBuilder) {
   ThisModule = &PModule;
   CurBuilder = &PBuilder;
 
-  MPBitcodeReader = ThisBackend.createBitcodeReader();
+  MPBitcodeReader = createBitcodeReader();
   // initialize the readers and writers
-  RelocObjParser = ThisBackend.createRelocObjParser();
-  DynObjReader = ThisBackend.createDynObjReader();
-  ArchiveParser = ThisBackend.createArchiveParser();
-  ELFExecObjParser = ThisBackend.createELFExecObjParser();
-  BinaryFileParser = ThisBackend.createBinaryFileParser();
+  RelocObjParser = createRelocObjParser();
+  DynObjReader = createDynObjReader();
+  ArchiveParser = createArchiveParser();
+  ELFExecObjParser = createELFExecObjParser();
+  BinaryFileParser = createBinaryFileParser();
   // SymDef Reader.
-  SymDefReader = ThisBackend.createSymDefReader();
+  SymDefReader = createSymDefReader();
   GroupReader = make<eld::GroupReader>(*ThisModule, this);
   ScriptReader = make<eld::ScriptReader>();
-  ObjWriter = ThisBackend.createWriter();
+  ObjWriter = createWriter();
   // initialize Relocator
   ThisBackend.initRelocator();
 
@@ -2327,7 +2328,7 @@ bool ObjectLinker::relocation(bool EmitRelocs) {
 
 /// emitOutput - emit the output file.
 bool ObjectLinker::emitOutput(llvm::FileOutputBuffer &POutput) {
-  return std::error_code() == getWriter()->writeObject(*ThisModule, POutput);
+  return std::error_code() == getWriter()->writeObject(POutput);
 }
 
 /// postProcessing - do modification after all processes
@@ -3914,4 +3915,36 @@ void ObjectLinker::collectEntrySections() const {
       SM.addEntrySection(ELFSect);
     }
   }
+}
+
+ArchiveParser *ObjectLinker::createArchiveParser() {
+  return make<eld::ArchiveParser>(*ThisModule);
+}
+
+ELFExecObjParser *ObjectLinker::createELFExecObjParser() {
+  return make<eld::ELFExecObjParser>(*ThisModule);
+}
+
+BitcodeReader *ObjectLinker::createBitcodeReader() {
+  return make<eld::BitcodeReader>(*ThisModule);
+}
+
+SymDefReader *ObjectLinker::createSymDefReader() {
+  return make<eld::SymDefReader>(*ThisModule);
+}
+
+ELFDynObjParser *ObjectLinker::createDynObjReader() {
+  return make<eld::ELFDynObjParser>(*ThisModule);
+}
+
+ELFRelocObjParser *ObjectLinker::createRelocObjParser() {
+  return make<eld::ELFRelocObjParser>(*ThisModule);
+}
+
+BinaryFileParser *ObjectLinker::createBinaryFileParser() {
+  return make<eld::BinaryFileParser>(*ThisModule);
+}
+
+ELFObjectWriter *ObjectLinker::createWriter() {
+  return make<eld::ELFObjectWriter>(*ThisModule);
 }

--- a/lib/Readers/ArchiveParser.cpp
+++ b/lib/Readers/ArchiveParser.cpp
@@ -281,7 +281,7 @@ eld::Expected<bool> ArchiveParser::computeSymInfoTableForELFMember(
       if (iter == symbolInfoTable.end())
         continue;
 
-      GNULDBackend &backend = *m_Module.getBackend();
+      GNULDBackend &backend = m_Module.getBackend();
       ArchiveFile::Symbol::SymbolType &type = iter->second;
       type = ArchiveFile::Symbol::NoType;
       if (rawSym->getBinding() == llvm::ELF::STB_WEAK) {

--- a/lib/Readers/ELFExecObjParser.cpp
+++ b/lib/Readers/ELFExecObjParser.cpp
@@ -73,7 +73,7 @@ eld::Expected<bool> ELFExecObjParser::parsePatchBase(ELFFileBase &inputFile) {
 eld::Expected<void> ELFExecObjParser::readSections(ELFReaderBase &ELFReader) {
   LinkerConfig &config = m_Module.getConfig();
   InputFile *inputFile = ELFReader.getInputFile();
-  GNULDBackend &backend = *m_Module.getBackend();
+  GNULDBackend &backend = m_Module.getBackend();
   eld::RegisterTimer T("Read Sections", "Link Summary",
                        config.options().printTimingStats());
 

--- a/lib/Readers/ELFReader.cpp
+++ b/lib/Readers/ELFReader.cpp
@@ -178,7 +178,7 @@ bool ELFReader<ELFT>::verifyFile(DiagnosticEngine *diagEngine) {
 
 template <class ELFT> eld::Expected<bool> ELFReader<ELFT>::checkFlags() const {
   ASSERT(m_LLVMELFFile, "m_LLVMELFFile must be initialized!");
-  GNULDBackend &backend = *m_Module.getBackend();
+  GNULDBackend &backend = m_Module.getBackend();
   Elf_Ehdr elfHeader = m_LLVMELFFile->getHeader();
   return backend.getInfo().checkFlags(elfHeader.e_flags, &m_InputFile);
 }
@@ -222,7 +222,7 @@ template <class ELFT>
 eld::Expected<LDSymbol *>
 ELFReader<ELFT>::createSymbol(llvm::StringRef stringTable, Elf_Sym rawSym,
                               std::size_t idx, bool isPatchable) {
-  GNULDBackend &backend = *m_Module.getBackend();
+  GNULDBackend &backend = m_Module.getBackend();
   IRBuilder &builder = *m_Module.getIRBuilder();
   ELFFileBase *EFileBase = llvm::cast<ELFFileBase>(&m_InputFile);
 
@@ -368,7 +368,7 @@ template <class ELFT> eld::Expected<bool> ELFReader<ELFT>::readSymbols() {
 
 template <class ELFT> std::string ELFReader<ELFT>::getFlagString() const {
   ASSERT(m_LLVMELFFile, "m_LLVMELFFile must be initialized!");
-  GNULDBackend &backend = *m_Module.getBackend();
+  GNULDBackend &backend = m_Module.getBackend();
   Elf_Ehdr elfHeader = m_LLVMELFFile->getHeader();
   return backend.getInfo().flagString(elfHeader.e_flags);
 }
@@ -388,21 +388,21 @@ template <class ELFT> void ELFReader<ELFT>::recordInputActions() const {
 
 template <class ELFT> bool ELFReader<ELFT>::checkMachine() const {
   ASSERT(m_LLVMELFFile, "m_LLVMELFFile must be initialized!");
-  GNULDBackend &backend = *m_Module.getBackend();
+  GNULDBackend &backend = m_Module.getBackend();
   const Elf_Ehdr &elfHeader = m_LLVMELFFile->getHeader();
   return elfHeader.e_machine == backend.getInfo().machine();
 }
 
 template <class ELFT> bool ELFReader<ELFT>::checkClass() const {
   ASSERT(m_LLVMELFFile, "m_LLVMELFFile must be initialized!");
-  GNULDBackend &backend = *m_Module.getBackend();
+  GNULDBackend &backend = m_Module.getBackend();
   const Elf_Ehdr &elfHeader = m_LLVMELFFile->getHeader();
   return elfHeader.e_ident[llvm::ELF::EI_CLASS] == backend.getInfo().ELFClass();
 }
 
 template <class ELFT> void ELFReader<ELFT>::checkOSABI() const {
   ASSERT(m_LLVMELFFile, "m_LLVMELFFile must be initialized!");
-  GNULDBackend &backend = *m_Module.getBackend();
+  GNULDBackend &backend = m_Module.getBackend();
   const Elf_Ehdr &elfHeader = m_LLVMELFFile->getHeader();
   backend.getInfo().setOSABI(this->m_InputFile,
                              elfHeader.e_ident[llvm::ELF::EI_OSABI]);

--- a/lib/Readers/ELFRelocObjParser.cpp
+++ b/lib/Readers/ELFRelocObjParser.cpp
@@ -82,7 +82,7 @@ eld::Expected<bool> ELFRelocObjParser::readSections(ELFReaderBase &ELFReader) {
   eld::RegisterTimer T("Read Sections", "Link Summary",
                        config.options().printTimingStats());
   InputFile *inputFile = ELFReader.getInputFile();
-  GNULDBackend &backend = *m_Module.getBackend();
+  GNULDBackend &backend = m_Module.getBackend();
 
   if (m_Module.getPrinter()->traceFiles())
     config.raise(Diag::trace_file) << inputFile->getInput()->decoratedPath();
@@ -206,7 +206,7 @@ eld::Expected<bool> ELFRelocObjParser::readSections(ELFReaderBase &ELFReader) {
 eld::Expected<bool>
 ELFRelocObjParser::readLinkOnceSection(ELFReaderBase &ELFReader,
                                        ELFSection *S) {
-  GNULDBackend &backend = *m_Module.getBackend();
+  GNULDBackend &backend = m_Module.getBackend();
   bool isPostLTOPhase = m_Module.isPostLTOPhase();
   InputFile *inputFile = ELFReader.getInputFile();
   LayoutInfo *layoutInfo = m_Module.getLayoutInfo();
@@ -338,7 +338,7 @@ ELFRelocObjParser::readGroupSection(ELFReaderBase &ELFReader, ELFSection *S) {
 
   // Group sections must only be added to output image for partial links.
   if (!alreadyExist && PartialLinking) {
-    GNULDBackend &backend = *m_Module.getBackend();
+    GNULDBackend &backend = m_Module.getBackend();
     if (!backend.readSection(*inputFile, S))
       return std::make_unique<plugin::DiagnosticEntry>(plugin::DiagnosticEntry(
           Diag::err_cannot_read_section, {S->name().str()}));
@@ -378,7 +378,7 @@ ELFRelocObjParser::readMergeStrSection(ELFReaderBase &ELFReader,
 eld::Expected<bool>
 ELFRelocObjParser::readDebugSection(ELFReaderBase &ELFReader, ELFSection *S) {
   LinkerConfig &config = m_Module.getConfig();
-  GNULDBackend &backend = *m_Module.getBackend();
+  GNULDBackend &backend = m_Module.getBackend();
   InputFile *inputFile = ELFReader.getInputFile();
 
   if (config.options().stripDebug()) {
@@ -423,7 +423,7 @@ ELFRelocObjParser::readTimingSection(ELFReaderBase &ELFReader, ELFSection *S) {
           << inputFile->getInput()->decoratedPath();
     }
   }
-  GNULDBackend &backend = *m_Module.getBackend();
+  GNULDBackend &backend = m_Module.getBackend();
   if (!backend.readSection(*inputFile, S)) {
     return std::make_unique<plugin::DiagnosticEntry>(plugin::DiagnosticEntry(
         Diag::err_cannot_read_target_section, {S->name().str()}));
@@ -434,7 +434,7 @@ ELFRelocObjParser::readTimingSection(ELFReaderBase &ELFReader, ELFSection *S) {
 eld::Expected<bool>
 ELFRelocObjParser::readDiscardSection(ELFReaderBase &ELFReader, ELFSection *S) {
   LinkerConfig &config = m_Module.getConfig();
-  GNULDBackend &backend = *m_Module.getBackend();
+  GNULDBackend &backend = m_Module.getBackend();
   InputFile *inputFile = ELFReader.getInputFile();
 
   // Discarded sections will be read, but it will be discarded in the final

--- a/lib/Readers/ExecELFReader.cpp
+++ b/lib/Readers/ExecELFReader.cpp
@@ -121,7 +121,7 @@ eld::Expected<bool> ExecELFReader<ELFT>::readRelocationSection(ELFSection *RS) {
   ELDEXP_RETURN_DIAGENTRY_IF_ERROR(expRelRange);
   auto relRange = std::move(expRelRange.value());
 
-  GNULDBackend &backend = *(this->m_Module.getBackend());
+  GNULDBackend &backend = this->m_Module.getBackend();
   InputFile *inputFile = this->getInputFile();
   ELFFileBase *EFile = llvm::cast<ELFFileBase>(inputFile);
 

--- a/lib/Readers/RelocELFReader.cpp
+++ b/lib/Readers/RelocELFReader.cpp
@@ -333,7 +333,7 @@ RelocELFReader<ELFT>::readRelocationSection(ELFSection *RS) {
   ELDEXP_RETURN_DIAGENTRY_IF_ERROR(expRelRange);
   auto relRange = std::move(expRelRange.value());
 
-  GNULDBackend &backend = *(this->m_Module.getBackend());
+  GNULDBackend &backend = this->m_Module.getBackend();
   InputFile *inputFile = this->getInputFile();
   ELFObjectFile *EObj = llvm::cast<ELFObjectFile>(inputFile);
 

--- a/lib/SymbolResolver/IRBuilder.cpp
+++ b/lib/SymbolResolver/IRBuilder.cpp
@@ -78,7 +78,7 @@ LDSymbol *IRBuilder::addSymbol(InputFile &Input, const std::string &SymbolName,
       // Add patchable symbols as "sym-def".
       // Ignore patchable non-global or hidden symbols.
       if (Bind == ResolveInfo::Global || Bind == ResolveInfo::Absolute) {
-        ThisModule.getBackend()->addSymDefProvideSymbol(
+        ThisModule.getBackend().addSymDefProvideSymbol(
             SymbolName, Type, Value, &Input, /* isPatchable */ true);
         // Also add them as undefined because it's needed to process
         // relocations.
@@ -97,8 +97,8 @@ LDSymbol *IRBuilder::addSymbol(InputFile &Input, const std::string &SymbolName,
     }
     // Non-patchable symbols are added as normal defined symbols.
   } else if (Input.getInput()->getAttribute().isJustSymbols()) {
-    ThisModule.getBackend()->addSymDefProvideSymbol(SymbolName, Type, Value,
-                                                    &Input);
+    ThisModule.getBackend().addSymDefProvideSymbol(SymbolName, Type, Value,
+                                                   &Input);
     return nullptr;
   }
   // rename symbols

--- a/lib/Target/AArch64/AArch64ErrataIslandFactory.cpp
+++ b/lib/Target/AArch64/AArch64ErrataIslandFactory.cpp
@@ -91,7 +91,7 @@ BranchIsland *AArch64ErrataIslandFactory::createAArch64ErrataIsland(
 
     Relocation *reloc = Relocation::Create(
         (*it)->type(),
-        pBuilder.getModule().getBackend()->getRelocator()->getSize(
+        pBuilder.getModule().getBackend().getRelocator()->getSize(
             (*it)->type()),
         make<FragmentRef>(*clone, (*it)->offset()), 0);
     if ((*it)->type() == llvm::ELF::R_AARCH64_JUMP26) {

--- a/lib/Target/AArch64/AArch64Info.cpp
+++ b/lib/Target/AArch64/AArch64Info.cpp
@@ -18,14 +18,14 @@ AArch64Info::AArch64Info(LinkerConfig &Config) : TargetInfo(Config) {}
 
 bool AArch64Info::needEhdr(Module &pModule, bool linkerScriptHasSectionsCmd,
                            bool isPhdr) {
-  return pModule.getBackend()->hasEhFrameHdr();
+  return pModule.getBackend().hasEhFrameHdr();
 }
 
 bool AArch64Info::InitializeDefaultMappings(Module &pModule) {
   // For android 64bit, the loader is unable to read the eh frame header
   // information and is reverting to not doing a binary search.
   if (isAndroid())
-    pModule.getBackend()->populateEhFrameHdrWithNoFDEInfo();
+    pModule.getBackend().populateEhFrameHdrWithNoFDEInfo();
 
   LinkerScript &pScript = pModule.getScript();
 


### PR DESCRIPTION
Also delay the need of backend so that we can access readers for sniffing objects

Resolves #280