### PR TITLE
Fix tests for reverse iteration

### DIFF
--- a/include/eld/Support/INIWriter.h
+++ b/include/eld/Support/INIWriter.h
@@ -71,7 +71,7 @@ public:
   /// \returns layout of this ini file in the form of an std::ostream
   friend std::ostream &operator<<(std::ostream &os, INIWriter const &m) {
     for (auto &section : m.ini) {
-      os << "[" << section.first().str() << "]\n";
+      os << "[" << section.first << "]\n";
       os << *section.second;
       os << "\n";
     }
@@ -105,7 +105,7 @@ public:
   }
 
 private:
-  llvm::StringMap<INISection *> ini;
+  std::map<std::string, INISection *> ini;
   std::unique_ptr<llvm::raw_fd_ostream> file = nullptr;
 };
 } // namespace eld

--- a/test/AArch64/standalone/linkerscript/ATScrewUp/ATScrewUp.test
+++ b/test/AArch64/standalone/linkerscript/ATScrewUp/ATScrewUp.test
@@ -3,6 +3,6 @@ RUN: %clang %clangopts -target aarch64 -c  %p/Inputs/foo.c  -o %t0.o
 RUN: %link %linkopts -march aarch64 -T %p/Inputs/script.t %t0.o -o %t1
 RUN: %readelf -s -W %t1 | %filecheck %s
 
-#CHECK:   00001000     0 NOTYPE  GLOBAL DEFAULT  ABS __tcm_qurt_pa_load_end__
-#CHECK:   00001000     0 NOTYPE  GLOBAL DEFAULT  ABS __tcm_qurt_pa_load_start__
+#CHECK-DAG:   00001000     0 NOTYPE  GLOBAL DEFAULT  ABS __tcm_qurt_pa_load_end__
+#CHECK-DAG:   00001000     0 NOTYPE  GLOBAL DEFAULT  ABS __tcm_qurt_pa_load_start__
 

--- a/test/AArch64/standalone/linkerscript/nonAllocfixup/nonAllocfixup.test
+++ b/test/AArch64/standalone/linkerscript/nonAllocfixup/nonAllocfixup.test
@@ -3,5 +3,5 @@ RUN: %clang %clangopts -target aarch64 -c %p/Inputs/2.c -o %t2.o -ffunction-sect
 RUN: %link %linkopts -march aarch64 -T %p/Inputs/script.t %t1.o %t2.o -o %t.out 2>&1
 RUN: %readelf -s %t.out | %filecheck %s
 
-CHECK:  {{[x0-9a-f]+}}    0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_start__
-CHECK:  {{[x0-9a-f]+}}    0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_end__
+CHECK-DAG:  {{[x0-9a-f]+}}    0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_start__
+CHECK-DAG:  {{[x0-9a-f]+}}    0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_end__

--- a/test/AArch64/standalone/linkerscript/nonAllocfixupPHDRS/nonAllocfixupPHDRS.test
+++ b/test/AArch64/standalone/linkerscript/nonAllocfixupPHDRS/nonAllocfixupPHDRS.test
@@ -3,5 +3,5 @@ RUN: %clang %clangopts -target aarch64 -c %p/Inputs/2.c -o %t2.o -ffunction-sect
 RUN: %link %linkopts -march aarch64 -T %p/Inputs/script.t %t1.o %t2.o -o %t.out 2>&1
 RUN: %readelf -s %t.out | %filecheck %s
 
-CHECK:  {{[x0-9a-f]+}}     0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_start__
-CHECK:  {{[x0-9a-f]+}}     0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_end__
+CHECK-DAG:  {{[x0-9a-f]+}}     0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_start__
+CHECK-DAG:  {{[x0-9a-f]+}}     0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_end__

--- a/test/ARM/standalone/linkerscript/ATScrewUp/ATScrewUp.test
+++ b/test/ARM/standalone/linkerscript/ATScrewUp/ATScrewUp.test
@@ -3,6 +3,6 @@ RUN: %clang %clangopts -target arm -c  %p/Inputs/foo.c  -o %t0.o
 RUN: %link %linkopts -march arm -T %p/Inputs/script.t %t0.o -o %t1
 RUN: %readelf -s -W %t1 | %filecheck %s
 
