### PR TITLE
Add --use-linker-script-extensions option

### DIFF
--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -1135,6 +1135,14 @@ public:
 
   void setNoDefaultPlugins() { UseDefaultPlugins = false; }
 
+  void setUseLinkerScriptExtensions(bool Enable) {
+    UseLinkerScriptExtensions = Enable;
+  }
+
+  bool shouldUseLinkerScriptExtensions() const {
+    return UseLinkerScriptExtensions;
+  }
+
 private:
   bool appendMapStyle(const std::string MapStyle);
   enum Status { YES, NO, Unknown };
@@ -1331,6 +1339,7 @@ private:
   std::string LinkLaunchDirectory;
   bool ShowRMSectNameInDiag = false;
   bool UseDefaultPlugins = true;
+  bool UseLinkerScriptExtensions = false;
 };
 
 } // namespace eld

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -1012,6 +1012,15 @@ def thin_archive_rule_matching_compatibility
       HelpText<"Provides rule-matching compatibility when fat archives are\n"
                "\t\t\tconverted to thin archives">,
       Group<grp_compatorignoredopts>;
+def use_linker_script_extensions
+    : Flag<["-", "--"], "use-linker-script-extensions">,
+      HelpText<"Use extended linker script extensions.\n"
+               "This breaks GNU-compatibility of linker scripts.">,
+      Group<grp_compatorignoredopts>;
+def no_use_linker_script_extensions
+    : Flag<["-", "--"], "no-use-linker-script-extensions">,
+      HelpText<"Do not use extended linker script extensions.">,
+      Group<grp_compatorignoredopts>;
 
 //===----------------------------------------------------------------------===//
 /// LTO options

--- a/include/eld/ScriptParser/ScriptLexer.h
+++ b/include/eld/ScriptParser/ScriptLexer.h
@@ -71,6 +71,8 @@ public:
   // Consume otken
   bool consume(llvm::StringRef Tok);
 
+  bool consume(LexState LState, llvm::StringRef Tok);
+
   // Expect next token to be expect
   void expect(llvm::StringRef Expect);
 

--- a/include/eld/ScriptParser/ScriptParser.h
+++ b/include/eld/ScriptParser/ScriptParser.h
@@ -217,6 +217,8 @@ private:
   /// '{' in between the pattern, as this case, would not be possible with
   /// LexState::Default.
   bool isValidSectionPattern(llvm::StringRef Pat);
+
+  const bool UseLinkerScriptExtensions;
 };
 } // namespace v2
 } // namespace eld

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -1168,6 +1168,11 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
     Config.options().setOMagic(true);
   }
 
+  if (Args.hasArg(T::use_linker_script_extensions))
+    Config.options().setUseLinkerScriptExtensions(true);
+  if (Args.hasArg(T::no_use_linker_script_extensions))
+    Config.options().setUseLinkerScriptExtensions(false);
+
   Config.options().setUnknownOptions(Args.getAllArgValues(T::UNKNOWN));
   return true;
 }

--- a/lib/ScriptParser/ScriptLexer.cpp
+++ b/lib/ScriptParser/ScriptLexer.cpp
@@ -281,6 +281,11 @@ bool ScriptLexer::consume(StringRef Tok) {
   return true;
 }
 
