### PR TITLE
Remove grep usage in GCExternCmd.test

### DIFF
--- a/test/Hexagon/standalone/linkerscript/GCExternCmd/GCExternCmd.test
+++ b/test/Hexagon/standalone/linkerscript/GCExternCmd/GCExternCmd.test
@@ -3,7 +3,8 @@ RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o -ffunction-sections -fdata-sect
 RUN: %clang %clangopts -c %p/Inputs/2.c -o %t2.o -ffunction-sections -fdata-sections
 RUN: %ar cr %aropts %tlib.a %t2.o
 RUN: %link %linkopts %t1.o %tlib.a --entry main -o %t.out -T=%p/Inputs/list --gc-sections 2>&1
-RUN: %readelf -s %t.out  | %grep -iE "extern|common" | %filecheck %s
+RUN: %readelf -s %t.out | %filecheck %s --check-prefix=EXTERN
+RUN: %readelf -s %t.out | %filecheck %s --check-prefix=CHAR
 
-#CHECK:  UND externSym
-#CHECK:  1 OBJECT    GLOBAL DEFAULT    1 commonChar
+#EXTERN:  UND externSym
+#CHAR:  1 OBJECT    GLOBAL DEFAULT    1 commonChar


### PR DESCRIPTION
This commit removes grep and uses filecheck for matching symbols. This fixes the test failure on windows.