### PR TITLE
Nightly musl test suite validation for x86_64 backend

### DIFF
--- a/.github/workflows/nightly-musl-builder.yml
+++ b/.github/workflows/nightly-musl-builder.yml
@@ -1,0 +1,110 @@
+name: Nightly builder for testing eld against musl-test-suite for x86_64
+
+on: 
+  schedule:
+      - cron: '0 2 * * *' # 2:00 AM
+  pull_request:
+    paths:
+      - '.github/workflows/nightly-musl-builder.yml'
+
+jobs:
+  test-eld-musl-x86_64:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Set up Clang 20
+        uses: egor-tensin/setup-clang@v1
+        with:
+          version: "20"
+          platform: x64
+
+      - name: Install system dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libc++-dev libc++abi-dev ccache libclang-rt-20-dev cmake ninja-build make
+          
+      - name: Verify clang installation
+        run: |
+          clang --version
+          clang++ --version
+
+      - name: Checkout LLVM Project
+        uses: actions/checkout@v4
+        with:
+          repository: llvm/llvm-project
+          path: llvm-project
+          ref: main
+
+      - name: Checkout ELD
+        uses: actions/checkout@v4
+        with:
+          path: llvm-project/llvm/tools/eld
+
+      - name: Configure ELD Build
+        run: |
+          mkdir -p obj
+          cd obj
+          cmake -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=$PWD/../install \
+            -DLLVM_ENABLE_PROJECTS="llvm;clang;compiler-rt" \
+            -DCMAKE_C_COMPILER=`which clang` \
+            -DCMAKE_CXX_COMPILER=`which clang++` \
+            -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
+            -DLLVM_TARGETS_TO_BUILD="X86" \
+            -DELD_TARGETS_TO_BUILD='x86_64' \
+            ../llvm-project/llvm
+
+      - name: Build ELD
+        run: |
+          cd obj 
+          ninja -j$(nproc) ld.eld FileCheck
+          ninja install
+
+      - name: Setup ELD Environment
+        run: |
+          echo "PATH=$PWD/install/bin:$PATH" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$PWD/obj/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+
+
+      - name: Download and Build musl
+        run: |
+          git clone --depth 1 https://github.com/bminor/musl.git
+          cd musl
+          CC=clang CXX=clang++ ./configure --prefix=$PWD/../musl-install
+          make -j$(nproc)
+          make install
+
+      - name: Fix musl-clang Wrapper for ELD
+        run: |
+          sed -i 's/exec \$(\$cc -print-prog-name=ld)/exec ld.$LD/' musl-install/bin/ld.musl-clang
+          
+      - name: Configure build environment and toolchain
+        run: |
+          # Set environment variables for subsequent steps
+          echo "LD=eld" >> $GITHUB_ENV
+          echo "PATH=$PWD/musl-install/bin:$PWD/install/bin:$PATH" >> $GITHUB_ENV
+          echo "CC=$PWD/musl-install/bin/musl-clang" >> $GITHUB_ENV
+          echo "CFLAGS=-Wno-unused-command-line-argument" >> $GITHUB_ENV
+
+      - name: Download and Setup libc-test
+        run: |
+          git clone --depth 1 https://repo.or.cz/libc-test.git
+          cd libc-test
+          cp config.mak.def config.mak
+          sed -i 's/LDFLAGS += -g/LDFLAGS += -g -static/' config.mak
+          sed -i '1s/$/ -Wno-parentheses/' config.mak
+
+      - name: Build and test libc-test with ELD + musl
+        run: | 
+          cd libc-test
+          make -j$(nproc) 2>&1 | tee build.log
+
+      - name: Validate test results with FileCheck
+        run: |  
+          cd libc-test       
+          FILECHECK="$PWD/../obj/bin/FileCheck"
+          $FILECHECK --check-prefixes=CHECK ../llvm-project/llvm/tools/eld/test/musl/x86_64/static/test-failures.txt < src/REPORT
+          $FILECHECK --check-prefixes=COUNT ../llvm-project/llvm/tools/eld/test/musl/x86_64/static/test-failures.txt < src/REPORT
+
+          echo "Test results validated"

--- a/test/musl/x86_64/static/test-failures.txt
+++ b/test/musl/x86_64/static/test-failures.txt
@@ -1,0 +1,20 @@
+CHECK-DAG: FAIL src/api/main.exe
+CHECK-DAG: FAIL src/functional/dlopen.exe
+CHECK-DAG: FAIL src/functional/strptime-static.exe
+CHECK-DAG: FAIL src/functional/strptime.exe
+CHECK-DAG: FAIL src/functional/tgmath-static.exe
+CHECK-DAG: FAIL src/functional/tgmath.exe
+CHECK-DAG: FAIL src/functional/tls_align-static.exe
+CHECK-DAG: FAIL src/functional/tls_align.exe
+CHECK-DAG: FAIL src/functional/tls_align_dlopen.exe
+CHECK-DAG: FAIL src/functional/tls_init-static.exe
+CHECK-DAG: FAIL src/functional/tls_init.exe
+CHECK-DAG: FAIL src/functional/tls_init_dlopen.exe
+CHECK-DAG: FAIL src/functional/tls_local_exec-static.exe
+CHECK-DAG: FAIL src/functional/tls_local_exec.exe
+CHECK-DAG: FAIL src/math/fmal.exe
+CHECK-DAG: FAIL src/math/powf.exe
+CHECK-DAG: FAIL src/regression/tls_get_new-dtv.exe
+
+COUNT-COUNT-17: {{^FAIL }}
+COUNT-NOT: {{^FAIL }}


### PR DESCRIPTION
Add Nightly ELD + musl Test Suite

**Stacked on #197 **

Adds nightly GitHub Actions workflow to test ELD linker against musl libc-test suite.