-#CHECK:   00001000     0 NOTYPE  GLOBAL DEFAULT  ABS __tcm_qurt_pa_load_end__
-#CHECK:   00001000     0 NOTYPE  GLOBAL DEFAULT  ABS __tcm_qurt_pa_load_start__
+#CHECK-DAG:   00001000     0 NOTYPE  GLOBAL DEFAULT  ABS __tcm_qurt_pa_load_end__
+#CHECK-DAG:   00001000     0 NOTYPE  GLOBAL DEFAULT  ABS __tcm_qurt_pa_load_start__
 

--- a/test/ARM/standalone/linkerscript/nonAllocfixup/nonAllocfixup.test
+++ b/test/ARM/standalone/linkerscript/nonAllocfixup/nonAllocfixup.test
@@ -3,5 +3,5 @@ RUN: %clang %clangopts -target arm -c %p/Inputs/2.c -o %t2.o -ffunction-sections
 RUN: %link %linkopts -march arm -T %p/Inputs/script.t %t1.o %t2.o -o %t.out 2>&1
 RUN: %readelf -s %t.out | %filecheck %s
 
-CHECK:  {{[x0-9a-f]+}}    0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_start__
-CHECK:  {{[x0-9a-f]+}}    0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_end__
+CHECK-DAG:  {{[x0-9a-f]+}}    0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_start__
+CHECK-DAG:  {{[x0-9a-f]+}}    0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_end__

--- a/test/ARM/standalone/linkerscript/nonAllocfixupPHDRS/nonAllocfixupPHDRS.test
+++ b/test/ARM/standalone/linkerscript/nonAllocfixupPHDRS/nonAllocfixupPHDRS.test
@@ -3,5 +3,5 @@ RUN: %clang %clangopts -target arm -c %p/Inputs/2.c -o %t2.o -ffunction-sections
 RUN: %link %linkopts -march arm -T %p/Inputs/script.t %t1.o %t2.o -o %t.out 2>&1
 RUN: %readelf -s %t.out | %filecheck %s
 
-CHECK:  {{[x0-9a-f]+}}     0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_start__
-CHECK:  {{[x0-9a-f]+}}     0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_end__
+CHECK-DAG:  {{[x0-9a-f]+}}     0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_start__
+CHECK-DAG:  {{[x0-9a-f]+}}     0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_end__

--- a/test/Common/standalone/AliasSymbolsReporting/AliasSymbolsReporting.test
+++ b/test/Common/standalone/AliasSymbolsReporting/AliasSymbolsReporting.test
@@ -9,5 +9,6 @@ RUN: %clang %clangg0opts -fno-pie -c %p/Inputs/1.c -o %t1.1.o
 RUN: %clang %clangg0opts -fno-pie -c %p/Inputs/2.c -o %t1.2.o -fPIC
 RUN: %link %linkg0opts %t1.2.o -o %t2.lib2.so -shared
 RUN: %link %linkg0opts -Bdynamic --no-emit-relocs %t1.1.o %t2.lib2.so -o %t2.out --verbose 2>&1 | %filecheck %s
-#CHECK: Global symbol bar from input file {{.*}}lib2.so has aliases: bar_more_alias, bar_alias
+#CHECK-DAG: bar_more_alias
+#CHECK-DAG: bar_alias
 #END_TEST

--- a/test/Common/standalone/ProvideOutputSectionPrologue/ProvideOutputSectionPrologue.test
+++ b/test/Common/standalone/ProvideOutputSectionPrologue/ProvideOutputSectionPrologue.test
@@ -15,7 +15,7 @@ RUN: %readelf -Sls %t1.1.out 2>&1 | %filecheck %s --check-prefix=READELF
 READELF: .foo {{.*}} {{0+}}1000
 READELF: Program Headers
 READELF: 0x{{0+}}1000 0x{{0+}}2000
-READELF: {{0+}}100 {{.*}} ABS A
-READELF: {{0+}}100 {{.*}} ABS S
-READELF: {{0+}}1000 {{.*}} ABS VMA
-READELF: {{0+}}2000 {{.*}} ABS LMA
+READELF-DAG: {{0+}}100 {{.*}} ABS A
+READELF-DAG: {{0+}}100 {{.*}} ABS S
+READELF-DAG: {{0+}}1000 {{.*}} ABS VMA
+READELF-DAG: {{0+}}2000 {{.*}} ABS LMA

--- a/test/Common/standalone/VersionScript/VersionScript.test
+++ b/test/Common/standalone/VersionScript/VersionScript.test
@@ -89,9 +89,9 @@ MAPCHECK5: Version Script file
 MAPCHECK5: {{.*}}/Inputs/vs5
 MAPCHECK5: Global:
 MAPCHECK5: Pattern: *
