### PR TITLE
Driver changes to inferred arch from program name/emulation

### DIFF
--- a/include/eld/Driver/ARMLinkDriver.h
+++ b/include/eld/Driver/ARMLinkDriver.h
@@ -37,9 +37,10 @@ public:
 class ARMLinkDriver : public GnuLdDriver {
 public:
   static ARMLinkDriver *Create(eld::LinkerConfig &C, DriverFlavor F,
-                               std::string Triple);
+                               std::string InferredArchFromProgramName);
 
-  ARMLinkDriver(eld::LinkerConfig &C, DriverFlavor F, std::string Triple);
+  ARMLinkDriver(eld::LinkerConfig &C, DriverFlavor F,
+                std::string InferredArchFromProgramName);
 
   virtual ~ARMLinkDriver() {}
 
@@ -69,6 +70,17 @@ public:
 
   static std::optional<llvm::Triple>
   ParseEmulation(std::string pEmulation, eld::DiagnosticEngine *DiagEngine);
+
+  static bool isSupportedEmulation(llvm::StringRef Emulation) {
+    return Emulation.starts_with("arm") || Emulation.starts_with("aarch64");
+  }
+  static std::string getInferredArch(llvm::StringRef Emulation) {
+    if (Emulation.starts_with("arm"))
+      return "arm";
+    if (Emulation.starts_with("aarch64"))
+      return "aarch64";
+    return "unknown";
+  }
 };
 
 #endif

--- a/include/eld/Driver/Driver.h
+++ b/include/eld/Driver/Driver.h
@@ -29,10 +29,10 @@ class GnuLdDriver;
 
 class DLL_A_EXPORT Driver {
 public:
-  Driver(DriverFlavor F, std::string Triple);
+  Driver(DriverFlavor F);
 
-  bool
-  setDriverFlavorAndTripleFromLinkCommand(llvm::ArrayRef<const char *> Args);
+  bool setDriverFlavorAndInferredArchFromLinkCommand(
+      llvm::ArrayRef<const char *> Args);
 
   static eld::Expected<Driver>
   createDriverForLinkCommand(llvm::ArrayRef<const char *> Args);
@@ -56,10 +56,10 @@ private:
   void InitTarget();
 
   eld::Expected<std::pair<DriverFlavor, std::string>>
-  getDriverFlavorAndTripleFromLinkCommand(llvm::ArrayRef<const char *> Args);
+  getDriverFlavorFromLinkCommand(llvm::ArrayRef<const char *> Args);
 
   std::pair<DriverFlavor, std::string>
-  parseDriverFlavorAndTripleFromProgramName(const char *argv0);
+  parseDriverFlavorFromProgramName(const char *argv0);
 
 protected:
   eld::DiagnosticEngine *DiagEngine = nullptr;
@@ -67,7 +67,7 @@ protected:
 
 private:
   DriverFlavor m_DriverFlavor = Invalid;
-  std::string m_Triple;
+  std::string InferredArchFromProgramName;
   std::vector<std::string> m_SupportedTargets;
 };
 

--- a/include/eld/Driver/GnuLdDriver.h
+++ b/include/eld/Driver/GnuLdDriver.h
@@ -52,7 +52,7 @@ public:
 class DLL_A_EXPORT GnuLdDriver {
 public:
   static GnuLdDriver *Create(eld::LinkerConfig &C, DriverFlavor F,
-                             std::string Triple);
+                             std::string InferredArchFromProgramName);
 
   GnuLdDriver(eld::LinkerConfig &C, DriverFlavor F = DriverFlavor::Invalid);
 

--- a/include/eld/Driver/HexagonLinkDriver.h
+++ b/include/eld/Driver/HexagonLinkDriver.h
@@ -33,9 +33,10 @@ public:
 class HexagonLinkDriver : public GnuLdDriver {
 public:
   static HexagonLinkDriver *Create(eld::LinkerConfig &C, DriverFlavor F,
-                                   std::string Triple);
+                                   std::string InferredArchFromProgramName);
 
