### PR TITLE
[RISC-V] Fix AUIPC to LUI rewriting for reverse order of relocations

### DIFF
--- a/lib/Target/RISCV/RISCVRelocator.cpp
+++ b/lib/Target/RISCV/RISCVRelocator.cpp
@@ -954,9 +954,6 @@ RISCVRelocator::Result applyLO(Relocation &pReloc, RISCVLDBackend &Backend,
           S + HIReloc->addend() - HIReloc->place(Backend.getModule()) + 0x800;
       if (isStaticLink && !llvm::isInt<20>(Result_Hi_Check >> 12) &&
           llvm::isInt<20>(Result_Hi >> 12)) {
-        int64_t Displacement = pReloc.place(Backend.getModule()) -
-                               HIReloc->place(Backend.getModule());
-        Result_lo += Displacement;
         pReloc.setType(pReloc.type() == llvm::ELF::R_RISCV_PCREL_LO12_I
                            ? llvm::ELF::R_RISCV_LO12_I
                            : llvm::ELF::R_RISCV_LO12_S);

--- a/test/RISCV/standalone/ConvertAUIPCToLUI/ConvertAUIPCToLUI.test
+++ b/test/RISCV/standalone/ConvertAUIPCToLUI/ConvertAUIPCToLUI.test
@@ -10,9 +10,27 @@ UNSUPPORTED: riscv32
 RUN: %clang %clangopts -fPIC -c %p/Inputs/t.c -ffunction-sections \
 RUN: -fno-asynchronous-unwind-tables -o %t1.o -mno-relax
 RUN: %link %linkopts  %t1.o -T %p/Inputs/tls.t -o %t.out 2>&1
-RUN: %objdump -d %t.out 2>&1 | %filecheck %s
-#END_TEST
-
+RUN: %objdump -d %t.out | %filecheck %s
 
 #CHECK: lui     a0, 0x0
 #CHECK: addi    a0, a0, 0x4
+
+RUN: %clang %clangopts -fno-pic -mcmodel=medany -c %p/Inputs/reverse.s -o %t.reverse.o
+RUN: %link %linkopts %t.reverse.o -T %p/Inputs/tls.t -o %t.reverse.out
+RUN: %objdump -d %t.reverse.out | %filecheck %s --check-prefix=REVERSE
+
+### Both lw instructions should have the same offset (0x88).
+REVERSE: <.Lpcrel_hi0>:
+REVERSE-NEXT:      lui a0, 0x0
+REVERSE-NEXT:      lw a0, 0x88(a0)
+REVERSE-NEXT:      j {{.+}} <.Lpcrel_hi1>
+
+REVERSE: <.Lpcrel_lo1>:
+REVERSE-NEXT:      lw a0, 0x88(a0)
+REVERSE-NEXT:      ret
+
+REVERSE: <.Lpcrel_hi1>:
+REVERSE-NEXT:       lui a0, 0x0
+REVERSE-NEXT:       j {{.+}} <.Lpcrel_lo1>
+
+#END_TEST

--- a/test/RISCV/standalone/ConvertAUIPCToLUI/Inputs/reverse.s
+++ b/test/RISCV/standalone/ConvertAUIPCToLUI/Inputs/reverse.s
@@ -1,0 +1,23 @@
+## .data lives at a low address.
+.data
+X:      .word 5
+
+## Code lives at least 2GB away, which is controlled by linker script.
+.text
+
+## Usually, R_RISCV_PCREL_LO12_I follows R_RISCV_PCREL_HI20.
+.Lpcrel_hi0:
+        auipc a0, %pcrel_hi(X)
+        lw a0, %pcrel_lo(.Lpcrel_hi0)(a0)
+
+        j .Lpcrel_hi1
+
+## R_RISCV_PCREL_HI20 relocation is processed after the paired R_RISCV_PCREL_LO12_I.
+## This should produce the same address because the resulting relocation is an absolute one.
+.Lpcrel_lo1:
+        lw a0, %pcrel_lo(.Lpcrel_hi1)(a0)
+        ret
+
+.Lpcrel_hi1:
+        auipc a0, %pcrel_hi(X)
+        j .Lpcrel_lo1

--- a/test/RISCV/standalone/ConvertAUIPCToLUI/Inputs/tls.t
+++ b/test/RISCV/standalone/ConvertAUIPCToLUI/Inputs/tls.t
@@ -1,10 +1,11 @@
 MEMORY {
+  DATA : ORIGIN = 0x88, LENGTH = 0x100
   RAM (rwx) : ORIGIN = 0x80002a50,  LENGTH = ((262144) << 10)
 }
 
 SECTIONS {
-  text : { *(.text) } > RAM
-  data : { *(.data); *(.sdata) } > RAM
+  data : { *(.data) *(.sdata) } > DATA
+  text : { *(.text) *(.text.*) } > RAM
   tbss : { *(.tbss) } > RAM
   PROVIDE(__tbss_align = ALIGNOF(tbss));
 }


### PR DESCRIPTION
R_RISCV_LO12_XXX relocations reference a R_RISCV_PCREL_HI20 relocation. There is a code branch that is supposed to handle these relocations in a reversed order but it has never been tested and it was incorrectly adjusting the address as if it was a relative offset.

The related code needs some NFC, which will follow.