### PR TITLE
Fix test build failure on windows

### DIFF
--- a/test/UnitTests/CMakeLists.txt
+++ b/test/UnitTests/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LLVM_LINK_COMPONENTS
     LTO
     MC
     Object
+    Option
     Passes
     Support
     Target


### PR DESCRIPTION
This patch aims to fix a test build failure that occurs due to `LLVMOptions` library not being linked.