### PR TITLE
[NFC] Cleanup eld target registration

### DIFF
--- a/include/eld/Support/Target.h
+++ b/include/eld/Support/Target.h
@@ -12,19 +12,12 @@
 //===----------------------------------------------------------------------===//
 #ifndef ELD_SUPPORT_TARGET_H
 #define ELD_SUPPORT_TARGET_H
-#include <list>
+#include "llvm/TargetParser/Triple.h"
 #include <string>
-
-namespace llvm {
-class Target;
-class Triple;
-} // namespace llvm
 
 namespace eld {
 
-class ELDTargetMachine;
 class TargetRegistry;
-class MCLinker;
 class LinkerScript;
 class LinkerConfig;
 class Module;
@@ -34,12 +27,6 @@ class GNULDBackend;
  *  \brief Target collects target specific information
  */
 struct Target {
-  typedef unsigned int (*TripleMatchQualityFnTy)(const llvm::Triple &pTriple);
-
-  typedef ELDTargetMachine *(*TargetMachineCtorTy)(const llvm::Target &,
-                                                   const eld::Target &,
-                                                   const std::string &);
-
   typedef bool (*EmulationFnTy)(LinkerScript &, LinkerConfig &);
 
   typedef GNULDBackend *(*GNULDBackendCtorTy)(Module &);
@@ -47,13 +34,7 @@ struct Target {
   Target();
 
   /// getName - get the target name
-  const char *name() const { return Name; }
-
-  unsigned int getTripleQuality(const llvm::Triple &pTriple) const;
-
-  /// createTargetMachine - create target-specific TargetMachine
-  ELDTargetMachine *createTargetMachine(const std::string &pTriple,
-                                        const llvm::Target &pTarget) const;
+  llvm::StringRef name() const { return Name; }
 
   /// emulate - given MCLinker default values for the other aspects of the
   /// target system.
@@ -63,14 +44,16 @@ struct Target {
   GNULDBackend *createLDBackend(Module &pModule) const;
 
   /// Name - The target name
-  const char *Name;
+  llvm::StringRef Name;
 
-  bool IsImplemented = false;
+  // Machine
+  uint16_t Machine = 0;
 
-  TripleMatchQualityFnTy TripleMatchQualityFn;
-  TargetMachineCtorTy TargetMachineCtorFn;
-  EmulationFnTy EmulationFn;
-  GNULDBackendCtorTy GNULDBackendCtorFn;
+  // Is64bit
+  bool Is64bit = false;
+
+  EmulationFnTy EmulationFn = nullptr;
+  GNULDBackendCtorTy GNULDBackendCtorFn = nullptr;
 };
 
 } // end namespace eld

--- a/include/eld/Support/TargetRegistry.h
+++ b/include/eld/Support/TargetRegistry.h
@@ -13,43 +13,25 @@
 #ifndef ELD_SUPPORT_TARGETREGISTRY_H
 #define ELD_SUPPORT_TARGETREGISTRY_H
 #include "eld/Support/Target.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/TargetParser/Triple.h"
-#include <list>
 #include <string>
+#include <vector>
 
 namespace eld {
 
-/** \class TargetRegistry
- *  \brief TargetRegistry is an object adapter of llvm::TargetRegistry
- */
 class TargetRegistry {
-public:
-  typedef std::list<eld::Target *> TargetListTy;
-  typedef TargetListTy::iterator iterator;
-
 private:
-  static TargetListTy s_TargetList;
+  static std::vector<eld::Target *> TargetList;
 
 public:
-  static iterator begin() { return s_TargetList.begin(); }
-  static iterator end() { return s_TargetList.end(); }
-
-  static size_t size() { return s_TargetList.size(); }
-  static bool empty() { return s_TargetList.empty(); }
-
-  static llvm::iterator_range<TargetListTy::iterator> targets() {
-    return llvm::make_range(s_TargetList.begin(), s_TargetList.end());
+  static llvm::iterator_range<std::vector<eld::Target *>::iterator> targets() {
+    return llvm::make_range(TargetList.begin(), TargetList.end());
   }
 
-  /// RegisterTarget - Register the given target. Attempts to register a
-  /// target which has already been registered will be ignored.
-  ///
-  /// Clients are responsible for ensuring that registration doesn't occur
-  /// while another thread is attempting to access the registry. Typically
-  /// this is done by initializing all targets at program startup.
-  static void RegisterTarget(Target &pTarget, const char *pName,
-                             Target::TripleMatchQualityFnTy pQualityFn);
+  static void RegisterTarget(Target &pTarget, llvm::StringRef Name,
+                             uint16_t Machine, bool is64bit = false);
 
   /// RegisterEmulation - Register a emulation function for the target.
   /// target.
@@ -66,37 +48,18 @@ public:
       T.GNULDBackendCtorFn = Fn;
   }
 
-  static const eld::Target *lookupTarget(const std::string &pTriple,
-                                         std::string &pError);
+  static const eld::Target *
+  lookupTarget(llvm::StringRef Name, llvm::Triple &pTriple, std::string &Error);
 
-  static const eld::Target *lookupTarget(const std::string &pArchName,
-                                         llvm::Triple &pTriple,
-                                         std::string &Error);
+  // Find a target for a machine
+  Target *lookupMachine(uint16_t Machine, bool is64bit) const;
 };
 
-/// RegisterTarget - Helper function for registering a target, for use in the
-/// target's initialization function. Usage:
-///
-/// Target TheFooTarget; // The global target instance.
-///
-template <llvm::Triple::ArchType TargetArchType = llvm::Triple::UnknownArch>
 struct RegisterTarget {
 public:
-  RegisterTarget(eld::Target &pTarget, const char *pName) {
-    // if we've registered one, then return immediately.
-    TargetRegistry::iterator target, ie = TargetRegistry::end();
-    for (target = TargetRegistry::begin(); target != ie; ++target) {
-      if (0 == strcmp((*target)->name(), pName))
-        return;
-    }
-
-    TargetRegistry::RegisterTarget(pTarget, pName, &getTripleMatchQuality);
-  }
-
-  static unsigned int getTripleMatchQuality(const llvm::Triple &pTriple) {
-    if (pTriple.getArch() == TargetArchType)
-      return 20;
-    return 0;
+  RegisterTarget(eld::Target &pTarget, llvm::StringRef Name, uint16_t Machine,
+                 bool is64bit = false) {
+    TargetRegistry::RegisterTarget(pTarget, Name, Machine, is64bit);
   }
 };
 } // end namespace eld

--- a/lib/Core/Linker.cpp
+++ b/lib/Core/Linker.cpp
@@ -834,13 +834,10 @@ bool Linker::initBackend(const eld::Target *PTarget) {
   Backend = PTarget->createLDBackend(*ThisModule);
   LinkerProgress->incrementAndDisplayProgress();
   bool HasError = false;
-  if (nullptr == Backend || !PTarget->IsImplemented) {
+  if (nullptr == Backend) {
     std::string AvailableTargets;
-    for (auto Target = TargetRegistry::begin(); Target != TargetRegistry::end();
-         Target++) {
-      if ((*Target)->IsImplemented)
-        AvailableTargets += (*Target)->name() + std::string(" ");
-    }
+    for (auto Target : TargetRegistry::targets())
+      AvailableTargets += std::string(Target->name()) + std::string(" ");
     ThisConfig->raise(Diag::err_cannot_init_backend)
         << ThisConfig->targets().triple().str() << AvailableTargets;
     HasError = true;

--- a/lib/LinkerWrapper/Driver.cpp
+++ b/lib/LinkerWrapper/Driver.cpp
@@ -73,16 +73,8 @@ void Driver::InitTarget() {
   eld::InitializeAllTargets();
   eld::InitializeAllEmulations();
 
-  for (auto it = eld::TargetRegistry::begin(); it != eld::TargetRegistry::end();
-       ++it) {
-    std::string TargetName = getStringFromTarget((*it)->Name);
-    if (TargetName.empty())
-      continue;
-    auto STIter = std::find(m_SupportedTargets.begin(),
-                            m_SupportedTargets.end(), TargetName);
-    if (STIter == m_SupportedTargets.end())
-      m_SupportedTargets.emplace_back(TargetName);
-  }
+  for (auto &target : eld::TargetRegistry::targets())
+    m_SupportedTargets.push_back(std::string(target->name()));
 }
 
 std::string Driver::getStringFromTarget(llvm::StringRef Target) const {

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -1593,7 +1593,7 @@ bool GnuLdDriver::doLink(llvm::opt::InputArgList &Args,
     return false;
   }
   const eld::Target *ELDTarget =
-      eld::TargetRegistry::lookupTarget(Triple.str(), error);
+      eld::TargetRegistry::lookupTarget(Triple.getArchName(), Triple, error);
   if (nullptr == ELDTarget) {
     Config.raise(Diag::cannot_find_target) << error;
     return false;
@@ -1602,9 +1602,6 @@ bool GnuLdDriver::doLink(llvm::opt::InputArgList &Args,
   // This is needed to make sure for -march aarch64,
   // default triple is not arm--linux-gnu else it will cause issues in LTO
   Config.targets().setTriple(Triple);
-  std::unique_ptr<eld::ELDTargetMachine> target_machine(
-      ELDTarget->createTargetMachine(Config.targets().triple().getTriple(),
-                                     *LLVMTarget));
   eld::LayoutInfo *layoutInfo = nullptr;
   if (!Config.options().layoutFile().empty() || Config.options().printMap())
     layoutInfo = eld::make<eld::LayoutInfo>(Config);

--- a/lib/Support/Target.cpp
+++ b/lib/Support/Target.cpp
@@ -19,23 +19,7 @@ using namespace eld;
 //===----------------------------------------------------------------------===//
 // Target
 //===----------------------------------------------------------------------===//
-Target::Target()
-    : Name(nullptr), TripleMatchQualityFn(nullptr),
-      TargetMachineCtorFn(nullptr), GNULDBackendCtorFn(nullptr) {}
-
-unsigned int Target::getTripleQuality(const llvm::Triple &Triple) const {
-  if (nullptr == TripleMatchQualityFn)
-    return 0;
-  return TripleMatchQualityFn(Triple);
-}
-
-ELDTargetMachine *
-Target::createTargetMachine(const std::string &Triple,
-                            const llvm::Target &Target) const {
-  if (nullptr == TargetMachineCtorFn)
-    return nullptr;
-  return TargetMachineCtorFn(Target, *this, Triple);
-}
+Target::Target() {}
 
 /// emulate - given MCLinker default values for the other aspects of the
 /// target system.

--- a/lib/Target/AArch64/TargetInfo/AArch64TargetInfo.cpp
+++ b/lib/Target/AArch64/TargetInfo/AArch64TargetInfo.cpp
@@ -6,6 +6,7 @@
 
 #include "eld/Support/Target.h"
 #include "eld/Support/TargetRegistry.h"
+#include "llvm/Object/ELF.h"
 
 namespace eld {
 
@@ -13,7 +14,7 @@ eld::Target TheAArch64Target;
 
 extern "C" void ELDInitializeAArch64LDTargetInfo() {
   // register into eld::TargetRegistry
-  eld::RegisterTarget<llvm::Triple::aarch64> X(TheAArch64Target, "aarch64");
+  eld::RegisterTarget X(TheAArch64Target, "aarch64", llvm::ELF::EM_AARCH64);
 }
 
 } // namespace eld

--- a/lib/Target/ARM/ARM.h
+++ b/lib/Target/ARM/ARM.h
@@ -24,7 +24,6 @@ struct Target;
 class GNULDBackend;
 
 extern eld::Target TheARMTarget;
-extern eld::Target TheThumbTarget;
 
 GNULDBackend *createARMLDBackend(const llvm::Target &, const std::string &);
 

--- a/lib/Target/ARM/ARMEmulation.cpp
+++ b/lib/Target/ARM/ARMEmulation.cpp
@@ -41,6 +41,4 @@ bool emulateARMLD(LinkerScript &pScript, LinkerConfig &pConfig) {
 extern "C" void ELDInitializeARMEmulation() {
   // Register the emulation
   eld::TargetRegistry::RegisterEmulation(eld::TheARMTarget, eld::emulateARMLD);
-  eld::TargetRegistry::RegisterEmulation(eld::TheThumbTarget,
-                                         eld::emulateARMLD);
 }

--- a/lib/Target/ARM/ARMLDBackend.cpp
+++ b/lib/Target/ARM/ARMLDBackend.cpp
@@ -1269,5 +1269,4 @@ GNULDBackend *createARMLDBackend(Module &pModule) {
 extern "C" void ELDInitializeARMLDBackend() {
   // Register the linker backend
   eld::TargetRegistry::RegisterGNULDBackend(TheARMTarget, createARMLDBackend);
-  eld::TargetRegistry::RegisterGNULDBackend(TheThumbTarget, createARMLDBackend);
 }

--- a/lib/Target/ARM/TargetInfo/ARMTargetInfo.cpp
+++ b/lib/Target/ARM/TargetInfo/ARMTargetInfo.cpp
@@ -15,16 +15,15 @@
 //===----------------------------------------------------------------------===//
 #include "eld/Support/Target.h"
 #include "eld/Support/TargetRegistry.h"
+#include "llvm/Object/ELF.h"
 
 namespace eld {
 
 eld::Target TheARMTarget;
-eld::Target TheThumbTarget;
 
 extern "C" void ELDInitializeARMLDTargetInfo() {
   // register into eld::TargetRegistry
-  eld::RegisterTarget<llvm::Triple::arm> X(TheARMTarget, "arm");
-  eld::RegisterTarget<llvm::Triple::thumb> Y(TheThumbTarget, "thumb");
+  eld::RegisterTarget X(TheARMTarget, "arm", llvm::ELF::EM_ARM);
 }
 
 } // namespace eld

--- a/lib/Target/Hexagon/TargetInfo/HexagonTargetInfo.cpp
+++ b/lib/Target/Hexagon/TargetInfo/HexagonTargetInfo.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 #include "eld/Support/Target.h"
 #include "eld/Support/TargetRegistry.h"
+#include "llvm/Object/ELF.h"
 
 namespace eld {
 
@@ -14,7 +15,7 @@ eld::Target TheHexagonTarget;
 
 extern "C" void ELDInitializeHexagonLDTargetInfo() {
   // register into eld::TargetRegistry
-  eld::RegisterTarget<llvm::Triple::hexagon> X(TheHexagonTarget, "hexagon");
+  eld::RegisterTarget X(TheHexagonTarget, "hexagon", llvm::ELF::EM_HEXAGON);
 }
 
 } // namespace eld

--- a/lib/Target/RISCV/TargetInfo/RISCVTargetInfo.cpp
+++ b/lib/Target/RISCV/TargetInfo/RISCVTargetInfo.cpp
@@ -6,6 +6,7 @@
 
 #include "eld/Support/Target.h"
 #include "eld/Support/TargetRegistry.h"
+#include "llvm/Object/ELF.h"
 
 namespace eld {
 
@@ -14,8 +15,8 @@ eld::Target TheRISCV64Target;
 
 extern "C" void ELDInitializeRISCVLDTargetInfo() {
   // register into eld::TargetRegistry
-  eld::RegisterTarget<llvm::Triple::riscv32> X(TheRISCV32Target, "riscv32");
-  eld::RegisterTarget<llvm::Triple::riscv64> Y(TheRISCV64Target, "riscv64");
+  eld::RegisterTarget X(TheRISCV32Target, "riscv32", llvm::ELF::EM_RISCV);
+  eld::RegisterTarget Y(TheRISCV64Target, "riscv64", llvm::ELF::EM_RISCV);
 }
 
 } // namespace eld

--- a/lib/Target/Template/TargetInfo/TemplateTargetInfo.cpp
+++ b/lib/Target/Template/TargetInfo/TemplateTargetInfo.cpp
@@ -14,7 +14,7 @@ eld::Target TheTemplateTarget;
 
 extern "C" void ELDInitializeTemplateLDTargetInfo() {
   // register into eld::TargetRegistry
-  eld::RegisterTarget<llvm::Triple::iu> X(TheTemplateTarget, "template");
+  eld::RegisterTarget X(TheTemplateTarget, "template", 0);
 }
 
 } // namespace eld

--- a/lib/Target/x86_64/TargetInfo/x86_64TargetInfo.cpp
+++ b/lib/Target/x86_64/TargetInfo/x86_64TargetInfo.cpp
@@ -6,6 +6,7 @@
 
 #include "eld/Support/Target.h"
 #include "eld/Support/TargetRegistry.h"
+#include "llvm/Object/ELF.h"
 
 namespace eld {
 
@@ -13,7 +14,7 @@ eld::Target Thex86_64Target;
 
 extern "C" void ELDInitializex86_64LDTargetInfo() {
   // register into eld::TargetRegistry
-  eld::RegisterTarget<llvm::Triple::x86_64> X(Thex86_64Target, "x86_64");
+  eld::RegisterTarget X(Thex86_64Target, "x86_64", llvm::ELF::EM_X86_64);
 }
 
 } // namespace eld


### PR DESCRIPTION
We dont see a need of so much infrastructure needed to register a target.