### PR TITLE
[NFC] Remove TargetBackend from ScriptParser init

### DIFF
--- a/include/eld/Script/ScriptFile.h
+++ b/include/eld/Script/ScriptFile.h
@@ -35,7 +35,6 @@ namespace eld {
 
 class ExcludeFiles;
 class Expression;
-class GNULDBackend;
 class InputBuilder;
 class LinkerConfig;
 class LinkerScriptFile;
@@ -79,7 +78,7 @@ public:
 
 public:
   ScriptFile(Kind PKind, Module &CurModule, LinkerScriptFile &PInput,
-             InputBuilder &PBuilder, GNULDBackend &PBackend);
+             InputBuilder &PBuilder);
 
   ~ScriptFile();
 
@@ -208,8 +207,6 @@ public:
 
   LinkerScriptFile &getLinkerScriptFile() { return ThisLinkerScriptFile; }
 
-  GNULDBackend &backend() { return ThisBackend; }
-
   /* Identify the first output section inside the first linker script */
   bool firstLinkerScriptWithOutputSection() const {
     return IsFirstLinkerScriptWithSectionCommand;
@@ -308,7 +305,6 @@ private:
   Kind ScriptFileKind;
   Module &ThisModule;
   LinkerScriptFile &ThisLinkerScriptFile;
-  GNULDBackend &ThisBackend;
   std::string Name;
   CommandQueue LinkerScriptCommandQueue;
   bool LinkerScriptHasSectionsCommand;

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -194,9 +194,8 @@ bool ObjectLinker::readLinkerScript(InputFile *Input) {
 
   ThisModule->getScript().addToHash(Input->getInput()->decoratedPath());
 
-  ScriptFile *S =
-      make<ScriptFile>(ScriptFile::LDScript, *ThisModule, *LSFile,
-                       CurBuilder->getInputBuilder(), getTargetBackend());
+  ScriptFile *S = make<ScriptFile>(ScriptFile::LDScript, *ThisModule, *LSFile,
+                                   CurBuilder->getInputBuilder());
 
   LSFile->setParsed();
   LSFile->setScriptFile(S);
@@ -338,7 +337,7 @@ bool ObjectLinker::parseVersionScript() {
     ScriptFile VersionScriptReader(
         ScriptFile::VersionScript, *ThisModule,
         *(llvm::dyn_cast<eld::LinkerScriptFile>(VersionScriptInputFile)),
-        CurBuilder->getInputBuilder(), getTargetBackend());
+        CurBuilder->getInputBuilder());
     bool SuccessFullInParse =
         getScriptReader()->readScript(ThisConfig, VersionScriptReader);
     if (!SuccessFullInParse)
@@ -1310,7 +1309,7 @@ bool ObjectLinker::parseListFile(std::string Filename, uint32_t Type) {
   ScriptFile SymbolListReader(
       (ScriptFile::Kind)Type, *ThisModule,
       *(llvm::dyn_cast<eld::LinkerScriptFile>(SymbolListInputFile)),
-      CurBuilder->getInputBuilder(), getTargetBackend());
+      CurBuilder->getInputBuilder());
   bool ParseSuccess =
       getScriptReader()->readScript(ThisConfig, SymbolListReader);
   if (!ParseSuccess)

--- a/lib/Script/ScriptFile.cpp
+++ b/lib/Script/ScriptFile.cpp
@@ -66,9 +66,9 @@ bool ScriptFile::IsFirstLinkerScriptWithSectionCommand = false;
 // ScriptFile
 //===----------------------------------------------------------------------===//
 ScriptFile::ScriptFile(Kind PKind, Module &CurModule, LinkerScriptFile &PInput,
-                       InputBuilder &PBuilder, GNULDBackend &PBackend)
+                       InputBuilder &PBuilder)
     : ScriptFileKind(PKind), ThisModule(CurModule),
-      ThisLinkerScriptFile(PInput), ThisBackend(PBackend),
+      ThisLinkerScriptFile(PInput),
       Name(PInput.getInput()->getResolvedPath().native()),
       LinkerScriptHasSectionsCommand(false),
       ScriptStateInSectionsCommmand(false),

--- a/tools/LSParserVerifier/LSParserVerifier.cpp
+++ b/tools/LSParserVerifier/LSParserVerifier.cpp
@@ -106,7 +106,7 @@ public:
     eld::LinkerScriptFile *IF = CreateLinkerScriptFile(filename);
     assert(IF && "IF must not be null!!");
     return eld::ScriptFile(eld::ScriptFile::LDScript, *m_Module, *IF,
-                           m_Builder->getInputBuilder(), *m_Backend);
+                           m_Builder->getInputBuilder());
   }
 
   eld::LinkerConfig *getConfig() { return m_Config; }


### PR DESCRIPTION
We have to delay referencing the target backend to support sniffing