### PR TITLE
Use Expression::resetOrZero for printing map-file

### DIFF
--- a/include/eld/Script/Expression.h
+++ b/include/eld/Script/Expression.h
@@ -191,6 +191,7 @@ public:
   /// \brief Evaluate the expression, commit and return the value when
   ///        evaluation is successful. Returns an error if evaluation fails.
   ///        This method is intended to be called by Expression users.
+  /// The result is set to 0 if the evaluation fails.
   eld::Expected<uint64_t> evaluateAndReturnError();
 
   /// evaluateAndRaiseError
@@ -200,6 +201,7 @@ public:
   ///        any case.
   /// This method is intended to be called by Expression
   ///        users.
+  /// The result is set to 0 if the evaluation fails.
   std::optional<uint64_t> evaluateAndRaiseError();
 
   /// eval

--- a/lib/LayoutMap/TextLayoutPrinter.cpp
+++ b/lib/LayoutMap/TextLayoutPrinter.cpp
@@ -1237,7 +1237,7 @@ void TextLayoutPrinter::printLayout(eld::Module &Module) {
              Cur, nullptr, (*Out)->getFirstFrag())) {
 
       printPadding(Cur, P.startOffset, P.endOffset - P.startOffset,
-                   P.Exp ? P.Exp->result() : 0, false, UseColor);
+                   P.Exp ? P.Exp->resultOrZero() : 0, false, UseColor);
     }
     for (OutputSectionEntry::iterator in = (*Out)->begin(),
                                       InEnd = (*Out)->end();
@@ -1301,7 +1301,7 @@ void TextLayoutPrinter::printLayout(eld::Module &Module) {
                                      : nullptr)) {
 
           printPadding(Cur, P.startOffset, P.endOffset - P.startOffset,
-                       P.Exp ? P.Exp->result() : 0, false, UseColor);
+                       P.Exp ? P.Exp->resultOrZero() : 0, false, UseColor);
         }
       }
     }

--- a/lib/LinkerWrapper/LayoutWrapper.cpp
+++ b/lib/LinkerWrapper/LayoutWrapper.cpp
@@ -51,7 +51,7 @@ LayoutWrapper::getPaddings(eld::plugin::OutputSection &Section) {
     if (!(p.endOffset - p.startOffset))
       continue;
     recordPadding(paddings, p.startOffset, p.endOffset - p.startOffset,
-                  p.Exp ? p.Exp->result() : 0, /*isAlignment*/ false);
+                  p.Exp ? p.Exp->resultOrZero() : 0, /*isAlignment*/ false);
   }
   for (eld::OutputSectionEntry::iterator it = entry->begin(),
                                          itEnd = entry->end();
@@ -83,7 +83,7 @@ LayoutWrapper::getPaddings(eld::plugin::OutputSection &Section) {
                NextRuleWithContent ? NextRuleWithContent->getFirstFrag()
                                    : nullptr)) {
         recordPadding(paddings, p.startOffset, p.endOffset - p.startOffset,
-                      p.Exp ? p.Exp->result() : 0, /*isAlignment*/ false);
+                      p.Exp ? p.Exp->resultOrZero() : 0, /*isAlignment*/ false);
       }
     }
   }


### PR DESCRIPTION
This commit replaces the use of `Expression::result` with `Expression::resultOrZero` in `TextLayoutPrinter` and `LayoutWrapper`. This is because map-file can be printed (or layout information can be requested) even when the link has failed before expression evaluation.