### PR TITLE
llvm-lit : use asserts mode for unsupported tests

### DIFF
--- a/test/AArch64/standalone/EmitRelocs/EmitRelocs.test
+++ b/test/AArch64/standalone/EmitRelocs/EmitRelocs.test
@@ -1,3 +1,4 @@
+#UNSUPPORTED: asserts
 RUN: %clang %clangopts -target aarch64 -c %p/test.c -o %t1.o
 RUN: %clang %clangopts -target aarch64 -c %p/bar.c -o %t2.o
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -8,6 +8,8 @@ import subprocess
 import lit.formats
 import lit.util
 
+from lit.llvm import llvm_config
+
 sys.path.insert(0, os.path.dirname(__file__))
 import eld_test_formats
 
@@ -114,6 +116,13 @@ if ('RISCV64' in config.eld_targets_to_build or
   config.available_features.add('64BitsArch')
 else:
   config.available_features.add('32BitsArch')
+
+# Use llvm-config to find what features are enabled
+llvm_config.feature_config(
+    [
+        ("--assertion-mode", {"ON": "asserts"}),
+    ]
+)
 
 # Default values
 clang = 'clang'

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -31,5 +31,8 @@ except KeyError as e:
     key, = e.args
     lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
 
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
+
 # Let the main config do the real work.
 lit_config.load_config(config, "@ELD_SOURCE_DIR@/test/lit.cfg")


### PR DESCRIPTION
A test fails randomly when asserts are turned ON, due to emit relocs non determinism and the relocation processing is multi-threaded.

Disable this test for now, and look into why the test would fail post 21.0 release

Fixes #15