### PR TITLE
Sniff nfc part1

### DIFF
--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -701,9 +701,9 @@ public:
 
   bool setMapStyle(llvm::StringRef MapStyle);
 
-  void setArgs(llvm::ArrayRef<const char *> &Argv) { CommandLineArgs = Argv; }
+  void setArgs(std::vector<const char *> &Argv) { CommandLineArgs = Argv; }
 
-  const llvm::ArrayRef<const char *> &args() const { return CommandLineArgs; }
+  const std::vector<const char *> &args() const { return CommandLineArgs; }
 
   // --Threads
   void enableThreads() { EnableThreads = true; }
@@ -1298,7 +1298,7 @@ private:
   std::string Entry;
   SymbolRenameMap SymbolRenames;
   AddressMapType AddressMap;
-  llvm::ArrayRef<const char *> CommandLineArgs;
+  std::vector<const char *> CommandLineArgs;
   llvm::StringRef ReportUndefPolicy;
   OrphanMode MOrphanMode = OrphanMode::Place;
   std::string LTOCacheDirectory = "";

--- a/include/eld/Config/LinkerConfig.h
+++ b/include/eld/Config/LinkerConfig.h
@@ -30,6 +30,7 @@ class DiagnosticEntry;
 } // namespace ELD
 
 namespace eld {
+class Module;
 class DiagnosticEngine;
 class SearchDirs;
 class LinkerConfig {
@@ -139,8 +140,7 @@ public:
 
   static const char *version();
 
-  void printOptions(llvm::raw_ostream &, GNULDBackend const &,
-                    bool UseColor = false);
+  void printOptions(llvm::raw_ostream &, Module const &, bool UseColor = false);
 
   bool isAssignOutputSectionsMultiThreaded() const {
     return EnableThreads & LinkerConfig::AssignOutputSections;

--- a/include/eld/Core/Linker.h
+++ b/include/eld/Core/Linker.h
@@ -21,6 +21,8 @@
 #include <string>
 #include <vector>
 
+class GnuLdDriver;
+
 namespace eld {
 
 class Module;
@@ -85,6 +87,11 @@ public:
 
   void unloadPlugins();
 
+  // Set the GNU linker driver after sniffing
+  void setDriver(GnuLdDriver *D) { Driver = D; }
+
+  GnuLdDriver *getDriver() const { return Driver; }
+
 private:
   bool initBackend(const eld::Target *PTarget);
 
@@ -120,16 +127,17 @@ private:
   void reportUnknownOptions() const;
 
 private:
-  Module *ThisModule;
-  LinkerConfig *ThisConfig;
-  GNULDBackend *Backend;
-  ObjectLinker *ObjLinker;
-  eld::IRBuilder *IR;
-  ProgressBar *LinkerProgress;
-  llvm::Timer *LinkTime;
-  llvm::Timer *TimingSectionTimer;
-  uint32_t UnresolvedSymbolPolicy;
-  uint64_t BeginningOfTime;
+  Module *ThisModule = nullptr;
+  GnuLdDriver *Driver = nullptr;
+  LinkerConfig *ThisConfig = nullptr;
+  GNULDBackend *Backend = nullptr;
+  ObjectLinker *ObjLinker = nullptr;
+  eld::IRBuilder *IR = nullptr;
+  ProgressBar *LinkerProgress = nullptr;
+  llvm::Timer *LinkTime = nullptr;
+  llvm::Timer *TimingSectionTimer = nullptr;
+  uint32_t UnresolvedSymbolPolicy = NotSet;
+  uint64_t BeginningOfTime = 0;
 };
 
 } // namespace eld

--- a/include/eld/Driver/ARMLinkDriver.h
+++ b/include/eld/Driver/ARMLinkDriver.h
@@ -36,10 +36,10 @@ public:
 
 class ARMLinkDriver : public GnuLdDriver {
 public:
-  static ARMLinkDriver *Create(eld::LinkerConfig &C, Flavor F,
+  static ARMLinkDriver *Create(eld::LinkerConfig &C, DriverFlavor F,
                                std::string Triple);
 
-  ARMLinkDriver(eld::LinkerConfig &C, Flavor F, std::string Triple);
+  ARMLinkDriver(eld::LinkerConfig &C, DriverFlavor F, std::string Triple);
 
   virtual ~ARMLinkDriver() {}
 

--- a/include/eld/Driver/Driver.h
+++ b/include/eld/Driver/Driver.h
@@ -29,9 +29,10 @@ class GnuLdDriver;
 
 class DLL_A_EXPORT Driver {
 public:
-  Driver(Flavor F, std::string Triple);
+  Driver(DriverFlavor F, std::string Triple);
 
-  bool setFlavorAndTripleFromLinkCommand(llvm::ArrayRef<const char *> Args);
+  bool
+  setDriverFlavorAndTripleFromLinkCommand(llvm::ArrayRef<const char *> Args);
 
   static eld::Expected<Driver>
   createDriverForLinkCommand(llvm::ArrayRef<const char *> Args);
@@ -50,22 +51,22 @@ public:
 private:
   std::string getStringFromTarget(llvm::StringRef Target) const;
 
-  Flavor getFlavorFromTarget(llvm::StringRef Target) const;
+  DriverFlavor getDriverFlavorFromTarget(llvm::StringRef Target) const;
 
   void InitTarget();
 
-  eld::Expected<std::pair<Flavor, std::string>>
-  getFlavorAndTripleFromLinkCommand(llvm::ArrayRef<const char *> Args);
+  eld::Expected<std::pair<DriverFlavor, std::string>>
+  getDriverFlavorAndTripleFromLinkCommand(llvm::ArrayRef<const char *> Args);
 
-  std::pair<Flavor, std::string>
-  parseFlavorAndTripleFromProgramName(const char *argv0);
+  std::pair<DriverFlavor, std::string>
+  parseDriverFlavorAndTripleFromProgramName(const char *argv0);
 
 protected:
   eld::DiagnosticEngine *DiagEngine = nullptr;
   eld::LinkerConfig Config;
 
 private:
-  Flavor m_Flavor = Invalid;
+  DriverFlavor m_DriverFlavor = Invalid;
   std::string m_Triple;
   std::vector<std::string> m_SupportedTargets;
 };

--- a/include/eld/Driver/Driver.h
+++ b/include/eld/Driver/Driver.h
@@ -36,7 +36,7 @@ public:
   static eld::Expected<Driver>
   createDriverForLinkCommand(llvm::ArrayRef<const char *> Args);
 
-  GnuLdDriver *getLinker();
+  GnuLdDriver *getLinkerDriver();
 
   virtual ~Driver();
 

--- a/include/eld/Driver/Flavor.h
+++ b/include/eld/Driver/Flavor.h
@@ -1,4 +1,5 @@
-//===- Flavor.h------------------------------------------------------------===//
+//===-
+//DriverFlavor.h------------------------------------------------------------===//
 // Part of the eld Project, under the BSD License
 // See https://github.com/qualcomm/eld/LICENSE.txt for license information.
 // SPDX-License-Identifier: BSD-3-Clause
@@ -9,14 +10,12 @@
 
 #include "eld/Support/Defines.h"
 
-enum Flavor {
+enum DriverFlavor {
   Invalid,
-  Hexagon, // Hexagon
-  ARM,     // ARM
-  AArch64, // AArch64
-  RISCV32, // RISCV32
-  RISCV64, // RISCV64
-  x86_64   // x86_64
+  Hexagon,         // Hexagon
+  ARM_AArch64,     // ARM, AArch64
+  RISCV32_RISCV64, // RISCV32
+  x86_64           // x86_64
 };
 
 #endif

--- a/include/eld/Driver/GnuLdDriver.h
+++ b/include/eld/Driver/GnuLdDriver.h
@@ -51,10 +51,10 @@ public:
 
 class DLL_A_EXPORT GnuLdDriver {
 public:
-  static GnuLdDriver *Create(eld::LinkerConfig &C, Flavor F,
+  static GnuLdDriver *Create(eld::LinkerConfig &C, DriverFlavor F,
                              std::string Triple);
 
-  GnuLdDriver(eld::LinkerConfig &C, Flavor F = Flavor::Invalid);
+  GnuLdDriver(eld::LinkerConfig &C, DriverFlavor F = DriverFlavor::Invalid);
 
   virtual ~GnuLdDriver();
 
@@ -143,7 +143,7 @@ protected:
   void printRepositoryVersion() const;
 
   // Returns the driver's flavor name.
-  std::string getFlavorName() const;
+  std::string getDriverFlavorName() const;
 
   const std::string &getProgramName() const { return LinkerProgramName; }
 
@@ -158,7 +158,7 @@ protected:
   static eld::Module *ThisModule;
   llvm::opt::OptTable *Table;
   std::once_flag once_flag;
-  const Flavor m_Flavor;
+  const DriverFlavor m_DriverFlavor;
   std::vector<std::string> m_SupportedTargets;
   std::string LinkerProgramName;
 };

--- a/include/eld/Driver/HexagonLinkDriver.h
+++ b/include/eld/Driver/HexagonLinkDriver.h
@@ -32,10 +32,10 @@ public:
 
 class HexagonLinkDriver : public GnuLdDriver {
 public:
-  static HexagonLinkDriver *Create(eld::LinkerConfig &C, Flavor F,
+  static HexagonLinkDriver *Create(eld::LinkerConfig &C, DriverFlavor F,
                                    std::string Triple);
 
-  HexagonLinkDriver(eld::LinkerConfig &C, Flavor F, std::string Triple);
+  HexagonLinkDriver(eld::LinkerConfig &C, DriverFlavor F, std::string Triple);
 
   virtual ~HexagonLinkDriver() {}
 

--- a/include/eld/Driver/RISCVLinkDriver.h
+++ b/include/eld/Driver/RISCVLinkDriver.h
@@ -31,10 +31,10 @@ public:
 
 class RISCVLinkDriver : public GnuLdDriver {
 public:
-  static RISCVLinkDriver *Create(eld::LinkerConfig &C, Flavor F,
+  static RISCVLinkDriver *Create(eld::LinkerConfig &C, DriverFlavor F,
                                  std::string Triple);
 
-  RISCVLinkDriver(eld::LinkerConfig &C, Flavor F, std::string Triple);
+  RISCVLinkDriver(eld::LinkerConfig &C, DriverFlavor F, std::string Triple);
 
   virtual ~RISCVLinkDriver() {}
 

--- a/include/eld/Driver/x86_64LinkDriver.h
+++ b/include/eld/Driver/x86_64LinkDriver.h
@@ -33,10 +33,10 @@ public:
 
 class x86_64LinkDriver : public GnuLdDriver {
 public:
-  static x86_64LinkDriver *Create(eld::LinkerConfig &C, Flavor F,
+  static x86_64LinkDriver *Create(eld::LinkerConfig &C, DriverFlavor F,
                                   std::string Triple);
 
-  x86_64LinkDriver(eld::LinkerConfig &C, Flavor F, std::string Triple);
+  x86_64LinkDriver(eld::LinkerConfig &C, DriverFlavor F, std::string Triple);
 
   virtual ~x86_64LinkDriver() {}
 

--- a/include/eld/LayoutMap/TextLayoutPrinter.h
+++ b/include/eld/LayoutMap/TextLayoutPrinter.h
@@ -53,7 +53,7 @@ public:
   void printSection(GNULDBackend const &Backend,
                     const OutputSectionEntry *Section, bool UseColor);
 
-  void printArchAndVersion(bool UseColor, GNULDBackend const &Backend);
+  void printArchAndVersion(bool UseColor, Module const &M);
 
   void printFragInfo(Fragment *F, LayoutFragmentInfo *Info, ELFSection *Section,
                      Module &M) const;

--- a/lib/Config/LinkerConfig.cpp
+++ b/lib/Config/LinkerConfig.cpp
@@ -62,8 +62,8 @@ void LinkerConfig::addCommandLine(llvm::StringRef Option,
 }
 
 // TODO: Use DIAG here.
-void LinkerConfig::printOptions(llvm::raw_ostream &Outs,
-                                GNULDBackend const &Backend, bool UseColor) {
+void LinkerConfig::printOptions(llvm::raw_ostream &Outs, Module const &M,
+                                bool UseColor) {
   Outs << "# Notable linker command/script options:\n";
   Outs << "# CPU Architecture Version: ";
   if (UseColor) {
@@ -105,7 +105,7 @@ void LinkerConfig::printOptions(llvm::raw_ostream &Outs,
     Outs << "Static\n";
   }
   // Print LTO flag status and parameters
-  if (Backend.getModule().needLTOToBeInvoked() || options().hasLTO()) {
+  if (M.needLTOToBeInvoked() || options().hasLTO()) {
     std::vector<llvm::StringRef> LtoOptions;
     if (UseColor)
       Outs.resetColor();
@@ -133,11 +133,12 @@ void LinkerConfig::printOptions(llvm::raw_ostream &Outs,
 
   if (UseColor)
     Outs.resetColor();
+
   Outs << "# ABI Page Size: ";
   if (UseColor)
     Outs.changeColor(llvm::raw_ostream::YELLOW);
   Outs << "0x";
-  Outs.write_hex(Backend.abiPageSize());
+  Outs.write_hex(M.getBackend().abiPageSize());
   Outs << "\n";
   if (UseColor)
     Outs.resetColor();

--- a/lib/Core/Linker.cpp
+++ b/lib/Core/Linker.cpp
@@ -306,7 +306,7 @@ bool Linker::initializeInputTree(std::vector<InputAction *> &Actions) {
 /// normalize - to convert the command line language to the input tree.
 bool Linker::normalize() {
   if (ThisModule->getPrinter()->traceCommandLine()) {
-    ThisConfig->printOptions(llvm::outs(), *Backend,
+    ThisConfig->printOptions(llvm::outs(), *ThisModule,
                              ThisConfig->options().color());
   }
 

--- a/lib/LayoutMap/TextLayoutPrinter.cpp
+++ b/lib/LayoutMap/TextLayoutPrinter.cpp
@@ -1087,8 +1087,7 @@ std::string TextLayoutPrinter::commandLineWithMappings() {
 }
 
 // Print Map file header information like Linker architecture, version, etc.
-void TextLayoutPrinter::printArchAndVersion(bool UseColor,
-                                            GNULDBackend const &Backend) {
+void TextLayoutPrinter::printArchAndVersion(bool UseColor, Module const &M) {
   if (!eld::getVendorName().empty())
     outputStream() << "# Linker from " << eld::getVendorName() << " Version "
                    << eld::getVendorVersion() << "\n";
@@ -1096,8 +1095,7 @@ void TextLayoutPrinter::printArchAndVersion(bool UseColor,
                  << "\n";
   outputStream() << "# Linker: " << getELDRevision() << "\n";
   outputStream() << "# LLVM: " << getLLVMRevision() << "\n";
-  this->ThisLayoutInfo->getConfig().printOptions(outputStream(), Backend,
-                                                    UseColor);
+  this->ThisLayoutInfo->getConfig().printOptions(outputStream(), M, UseColor);
 
   // Print the command line in the Map file.
   std::string CommandLine;
@@ -1153,7 +1151,7 @@ void TextLayoutPrinter::printMapFile(eld::Module &Module) {
                   Backend.config().options().colorMap();
   LinkerScript const &Script = Module.getScript();
 
-  printArchAndVersion(UseColor, Backend);
+  printArchAndVersion(UseColor, Module);
   printStats(ThisLayoutInfo->getLinkStats(), Module);
   printIsFileHeaderLoadedInfo(Backend.isFileHeaderLoaded(), UseColor);
   printIsPHDRSLoadedInfo(Backend.isPHDRSLoaded(), UseColor);

--- a/lib/LinkerWrapper/ARMLinkDriver.cpp
+++ b/lib/LinkerWrapper/ARMLinkDriver.cpp
@@ -174,7 +174,7 @@ int ARMLinkDriver::link(llvm::ArrayRef<const char *> Args,
         << llvm::join(ELDFlagsArgs, " ");
   llvm::opt::InputArgList ArgList(allArgs.data(),
                                   allArgs.data() + allArgs.size());
-  Config.options().setArgs(Args);
+  Config.options().setArgs(allArgs);
   std::vector<eld::InputAction *> Action;
 
   //===--------------------------------------------------------------------===//

--- a/lib/LinkerWrapper/ARMLinkDriver.cpp
+++ b/lib/LinkerWrapper/ARMLinkDriver.cpp
@@ -62,14 +62,15 @@ ARMLinkDriver::ParseEmulation(std::string pEmulation,
 OPT_ARMLinkOptTable::OPT_ARMLinkOptTable()
     : GenericOptTable(OptionStrTable, OptionPrefixesTable, infoTable) {}
 
-ARMLinkDriver *ARMLinkDriver::Create(eld::LinkerConfig &C, Flavor F,
+ARMLinkDriver *ARMLinkDriver::Create(eld::LinkerConfig &C, DriverFlavor F,
                                      std::string Triple) {
   return eld::make<ARMLinkDriver>(C, F, Triple);
 }
 
-ARMLinkDriver::ARMLinkDriver(eld::LinkerConfig &C, Flavor F, std::string Triple)
+ARMLinkDriver::ARMLinkDriver(eld::LinkerConfig &C, DriverFlavor F,
+                             std::string Triple)
     : GnuLdDriver(C, F) {
-  if (F == Flavor::ARM)
+  if (F == DriverFlavor::ARM_AArch64)
     Config.targets().setArch("arm");
   else
     Config.targets().setArch("aarch64");

--- a/lib/LinkerWrapper/Driver.cpp
+++ b/lib/LinkerWrapper/Driver.cpp
@@ -33,7 +33,7 @@ Driver::Driver(Flavor F, std::string Triple)
 
 Driver::~Driver() { delete DiagEngine; }
 
-GnuLdDriver *Driver::getLinker() {
+GnuLdDriver *Driver::getLinkerDriver() {
   if (!m_SupportedTargets.size())
     InitTarget();
   GnuLdDriver *LinkDriver = nullptr;

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -1628,7 +1628,10 @@ bool GnuLdDriver::doLink(llvm::opt::InputArgList &Args,
 
   bool linkStatus = false;
   {
+    // Set up the linker and set the driver
     eld::Linker linker(*ThisModule, Config);
+    linker.setDriver(this);
+    // Install default Signal handler
     llvm::sys::AddSignalHandler(defaultSignalHandler, nullptr);
     Config.raise(Diag::default_signal_handler);
     linkStatus = linker.prepare(actions, ELDTarget);

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -70,31 +70,29 @@ static constexpr llvm::opt::OptTable::Info infoTable[] = {
 OPT_GnuLdOptTable::OPT_GnuLdOptTable()
     : GenericOptTable(OptionStrTable, OptionPrefixesTable, infoTable) {}
 
-GnuLdDriver::GnuLdDriver(LinkerConfig &C, Flavor F)
+GnuLdDriver::GnuLdDriver(LinkerConfig &C, DriverFlavor F)
     : Config(C), DiagEngine(C.getDiagEngine()), m_Script(DiagEngine),
-      m_Flavor(F) {}
+      m_DriverFlavor(F) {}
 
 GnuLdDriver::~GnuLdDriver() {}
 
-GnuLdDriver *GnuLdDriver::Create(LinkerConfig &C, Flavor F,
+GnuLdDriver *GnuLdDriver::Create(LinkerConfig &C, DriverFlavor F,
                                  std::string Triple) {
   switch (F) {
 #ifdef ELD_ENABLE_TARGET_HEXAGON
-  case Flavor::Hexagon:
+  case DriverFlavor::Hexagon:
     return HexagonLinkDriver::Create(C, F, Triple);
 #endif
 #if defined(ELD_ENABLE_TARGET_ARM) || defined(ELD_ENABLE_TARGET_AARCH64)
-  case Flavor::ARM:
-  case Flavor::AArch64:
+  case DriverFlavor::ARM_AArch64:
     return ARMLinkDriver::Create(C, F, Triple);
 #endif
 #ifdef ELD_ENABLE_TARGET_RISCV
-  case Flavor::RISCV32:
-  case Flavor::RISCV64:
+  case DriverFlavor::RISCV32_RISCV64:
     return RISCVLinkDriver::Create(C, F, Triple);
 #endif
 #ifdef ELD_ENABLE_TARGET_X86_64
-  case Flavor::x86_64:
+  case DriverFlavor::x86_64:
     return x86_64LinkDriver::Create(C, F, Triple);
 #endif
   default:
@@ -1690,28 +1688,24 @@ bool GnuLdDriver::handleReproduce(llvm::opt::InputArgList &Args,
   return true;
 }
 
-std::string GnuLdDriver::getFlavorName() const {
-  switch (m_Flavor) {
-  case Flavor::AArch64:
-    return "AArch64";
-  case Flavor::ARM:
-    return "ARM";
-  case Flavor::Hexagon:
+std::string GnuLdDriver::getDriverFlavorName() const {
+  switch (m_DriverFlavor) {
+  case DriverFlavor::ARM_AArch64:
+    return "ARM/AArch64";
+  case DriverFlavor::Hexagon:
     return "Hexagon";
-  case Flavor::RISCV32:
-    return "RISCV32";
-  case Flavor::RISCV64:
-    return "RISCV64";
-  case Flavor::x86_64:
+  case DriverFlavor::RISCV32_RISCV64:
+    return "RISCV32/RISCV64";
+  case DriverFlavor::x86_64:
     return "x86_64";
-  case Flavor::Invalid:
+  case DriverFlavor::Invalid:
     break;
   }
-  ASSERT(false, "Invalid Flavor!");
+  ASSERT(false, "Invalid DriverFlavor!");
 }
 
 void GnuLdDriver::printRepositoryVersion() const {
-  std::string flavorName = getFlavorName();
+  std::string flavorName = getDriverFlavorName();
   if (!flavorName.empty())
     outs() << flavorName << " ";
   outs() << "Linker repository revision: " << eld::getELDRepositoryVersion()

--- a/lib/LinkerWrapper/HexagonLinkDriver.cpp
+++ b/lib/LinkerWrapper/HexagonLinkDriver.cpp
@@ -108,7 +108,7 @@ int HexagonLinkDriver::link(llvm::ArrayRef<const char *> Args,
 
   llvm::opt::InputArgList ArgList(allArgs.data(),
                                   allArgs.data() + allArgs.size());
-  Config.options().setArgs(Args);
+  Config.options().setArgs(allArgs);
 
   std::vector<eld::InputAction *> Action;
 

--- a/lib/LinkerWrapper/HexagonLinkDriver.cpp
+++ b/lib/LinkerWrapper/HexagonLinkDriver.cpp
@@ -45,12 +45,13 @@ static constexpr llvm::opt::OptTable::Info infoTable[] = {
 OPT_HexagonLinkOptTable::OPT_HexagonLinkOptTable()
     : GenericOptTable(OptionStrTable, OptionPrefixesTable, infoTable) {}
 
-HexagonLinkDriver *HexagonLinkDriver::Create(eld::LinkerConfig &C, Flavor F,
+HexagonLinkDriver *HexagonLinkDriver::Create(eld::LinkerConfig &C,
+                                             DriverFlavor F,
                                              std::string Triple) {
   return eld::make<HexagonLinkDriver>(C, F, Triple);
 }
 
-HexagonLinkDriver::HexagonLinkDriver(eld::LinkerConfig &C, Flavor F,
+HexagonLinkDriver::HexagonLinkDriver(eld::LinkerConfig &C, DriverFlavor F,
                                      std::string Triple)
     : GnuLdDriver(C, F) {
   Config.targets().setArch("hexagon");

--- a/lib/LinkerWrapper/RISCVLinkDriver.cpp
+++ b/lib/LinkerWrapper/RISCVLinkDriver.cpp
@@ -55,15 +55,15 @@ static Triple ParseEmulation(std::string pEmulation, Triple &triple,
 OPT_RISCVLinkOptTable::OPT_RISCVLinkOptTable()
     : GenericOptTable(OptionStrTable, OptionPrefixesTable, infoTable) {}
 
-RISCVLinkDriver *RISCVLinkDriver::Create(eld::LinkerConfig &C, Flavor F,
+RISCVLinkDriver *RISCVLinkDriver::Create(eld::LinkerConfig &C, DriverFlavor F,
                                          std::string Triple) {
   return eld::make<RISCVLinkDriver>(C, F, Triple);
 }
 
-RISCVLinkDriver::RISCVLinkDriver(eld::LinkerConfig &C, Flavor F,
+RISCVLinkDriver::RISCVLinkDriver(eld::LinkerConfig &C, DriverFlavor F,
                                  std::string Triple)
     : GnuLdDriver(C, F) {
-  if (F == Flavor::RISCV32)
+  if (F == DriverFlavor::RISCV32_RISCV64)
     Config.targets().setArch("riscv32");
   else
     Config.targets().setArch("riscv64");

--- a/lib/LinkerWrapper/RISCVLinkDriver.cpp
+++ b/lib/LinkerWrapper/RISCVLinkDriver.cpp
@@ -163,7 +163,7 @@ int RISCVLinkDriver::link(llvm::ArrayRef<const char *> Args,
         << llvm::join(ELDFlagsArgs, " ");
   llvm::opt::InputArgList ArgList(allArgs.data(),
                                   allArgs.data() + allArgs.size());
-  Config.options().setArgs(Args);
+  Config.options().setArgs(allArgs);
   std::vector<eld::InputAction *> Action;
 
   //===--------------------------------------------------------------------===//

--- a/lib/LinkerWrapper/x86_64LinkDriver.cpp
+++ b/lib/LinkerWrapper/x86_64LinkDriver.cpp
@@ -97,7 +97,7 @@ int x86_64LinkDriver::link(llvm::ArrayRef<const char *> Args,
         << llvm::join(ELDFlagsArgs, " ");
   llvm::opt::InputArgList ArgList(allArgs.data(),
                                   allArgs.data() + allArgs.size());
-  Config.options().setArgs(Args);
+  Config.options().setArgs(allArgs);
   std::vector<eld::InputAction *> Action;
 
   //===--------------------------------------------------------------------===//

--- a/lib/LinkerWrapper/x86_64LinkDriver.cpp
+++ b/lib/LinkerWrapper/x86_64LinkDriver.cpp
@@ -37,12 +37,12 @@ static constexpr llvm::opt::OptTable::Info infoTable[] = {
 OPT_x86_64LinkOptTable::OPT_x86_64LinkOptTable()
     : GenericOptTable(OptionStrTable, OptionPrefixesTable, infoTable) {}
 
-x86_64LinkDriver *x86_64LinkDriver::Create(eld::LinkerConfig &C, Flavor F,
+x86_64LinkDriver *x86_64LinkDriver::Create(eld::LinkerConfig &C, DriverFlavor F,
                                            std::string Triple) {
   return eld::make<x86_64LinkDriver>(C, F, Triple);
 }
 
-x86_64LinkDriver::x86_64LinkDriver(eld::LinkerConfig &C, Flavor F,
+x86_64LinkDriver::x86_64LinkDriver(eld::LinkerConfig &C, DriverFlavor F,
                                    std::string Triple)
     : GnuLdDriver(C, F) {
   Config.targets().setArch("x86_64");

--- a/test/UnitTests/LinkerDriverTests/LinkerDriverTest.cpp
+++ b/test/UnitTests/LinkerDriverTests/LinkerDriverTest.cpp
@@ -24,12 +24,12 @@ protected:
 TEST_F(DriverTest, InvalidTarget) {
   Driver *driver = new Driver(Flavor::Invalid, "random");
   // Default to the first target.
-  ASSERT_NE(driver->getLinker(), nullptr);
+  ASSERT_NE(driver->getLinkerDriver(), nullptr);
   delete driver;
 }
 
 TEST_F(DriverTest, ValidTarget) {
   Driver *driver = new Driver(Flavor::Hexagon, "hexagon");
-  ASSERT_NE(driver->getLinker(), nullptr);
+  ASSERT_NE(driver->getLinkerDriver(), nullptr);
   delete driver;
 }

--- a/test/UnitTests/LinkerDriverTests/LinkerDriverTest.cpp
+++ b/test/UnitTests/LinkerDriverTests/LinkerDriverTest.cpp
@@ -22,14 +22,14 @@ protected:
 // Testcases
 //
 TEST_F(DriverTest, InvalidTarget) {
-  Driver *driver = new Driver(Flavor::Invalid, "random");
+  Driver *driver = new Driver(DriverFlavor::Invalid, "random");
   // Default to the first target.
   ASSERT_NE(driver->getLinkerDriver(), nullptr);
   delete driver;
 }
 
 TEST_F(DriverTest, ValidTarget) {
-  Driver *driver = new Driver(Flavor::Hexagon, "hexagon");
+  Driver *driver = new Driver(DriverFlavor::Hexagon, "hexagon");
   ASSERT_NE(driver->getLinkerDriver(), nullptr);
   delete driver;
 }

--- a/tools/eld/eld.cpp
+++ b/tools/eld/eld.cpp
@@ -65,10 +65,10 @@ int main(int Argc, const char **Argv) {
   std::vector<const char *> Args(Argv, Argv + Argc);
 
   // Parse all the options.
-  Driver driver(Flavor::Invalid, /*Triple=*/"");
+  Driver driver(DriverFlavor::Invalid, /*Triple=*/"");
 
   Args = maybeExpandResponseFiles(Args, Alloc);
-  if (!driver.setFlavorAndTripleFromLinkCommand(Args))
+  if (!driver.setDriverFlavorAndTripleFromLinkCommand(Args))
     return 1;
 
   GnuLdDriver *Linker = driver.getLinkerDriver();

--- a/tools/eld/eld.cpp
+++ b/tools/eld/eld.cpp
@@ -71,7 +71,7 @@ int main(int Argc, const char **Argv) {
   if (!driver.setFlavorAndTripleFromLinkCommand(Args))
     return 1;
 
-  GnuLdDriver *Linker = driver.getLinker();
+  GnuLdDriver *Linker = driver.getLinkerDriver();
 
   bool Status = Linker->link(Args);
 


### PR DESCRIPTION
Build sniffing infrastructure incrementally.

There are some cleanups needed before we can start pushing the functionality that allows linker to sniff objects and delay initialization of backend.