-  HexagonLinkDriver(eld::LinkerConfig &C, DriverFlavor F, std::string Triple);
+  HexagonLinkDriver(eld::LinkerConfig &C, DriverFlavor F,
+                    std::string InferredArchFromProgramName);
 
   virtual ~HexagonLinkDriver() {}
 
@@ -68,6 +69,10 @@ public:
                           std::vector<eld::InputAction *> &actions);
 
   static bool isValidEmulation(llvm::StringRef Emulation);
+
+  static std::string getInferredArch(llvm::StringRef Emulation) {
+    return "hexagon";
+  }
 };
 
 #endif

--- a/include/eld/Driver/RISCVLinkDriver.h
+++ b/include/eld/Driver/RISCVLinkDriver.h
@@ -32,9 +32,10 @@ public:
 class RISCVLinkDriver : public GnuLdDriver {
 public:
   static RISCVLinkDriver *Create(eld::LinkerConfig &C, DriverFlavor F,
-                                 std::string Triple);
+                                 std::string InferredArchFromProgramName);
 
-  RISCVLinkDriver(eld::LinkerConfig &C, DriverFlavor F, std::string Triple);
+  RISCVLinkDriver(eld::LinkerConfig &C, DriverFlavor F,
+                  std::string InferredArchFromProgramName);
 
   virtual ~RISCVLinkDriver() {}
 
@@ -68,6 +69,13 @@ public:
 
   static bool isSupportedEmulation(llvm::StringRef Emulation) {
     return Emulation == "elf64lriscv" || Emulation == "elf32lriscv";
+  }
+  static std::string getInferredArch(llvm::StringRef Emulation) {
+    if (Emulation == "elf32lriscv")
+      return "riscv32";
+    if (Emulation == "elf64lriscv")
+      return "riscv64";
+    return "unknown";
   }
 };
 

--- a/include/eld/Driver/x86_64LinkDriver.h
+++ b/include/eld/Driver/x86_64LinkDriver.h
@@ -34,9 +34,10 @@ public:
 class x86_64LinkDriver : public GnuLdDriver {
 public:
   static x86_64LinkDriver *Create(eld::LinkerConfig &C, DriverFlavor F,
-                                  std::string Triple);
+                                  std::string InferredArchFromProgramName);
 
-  x86_64LinkDriver(eld::LinkerConfig &C, DriverFlavor F, std::string Triple);
+  x86_64LinkDriver(eld::LinkerConfig &C, DriverFlavor F,
+                   std::string InferredArchFromProgramName);
 
   virtual ~x86_64LinkDriver() {}
 
@@ -69,6 +70,10 @@ public:
   template <class T = OPT_x86_64LinkOptTable>
   bool createInputActions(llvm::opt::InputArgList &Args,
                           std::vector<eld::InputAction *> &actions);
+
+  static std::string getInferredArch(llvm::StringRef Emulation) {
+    return "x86_64";
+  }
 };
 
 #endif

