### PR TITLE
[ARM][AArch64] Fix computation of local-exec TLS relocations

### DIFF
--- a/include/eld/Target/Relocator.h
+++ b/include/eld/Target/Relocator.h
@@ -145,6 +145,14 @@ public:
   // Get the address for a relocation
   Relocation::Address getSymValue(const Relocation *R);
 
+  std::optional<uint64_t> getFirstTLSSegmentVirtualAddr() const;
+
+  std::optional<uint64_t> getMaxTLSSegmentAlign() const;
+
+  /// Compute and store any offsets that are required for computing
+  /// TLS relocations.
+  virtual void computeTLSOffsets() {}
+
 private:
   enum ErrType { Undef, Invisible };
   LinkerConfig &m_Config;

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -2136,6 +2136,8 @@ bool ObjectLinker::relocation(bool EmitRelocs) {
   // Mapping section to count and max_size.
   llvm::DenseMap<ELFSection *, unsigned> RelocCount, MaxSectSize;
 
+  ThisBackend.getRelocator()->computeTLSOffsets();
+
   auto EmitOneReloc = [&](Relocation *Relocation) -> bool {
     if (!EmitRelocs)
       return true;

--- a/lib/Target/AArch64/AArch64Relocator.h
+++ b/lib/Target/AArch64/AArch64Relocator.h
@@ -75,6 +75,12 @@ public:
   void partialScanRelocation(Relocation &pReloc,
                              const ELFSection &pSection) override;
 
+  void computeTLSOffsets() override;
+
+  std::optional<uint64_t> getStaticTLSBlockVarOffset() const {
+    return StaticTLSBlockVarOffset;
+  }
+
 private:
   bool isInvalidReloc(Relocation &pType) const;
   void scanLocalReloc(InputFile &pInput, Relocation &pReloc,
@@ -86,6 +92,11 @@ private:
 
 private:
   AArch64GNUInfoLDBackend &m_Target;
+  /// The static TLS block contains an optional gap at the beginning,
+  /// that is followed by an optional alignment padding. The TLS variables
+  /// are stored after the alignment padding. This member stores the
+  /// offset in the static TLS block from where the variables start.
+  std::optional<uint64_t> StaticTLSBlockVarOffset;
 };
 
 } // namespace eld

--- a/lib/Target/ARM/ARMRelocator.h
+++ b/lib/Target/ARM/ARMRelocator.h
@@ -66,6 +66,12 @@ public:
 
   uint32_t getNumRelocs() const override;
 
+  void computeTLSOffsets() override;
+
+  std::optional<uint64_t> getStaticTLSBlockVarOffset() const {
+    return StaticTLSBlockVarOffset;
+  }
+
 private:
   bool isInvalidReloc(Relocation &pType) const;
   void scanLocalReloc(InputFile &pInput, Relocation::Type, Relocation &pReloc,
@@ -83,6 +89,12 @@ private:
 
 private:
   ARMGNULDBackend &m_Target;
+
+  /// The static TLS block contains an optional gap at the beginning,
+  /// that is followed by an optional alignment padding. The TLS variables
+  /// are stored after the alignment padding. This member stores the
+  /// offset in the static TLS block from where the variables start.
+  std::optional<uint64_t> StaticTLSBlockVarOffset;
 };
 
 } // namespace eld

--- a/test/AArch64/standalone/TLSLocalExec/Inputs/1.c
+++ b/test/AArch64/standalone/TLSLocalExec/Inputs/1.c
@@ -1,0 +1,4 @@
+__thread int a = 12;
+__attribute__((aligned(128))) __thread int b = 13;
+
+int foo() { return a; }

--- a/test/AArch64/standalone/TLSLocalExec/Inputs/script.t
+++ b/test/AArch64/standalone/TLSLocalExec/Inputs/script.t
@@ -1,0 +1,13 @@
+PHDRS {
+  A PT_LOAD;
+  B PT_LOAD;
+  C PT_LOAD;
+  T1 PT_TLS;
+}
+
+SECTIONS {
+  .text (0x1000) : { *(.text*) } :A
+  .data : { *(.data*) } :B
+  .tdata (0x4000) : { *(.tdata*) } :B :T1
+  .tbss : { *(.tbss*) } :C :T1
+}

