### PR TITLE
Fix windows test failures due to invalid tar flags

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -159,7 +159,9 @@ linkdriverg0opts = ''
 # additional options to link a dynamic executable with the clang driver
 linkdriverdynopts = "-Wl,-rpath,'$ORIGIN'"
 tar = 'tar'
-gnutaropts = '--warning=no-timestamp'
+gnutaropts = ''
+if platform.system() == 'Linux':
+  gnutaropts = '--warning=no-timestamp'
 mv = 'mv'
 echo = 'echo'
 diff = 'diff'
@@ -446,7 +448,7 @@ if platform.system() == 'Windows':
 elif platform.system() == 'Linux':
     python = which("python3")
 
-tar = which(tar) + ' --force-local'
+tar = which(tar)
 mv = which(mv)
 diff = which(diff)
 touch = which(touch)


### PR DESCRIPTION
This patch aims to fix windows test failures that use invalid options `-force-local` and `--warning=no-timestamp` with the tar functionality.