### PR TITLE
Revert removal of `--force-local` flag

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -457,7 +457,7 @@ if platform.system() == 'Windows':
 elif platform.system() == 'Linux':
     python = which("python3")
 
-tar = which(tar)
+tar = which(tar) + ' --force-local'
 mv = which(mv)
 diff = which(diff)
 touch = which(touch)


### PR DESCRIPTION
This patch aims to revert part of the commit
4627b98 adding `--force-local flag back as an argument for `tar.exe`. `tar.exe` by default treats paths with `:` as remote file paths. `--force-local` enables `tar.exe` to treat paths with `:` as local paths.