--- a/test/AArch64/standalone/TLSLocalExec/TLSLocalExec.test
+++ b/test/AArch64/standalone/TLSLocalExec/TLSLocalExec.test
@@ -1,0 +1,20 @@
+#---TLSLocalExec.test--------------------------- PartialLink -----------------#
+#BEGIN_COMMENT
+# This tests checks that eld correctly computes TLS local-exec
+# relocation computation when the TLS segment alignment is greater
+# than 16.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c
+RUN: %link %linkopts -o %t1.1.out %t1.1.o
+RUN: %readelf -l %t1.1.out | %filecheck %s --check-prefix=READELF
+RUN: %objdump -d %t1.1.out | %filecheck %s --check-prefix=OBJDUMP
+RUN: %link %linkopts -o %t1.1.script.out %t1.1.o -T %p/Inputs/script.t
+RUN: %readelf -l %t1.1.script.out | %filecheck %s --check-prefix=READELF_SCRIPT
+RUN: %objdump -d %t1.1.script.out | %filecheck %s --check-prefix=OBJDUMP
+#END_TEST
+
+READELF: TLS {{.*}} R 0x80
+OBJDUMP: add {{.*}} #0x80
+
+READELF_SCRIPT: TLS {{.*}} RW 0x80

--- a/test/AArch64/standalone/TLSLocalExecMultipleSegments/Inputs/1.c
+++ b/test/AArch64/standalone/TLSLocalExecMultipleSegments/Inputs/1.c
@@ -1,0 +1,6 @@
+__thread int u;
+__attribute((aligned(256))) __thread int v;
+__thread int a = 12;
+__attribute__((aligned(128))) __thread int b = 13;
+
+int foo(void) { return a; }

--- a/test/AArch64/standalone/TLSLocalExecMultipleSegments/Inputs/script.t
+++ b/test/AArch64/standalone/TLSLocalExecMultipleSegments/Inputs/script.t
@@ -1,0 +1,14 @@
+PHDRS {
+  A PT_LOAD;
+  B PT_LOAD;
+  C PT_LOAD;
+  T1 PT_TLS;
+  T2 PT_TLS;
+}
+
+SECTIONS {
+  .text (0x1000) : { *(.text*) } :A
+  .data : { *(.data*) } :B
+  .tdata (0x4000) : { *(.tdata*) } :B :T1
+  .tbss : { *(.tbss*) } :C :T2
+}

--- a/test/AArch64/standalone/TLSLocalExecMultipleSegments/Inputs/script2.t
+++ b/test/AArch64/standalone/TLSLocalExecMultipleSegments/Inputs/script2.t
@@ -1,0 +1,14 @@
+PHDRS {
+  A PT_LOAD;
+  B PT_LOAD;
+  C PT_LOAD;
+  T1 PT_TLS;
+  T2 PT_TLS;
+}
+
+SECTIONS {
+  .text (0x1000) : { *(.text*) } :A
+  .data : { *(.data*) } :B
+  .tdata (0x4000) : ALIGN(0x400) { *(.tdata*) } :B :T1
+  .tbss : SUBALIGN(0x200) { *(.tbss*) } :C :T2
+}

