### PR TITLE
Fix incorrect padding value when both fill expr and command are used

### DIFF
--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -1887,6 +1887,8 @@ void GNULDBackend::evaluateAssignments(OutputSectionEntry *out,
   PaddingT padding;
 
   Expression *fillExpression = out->epilog().fillExp();
+  if (fillExpression)
+    fillExpression->evaluateAndRaiseError();
 
   padding.Exp = fillExpression;
 

--- a/test/Common/standalone/linkerscript/FillExpAndFillCommandCombined/FillExpAndFillCommandCombined.test
+++ b/test/Common/standalone/linkerscript/FillExpAndFillCommandCombined/FillExpAndFillCommandCombined.test
@@ -1,0 +1,12 @@
+#---FillExpAndFillCommandCombined.test--------------------------- Executable --------------------#
+#BEGIN_COMMENT
+# This tests check that the padding contains content as per the
+# fill expression / command when both of them are used.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t
+RUN: %readelf -x text %t1.1.out 2>&1 | %filecheck %s
+#END_TEST
+
+CHECK: 0x00000016 deadbeef abababab bcbcbcbc

--- a/test/Common/standalone/linkerscript/FillExpAndFillCommandCombined/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/FillExpAndFillCommandCombined/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/Common/standalone/linkerscript/FillExpAndFillCommandCombined/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/FillExpAndFillCommandCombined/Inputs/script.t
@@ -1,0 +1,10 @@
+SECTIONS {
+  text (0x16) : {
+    . = . + 4;
+    FILL(0xabababab)
+    . = . + 4;
+    FILL(0xbcbcbcbc)
+    . = . + 4;
+    *(.text*)
+  } =0xdeadbeef
+}


### PR DESCRIPTION
This commit fixes the incorrect padding value when both fill expression and fill command is specified for an output section. The issue was we were not evaluating the epilogue fill expression when the first rule contained a FILL command.

Resolves #352 