### PR TITLE
[RISC-V] Fix and simplify failing ALIGN relaxation tests

### DIFF
--- a/test/RISCV/standalone/AlignRelaxRelocs/AlignRelaxRelocsPartialLink/AlignRelaxRelocsPartialLink.test
+++ b/test/RISCV/standalone/AlignRelaxRelocs/AlignRelaxRelocsPartialLink/AlignRelaxRelocsPartialLink.test
@@ -4,10 +4,10 @@
 # R_RISCV_RELAX reloc
 #END_COMMENT
 #START_TEST
-RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -fno-asynchronous-unwind-tables
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.s -c
 RUN: %link %linkopts -o %t1.1.out %t1.1.o -r
 RUN: %readelf -r %t1.1.out | %filecheck %s
 #END_TEST
-CHECK: R_RISCV_ALIGN
 CHECK: R_RISCV_RELAX 0
+CHECK: R_RISCV_ALIGN
 CHECK: R_RISCV_RELAX 0

--- a/test/RISCV/standalone/AlignRelaxRelocs/AlignRelaxRelocsPartialLink/Inputs/1.c
+++ b/test/RISCV/standalone/AlignRelaxRelocs/AlignRelaxRelocsPartialLink/Inputs/1.c
@@ -1,2 +1,0 @@
-__thread int a = 10;
-__attribute__((aligned(32))) int foo() { return a; }

--- a/test/RISCV/standalone/AlignRelaxRelocs/AlignRelaxRelocsPartialLink/Inputs/1.s
+++ b/test/RISCV/standalone/AlignRelaxRelocs/AlignRelaxRelocsPartialLink/Inputs/1.s
@@ -1,0 +1,6 @@
+.text
+	call norelax
+	.align 5
+	call norelax
+
+.equ norelax, 0x40000000

--- a/test/RISCV/standalone/Relaxation/ALIGN/ALIGN.test
+++ b/test/RISCV/standalone/Relaxation/ALIGN/ALIGN.test
@@ -13,8 +13,8 @@ RUN: %objdump -d %t2.out 2>&1 | %filecheck %s --check-prefix=DUMP
 RUN: %filecheck %s --input-file=%t2.map  --check-prefix=MAP-NORELAX
 #END_TEST
 
-CHECK: Verbose: RISCV_ALIGN : Need only 8 bytes in section .text+0x18 file {{.*}}align.o
-CHECK: Verbose: RISCV_ALIGN : Deleting 6 bytes for symbol '' in section .text+0x20 file {{.*}}align.o
+CHECK: Verbose: RISCV_ALIGN : Need only 8 bytes in section .text+0x8 file {{.*}}align.o
+CHECK: Verbose: RISCV_ALIGN : Deleting 6 bytes for symbol '' in section .text+0x10 file {{.*}}align.o
 
 DUMP: nop
 DUMP: nop

--- a/test/RISCV/standalone/Relaxation/ALIGN/Inputs/align.s
+++ b/test/RISCV/standalone/Relaxation/ALIGN/Inputs/align.s
@@ -1,31 +1,10 @@
 	.text
 	.align	1
-	.globl	foo
-	.type	foo, @function
-foo:
-	addi	sp,sp,-16
-	sw	s0,12(sp)
-	addi	s0,sp,16
-	li	a5,0
-	mv	a0,a5
-	lw	s0,12(sp)
-	addi	sp,sp,16
-	jr	ra
-	.size	foo, .-foo
-	.align	1
 	.globl	main
 	.type	main, @function
 main:
-	addi	sp,sp,-16
-	sw	ra,12(sp)
-	sw	s0,8(sp)
-	addi	s0,sp,16
+	call	norelax
 	.align  4
-	call	foo
-	mv	a5,a0
-	mv	a0,a5
-	lw	ra,12(sp)
-	lw	s0,8(sp)
-	addi	sp,sp,16
-	jr	ra
-	.size	main, .-main
+	call	main
+
+.equ norelax, 0x40000000

--- a/test/RISCV/standalone/Relaxation/UnalignedCrash-QTOOL-105850/Inputs/1.s
+++ b/test/RISCV/standalone/Relaxation/UnalignedCrash-QTOOL-105850/Inputs/1.s
@@ -1,6 +1,10 @@
         .text
         .globl  foo
         .type   foo, @function
+        call norelax
+        call norelax
+        call norelax
+        call norelax
         .balign 32
 foo:    nop
         // Add a relaxation relocation as RISC-V ABI demands that R_ALIGN
@@ -11,3 +15,5 @@ foo:    nop
         lw      a0,%pcrel_lo(.Lpcrel_hi6)(a5)
         ret
         .size   foo, .-foo
+
+.equ norelax, 0x40000000

--- a/test/RISCV/standalone/Relaxation/UnalignedCrash-QTOOL-105850/UnalignedCrash-QTOOL-105850.test
+++ b/test/RISCV/standalone/Relaxation/UnalignedCrash-QTOOL-105850/UnalignedCrash-QTOOL-105850.test
@@ -5,5 +5,5 @@
 # START_TEST
 #RUN: %clang %clangopts -c %p/Inputs/1.s -o %t.o
 #RUN: not %link %linkopts %t.o -T %p/Inputs/1.t -o %t.out 2>&1 | %filecheck %s
-# CHECK: Error: Insufficient number of spare bytes for alignment relaxation: present 30, needed 31 in section .text+0x1f file {{.*}}.o
+# CHECK: Error: Insufficient number of spare bytes for alignment relaxation: present 30, needed 31 in section .text+{{.+}} file {{.*}}.o
 # END_TEST


### PR DESCRIPTION
After #150816, assembler does not emit R_RISCV_ALIGN relocation if there are no relaxable instructions before it. Some tests relied on R_RISCV_ALIGN to be present in particular locations.