+bool ScriptLexer::consume(enum LexState LState, llvm::StringRef Tok) {
+  llvm::SaveAndRestore SaveLexState(LexState, LState);
+  return consume(Tok);
+}
+
 void ScriptLexer::skip() { (void)next(); }
 
 void ScriptLexer::expect(StringRef Expect) {

--- a/test/Common/standalone/linkerscript/LinkerScriptExtensions/OutputSectionDescColon/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/LinkerScriptExtensions/OutputSectionDescColon/Inputs/1.c
@@ -1,0 +1,2 @@
+int foo() { return 1;}
+int bar() { return 3;}

--- a/test/Common/standalone/linkerscript/LinkerScriptExtensions/OutputSectionDescColon/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/LinkerScriptExtensions/OutputSectionDescColon/Inputs/script.t
@@ -1,0 +1,4 @@
+SECTIONS {
+  FOO: { *(.text.foo) }
+  BAR: { *(.text.bar) }
+}

--- a/test/Common/standalone/linkerscript/LinkerScriptExtensions/OutputSectionDescColon/OutputSectionDescColon.test
+++ b/test/Common/standalone/linkerscript/LinkerScriptExtensions/OutputSectionDescColon/OutputSectionDescColon.test
@@ -1,0 +1,19 @@
+#---LoadSectionsAfterDebugSections.test-------------- Executable,LS --------------------#
+#BEGIN_COMMENT
+# This test checks that the linker accepts 'OutSection: { ... }' syntax when
+# --use-linker-script-extensions option is used.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
+RUN: %not %link %linkopts -o %t1.1.err.out %t1.1.o -T %p/Inputs/script.t 2>&1 \
+RUN:   | %filecheck %s --check-prefix=ERR --strict-whitespace --match-full-lines
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t --use-linker-script-extensions
+RUN: %readelf -S %t1.1.out | %filecheck %s -check-prefix=READELF
+#END_TEST
+
+ERR:Error: {{.*}}Inputs/script.t:2: : expected, but got {
+ERR:>>>   FOO: { *(.text.foo) }
+ERR:>>>        ^
+
+READELF: FOO PROGBITS
+READELF: BAR PROGBITS

--- a/test/Common/standalone/linkerscript/LinkerScriptExtensions/SymbolAssignmentSpace/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/LinkerScriptExtensions/SymbolAssignmentSpace/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/Common/standalone/linkerscript/LinkerScriptExtensions/SymbolAssignmentSpace/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/LinkerScriptExtensions/SymbolAssignmentSpace/Inputs/script.t
@@ -1,0 +1,12 @@
+u1 = 0x1;
+v1= u1;
+w=u1;
+SECTIONS {
+  v2 =v1;
+  .text : {
+    *(.text)
+    v3= v2;
+  }
+  v4=u1;
+}
+v5= v4;

--- a/test/Common/standalone/linkerscript/LinkerScriptExtensions/SymbolAssignmentSpace/SymbolAssignmentSpace.test
+++ b/test/Common/standalone/linkerscript/LinkerScriptExtensions/SymbolAssignmentSpace/SymbolAssignmentSpace.test
@@ -1,0 +1,24 @@
+#---LoadSectionsAfterDebugSections.test-------------- Executable,LS --------------------#
+#BEGIN_COMMENT
+# This test checks that the linker accepts '<symbol>=<expr>' linker script syntax when
+# --use-linker-script-extensions is used.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c
+RUN: %not %link %linkopts -o %t1.1.err.out %t1.1.o -T %p/Inputs/script.t 2>&1 \
+RUN:   | %filecheck %s --check-prefix=ERR --strict-whitespace --match-full-lines
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t --use-linker-script-extensions
+RUN: %readelf -s %t1.1.out | %filecheck %s -check-prefix=READELF
+#END_TEST
+
+ERR:Error: {{.*}}Inputs/script.t:2: unknown directive: v1=
+ERR:>>> v1= u1;
+ERR:>>> ^
+
+READELF-DAG: {{0+}}1 {{.*}} u1
+READELF-DAG: {{0+}}1 {{.*}} w
+READELF-DAG: {{0+}}1 {{.*}} v1
+READELF-DAG: {{0+}}1 {{.*}} v2
+READELF-DAG: {{0+}}1 {{.*}} v3
+READELF-DAG: {{0+}}1 {{.*}} v4
+READELF-DAG: {{0+}}1 {{.*}} v5


### PR DESCRIPTION
This commit adds --[no-]use-linker-script-extensions option. This option changes the default LexState from `LexState::Default` to `LexState::Expr`. This effectively allows the use of the below syntaxes:

- `<symbol>=<expression>`

- `FOO: { *(.text.foo) }`

On the downside, using this option breaks linker script compatibility with GNU ld.

We can also move other non-gnu features such as plugin linker script commands and INCLUDE_OPTIONAL in linker script extensions bucket as well.