### PR TITLE
Improve compatible checks for RISC-V

### DIFF
--- a/include/eld/Readers/ELFReader.h
+++ b/include/eld/Readers/ELFReader.h
@@ -99,6 +99,10 @@ protected:
   explicit ELFReader(Module &module, InputFile &inputFile,
                      plugin::DiagnosticEntry &diagEntry);
 
+  // Check if the file contains executable sections for
+  // compatibility checks on some ABI platforms
+  bool hasExecutableSections() const;
+
   /// Creates and returns an instance of llvm::object::ELFFile<ELFT> for the
   /// inputFile.
   static std::optional<llvm::object::ELFFile<ELFT>>

--- a/include/eld/Target/TargetInfo.h
+++ b/include/eld/Target/TargetInfo.h
@@ -59,7 +59,7 @@ public:
   virtual uint64_t startAddr(bool linkerScriptHasSectionsCommand,
                              bool isDynExec, bool loadPhdr) const = 0;
 
-  virtual bool checkFlags(uint64_t flags, const InputFile *pInput) const;
+  virtual bool checkFlags(uint64_t flags, const InputFile *pInput, bool) const;
 
   /// flags - the value of ElfXX_Ehdr::e_flags
   virtual uint64_t flags() const = 0;

--- a/lib/Target/Hexagon/HexagonInfo.cpp
+++ b/lib/Target/Hexagon/HexagonInfo.cpp
@@ -253,8 +253,8 @@ HexagonInfo::ArchSupport HexagonInfo::getArchSupport(uint64_t pFlag) const {
   return HexagonInfo::ArchSupport::NotSupported;
 }
 