--- a/test/AArch64/standalone/TLSLocalExecMultipleSegments/TLSLocalExecMultipleSegments.test
+++ b/test/AArch64/standalone/TLSLocalExecMultipleSegments/TLSLocalExecMultipleSegments.test
@@ -1,0 +1,24 @@
+#---TLSLocalExecMultipleSegments.test--------------------------- PartialLink -----------------#
+#BEGIN_COMMENT
+# This tests checks that eld correctly computes TLS local-exec
+# relocation computation when the TLS segment alignment is greater
+# than 16 and there are multiple TLS segments.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t
+RUN: %readelf -l %t1.1.out | %filecheck %s --check-prefix=READELF
+RUN: %objdump -d %t1.1.out | %filecheck %s --check-prefix=OBJDUMP
+RUN: %link %linkopts -o %t1.2.out %t1.1.o -T %p/Inputs/script2.t
+RUN: %readelf -l %t1.2.out | %filecheck %s --check-prefix=READELF_2
+RUN: %objdump -d %t1.2.out | %filecheck %s --check-prefix=OBJDUMP_2
+#END_TEST
+
+READELF: TLS {{.*}} RW 0x100
+READELF: TLS {{.*}} RW 0x100
+OBJDUMP: add {{.*}} #0x100
+
+READELF_2: TLS {{.*}} RW 0x400
+READELF_2: TLS {{.*}} RW 0x200
+OBJDUMP_2: add {{.*}} #0x400
+

--- a/test/ARM/standalone/TLSLocalExec/Inputs/1.c
+++ b/test/ARM/standalone/TLSLocalExec/Inputs/1.c
@@ -1,0 +1,4 @@
+__thread int a = 12;
+__attribute__((aligned(128))) __thread int b = 13;
+
+int foo() { return a; }

--- a/test/ARM/standalone/TLSLocalExec/Inputs/script.t
+++ b/test/ARM/standalone/TLSLocalExec/Inputs/script.t
@@ -1,0 +1,13 @@
+PHDRS {
+  A PT_LOAD;
+  B PT_LOAD;
+  C PT_LOAD;
+  T1 PT_TLS;
+}
+
+SECTIONS {
+  .text (0x1000) : { *(.text*) } :A
+  .data : { *(.data*) } :B
+  .tdata (0x4000) : { *(.tdata*) } :B :T1
+  .tbss : { *(.tbss*) } :C :T1
+}

--- a/test/ARM/standalone/TLSLocalExec/TLSLocalExec.test
+++ b/test/ARM/standalone/TLSLocalExec/TLSLocalExec.test
@@ -1,0 +1,20 @@
+#---TLSLocalExec.test--------------------------- PartialLink -----------------#
+#BEGIN_COMMENT
+# This tests checks that eld correctly computes TLS local-exec
+# relocation computation when the TLS segment alignment is greater
+# than 16.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c
+RUN: %link %linkopts -o %t1.1.out %t1.1.o --defsym __aeabi_read_tp=0
+RUN: %readelf -l %t1.1.out | %filecheck %s --check-prefix=READELF
+RUN: %objdump -d %t1.1.out | %filecheck %s --check-prefix=OBJDUMP
+RUN: %link %linkopts -o %t1.1.script.out %t1.1.o --defsym __aeabi_read_tp=0 -T %p/Inputs/script.t
+RUN: %readelf -l %t1.1.script.out | %filecheck %s --check-prefix=READELF_SCRIPT
+RUN: %objdump -d %t1.1.script.out | %filecheck %s --check-prefix=OBJDUMP
+#END_TEST
+
+READELF: TLS {{.*}} R 0x80
+OBJDUMP: .word   0x{{0+}}80
+
+READELF_SCRIPT: TLS {{.*}} RW 0x80

--- a/test/ARM/standalone/TLSLocalExecMultipleSegments/Inputs/1.c
+++ b/test/ARM/standalone/TLSLocalExecMultipleSegments/Inputs/1.c
@@ -1,0 +1,6 @@
+__thread int u;
+__attribute((aligned(256))) __thread int v;
+__thread int a = 12;
+__attribute__((aligned(128))) __thread int b = 13;
+
+int foo(void) { return a; }