-MAPCHECK5: # bar {{.*}}5.o
-MAPCHECK5: # baz {{.*}}5.o
-MAPCHECK5: # foo {{.*}}5.o
+MAPCHECK5-DAG: # bar {{.*}}5.o
+MAPCHECK5-DAG: # baz {{.*}}5.o
+MAPCHECK5-DAG: # foo {{.*}}5.o
 MAPCHECK5: Local:
 MAPCHECK5: Pattern: *
 
@@ -104,9 +104,9 @@ MAPCHECK51: Version Script file
 MAPCHECK51: {{.*}}/Inputs/vs5
 MAPCHECK51: Global:
 MAPCHECK51: Pattern: *
-MAPCHECK51: # bar {{.*}}5.o
-MAPCHECK51: # baz {{.*}}5.o
-MAPCHECK51: # foo {{.*}}5.o
+MAPCHECK51-DAG: # bar {{.*}}5.o
+MAPCHECK51-DAG: # baz {{.*}}5.o
+MAPCHECK51-DAG: # foo {{.*}}5.o
 MAPCHECK51: Local:
 MAPCHECK51: Pattern: *
 
@@ -156,12 +156,12 @@ MAPCHECK8: Version Script file
 MAPCHECK8: {{.*}}/Inputs/vs5
 MAPCHECK8: Global:
 MAPCHECK8: Pattern: *
-MAPCHECK8: # f_exe {{.*}}8_2.o
-MAPCHECK8: # bar {{.*}}8.so
-MAPCHECK8: # main {{.*}}8_2.o
-MAPCHECK8: # baz {{.*}}8.so
-MAPCHECK8: # func_exe {{.*}}8_2.o
-MAPCHECK8: # foo {{.*}}8.so
+MAPCHECK8-DAG: # f_exe {{.*}}8_2.o
+MAPCHECK8-DAG: # bar {{.*}}8.so
+MAPCHECK8-DAG: # main {{.*}}8_2.o
+MAPCHECK8-DAG: # baz {{.*}}8.so
+MAPCHECK8-DAG: # func_exe {{.*}}8_2.o
+MAPCHECK8-DAG: # foo {{.*}}8.so
 MAPCHECK8: Local:
 MAPCHECK8: Pattern: *
 

--- a/test/Common/standalone/linkerscript/ATScrewUp/ATScrewUp.test
+++ b/test/Common/standalone/linkerscript/ATScrewUp/ATScrewUp.test
@@ -3,6 +3,6 @@ RUN: %clang %clangopts -c  %p/Inputs/foo.c  -o %t0.o
 RUN: %link %linkopts -T %p/Inputs/script.t %t0.o -o %t1
 RUN: %readelf -s -W %t1 | %filecheck %s
 
-#CHECK:   00001000     0 NOTYPE  GLOBAL DEFAULT  ABS __tcm_qurt_pa_load_end__
-#CHECK:   00001000     0 NOTYPE  GLOBAL DEFAULT  ABS __tcm_qurt_pa_load_start__
+#CHECK-DAG:   00001000     0 NOTYPE  GLOBAL DEFAULT  ABS __tcm_qurt_pa_load_end__
+#CHECK-DAG:   00001000     0 NOTYPE  GLOBAL DEFAULT  ABS __tcm_qurt_pa_load_start__
 

--- a/test/Common/standalone/linkerscript/ProvideSymbolNoSpaceAroundEqualTo/ProvideSymbolNoSpaceAroundEqualTo.test
+++ b/test/Common/standalone/linkerscript/ProvideSymbolNoSpaceAroundEqualTo/ProvideSymbolNoSpaceAroundEqualTo.test
@@ -6,6 +6,6 @@ RUN: %touch %t1.1.o
 RUN: %link %emulation %linkopts -o %t1.a.out %t1.1.o -T %p/Inputs/script.t -u foo -u bar -u baz
 RUN: %readelf -s %t1.a.out | %filecheck %s
 
-CHECK: 11 {{.*}} ABS bar
-CHECK: 11 {{.*}} ABS baz
-CHECK: 11 {{.*}} ABS foo
+CHECK-DAG: 11 {{.*}} ABS bar
+CHECK-DAG: 11 {{.*}} ABS baz
+CHECK-DAG: 11 {{.*}} ABS foo