--- a/lib/LinkerWrapper/ARMLinkDriver.cpp
+++ b/lib/LinkerWrapper/ARMLinkDriver.cpp
@@ -63,17 +63,14 @@ OPT_ARMLinkOptTable::OPT_ARMLinkOptTable()
     : GenericOptTable(OptionStrTable, OptionPrefixesTable, infoTable) {}
 
 ARMLinkDriver *ARMLinkDriver::Create(eld::LinkerConfig &C, DriverFlavor F,
-                                     std::string Triple) {
-  return eld::make<ARMLinkDriver>(C, F, Triple);
+                                     std::string InferredArch) {
+  return eld::make<ARMLinkDriver>(C, F, InferredArch);
 }
 
 ARMLinkDriver::ARMLinkDriver(eld::LinkerConfig &C, DriverFlavor F,
-                             std::string Triple)
+                             std::string InferredArch)
     : GnuLdDriver(C, F) {
-  if (F == DriverFlavor::ARM_AArch64)
-    Config.targets().setArch("arm");
-  else
-    Config.targets().setArch("aarch64");
+  Config.targets().setArch(InferredArch);
 }
 
 opt::OptTable *ARMLinkDriver::parseOptions(ArrayRef<const char *> Args,

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -78,23 +78,23 @@ GnuLdDriver::GnuLdDriver(LinkerConfig &C, DriverFlavor F)
 GnuLdDriver::~GnuLdDriver() {}
 
 GnuLdDriver *GnuLdDriver::Create(LinkerConfig &C, DriverFlavor F,
-                                 std::string Triple) {
+                                 std::string InferredArch) {
   switch (F) {
 #ifdef ELD_ENABLE_TARGET_HEXAGON
   case DriverFlavor::Hexagon:
-    return HexagonLinkDriver::Create(C, F, Triple);
+    return HexagonLinkDriver::Create(C, F, InferredArch);
 #endif
 #if defined(ELD_ENABLE_TARGET_ARM) || defined(ELD_ENABLE_TARGET_AARCH64)
   case DriverFlavor::ARM_AArch64:
-    return ARMLinkDriver::Create(C, F, Triple);
+    return ARMLinkDriver::Create(C, F, InferredArch);
 #endif
 #ifdef ELD_ENABLE_TARGET_RISCV
   case DriverFlavor::RISCV32_RISCV64:
-    return RISCVLinkDriver::Create(C, F, Triple);
+    return RISCVLinkDriver::Create(C, F, InferredArch);
 #endif
 #ifdef ELD_ENABLE_TARGET_X86_64
   case DriverFlavor::x86_64:
-    return x86_64LinkDriver::Create(C, F, Triple);
+    return x86_64LinkDriver::Create(C, F, InferredArch);
 #endif
   default:
     return eld::make<GnuLdDriver>(C, F);
@@ -1699,9 +1699,7 @@ std::vector<const char *> GnuLdDriver::getAllArgs(
 }
 
 int GnuLdDriver::link(llvm::ArrayRef<const char *> Args) {
-  // If argv[0] is empty then use ld.eld.
-  LinkerProgramName =
-      (Args[0][0] ? llvm::sys::path::filename(Args[0]) : "ld.eld");
+  LinkerProgramName = llvm::sys::path::filename(Args[0]);
   return link(Args, Driver::getELDFlagsArgs());
 }
 
@@ -1763,7 +1761,7 @@ int GnuLdDriver::link(llvm::ArrayRef<const char *> Args,
   //===--------------------------------------------------------------------===//
   static int StaticSymbol;
   std::string lfile =
-      llvm::sys::fs::getMainExecutable(allArgs[0], &StaticSymbol);
+      llvm::sys::fs::getMainExecutable(LinkerProgramName.data(), &StaticSymbol);
   SmallString<128> lpath(lfile);
   llvm::sys::path::remove_filename(lpath);
   Config.options().setLinkerPath(std::string(lpath));

--- a/lib/LinkerWrapper/HexagonLinkDriver.cpp
+++ b/lib/LinkerWrapper/HexagonLinkDriver.cpp
@@ -47,17 +47,14 @@ OPT_HexagonLinkOptTable::OPT_HexagonLinkOptTable()
 
 HexagonLinkDriver *HexagonLinkDriver::Create(eld::LinkerConfig &C,
                                              DriverFlavor F,
-                                             std::string Triple) {
-  return eld::make<HexagonLinkDriver>(C, F, Triple);
+                                             std::string InferredArch) {
+  return eld::make<HexagonLinkDriver>(C, F, InferredArch);
 }
 
 HexagonLinkDriver::HexagonLinkDriver(eld::LinkerConfig &C, DriverFlavor F,
-                                     std::string Triple)
+                                     std::string InferredArch)
     : GnuLdDriver(C, F) {
-  Config.targets().setArch("hexagon");
-
-  if (!Triple.empty())
-    Config.targets().setTriple(Triple);
+  Config.targets().setArch(InferredArch);
 }
 
 opt::OptTable *

--- a/lib/LinkerWrapper/RISCVLinkDriver.cpp
+++ b/lib/LinkerWrapper/RISCVLinkDriver.cpp
@@ -56,17 +56,14 @@ OPT_RISCVLinkOptTable::OPT_RISCVLinkOptTable()
     : GenericOptTable(OptionStrTable, OptionPrefixesTable, infoTable) {}
 
 RISCVLinkDriver *RISCVLinkDriver::Create(eld::LinkerConfig &C, DriverFlavor F,
-                                         std::string Triple) {
-  return eld::make<RISCVLinkDriver>(C, F, Triple);
+                                         std::string InferredArch) {
+  return eld::make<RISCVLinkDriver>(C, F, InferredArch);
 }
 
 RISCVLinkDriver::RISCVLinkDriver(eld::LinkerConfig &C, DriverFlavor F,
-                                 std::string Triple)
+                                 std::string InferredArch)
     : GnuLdDriver(C, F) {
-  if (F == DriverFlavor::RISCV32_RISCV64)
-    Config.targets().setArch("riscv32");
-  else
-    Config.targets().setArch("riscv64");
+  Config.targets().setArch(InferredArch);
 }
 
 opt::OptTable *RISCVLinkDriver::parseOptions(ArrayRef<const char *> Args,

--- a/lib/LinkerWrapper/x86_64LinkDriver.cpp
+++ b/lib/LinkerWrapper/x86_64LinkDriver.cpp
@@ -38,14 +38,14 @@ OPT_x86_64LinkOptTable::OPT_x86_64LinkOptTable()
     : GenericOptTable(OptionStrTable, OptionPrefixesTable, infoTable) {}
 
 x86_64LinkDriver *x86_64LinkDriver::Create(eld::LinkerConfig &C, DriverFlavor F,
-                                           std::string Triple) {
-  return eld::make<x86_64LinkDriver>(C, F, Triple);
+                                           std::string InferredArch) {
+  return eld::make<x86_64LinkDriver>(C, F, InferredArch);
 }
 
 x86_64LinkDriver::x86_64LinkDriver(eld::LinkerConfig &C, DriverFlavor F,
-                                   std::string Triple)
+                                   std::string InferredArch)
     : GnuLdDriver(C, F) {
-  Config.targets().setArch("x86_64");
+  Config.targets().setArch(InferredArch);
 }
 
 opt::OptTable *

--- a/test/UnitTests/LinkerDriverTests/LinkerDriverTest.cpp
+++ b/test/UnitTests/LinkerDriverTests/LinkerDriverTest.cpp
@@ -22,14 +22,14 @@ protected:
 // Testcases
 //
 TEST_F(DriverTest, InvalidTarget) {
-  Driver *driver = new Driver(DriverFlavor::Invalid, "random");
+  Driver *driver = new Driver(DriverFlavor::Invalid);
   // Default to the first target.
   ASSERT_NE(driver->getLinkerDriver(), nullptr);
   delete driver;
 }
 
 TEST_F(DriverTest, ValidTarget) {
-  Driver *driver = new Driver(DriverFlavor::Hexagon, "hexagon");
+  Driver *driver = new Driver(DriverFlavor::Hexagon);
   ASSERT_NE(driver->getLinkerDriver(), nullptr);
   delete driver;
 }

--- a/tools/eld/eld.cpp
+++ b/tools/eld/eld.cpp
@@ -65,10 +65,10 @@ int main(int Argc, const char **Argv) {
   std::vector<const char *> Args(Argv, Argv + Argc);
 
   // Parse all the options.
-  Driver driver(DriverFlavor::Invalid, /*Triple=*/"");
+  Driver driver(DriverFlavor::Invalid);
 
   Args = maybeExpandResponseFiles(Args, Alloc);
-  if (!driver.setDriverFlavorAndTripleFromLinkCommand(Args))
+  if (!driver.setDriverFlavorAndInferredArchFromLinkCommand(Args))
     return 1;
 
   GnuLdDriver *Linker = driver.getLinkerDriver();


### PR DESCRIPTION
Architecture needs to be inferred from program name / emulation.

This is to make sure that we are able to find the target if emulation or directly using the program name.

Currently it is derived from Driver flavor.

There should be no functional change.

Resolves #324