### PR TITLE
Fix plugin api docs

### DIFF
--- a/docs/userguide/documentation/linker_plugins/api_docs.rst
+++ b/docs/userguide/documentation/linker_plugins/api_docs.rst
@@ -4,8 +4,9 @@ Linker Plugin API Usage and Reference
 Linker Wrapper
 ----------------
 
-.. figure:: ../images/LinkerWrapper.png
-   :figwidth: 80%
+.. graphviz:: ../images/LinkerWrapper.dot
+   :alt: LinkerWrapper flow.
+----------------------------------------------
 
    Plugins interacts with the linker using LinkerWrapper.
 


### PR DESCRIPTION
This patch fixes a minor bug in the plugin api documentation where a .png image is being used instead of a .dot image.