### PR TITLE
Fix UnaryOperator expression name

### DIFF
--- a/include/eld/Script/Expression.h
+++ b/include/eld/Script/Expression.h
@@ -987,7 +987,7 @@ private:
 class UnaryNot : public Expression {
 public:
   UnaryNot(Module &Module, Expression &Expr)
-      : Expression("~", Expression::UNARYNOT, Module),
+      : Expression("!", Expression::UNARYNOT, Module),
         ExpressionToEvaluate(Expr) {}
 
   // Casting support

--- a/test/Common/Plugin/BasicLinkerScriptGenerator/BasicLinkerScriptGenerator.UnaryNot.test
+++ b/test/Common/Plugin/BasicLinkerScriptGenerator/BasicLinkerScriptGenerator.UnaryNot.test
@@ -1,0 +1,10 @@
+#---BasicLinkerScriptGenerator.UnaryNot.test----------------------- Executable,LS --------------------#
+#BEGIN_COMMENT
+# This tests checks that the behavior of printing the unary not operator.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -L%libsdir/test -T %p/Inputs/script.UnaryNot.t 2>&1 | %filecheck %s
+#END_TEST
+CHECK: a = !0x100;
+CHECK: LINKER_PLUGIN("BasicLinkerScriptGenerator", "BasicLinkerScriptGenerator");

--- a/test/Common/Plugin/BasicLinkerScriptGenerator/Inputs/script.UnaryNot.t
+++ b/test/Common/Plugin/BasicLinkerScriptGenerator/Inputs/script.UnaryNot.t
@@ -1,0 +1,3 @@
+a = !0x100;
+
+LINKER_PLUGIN("BasicLinkerScriptGenerator", "BasicLinkerScriptGenerator")


### PR DESCRIPTION
This commit fixes unary operator expression name from '~' to '!'.

Resolves #337