### PR TITLE
Add missing DLL_A_EXPORT macros in plugin tests

### DIFF
--- a/test/Common/Plugin/ActBeforePerformingLayout/ActBeforePerformingLayoutPlugin.cpp
+++ b/test/Common/Plugin/ActBeforePerformingLayout/ActBeforePerformingLayoutPlugin.cpp
@@ -12,19 +12,4 @@ public:
   }
 };
 
-eld::plugin::PluginBase *ThisPlugin = nullptr;
-
-extern "C" {
-bool RegisterAll() {
-  ThisPlugin = new ActBeforePerformingLayoutPlugin();
-  return true;
-}
-
-eld::plugin::PluginBase *getPlugin(const char *T) { return ThisPlugin; }
-
-void Cleanup() {
-  if (ThisPlugin)
-    delete ThisPlugin;
-  ThisPlugin = nullptr;
-}
-}
+ELD_REGISTER_PLUGIN(ActBeforePerformingLayoutPlugin)

--- a/test/Common/Plugin/ActBeforeRuleMatching/ActBeforeRuleMatchingPlugin.cpp
+++ b/test/Common/Plugin/ActBeforeRuleMatching/ActBeforeRuleMatchingPlugin.cpp
@@ -12,19 +12,4 @@ public:
   }
 };
 
-eld::plugin::PluginBase *ThisPlugin = nullptr;
-
-extern "C" {
-bool RegisterAll() {
-  ThisPlugin = new ActBeforeRuleMatchingPlugin();
-  return true;
-}
-
-eld::plugin::PluginBase *getPlugin(const char *T) { return ThisPlugin; }
-
-void Cleanup() {
-  if (ThisPlugin)
-    delete ThisPlugin;
-  ThisPlugin = nullptr;
-}
-}
+ELD_REGISTER_PLUGIN(ActBeforeRuleMatchingPlugin)

--- a/test/Common/Plugin/ActBeforeWritingOutput/ActBeforeWritingOutputPlugin.cpp
+++ b/test/Common/Plugin/ActBeforeWritingOutput/ActBeforeWritingOutputPlugin.cpp
@@ -12,19 +12,4 @@ public:
   }
 };
 
-eld::plugin::PluginBase *ThisPlugin = nullptr;
-
-extern "C" {
-bool RegisterAll() {
-  ThisPlugin = new ActBeforeWritingOutputPlugin();
-  return true;
-}
-
-eld::plugin::PluginBase *getPlugin(const char *T) { return ThisPlugin; }
-
-void Cleanup() {
-  if (ThisPlugin)
-    delete ThisPlugin;
-  ThisPlugin = nullptr;
-}
-}
+ELD_REGISTER_PLUGIN(ActBeforeWritingOutputPlugin)

--- a/test/Common/Plugin/AddChunkToOutputInCreatingSections/AddChunkToOutputCSPlugin.cpp
+++ b/test/Common/Plugin/AddChunkToOutputInCreatingSections/AddChunkToOutputCSPlugin.cpp
@@ -27,19 +27,4 @@ public:
   }
 };
 
-eld::plugin::PluginBase *ThisPlugin = nullptr;
-
-extern "C" {
-bool RegisterAll() {
-  ThisPlugin = new AddChunkToOutputCSPlugin();
-  return true;
-}
-
-eld::plugin::PluginBase *getPlugin(const char *T) { return ThisPlugin; }
-
-void Cleanup() {
-  if (ThisPlugin)
-    delete ThisPlugin;
-  ThisPlugin = nullptr;
-}
-}
+ELD_REGISTER_PLUGIN(AddChunkToOutputCSPlugin)

