### PR TITLE
Parse MEMORY command expressions in LexState::Expr

### DIFF
--- a/lib/ScriptParser/ScriptParser.cpp
+++ b/lib/ScriptParser/ScriptParser.cpp
@@ -953,7 +953,7 @@ void ScriptParser::readMemory() {
       MemoryAttrs = readMemoryAttributes();
       expect(")");
     }
-    expect(":");
+    expect(LexState::Expr, ":");
     Expression *Origin = readMemoryAssignment({"ORIGIN", "org", "o"});
     expect(",");
     Expression *Length = readMemoryAssignment({"LENGTH", "len", "l"});
@@ -988,7 +988,7 @@ ScriptParser::readMemoryAssignment(std::vector<llvm::StringRef> Names) {
     setError("expected one of: " + NamesJoined);
     return nullptr;
   }
-  expect("=");
+  expect(LexState::Expr, "=");
   return readExpr();
 }
 

--- a/test/Common/standalone/linkerscript/MEMORY/NoSpaceAroundColonAndEqualTo/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/MEMORY/NoSpaceAroundColonAndEqualTo/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/Common/standalone/linkerscript/MEMORY/NoSpaceAroundColonAndEqualTo/Inputs/script1.t
+++ b/test/Common/standalone/linkerscript/MEMORY/NoSpaceAroundColonAndEqualTo/Inputs/script1.t
@@ -1,0 +1,8 @@
+MEMORY {
+  RAM :ORIGIN = 0x1000, LENGTH = 0x1000
+}
+
+SECTIONS {
+  .foo : { *(.text.foo) } >RAM
+  .text : { *(*text*) } >RAM
+}

--- a/test/Common/standalone/linkerscript/MEMORY/NoSpaceAroundColonAndEqualTo/Inputs/script2.t
+++ b/test/Common/standalone/linkerscript/MEMORY/NoSpaceAroundColonAndEqualTo/Inputs/script2.t
@@ -1,0 +1,8 @@
+MEMORY {
+  RAM : ORIGIN =0x1000, LENGTH = 0x1000
+}
+
+SECTIONS {
+  .foo : { *(.text.foo) } >RAM
+  .text : { *(*text*) } >RAM
+}

--- a/test/Common/standalone/linkerscript/MEMORY/NoSpaceAroundColonAndEqualTo/Inputs/script3.t
+++ b/test/Common/standalone/linkerscript/MEMORY/NoSpaceAroundColonAndEqualTo/Inputs/script3.t
@@ -1,0 +1,8 @@
+MEMORY {
+  RAM :ORIGIN =0x1000, LENGTH = 0x1000
+}
+
+SECTIONS {
+  .foo : { *(.text.foo) } >RAM
+  .text : { *(*text*) } >RAM
+}

--- a/test/Common/standalone/linkerscript/MEMORY/NoSpaceAroundColonAndEqualTo/Inputs/script4.t
+++ b/test/Common/standalone/linkerscript/MEMORY/NoSpaceAroundColonAndEqualTo/Inputs/script4.t
@@ -1,0 +1,8 @@
+MEMORY {
+  RAM : ORIGIN= 0x1000, LENGTH = 0x1000
+}
+
+SECTIONS {
+  .foo : { *(.text.foo) } >RAM
+  .text : { *(*text*) } >RAM
+}

--- a/test/Common/standalone/linkerscript/MEMORY/NoSpaceAroundColonAndEqualTo/NoSpaceAroundColonAndEqualTo.test
+++ b/test/Common/standalone/linkerscript/MEMORY/NoSpaceAroundColonAndEqualTo/NoSpaceAroundColonAndEqualTo.test
@@ -1,0 +1,23 @@
+#---NoSpaceAroundColonAndEqualTo.test--------------------- Executable,LS------------------#
+#BEGIN_COMMENT
+# This test checks that the linker correctly parses the ORIGIN/LENGTH
+# expressions when there is no space between ':' and 'ORIGIN' and
+# command.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
+RUN: %link %linkopts -o %t1.1.1.out %t1.1.o %p/Inputs/script1.t
+RUN: %readelf -S %t1.1.1.out | %filecheck %s
+RUN: %link %linkopts -o %t1.1.2.out %t1.1.o %p/Inputs/script2.t
+RUN: %readelf -S %t1.1.2.out | %filecheck %s
+RUN: %link %linkopts -o %t1.1.3.out %t1.1.o %p/Inputs/script3.t
+RUN: %readelf -S %t1.1.3.out | %filecheck %s
+RUN: %not %link %linkopts -o %t1.1.4.out %t1.1.o %p/Inputs/script4.t 2>&1 \
+RUN:   | %filecheck %s --check-prefix=ERR --strict-whitespace --match-full-lines
+#END_TEST
+
+#CHECK: .foo PROGBITS {{0+}}1000
+ERR:Error:{{.*}}script4.t:2: expected one of: ORIGIN, org, or o
+ERR:>>>   RAM : ORIGIN= 0x1000, LENGTH = 0x1000
+ERR:>>>         ^
+


### PR DESCRIPTION
Tihs commit modifies the LexState for parsing ':' and '=' inside MEMORY command. This is done to make parsing more compatible with GNU linker.

Resolves #340