### PR TITLE
Return 0 instead of asserting if expression does not have result

### DIFF
--- a/lib/Script/Expression.cpp
+++ b/lib/Script/Expression.cpp
@@ -31,8 +31,7 @@ void Expression::setContext(const std::string &Context) {
 }
 
 uint64_t Expression::result() const {
-  ASSERT(MResult, "Expression result is not yet committed");
-  return *MResult;
+  return resultOrZero();
 }
 
 uint64_t Expression::resultOrZero() const {


### PR DESCRIPTION
This commit modifies Expression::result to return 0, instead of asserting out, in-case the expression does not have a result.

For most cases, expression value of 0 is reasonable if the expression has not been or could not have been evaluated. The main motivation for this change is to ensure that eld does not accidentally crash due to assertion for valid cases where expression is not evaluated. These cases include: emitting map-file when the link crashes, emitting diagnostics, continuing the link despite some errors (no-inhibit execution), and more.