--- a/test/Common/Plugin/AuxiliarySymbolName/AuxiliarySymbolNamePlugin.cpp
+++ b/test/Common/Plugin/AuxiliarySymbolName/AuxiliarySymbolNamePlugin.cpp
@@ -59,16 +59,16 @@ public:
 std::unordered_map<std::string, eld::plugin::PluginBase *> plugins;
 
 extern "C" {
-bool RegisterAll() {
+bool DLL_A_EXPORT RegisterAll() {
   plugins["AuxiliarySymbolNamePlugin"] = new AuxiliarySymbolNamePlugin();
   plugins["AuxiliarySymbolNamePluginAgain"] =
       new AuxiliarySymbolNamePluginAgain();
   return true;
 }
 
-eld::plugin::PluginBase *getPlugin(const char *T) { return plugins[T]; }
+eld::plugin::PluginBase DLL_A_EXPORT *getPlugin(const char *T) { return plugins[T]; }
 
-void Cleanup() {
+void DLL_A_EXPORT Cleanup() {
   for (auto &P : plugins) {
     delete P.second;
   }

--- a/test/Common/Plugin/AuxiliarySymbolNameTrace/AuxiliarySymbolNameTracePlugin.cpp
+++ b/test/Common/Plugin/AuxiliarySymbolNameTrace/AuxiliarySymbolNameTracePlugin.cpp
@@ -21,21 +21,4 @@ public:
   }
 };
 
-std::unordered_map<std::string, eld::plugin::PluginBase *> plugins;
-
-extern "C" {
-bool RegisterAll() {
-  plugins["AuxiliarySymbolNameTracePlugin"] =
-      new AuxiliarySymbolNameTracePlugin();
-  return true;
-}
-
-eld::plugin::PluginBase *getPlugin(const char *T) { return plugins[T]; }
-
-void Cleanup() {
-  for (auto &P : plugins) {
-    delete P.second;
-  }
-  plugins.clear();
-}
-}
+ELD_REGISTER_PLUGIN(AuxiliarySymbolNameTracePlugin)

--- a/test/Common/Plugin/DoesRuleMatchWithSection/DoesRuleMatchWithSectionPlugin.cpp
+++ b/test/Common/Plugin/DoesRuleMatchWithSection/DoesRuleMatchWithSectionPlugin.cpp
@@ -50,19 +50,4 @@ private:
   eld::plugin::Section BarSect;
 };
 
-eld::plugin::PluginBase *ThisPlugin = nullptr;
-
-extern "C" {
-bool RegisterAll() {
-  ThisPlugin = new DoesRuleMatchWithSectionPlugin();
-  return true;
-}
-
-eld::plugin::PluginBase *getPlugin(const char *T) { return ThisPlugin; }
-
-void Cleanup() {
-  if (ThisPlugin)
-    delete ThisPlugin;
-  ThisPlugin = nullptr;
-}
-}
+ELD_REGISTER_PLUGIN(DoesRuleMatchWithSectionPlugin)

--- a/test/Common/Plugin/OutputSectionsBeforePerformingLayout/outputsectionsbeforeperforminglayout.cpp
+++ b/test/Common/Plugin/OutputSectionsBeforePerformingLayout/outputsectionsbeforeperforminglayout.cpp
@@ -16,19 +16,6 @@ public:
     }
   }
 };
-eld::plugin::PluginBase *ThisPlugin = nullptr;
 
-extern "C" {
-bool RegisterAll() {
-  ThisPlugin = new OutSectionsBeforePerformingLayout();
-  return true;
-}
 
-eld::plugin::PluginBase *getPlugin(const char *T) { return ThisPlugin; }
-
-void Cleanup() {
-  if (ThisPlugin)
-    delete ThisPlugin;
-  ThisPlugin = nullptr;
-}
-}
+ELD_REGISTER_PLUGIN(OutSectionsBeforePerformingLayout)

--- a/test/Common/Plugin/RMSectNameInDiag/RMSectNameInDiagPlugin.cpp
+++ b/test/Common/Plugin/RMSectNameInDiag/RMSectNameInDiagPlugin.cpp
@@ -37,19 +37,4 @@ private:
   }
 };
 
-eld::plugin::PluginBase *ThisPlugin = nullptr;
-
-extern "C" {
-bool RegisterAll() {
-  ThisPlugin = new RMSectNameInDiagPlugin();
-  return true;
-}
-
-eld::plugin::PluginBase *getPlugin(const char *T) { return ThisPlugin; }
-
-void Cleanup() {
-  if (ThisPlugin)
-    delete ThisPlugin;
-  ThisPlugin = nullptr;
-}
-}
+ELD_REGISTER_PLUGIN(RMSectNameInDiagPlugin)

--- a/test/Hexagon/Plugin/TrampolineInfo/CMakeLists.txt
+++ b/test/Hexagon/Plugin/TrampolineInfo/CMakeLists.txt
@@ -10,7 +10,7 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   add_llvm_library(TrampolineInfoPlugin ${SHARED_LIB_SOURCES} LINK_LIBS LW)
 
   set_target_properties(
-    RuleMatchingSectNameMap PROPERTIES LIBRARY_OUTPUT_DIRECTORY
+    TrampolineInfoPlugin PROPERTIES LIBRARY_OUTPUT_DIRECTORY
                                        "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/test")
 
   set(BUILD_SHARED_LIBS ${bsl})

--- a/test/Hexagon/Plugin/TrampolineInfo/TrampolineInfoPlugin.cpp
+++ b/test/Hexagon/Plugin/TrampolineInfo/TrampolineInfoPlugin.cpp
@@ -22,19 +22,4 @@ public:
   }
 };
 
-eld::plugin::PluginBase *ThisPlugin = nullptr;
-
-extern "C" {
-bool RegisterAll() {
-  ThisPlugin = new TrampolineInfoPlugin();
-  return true;
-}
-
-eld::plugin::PluginBase *getPlugin(const char *T) { return ThisPlugin; }
-
-void Cleanup() {
-  if (ThisPlugin)
-    delete ThisPlugin;
-  ThisPlugin = nullptr;
-}
-}
+ELD_REGISTER_PLUGIN(TrampolineInfoPlugin)


### PR DESCRIPTION
This patch adds missing DLL_A_EXPORT macros in the plugin tests.