### PR TITLE
Fix LIT tests and LIT Config for Windows

### DIFF
--- a/test/Common/Plugin/SearchDiagnosticsPlugin/SearchDiagnosticsPlugin.test
+++ b/test/Common/Plugin/SearchDiagnosticsPlugin/SearchDiagnosticsPlugin.test
@@ -11,9 +11,9 @@ RUN: mkdir %t-fake-path
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o
 RUN: %link %linkopts --verbose -L%t-fake-path -L %libsdir/test/ --plugin-config %p/Inputs/PluginConfig.yaml --plugin-config %p/Inputs/plugin.config  %t1.o 2>&1 | %filecheck %s
 
-CHECK: Verbose: Trying to open `libSearchDiagnosticsPlugin.so' for linker plugin `libSearchDiagnosticsPlugin.so' (file path):
-CHECK: Verbose: Trying to open `{{.+}}fake-path/libSearchDiagnosticsPlugin.so' for linker plugin `libSearchDiagnosticsPlugin.so' (search path): not found
-CHECK: Verbose: Trying to open `{{.+}}libSearchDiagnosticsPlugin.so' for linker plugin `libSearchDiagnosticsPlugin.so' (rpath):
-CHECK: Verbose: Trying to open `libSectionTypes.so' for linker plugin `libSectionTypes.so' (file path):
+CHECK: Verbose: Trying to open `{{.*}}SearchDiagnosticsPlugin{{.*}}' for linker plugin `{{.*}}SearchDiagnosticsPlugin{{.*}}' (file path):
+CHECK: Verbose: Trying to open `{{.*}}fake-path{{.*}}SearchDiagnosticsPlugin{{.*}}' for linker plugin `{{.*}}SearchDiagnosticsPlugin{{.*}}' (search path): not found
+CHECK: Verbose: Trying to open `{{.*}}SearchDiagnosticsPlugin{{.*}}' for linker plugin `{{.*}}SearchDiagnosticsPlugin{{.*}}' (rpath):
+CHECK: Verbose: Trying to open `{{.*}}SectionTypes{{.*}}' for linker plugin `{{.*}}SectionTypes{{.*}}' (file path):
 
 #END_TEST

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -319,6 +319,7 @@ if config.test_target == 'ARM':
     # Features for buildbot to XFAIL tests while they are being fixed.
     if platform.system() == 'Windows':
         config.available_features.add('arm-windows')
+        config.available_features.add('windows')
     elif platform.system() == 'Linux':
         config.available_features.add('arm-linux')
     if ('arm-windows' in config.available_features or
@@ -347,6 +348,7 @@ if config.test_target == 'AArch64':
     # Features for buildbot to XFAIL tests while they are being fixed.
     if platform.system() == 'Windows':
         config.available_features.add('aarch64-windows')
+        config.available_features.add('windows')
     elif platform.system() == 'Linux':
         config.available_features.add('aarch64-linux')
     if ('aarch64-windows' in config.available_features or


### PR DESCRIPTION
This patch fixes LIT test checks to make them windows compatible and also makes changes in the LIT config
to support `Unsupported:Windows` tests