### PR TITLE
enable asserts - ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
           -DLLVM_ENABLE_PROJECTS="llvm;clang;clang-tools-extra" \
           -DLLVM_CCACHE_DIR=$CACHE_DIR \
           -DLLVM_CCACHE_BUILD:BOOL=ON \
+          -DLLVM_ENABLE_ASSERTIONS:BOOL=ON \
           -DCMAKE_INSTALL_RPATH:STRING="$ORIGIN/../lib" \
           -DCMAKE_C_COMPILER:STRING=`which clang` \
           -DCMAKE_CXX_COMPILER:STRING=`which clang++` \


### PR DESCRIPTION
we had asserts disabled for a while in the builds, enable it back