### PR TITLE
Fix Relaxation/UnalignedCrash/UnalignedCrash.test

### DIFF
--- a/test/RISCV/standalone/Relaxation/InsufficientAlignmentRelaxation/Inputs/1.s
+++ b/test/RISCV/standalone/Relaxation/InsufficientAlignmentRelaxation/Inputs/1.s
@@ -1,10 +1,9 @@
         .text
         .globl  foo
         .type   foo, @function
-        call norelax
-        call norelax
-        call norelax
-        call norelax
+        .option rvc
+        j 1f
+        .option norvc
         .balign 32
 foo:    nop
         // Add a relaxation relocation as RISC-V ABI demands that R_ALIGN
@@ -16,4 +15,5 @@ foo:    nop
         ret
         .size   foo, .-foo
 
-.equ norelax, 0x40000000
+1:
+ nop

--- a/test/RISCV/standalone/Relaxation/InsufficientAlignmentRelaxation/Inputs/1.t
+++ b/test/RISCV/standalone/Relaxation/InsufficientAlignmentRelaxation/Inputs/1.t
@@ -1,5 +1,5 @@
 SECTIONS {
-  text (0xFE1) : {
+  text (0x0) : {
     *(.text)
   }
 }

--- a/test/RISCV/standalone/Relaxation/InsufficientAlignmentRelaxation/InsufficientAlignmentRelaxation.test
+++ b/test/RISCV/standalone/Relaxation/InsufficientAlignmentRelaxation/InsufficientAlignmentRelaxation.test
@@ -5,6 +5,7 @@
 # END_COMMENT
 # START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.s -o %t.1.o
+RUN: %objdump -dr %t.1.o
 RUN: %not %link %linkopts -o %t.1.out %t.1.o -T %p/Inputs/1.t 2>&1 | %filecheck %s
 # END_TEST
 

--- a/test/RISCV/standalone/Relaxation/InsufficientAlignmentRelaxation/InsufficientAlignmentRelaxation.test
+++ b/test/RISCV/standalone/Relaxation/InsufficientAlignmentRelaxation/InsufficientAlignmentRelaxation.test
@@ -1,0 +1,11 @@
+#----------InsufficientAlignmentRelaxation.test----------------- Executable------------------#
+# BEGIN_COMMENT
+# This test checks that the linker correctly emits insufficient bytes for alignment
+# relaxation error.
+# END_COMMENT
+# START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.s -o %t.1.o
+RUN: %not %link %linkopts -o %t.1.out %t.1.o -T %p/Inputs/1.t 2>&1 | %filecheck %s
+# END_TEST
+
+CHECK: Error: Insufficient number of spare bytes for alignment relaxation: present 28, needed 30 in section .text+0x20 file {{.*}}1.o

--- a/test/RISCV/standalone/Relaxation/UnalignedCrash-QTOOL-105850/UnalignedCrash-QTOOL-105850.test
+++ b/test/RISCV/standalone/Relaxation/UnalignedCrash-QTOOL-105850/UnalignedCrash-QTOOL-105850.test
@@ -1,9 +1,0 @@
-#----------UnalignedCrash-QTOOL-105850.test----------------- Executable------------------#
-# BEGIN_COMMENT
-# Test that the linker does not crash.
-# END_COMMENT
-# START_TEST
-#RUN: %clang %clangopts -c %p/Inputs/1.s -o %t.o
-#RUN: not %link %linkopts %t.o -T %p/Inputs/1.t -o %t.out 2>&1 | %filecheck %s
-# CHECK: Error: Insufficient number of spare bytes for alignment relaxation: present 30, needed 31 in section .text+{{.+}} file {{.*}}.o
-# END_TEST


### PR DESCRIPTION
This commit fixes the test
RISCV/standalone/Relaxation/UnalignedCrash/UnalignedCrash.test. The test checks that the link command fails with the insufficient bytes for alignment relaxation error. However, for this test, the link should pass without any errors. It was currently erroring out because of the incorrect fragment address. This commit fixes the test so that the link should fail with the insufficient bytes for alignment relaxation error without relying on the incorrect fragment address.

Resolves #363