--- a/test/Hexagon/linux/TLS/GDGOT/gdgot.test
+++ b/test/Hexagon/linux/TLS/GDGOT/gdgot.test
@@ -5,9 +5,9 @@ RUN: %link %linkopts  %linkg0opts  -shared  %t1.o  %t2.o  -o %t.so
 RUN: %readelf -l -r -S -s -W %t.so |   %filecheck %s
 
 # CHECK-NOT: TPREL
-# CHECK:  R_HEX_DTPMOD_32   00000004   src1 + 0
-# CHECK:  R_HEX_DTPREL_32   00000004   src1 + 0
-# CHECK:  R_HEX_DTPMOD_32   00000000   src2 + 0
-# CHECK:  R_HEX_DTPREL_32   00000000   src2 + 0
-# CHECK:  R_HEX_JMP_SLOT    00000000   __tls_get_addr
+# CHECK-DAG:  R_HEX_DTPMOD_32   00000004   src1 + 0
+# CHECK-DAG:  R_HEX_DTPREL_32   00000004   src1 + 0
+# CHECK-DAG:  R_HEX_DTPMOD_32   00000000   src2 + 0
+# CHECK-DAG:  R_HEX_DTPREL_32   00000000   src2 + 0
+# CHECK-DAG:  R_HEX_JMP_SLOT    00000000   __tls_get_addr
 

--- a/test/Hexagon/linux/TLS/IE/ie.test
+++ b/test/Hexagon/linux/TLS/IE/ie.test
@@ -6,7 +6,7 @@ RUN: %link %linkopts -G0 -dy  %t1.o  %t2.so  -o %t.out
 RUN: %readelf -l -r -S -s -W %t.out |   %filecheck %s
 
 # CHECK:  TLS            {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} 0x00004 0x00008 R   0x8
-# CHECK:  R_HEX_TPREL_32         00000000   src1 + 0
-# CHECK:  R_HEX_TPREL_32         00000000   src2 + 0
+# CHECK-DAG:  R_HEX_TPREL_32         00000000   src1 + 0
+# CHECK-DAG:  R_HEX_TPREL_32         00000000   src2 + 0
 # CHECK:  00000000     4 TLS     GLOBAL DEFAULT    {{[0-9]}} dst
 

--- a/test/Hexagon/linux/linkerscript/ATScrewUp/ATScrewUp.test
+++ b/test/Hexagon/linux/linkerscript/ATScrewUp/ATScrewUp.test
@@ -3,6 +3,6 @@ RUN: %clang %clangopts -c  %p/Inputs/foo.c  -o %t0.o
 RUN: %link %linkopts -T %p/Inputs/script.t %t0.o -o %t1
 RUN: %readelf -s -W %t1 | %filecheck %s
 
-#CHECK:   00001000     0 NOTYPE  GLOBAL DEFAULT  ABS __tcm_qurt_pa_load_end__
-#CHECK:   00001000     0 NOTYPE  GLOBAL DEFAULT  ABS __tcm_qurt_pa_load_start__
+#CHECK-DAG:   00001000     0 NOTYPE  GLOBAL DEFAULT  ABS __tcm_qurt_pa_load_end__
+#CHECK-DAG:   00001000     0 NOTYPE  GLOBAL DEFAULT  ABS __tcm_qurt_pa_load_start__
 

--- a/test/Hexagon/linux/linkerscript/nonAllocfixup/nonAllocfixup.test
+++ b/test/Hexagon/linux/linkerscript/nonAllocfixup/nonAllocfixup.test
@@ -3,5 +3,5 @@ RUN: %clang %clangopts -c %p/Inputs/2.c -o %t2.o -ffunction-sections %clangg0opt
 RUN: %link %linkopts -T %p/Inputs/script.t %t1.o %t2.o -o %t.out  %linkg0opts  2>&1
 RUN: %readelf -s %t.out | %filecheck %s
 
-CHECK:  {{[x0-9a-f]+}}    0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_start__
-CHECK:  {{[x0-9a-f]+}}    0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_end__
+CHECK-DAG:  {{[x0-9a-f]+}}    0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_start__
+CHECK-DAG:  {{[x0-9a-f]+}}    0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_end__

--- a/test/Hexagon/linux/linkerscript/nonAllocfixupPHDRS/nonAllocfixupPHDRS.test
+++ b/test/Hexagon/linux/linkerscript/nonAllocfixupPHDRS/nonAllocfixupPHDRS.test
@@ -3,5 +3,5 @@ RUN: %clang %clangopts -c %p/Inputs/2.c -o %t2.o -ffunction-sections %clangg0opt
 RUN: %link %linkopts -T %p/Inputs/script.t %t1.o %t2.o -o %t.out  %linkg0opts  2>&1
 RUN: %readelf -s %t.out | %filecheck %s
 
