### PR TITLE
Support DriverFlavor

### DIFF
--- a/include/eld/Driver/GnuLdDriver.h
+++ b/include/eld/Driver/GnuLdDriver.h
@@ -62,11 +62,11 @@ public:
 
   // Main entry point.
   virtual int link(llvm::ArrayRef<const char *> Args,
-                   llvm::ArrayRef<llvm::StringRef> ELDFlagsArgs) = 0;
+                   llvm::ArrayRef<llvm::StringRef> ELDFlagsArgs);
 
   virtual llvm::opt::OptTable *
   parseOptions(llvm::ArrayRef<const char *> ArgsArr,
-               llvm::opt::InputArgList &ArgList) = 0;
+               llvm::opt::InputArgList &ArgList);
 
   // Check if the options are invalid.
   template <class T> bool checkOptions(llvm::opt::InputArgList &Args) const;
@@ -147,6 +147,8 @@ protected:
 
   const std::string &getProgramName() const { return LinkerProgramName; }
 
+  void setDriverFlavor(DriverFlavor F) { m_DriverFlavor = F; }
+
 private:
   // Raise diag entry for trace.
   bool checkAndRaiseTraceDiagEntry(eld::Expected<void> E) const;
@@ -158,7 +160,7 @@ protected:
   static eld::Module *ThisModule;
   llvm::opt::OptTable *Table;
   std::once_flag once_flag;
-  const DriverFlavor m_DriverFlavor;
+  DriverFlavor m_DriverFlavor;
   std::vector<std::string> m_SupportedTargets;
   std::string LinkerProgramName;
 };

--- a/include/eld/Object/ObjectLinker.h
+++ b/include/eld/Object/ObjectLinker.h
@@ -466,9 +466,6 @@ private:
   ELFDynObjParser *createDynObjReader();
   ELFObjectWriter *createWriter();
 
-  // Initialize the target machine when sniffing object files
-  eld::Expected<bool> initializeTarget(InputFile *I);
-
 private:
   LinkerConfig &ThisConfig;
   Module *ThisModule = nullptr;

--- a/test/Common/standalone/CommandLine/PrintRepositoryVersion/PrintRepositoryVersion.test
+++ b/test/Common/standalone/CommandLine/PrintRepositoryVersion/PrintRepositoryVersion.test
@@ -4,6 +4,6 @@
 #END_COMMENT
 #START_TEST
 RUN: %link --repository-version 2>&1 | %filecheck %s
-#CHECK: {{AArch64|ARM|Hexagon|RISCV32|RISCV64|x86_64}} Linker repository revision: ({{[a-z0-9]+}})
+#CHECK: {{ARM/AArch64|Hexagon|RISCV32/RISCV64|x86_64}} eld repository revision: ({{[a-z0-9]+}})
 #CHECK: {{(LLVM repository revision: \(.* [a-z0-9]+\))?}}
 #END_TEST

--- a/test/Common/standalone/CommandLine/Reproduce/PatchBase.test
+++ b/test/Common/standalone/CommandLine/Reproduce/PatchBase.test
@@ -8,8 +8,8 @@ REQUIRES: riscv32 || riscv64
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.1.o
 RUN: %link %linkopts %t.1.o -o %t.base.out
 RUN: %clang %clangopts -c %p/Inputs/2.c -o %t.2.o
-RUN: %link %linkopts --patch-base=%t.base.out %t.2.o -o %t.out --reproduce %t0.tar --dump-mapping-file %t.mapping --dump-response-file %t.response
+RUN: %link %linkopts  --patch-base=%t.base.out %t.2.o -o %t.out --reproduce %t0.tar --dump-mapping-file %t.mapping --dump-response-file %t.response
 RUN: %filecheck %s --check-prefix=CHECK_MAPPING <%t.mapping
 RUN: %filecheck %s --check-prefix=CHECK_RESPONSE <%t.response
 CHECK_MAPPING: .base.out=Object/PatchBase.test.tmp.base.out
-CHECK_RESPONSE: --patch-base{{[= ]}}Object/PatchBase.test.tmp.base.out
+CHECK_RESPONSE: --patch-base={{.*}}PatchBase.test.tmp.base.out


### PR DESCRIPTION
There are multiple issues in the patch that are interconnected.

Though each driver was supporting multiple architectures, it was not clear, make the mapping of architecture names to driver very clear.

The common Gnuld driver knows about few RISC-V options and emitting warnings/errors. Move it the respective driver, in this case RISC-V

The reproduce command line would write the location of the patch base file instead of preserving the filename that was passed in the command line.

Make the commmon Gnu ld driver able to parse options to prepare linker for sniffing.