### PR TITLE
Fix missed code changes for linker detection of non contiguous tls se…

### DIFF
--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -5130,7 +5130,11 @@ bool GNULDBackend::setupTLS() {
   out = outBegin;
   while (out != outEnd) {
     auto sec = (*out)->getSection();
-    if (sec->isTLS() && (sec->size() > 0)) {
+    if (!sec->size()) {
+      out++;
+      continue;
+    }
+    if (sec->isTLS()) {
       if (seenTLS && !lastSectTLS) {
         config().raise(Diag::non_contiguous_TLS)
             << firstTLS->name() << sec->name();


### PR DESCRIPTION
…ctions

When the linker sees a empty non TLS section following a TLS section linker would error out specifying the image does not have contiguous TLS sections due to loader treating the TLS sections as part of the initial TLS image.

This change relaxes the condition to only flag the error if the sections are non empty

Resolves #393