-CHECK:  {{[x0-9a-f]+}}     0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_start__
-CHECK:  {{[x0-9a-f]+}}     0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_end__
+CHECK-DAG:  {{[x0-9a-f]+}}     0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_start__
+CHECK-DAG:  {{[x0-9a-f]+}}     0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_end__

--- a/test/Hexagon/standalone/linkerscript/ATScrewUp/ATScrewUp.test
+++ b/test/Hexagon/standalone/linkerscript/ATScrewUp/ATScrewUp.test
@@ -3,6 +3,6 @@ RUN: %clang %clangopts -c  %p/Inputs/foo.c  -o %t0.o
 RUN: %link %linkopts -T %p/Inputs/script.t %t0.o -o %t1
 RUN: %readelf -s -W %t1 | %filecheck %s
 
-#CHECK:   00001000     0 NOTYPE  GLOBAL DEFAULT  ABS __tcm_qurt_pa_load_end__
-#CHECK:   00001000     0 NOTYPE  GLOBAL DEFAULT  ABS __tcm_qurt_pa_load_start__
+#CHECK-DAG:   00001000     0 NOTYPE  GLOBAL DEFAULT  ABS __tcm_qurt_pa_load_end__
+#CHECK-DAG:   00001000     0 NOTYPE  GLOBAL DEFAULT  ABS __tcm_qurt_pa_load_start__
 

--- a/test/Hexagon/standalone/linkerscript/nonAllocfixup/nonAllocfixup.test
+++ b/test/Hexagon/standalone/linkerscript/nonAllocfixup/nonAllocfixup.test
@@ -3,5 +3,5 @@ RUN: %clang %clangopts -c %p/Inputs/2.c -o %t2.o -ffunction-sections %clangg0opt
 RUN: %link %linkopts -T %p/Inputs/script.t %t1.o %t2.o -o %t.out  %linkg0opts  2>&1
 RUN: %readelf -s %t.out | %filecheck %s
 
-CHECK:  {{[x0-9a-f]+}}    0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_start__
-CHECK:  {{[x0-9a-f]+}}    0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_end__
+CHECK-DAG:  {{[x0-9a-f]+}}    0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_start__
+CHECK-DAG:  {{[x0-9a-f]+}}    0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_end__

--- a/test/Hexagon/standalone/linkerscript/nonAllocfixupPHDRS/nonAllocfixupPHDRS.test
+++ b/test/Hexagon/standalone/linkerscript/nonAllocfixupPHDRS/nonAllocfixupPHDRS.test
@@ -3,5 +3,5 @@ RUN: %clang %clangopts -c %p/Inputs/2.c -o %t2.o -ffunction-sections %clangg0opt
 RUN: %link %linkopts -T %p/Inputs/script.t %t1.o %t2.o -o %t.out  %linkg0opts  2>&1
 RUN: %readelf -s %t.out | %filecheck %s
 
-CHECK:  {{[x0-9a-f]+}}     0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_start__
-CHECK:  {{[x0-9a-f]+}}     0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_end__
+CHECK-DAG:  {{[x0-9a-f]+}}     0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_start__
+CHECK-DAG:  {{[x0-9a-f]+}}     0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_end__

--- a/test/Hexagon/standalone/nonAllocfixupPHDRS/nonAllocfixupPHDRS.test
+++ b/test/Hexagon/standalone/nonAllocfixupPHDRS/nonAllocfixupPHDRS.test
@@ -3,5 +3,5 @@ RUN: %clang %clangopts -c %p/Inputs/2.c -o %t2.o -ffunction-sections -G0
 RUN: %link %linkopts -T %p/Inputs/script.t %t1.o %t2.o -o %t.out -G0 2>&1
 RUN: %readelf -s %t.out | %filecheck %s
 
-CHECK:  {{[x0-9a-f]+}}     0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_start__
-CHECK:  {{[x0-9a-f]+}}     0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_end__
+CHECK-DAG:  {{[x0-9a-f]+}}     0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_start__
+CHECK-DAG:  {{[x0-9a-f]+}}     0 NOTYPE  GLOBAL DEFAULT  ABS __unrecognized_end__


### PR DESCRIPTION
Adds CHECK-DAGs to iteration-sensitive tests. INIWriter now uses a std::map instead of a StringMap for consistent iteration.