### PR TITLE
Change LIT checks for windows compatibility

### DIFF
--- a/test/Common/Plugin/ReproducerWithFindConfigFile/ReproducerWithFindConfigFile.test
+++ b/test/Common/Plugin/ReproducerWithFindConfigFile/ReproducerWithFindConfigFile.test
@@ -25,5 +25,5 @@ MAPPING-DAG: other-file.txt={{.*}}Inputs{{.*}}other-file.txt
 CONFIG_DIR: some-file.txt{{.*}}
 CONFIG_DIR-NOT:other-file
 
-REPRODUCE: Found config file {{.*}}/Inputs/some-file.txt
+REPRODUCE: Found config file {{.*}}Inputs{{.*}}some-file.txt
 REPRODUCE: Contents of config file: Hello, World!

--- a/test/Common/Plugin/ReproducerWithFindConfigFileAbsolutePath/ReproducerWithFindConfigFile.test
+++ b/test/Common/Plugin/ReproducerWithFindConfigFileAbsolutePath/ReproducerWithFindConfigFile.test
@@ -23,7 +23,7 @@ CHECK: Found config file {{.*}}some-file.txt
 CHECK: Contents of config file: Hello, World!
 
 MAPPING: [StringMap]
-MAPPING-DAG: [[PREFIX:.*]]some-file.txt=[[PREFIX]]some-file.txt
+MAPPING-DAG: [[LEFT:[^=]*some-file\.txt]]=[[RIGHT:[^=]*some-file\.txt]]
 
 CONFIG_DIR: some-file.txt{{.*}}
 


### PR DESCRIPTION
This patch changes some LIT test checks to the make the checks windows compatible.