-bool HexagonInfo::checkFlags(uint64_t pFlag,
-                             const InputFile *pInputFile) const {
+bool HexagonInfo::checkFlags(uint64_t pFlag, const InputFile *pInputFile,
+                             bool) const {
   if (!pFlag)
     return true;
 

--- a/lib/Target/Hexagon/HexagonInfo.h
+++ b/lib/Target/Hexagon/HexagonInfo.h
@@ -54,7 +54,8 @@ public:
 
   uint8_t OSABI() const override;
 
-  bool checkFlags(uint64_t flag, const InputFile *pInputFile) const override;
+  bool checkFlags(uint64_t flag, const InputFile *pInputFile,
+                  bool) const override;
 
   std::string flagString(uint64_t pFlag) const override;
 

--- a/lib/Target/RISCV/RISCVInfo.cpp
+++ b/lib/Target/RISCV/RISCVInfo.cpp
@@ -86,7 +86,13 @@ bool RISCVInfo::isCompatible(uint64_t pFlag, const std::string &pFile) const {
   return true;
 }
 
-bool RISCVInfo::checkFlags(uint64_t flag, const InputFile *pInputFile) const {
+bool RISCVInfo::checkFlags(uint64_t flag, const InputFile *pInputFile,
+                           bool hasExecutableSections) const {
+  // If flag is empty and no executable sections found in the ELF file
+  // skip checking for compatibility
+  if (!flag && !hasExecutableSections)
+    return true;
+
   // Choose the default architecture from the input files, only if mcpu option
   // is not specified on the command line.
   if ((m_CmdLineFlag == UNKNOWN) && (m_OutputFlag == UNKNOWN))

--- a/lib/Target/RISCV/RISCVInfo.h
+++ b/lib/Target/RISCV/RISCVInfo.h
@@ -26,7 +26,8 @@ public:
 
   uint8_t OSABI() const override;
 
-  bool checkFlags(uint64_t flag, const InputFile *pInputFile) const override;
+  bool checkFlags(uint64_t flag, const InputFile *pInputFile,
+                  bool hasExecutableSections) const override;
 
   std::string flagString(uint64_t pFlag) const override;
 

--- a/lib/Target/TargetInfo.cpp
+++ b/lib/Target/TargetInfo.cpp
@@ -87,7 +87,8 @@ const NameMap map[] = {
 //===----------------------------------------------------------------------===//
 TargetInfo::TargetInfo(LinkerConfig &pConfig) : m_Config(pConfig) {}
 
-bool TargetInfo::checkFlags(uint64_t flag, const InputFile *pInputFile) const {
+bool TargetInfo::checkFlags(uint64_t flag, const InputFile *pInputFile,
+                            bool) const {
   return true;
 }
 

--- a/lib/Target/Template/TemplateInfo.cpp
+++ b/lib/Target/Template/TemplateInfo.cpp
@@ -29,7 +29,7 @@ TemplateInfo::TemplateInfo(LinkerConfig &pConfig) : TargetInfo(pConfig) {
 
 uint64_t TemplateInfo::translateFlag(uint64_t pFlag) const { return pFlag; }
 
-bool TemplateInfo::checkFlags(uint64_t pFlag, const std::string &name) {
+bool TemplateInfo::checkFlags(uint64_t pFlag, const std::string &name, bool) {
   // Choose the default architecture from the input files, only if mcpu option
   // is not specified on the command line.
   if ((m_CmdLineFlag == UNKNOWN) && (m_OutputFlag == UNKNOWN)) {

--- a/lib/Target/Template/TemplateInfo.h
+++ b/lib/Target/Template/TemplateInfo.h
@@ -26,7 +26,7 @@ public:
 
   uint8_t OSABI() const override;
 
-  bool checkFlags(uint64_t flag, const std::string &name) override;
+  bool checkFlags(uint64_t flag, const std::string &name, bool) override;
 
   const char *flagString(uint64_t pFlag) const override;
 

--- a/lib/Target/x86_64/x86_64Info.cpp
+++ b/lib/Target/x86_64/x86_64Info.cpp
@@ -34,7 +34,8 @@ bool x86_64Info::isABIFlagSet(uint64_t inputFlag, uint32_t ABIFlag) const {
   return (inputFlag & ABIFlag) == ABIFlag;
 }
 
-bool x86_64Info::checkFlags(uint64_t pFlag, const InputFile *pInputFile) const {
+bool x86_64Info::checkFlags(uint64_t pFlag, const InputFile *pInputFile,
+                            bool) const {
   // Choose the default architecture from the input files, only if mcpu option
   // is not specified on the command line.
   if ((m_CmdLineFlag == UNKNOWN) && (m_OutputFlag == UNKNOWN)) {

--- a/lib/Target/x86_64/x86_64Info.h
+++ b/lib/Target/x86_64/x86_64Info.h
@@ -25,7 +25,8 @@ public:
 
   uint8_t OSABI() const override;
 
-  bool checkFlags(uint64_t flag, const InputFile *pInputFile) const override;
+  bool checkFlags(uint64_t flag, const InputFile *pInputFile,
+                  bool) const override;
 
   std::string flagString(uint64_t pFlag) const override;
 

--- a/test/RISCV/standalone/EFlags/EFlags.test
+++ b/test/RISCV/standalone/EFlags/EFlags.test
@@ -1,0 +1,17 @@
+UNSUPPORTED: riscv64
+#----------EFlags.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+# This checks that the linker will error out appropriately when mixing
+# object files with incompatible flags
+#END_COMMENT
+#START_TEST
+RUN: %yaml2obj %p/Inputs/emptyelf.yaml -o %t.emptyelf.o
+RUN: %clang %clangopts -mabi=ilp32f -c %p/Inputs/1.c -o %t.1.o
+RUN: %eld %t.emptyelf.o %t.1.o -o %t1.out
+RUN: %readelf -h %t1.out | %filecheck %s -check-prefix=EFLAGS
+RUN: %yaml2obj %p/Inputs/flagszero_with_exec_sections.yaml -o %t.f.o
+RUN: %not %eld %t.f.o %t.1.o -o %t1.out 2>&1 | %filecheck %s
+#END_TEST
+
+EFLAGS: Flags: 0x3
+CHECK: Error: Incompatible object files when reading {{.*}}1.o

--- a/test/RISCV/standalone/EFlags/Inputs/1.c
+++ b/test/RISCV/standalone/EFlags/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 0; }

--- a/test/RISCV/standalone/EFlags/Inputs/emptyelf.yaml
+++ b/test/RISCV/standalone/EFlags/Inputs/emptyelf.yaml
@@ -1,0 +1,15 @@
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS32
+  Data:            ELFDATA2LSB
+  Type:            ET_EXEC
+  Machine:         EM_RISCV
+  Flags:           [ ]
+ProgramHeaders:
+  - Type:            PT_LOAD
+    Flags:           [ PF_X, PF_R ]
+    Align:           0x1000
+    Offset:          0x0
+Sections:
+Symbols:
+...

--- a/test/RISCV/standalone/EFlags/Inputs/flagszero_with_exec_sections.yaml
+++ b/test/RISCV/standalone/EFlags/Inputs/flagszero_with_exec_sections.yaml
@@ -1,0 +1,21 @@
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS32
+  Data:            ELFDATA2LSB
+  Type:            ET_EXEC
+  Machine:         EM_RISCV
+  Flags:           [ ]
+ProgramHeaders:
+  - Type:            PT_LOAD
+    Flags:           [ PF_X, PF_R ]
+    Align:           0x1000
+    Offset:          0x0
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    AddressAlign:    0x4
+    EntSize:         0x4
+    Content:         20
+Symbols:
+...


### PR DESCRIPTION
The psabi has a note under
https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc# elf-object-files that "The static linker may ignore the compatibility checks if all fields in the e_flags are zero and all sections in the input file are non-executable sections."

Currently, eld produces errors for the reproducers below which I think are reasonable enough patterns and don't have great workarounds short of manually editing the binary blob elfs.

Resolves #407