### PR TITLE
Fix assertion failure due to invalid glob pattern in linker script

### DIFF
--- a/include/eld/Diagnostics/DiagnosticEngine.h
+++ b/include/eld/Diagnostics/DiagnosticEngine.h
@@ -258,6 +258,8 @@ public:
   /// signal by out-of-memory killer.
   bool isUsable();
 
+  static void ignoreLLVMError(llvm::Error E);
+
 private:
   // -----  emission  ----- //
   // emit - process the message to printer

--- a/include/eld/Script/ScriptFile.h
+++ b/include/eld/Script/ScriptFile.h
@@ -182,11 +182,11 @@ public:
   ExcludePattern *createExcludePattern(StrToken *S);
 
   /* WildcardPattern */
-  WildcardPattern *createWildCardPattern(
+  WildcardPattern * createAndRegisterWildcardPattern(
       StrToken *S, WildcardPattern::SortPolicy P = WildcardPattern::SORT_NONE,
       ExcludeFiles *E = nullptr);
 
-  WildcardPattern *createWildCardPattern(
+  WildcardPattern * createAndRegisterWildcardPattern(
       llvm::StringRef S,
       WildcardPattern::SortPolicy P = WildcardPattern::SORT_NONE,
       ExcludeFiles *E = nullptr);
@@ -302,6 +302,13 @@ public:
 
   // ----------------- process assignments in link order --------
   void processAssignments();
+
+  WildcardPattern *findWildcardPattern(const std::string &P) {
+    auto it = ScriptWildcardPatternMap.find(P);
+    if (it != ScriptWildcardPatternMap.end())
+      return it->second;
+    return nullptr;
+  }
 
 private:
   Kind ScriptFileKind;

--- a/include/eld/Script/WildcardPattern.h
+++ b/include/eld/Script/WildcardPattern.h
@@ -19,6 +19,7 @@
 #include "eld/Script/StrToken.h"
 #include "eld/Script/StringList.h"
 #include "eld/SymbolResolver/ResolveInfo.h"
+#include "eld/PluginAPI/Expected.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/GlobPattern.h"
 
@@ -52,6 +53,10 @@ public:
                            ExcludeFiles *PExcludeFileList = nullptr);
 
   ~WildcardPattern();
+
+  static WildcardPattern *
+  create(StrToken *S, SortPolicy PPolicy = SORT_NONE,
+         ExcludeFiles *PExcludeFileList = nullptr);
 
   SortPolicy sortPolicy() const { return MSortPolicy; }
 

--- a/include/eld/ScriptParser/ScriptParser.h
+++ b/include/eld/ScriptParser/ScriptParser.h
@@ -219,6 +219,17 @@ private:
   bool isValidSectionPattern(llvm::StringRef Pat);
 
   StrToken *readName(llvm::StringRef Name);
+
+  WildcardPattern *createAndRegisterWildcardPattern(
+      StrToken *S, WildcardPattern::SortPolicy P = WildcardPattern::SORT_NONE,
+      ExcludeFiles *E = nullptr);
+
+  WildcardPattern *createAndRegisterWildcardPattern(
+      llvm::StringRef S,
+      WildcardPattern::SortPolicy P = WildcardPattern::SORT_NONE,
+      ExcludeFiles *E = nullptr);
+
+  ExcludePattern *createExcludePattern(StrToken *S);
 };
 } // namespace v2
 } // namespace eld

--- a/lib/Script/CMakeLists.txt
+++ b/lib/Script/CMakeLists.txt
@@ -43,4 +43,4 @@ llvm_add_library(
   VersionScript.cpp
   WildcardPattern.cpp)
 
-target_link_libraries(ELDScript PRIVATE ELDCore ELDSupport ELDScriptParser)
+target_link_libraries(ELDScript PRIVATE ELDCore ELDSupport ELDScriptParser ELDDiagnostics)

--- a/test/Common/standalone/linkerscript/InvalidGlobPattern/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/InvalidGlobPattern/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/Common/standalone/linkerscript/InvalidGlobPattern/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/InvalidGlobPattern/Inputs/script.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  MYSEC :
+  {
+    *([
+  }
+}

--- a/test/Common/standalone/linkerscript/InvalidGlobPattern/InvalidGlobPattern.test
+++ b/test/Common/standalone/linkerscript/InvalidGlobPattern/InvalidGlobPattern.test
@@ -1,0 +1,10 @@
+#---InvalidGlobPattern.test--------------------- Executable,LS ------------------#
+#BEGIN_COMMENT
+# This test the linker emits an error for invalid glob pattern in linker script.
+#END_COMMENT
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
+RUN: %not %link %linkopts -o %t.1.out %t1.1.o -T %p/Inputs/script.t 2>&1 | %filecheck %s --check-prefix=ERR --strict-whitespace --match-full-lines
+
+ERR:Error: {{.*}}/script.t:4: Invalid glob pattern: [
+ERR:>>>     *([
+ERR:>>>       ^


### PR DESCRIPTION
This commit fixes linker assertion failure due to invalid glob pattern in linker script. With this commit, the linker errors out instead of crashing due to assertion failure.

Resolves #284