### PR TITLE
[RISC-V] NFC: Separate paired relocs map

### DIFF
--- a/include/eld/Readers/Relocation.h
+++ b/include/eld/Readers/Relocation.h
@@ -145,7 +145,7 @@ public:
 
   bool isMergeKind() const;
 
-  bool issueOverflow(Relocator &);
+  bool issueOverflow(Relocator &) const;
 
 private:
   /// m_pSymInfo - resolved symbol info of relocation target symbol

--- a/include/eld/Target/Relocator.h
+++ b/include/eld/Target/Relocator.h
@@ -143,7 +143,7 @@ public:
   bool doDeMangle() const;
 
   // Get the address for a relocation
-  Relocation::Address getSymValue(Relocation *R);
+  Relocation::Address getSymValue(const Relocation *R);
 
 private:
   enum ErrType { Undef, Invisible };

--- a/lib/Readers/Relocation.cpp
+++ b/lib/Readers/Relocation.cpp
@@ -202,7 +202,7 @@ std::string Relocation::getFragmentPath(ResolveInfo *symInfo, Fragment *frag,
   return "(Not Applicable)";
 }
 
-bool Relocation::issueOverflow(Relocator &pRelocator) {
+bool Relocation::issueOverflow(Relocator &pRelocator) const {
   DiagnosticEngine *DiagEngine = pRelocator.config().getDiagEngine();
   const GeneralOptions &options = pRelocator.config().options();
   DiagEngine->raise(Diag::result_overflow_moreinfo)

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -61,7 +61,7 @@ Relocator *RISCVLDBackend::getRelocator() const {
   return m_pRelocator;
 }
 
-Relocation::Address RISCVLDBackend::getSymbolValuePLT(Relocation &R) {
+Relocation::Address RISCVLDBackend::getSymbolValuePLT(const Relocation &R) {
   ResolveInfo *rsym = R.symInfo();
   if (rsym && (rsym->reserved() & Relocator::ReservePLT)) {
     if (const Fragment *S = findEntryInPLT(rsym))
@@ -618,8 +618,8 @@ bool RISCVLDBackend::addSymbolToOutput(ResolveInfo *Info) {
   }
   return true;
 }
-bool RISCVLDBackend::isGOTReloc(Relocation *reloc) const {
-  switch (reloc->type()) {
+bool RISCVLDBackend::isGOTReloc(const Relocation &reloc) const {
+  switch (reloc.type()) {
   case llvm::ELF::R_RISCV_GOT_HI20:
   case llvm::ELF::R_RISCV_TLS_GOT_HI20:
   case llvm::ELF::R_RISCV_TLS_GD_HI20:
@@ -664,10 +664,10 @@ bool RISCVLDBackend::doRelaxationPC(Relocation *reloc, Relocator::DWord G) {
 
   if (new_type) {
     // Lookup reloc to get actual addend of HI.
-    Relocation *HIReloc = m_PairedRelocs[reloc];
+    const Relocation *HIReloc = getBaseReloc(*reloc);
     // If this is a GOT relocation, we cannot convert
     // this relative to GP.
-    if (isGOTReloc(HIReloc))
+    if (isGOTReloc(*HIReloc))
       return false;
     if (!HIReloc)
       ASSERT(0, "HIReloc not found! Internal Error!");
@@ -743,7 +743,7 @@ void RISCVLDBackend::translatePseudoRelocation(Relocation *reloc) {
       make<FragmentRef>(*(reloc->targetRef()->frag()), offset + 4);
   Relocation *reloc_jalr = Relocation::Create(llvm::ELF::R_RISCV_PCREL_LO12_I,
                                               32, fragRef, reloc->addend());
-  m_PairedRelocs[reloc_jalr] = reloc;
+  m_BaseRelocs[reloc_jalr] = reloc;
   reloc_jalr->setSymInfo(reloc->symInfo());
   m_InternalRelocs.push_back(reloc_jalr);
 }
@@ -977,9 +977,8 @@ bool RISCVLDBackend::handleRelocation(ELFSection *pSection,
     auto offsetToReloc = relocMap.find(pOffset);
     if (offsetToReloc == relocMap.end())
       relocMap.insert(std::make_pair(pOffset, reloc));
-    else {
-      m_PairedRelocs.insert(std::make_pair(reloc, offsetToReloc->second));
-    }
+    else
+      m_GroupRelocs.insert(std::make_pair(reloc, offsetToReloc->second));
     return true;
   }
   // R_RISCV_PCREL_LO* relocations have the corresponding HI reloc as the
@@ -1012,7 +1011,7 @@ bool RISCVLDBackend::handleRelocation(ELFSection *pSection,
     Relocation *reloc = IRBuilder::addRelocation(
         getRelocator(), pSection, pType, *hi_reloc->symInfo()->outSymbol(),
         pOffset, pAddend);
-    m_PairedRelocs[reloc] = hi_reloc;
+    m_BaseRelocs[reloc] = hi_reloc;
     if (reloc) {
       reloc->setSymInfo(hi_reloc->symInfo());
       pSection->addRelocation(reloc);
@@ -1518,8 +1517,8 @@ RISCVLDBackend::postProcessing(llvm::FileOutputBuffer &pOutput) {
   eld::Expected<void> expBasePostProcess =
       GNULDBackend::postProcessing(pOutput);
   ELDEXP_RETURN_DIAGENTRY_IF_ERROR(expBasePostProcess);
-  for (auto &RelocPair : m_PairedRelocs) {
-    Relocation *pReloc = RelocPair.first;
+  for (auto &RelocPair : m_GroupRelocs) {
+    const Relocation *pReloc = RelocPair.first;
     if (pReloc->type() != llvm::ELF::R_RISCV_SUB_ULEB128)
       continue;
     FragmentRef::Offset Off = pReloc->targetRef()->getOutputOffset(m_Module);

--- a/lib/Target/RISCV/RISCVLDBackend.h
+++ b/lib/Target/RISCV/RISCVLDBackend.h
@@ -168,15 +168,22 @@ public:
 
   void setDefaultConfigs() override;
 
-  Relocation *getPairedReloc(Relocation *R) const {
-    auto reloc = m_PairedRelocs.find(R);
-    if (reloc == m_PairedRelocs.end())
+  Relocation *getGroupReloc(const Relocation &R) const {
+    auto reloc = m_GroupRelocs.find(&R);
+    if (reloc == m_GroupRelocs.end())
+      return nullptr;
+    return reloc->second;
+  }
+
+  const Relocation *getBaseReloc(const Relocation &R) const {
+    auto reloc = m_BaseRelocs.find(&R);
+    if (reloc == m_BaseRelocs.end())
       return nullptr;
     return reloc->second;
   }
 
   // Get the value of the symbol, using the PLT slot if one exists.
-  Relocation::Address getSymbolValuePLT(Relocation &R);
+  Relocation::Address getSymbolValuePLT(const Relocation &R);
 
 private:
   Relocation *findHIRelocation(ELFSection *S, uint64_t Value);
@@ -195,7 +202,7 @@ private:
                               uint64_t Offset, unsigned NumBytes,
                               llvm::StringRef SymbolName);
 
-  bool isGOTReloc(Relocation *reloc) const;
+  bool isGOTReloc(const Relocation &reloc) const;
 
   bool doRelaxationCall(Relocation *R, bool DoCompressed);
   bool doRelaxationQCCall(Relocation *R, bool DoCompressed);
@@ -242,8 +249,17 @@ private:
 
   void defineGOTSymbol(Fragment &);
 
-public:
-  llvm::DenseMap<Relocation *, Relocation *> m_PairedRelocs;
+  /// A map to track the first relocation at one location. Multiple relocations
+  /// at one location should be applied consecutively, and not override each
+  /// other. Since we are caching the value in the relocation object, it is
+  /// important to update the cached value in the very first relocation in a
+  /// group.
+  llvm::DenseMap<const Relocation *, Relocation *> m_GroupRelocs;
+
+  /// A map to keep track of the relocation that defines the base address for
+  /// relative relocations. This is a concept in RISC-V and applies to
+  /// relocations consisting of a HI20 and LO12 pairs.
+  llvm::DenseMap<const Relocation *, const Relocation *> m_BaseRelocs;
 
 private:
   /// RISCV Attribute Section

--- a/lib/Target/RISCV/RISCVRelocator.cpp
+++ b/lib/Target/RISCV/RISCVRelocator.cpp
@@ -55,7 +55,7 @@ DECL_RISCV_APPLY_RELOC_FUNC(applyRelax)
 DECL_RISCV_APPLY_RELOC_FUNC(applyGPRel)
 DECL_RISCV_APPLY_RELOC_FUNC(applyCompressedLUI)
 DECL_RISCV_APPLY_RELOC_FUNC(applyTprelAdd)
-DECL_RISCV_APPLY_RELOC_FUNC(relocGOT)
+DECL_RISCV_APPLY_RELOC_FUNC(applyGOT)
 DECL_RISCV_APPLY_RELOC_FUNC(applyVendor)
 
 #undef DECL_RISCV_APPLY_RELOC_FUNC
@@ -96,9 +96,9 @@ RelocationDescMap RelocDescs = {
     PUBLIC_RELOC_DESC_ENTRY(R_RISCV_JAL, applyJumpOrCall),
     PUBLIC_RELOC_DESC_ENTRY(R_RISCV_CALL, applyJumpOrCall),
     PUBLIC_RELOC_DESC_ENTRY(R_RISCV_CALL_PLT, unsupported),
-    PUBLIC_RELOC_DESC_ENTRY(R_RISCV_GOT_HI20, relocGOT),
-    PUBLIC_RELOC_DESC_ENTRY(R_RISCV_TLS_GOT_HI20, relocGOT),
-    PUBLIC_RELOC_DESC_ENTRY(R_RISCV_TLS_GD_HI20, relocGOT),
+    PUBLIC_RELOC_DESC_ENTRY(R_RISCV_GOT_HI20, applyGOT),
+    PUBLIC_RELOC_DESC_ENTRY(R_RISCV_TLS_GOT_HI20, applyGOT),
+    PUBLIC_RELOC_DESC_ENTRY(R_RISCV_TLS_GD_HI20, applyGOT),
     PUBLIC_RELOC_DESC_ENTRY(R_RISCV_PCREL_HI20, applyHI),
     PUBLIC_RELOC_DESC_ENTRY(R_RISCV_PCREL_LO12_I, applyLO),
     PUBLIC_RELOC_DESC_ENTRY(R_RISCV_PCREL_LO12_S, applyLO),
@@ -924,7 +924,7 @@ RISCVRelocator::Result applyLO(Relocation &pReloc, RISCVLDBackend &Backend,
   return ApplyReloc(pReloc, Result_lo, pRelocDesc, Backend.config());
 }
 
-RISCVRelocator::Result relocGOT(Relocation &pReloc, RISCVLDBackend &Backend,
+RISCVRelocator::Result applyGOT(Relocation &pReloc, RISCVLDBackend &Backend,
                                 RelocationDescription &pRelocDesc) {
   if (!(pReloc.symInfo()->reserved() & Relocator::ReserveGOT)) {
     return Relocator::BadReloc;

--- a/lib/Target/RISCV/RISCVRelocator.cpp
+++ b/lib/Target/RISCV/RISCVRelocator.cpp
@@ -51,7 +51,6 @@ DECL_RISCV_APPLY_RELOC_FUNC(applyHI)
 DECL_RISCV_APPLY_RELOC_FUNC(applyLO)
 DECL_RISCV_APPLY_RELOC_FUNC(applyJumpOrCall)
 DECL_RISCV_APPLY_RELOC_FUNC(applyAlign)
-DECL_RISCV_APPLY_RELOC_FUNC(applyRelax)
 DECL_RISCV_APPLY_RELOC_FUNC(applyGPRel)
 DECL_RISCV_APPLY_RELOC_FUNC(applyCompressedLUI)
 DECL_RISCV_APPLY_RELOC_FUNC(applyTprelAdd)
@@ -121,7 +120,7 @@ RelocationDescMap RelocDescs = {
     PUBLIC_RELOC_DESC_ENTRY(R_RISCV_ALIGN, applyAlign),
     PUBLIC_RELOC_DESC_ENTRY(R_RISCV_RVC_BRANCH, applyJumpOrCall),
     PUBLIC_RELOC_DESC_ENTRY(R_RISCV_RVC_JUMP, applyJumpOrCall),
-    PUBLIC_RELOC_DESC_ENTRY(R_RISCV_RELAX, applyRelax),
+    PUBLIC_RELOC_DESC_ENTRY(R_RISCV_RELAX, applyNone),
     PUBLIC_RELOC_DESC_ENTRY(R_RISCV_SUB6, applyAbs),
     PUBLIC_RELOC_DESC_ENTRY(R_RISCV_SET6, applyAbs),
     PUBLIC_RELOC_DESC_ENTRY(R_RISCV_SET8, applyAbs),
@@ -938,14 +937,6 @@ RISCVRelocator::Result applyGOT(Relocation &pReloc, RISCVLDBackend &Backend,
   Result -= pReloc.place(Backend.getModule());
 
   return ApplyReloc(pReloc, Result, pRelocDesc, Backend.config());
-}
-
-// R_RISCV_RELAX
-RISCVRelocator::Result applyRelax(Relocation &pReloc, RISCVLDBackend &,
-                                  RelocationDescription &pRelocDesc) {
-  // TODO: Add support for relaxations
-
-  return RISCVRelocator::OK;
 }
 
 RISCVRelocator::Result applyJumpOrCall(Relocation &pReloc,

--- a/lib/Target/RISCV/RISCVRelocator.cpp
+++ b/lib/Target/RISCV/RISCVRelocator.cpp
@@ -764,9 +764,9 @@ RISCVRelocator::Result applyAbs(Relocation &pReloc, RISCVLDBackend &Backend,
   uint64_t A = pReloc.addend();
   uint64_t Result = 0;
 
-  Relocation *pairedReloc = Backend.getPairedReloc(&pReloc);
+  Relocation *groupReloc = Backend.getGroupReloc(pReloc);
   Relocation::DWord TargetData =
-      pairedReloc ? pairedReloc->target() : pReloc.target();
+      groupReloc ? groupReloc->target() : pReloc.target();
 
   if (pReloc.type() >= llvm::ELF::R_RISCV_ADD8 &&
       pReloc.type() <= llvm::ELF::R_RISCV_ADD64)
@@ -790,8 +790,8 @@ RISCVRelocator::Result applyAbs(Relocation &pReloc, RISCVLDBackend &Backend,
   RISCVRelocator::Result Res =
       ApplyReloc(pReloc, Result, pRelocDesc, Backend.config());
   // Update the target word for the paired reloc
-  if (pairedReloc) {
-    pairedReloc->target() = pReloc.target();
+  if (groupReloc) {
+    groupReloc->target() = pReloc.target();
   }
   return Res;
 }
@@ -854,10 +854,10 @@ RISCVRelocator::Result applyLO(Relocation &pReloc, RISCVLDBackend &Backend,
     return RISCVRelocator::Unsupport;
 
   int64_t S;
-  Relocation *HIReloc = nullptr;
+  const Relocation *HIReloc = nullptr;
   if (pReloc.type() == llvm::ELF::R_RISCV_PCREL_LO12_I ||
       pReloc.type() == llvm::ELF::R_RISCV_PCREL_LO12_S) {
-    HIReloc = Backend.m_PairedRelocs[&pReloc];
+    HIReloc = Backend.getBaseReloc(pReloc);
     if (!HIReloc)
       return RISCVRelocator::BadReloc;
     if (HIReloc->type() == llvm::ELF::R_RISCV_GOT_HI20 ||
@@ -985,7 +985,7 @@ RISCVRelocator::Result applyGPRel(Relocation &pReloc, RISCVLDBackend &Backend,
   int64_t S = Backend.getSymbolValuePLT(pReloc);
 
   // Get the symbol value always from the HIRELOC.
-  Relocation *HIReloc = Backend.m_PairedRelocs[&pReloc];
+  const Relocation *HIReloc = Backend.getBaseReloc(pReloc);
   if (HIReloc)
     S = Backend.getSymbolValuePLT(*HIReloc);
 

--- a/lib/Target/Relocator.cpp
+++ b/lib/Target/Relocator.cpp
@@ -289,7 +289,7 @@ bool Relocator::doDeMangle() const {
   return m_Config.options().shouldDemangle();
 }
 
-Relocation::Address Relocator::getSymValue(Relocation *R) {
+Relocation::Address Relocator::getSymValue(const Relocation *R) {
   if (R->symInfo() && R->symInfo()->isThreadLocal())
     return getTarget().finalizeTLSSymbol(R->symInfo()->outSymbol());
   return R->symValue(m_Module);


### PR DESCRIPTION
The paired relocaton map was used for two unrelated purposes:
- to reference the first relocation in a "group" relocation chain,
- to reference the base relocation for RISC-V relocations that take a local label instead of the symbol (R_RISCV_PCREL_LO12_I, etc).

Now there will be two separate maps. Group relocation processing is defined in gABI so it can be further moved to the generic code.

Also, add consts and convert pointers to references in the affected code.