--- a/test/ARM/standalone/TLSLocalExecMultipleSegments/Inputs/script.t
+++ b/test/ARM/standalone/TLSLocalExecMultipleSegments/Inputs/script.t
@@ -1,0 +1,14 @@
+PHDRS {
+  A PT_LOAD;
+  B PT_LOAD;
+  C PT_LOAD;
+  T1 PT_TLS;
+  T2 PT_TLS;
+}
+
+SECTIONS {
+  .text (0x1000) : { *(.text*) } :A
+  .data : { *(.data*) } :B
+  .tdata (0x4000) : { *(.tdata*) } :B :T1
+  .tbss : { *(.tbss*) } :C :T2
+}

--- a/test/ARM/standalone/TLSLocalExecMultipleSegments/Inputs/script2.t
+++ b/test/ARM/standalone/TLSLocalExecMultipleSegments/Inputs/script2.t
@@ -1,0 +1,14 @@
+PHDRS {
+  A PT_LOAD;
+  B PT_LOAD;
+  C PT_LOAD;
+  T1 PT_TLS;
+  T2 PT_TLS;
+}
+
+SECTIONS {
+  .text (0x1000) : { *(.text*) } :A
+  .data : { *(.data*) } :B
+  .tdata (0x4000) : ALIGN(0x400) { *(.tdata*) } :B :T1
+  .tbss : SUBALIGN(0x200) { *(.tbss*) } :C :T2
+}

--- a/test/ARM/standalone/TLSLocalExecMultipleSegments/TLSLocalExecMultipleSegments.test
+++ b/test/ARM/standalone/TLSLocalExecMultipleSegments/TLSLocalExecMultipleSegments.test
@@ -1,0 +1,24 @@
+#---TLSLocalExecMultipleSegments.test--------------------------- PartialLink -----------------#
+#BEGIN_COMMENT
+# This tests checks that eld correctly computes TLS local-exec
+# relocation computation when the TLS segment alignment is greater
+# than 16 and when there are multiple TLS segments.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c
+RUN: %link %linkopts -o %t1.1.out %t1.1.o --defsym __aeabi_read_tp=0 -T %p/Inputs/script.t
+RUN: %readelf -l %t1.1.out | %filecheck %s --check-prefix=READELF
+RUN: %objdump -d %t1.1.out | %filecheck %s --check-prefix=OBJDUMP
+RUN: %link %linkopts -o %t1.2.out %t1.1.o --defsym __aeabi_read_tp=0 -T %p/Inputs/script2.t
+RUN: %readelf -l %t1.2.out | %filecheck %s --check-prefix=READELF_2
+RUN: %objdump -d %t1.2.out | %filecheck %s --check-prefix=OBJDUMP_2
+#END_TEST
+
+READELF: TLS {{.*}} RW 0x100
+READELF: TLS {{.*}} RW 0x100
+OBJDUMP: .word   0x{{0+}}100
+
+READELF_2: TLS {{.*}} RW 0x400
+READELF_2: TLS {{.*}} RW 0x200
+OBJDUMP_2: .word   0x{{0+}}400
+


### PR DESCRIPTION
This commit fixes computation of local-exec TLS relocations for
ARM and AArch64. Previously, we were not using the correct start offset
in static thread local storage block for computing the relocation.

Lets understand this with the help of an example

```

             <--------- Static thread local storage block  ------------------>
| --------- | ----------------- | --------------------- | ----------------------- |
     TCB    TP  Reserved space      Alignment padding      Thread variables

```
ARM/AArch64 local-exec relocation resolves to:
  SymbolValueInTLSSegment + Reserved Space + Alignment padding

Previously, we were not accounting for the alignment padding. But why is
this alignment padding required? It is required so that the symbol
alignments assumed at the compile/link time is satisfied at runtime as
well. The exact condition that should be satisfied is:

&nbsp;&nbsp; VMA(TP) + Reserved space + Alignment padding congruent to TLSSegment[vaddr] (modulo TLSSegment[align])

This condition becomes more clear with the help of an example:

&nbsp;&nbsp;  StartVMAForStaticThreadVariables = VMA(TP) + Reserved space + Alignment padding

&nbsp;&nbsp;  StartVMAForStaticThreadVariables should be congruent to TLSSegment[vaddr] (modulo TLSSegment[align])

Resolves #302