### PR TITLE
Fix LIT Test conditions for Windows build

### DIFF
--- a/test/Common/Plugin/InvalidStateOverrideLSRule/InvalidStateOverrideLSRule.test
+++ b/test/Common/Plugin/InvalidStateOverrideLSRule/InvalidStateOverrideLSRule.test
@@ -8,6 +8,6 @@
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -ffunction-sections
 RUN: %not %link %linkopts %t1.1.o -T %p/Inputs/script.t -o %t2.out --plugin-config %p/Inputs/plugin.config 2>&1 | %filecheck %s
 
-#CHECK: Error: Link state 'BeforeLayout' is invalid for the API 'overrideLinkerScriptRule'. Valid link states: []
+#CHECK: Error: Link state 'BeforeLayout' is invalid for the API '{{.*}}overrideLinkerScriptRule{{.*}}'. Valid link states: []
 #CHECK: Fatal: Linking had errors.
 

--- a/test/Common/Plugin/ReproducerWithFindConfigFile/ReproducerWithFindConfigFile.test
+++ b/test/Common/Plugin/ReproducerWithFindConfigFile/ReproducerWithFindConfigFile.test
@@ -15,12 +15,12 @@ RUN: cd %t1.reproduce
 RUN: %link @%t1.response.txt 2>&1 | %filecheck %s --check-prefix=REPRODUCE
 #END_TEST
 
-CHECK: Found config file {{.*}}/Inputs/some-file.txt
+CHECK: Found config file {{.*}}Inputs{{.*}}some-file.txt
 CHECK: Contents of config file: Hello, World!
 
 MAPPING: [StringMap]
-MAPPING-DAG: some-file.txt={{.*}}/Inputs/some-file.txt
-MAPPING-DAG: other-file.txt={{.*}}/Inputs/other-file.txt
+MAPPING-DAG: some-file.txt={{.*}}Inputs{{.*}}some-file.txt
+MAPPING-DAG: other-file.txt={{.*}}Inputs{{.*}}other-file.txt
 
 CONFIG_DIR: some-file.txt{{.*}}
 CONFIG_DIR-NOT:other-file

--- a/test/Common/Plugin/UniversalPluginInitAndDestroy/UniversalPluginInitAndDestroy.test
+++ b/test/Common/Plugin/UniversalPluginInitAndDestroy/UniversalPluginInitAndDestroy.test
@@ -12,7 +12,7 @@ CHECK: Hello World!
 CHECK: options: Hey
 CHECK: Bye World!
 
-TRACE: Note: Using the absolute path {{.*}}libUPInitAndDestroy.so{{.*}} for library UPInitAndDestroy
+TRACE: Note: Using the absolute path {{.*}}UPInitAndDestroy{{.*}} for library UPInitAndDestroy
 TRACE: Trace: Calling UPInitAndDestroy::Init plugin hook
 TRACE: Trace: Calling UPInitAndDestroy::Destroy plugin hook
-TRACE: Note: Unloaded Library {{.*}}libUPInitAndDestroy.so{{.*}}
+TRACE: Note: Unloaded Library {{.*}}UPInitAndDestroy{{.*}}


### PR DESCRIPTION
This patch fixes LIT test conditions in certain linker tests to enable them to work on windows.