### PR TITLE
[NFC] Add eflags tests

### DIFF
--- a/test/ARM/standalone/EFlags/eflags.test
+++ b/test/ARM/standalone/EFlags/eflags.test
@@ -1,0 +1,17 @@
+#<SYMDEFS>#
+#DO NOT EDIT#
+0x0	FUNC	foo
+
+#---eflags.test--------------------------- Executable --------------------#
+#BEGIN_COMMENT
+# Check that eflags are emitted for empty.o files and symdef files
+#END_COMMENT
+#START_TEST
+#RUN: %rm -f %t.o
+#RUN: %touch %t.o
+#RUN: %link %emulation %t.o -o %t.empty
+#RUN: %link %emulation %s -o %t.symdef
+#RUN: %readelf -h %t.empty | %filecheck %s
+#RUN: %readelf -h %t.symdef | %filecheck %s
+#END_TEST
+#CHECK: Flags: 0x5000000

--- a/test/Hexagon/standalone/EFlags/eflags.test
+++ b/test/Hexagon/standalone/EFlags/eflags.test
@@ -1,0 +1,17 @@
+#<SYMDEFS>#
+#DO NOT EDIT#
+0x0	FUNC	foo
+
+#---eflags.test--------------------------- Executable --------------------#
+#BEGIN_COMMENT
+# Check that eflags are emitted for empty.o files and symdef files
+#END_COMMENT
+#START_TEST
+#RUN: %rm -f %t.o
+#RUN: %touch %t.o
+#RUN: %link -mv75 %t.o -o %t.empty
+#RUN: %link -mv75 %s -o %t.symdef
+#RUN: %readelf -h %t.empty | %filecheck %s
+#RUN: %readelf -h %t.symdef | %filecheck %s
+#END_TEST
+#CHECK: Flags: 0x75


### PR DESCRIPTION
Tests that arch flags are retained with symdef files and empty .o files.