### PR TITLE
Fix hexagon linux test failures.

### DIFF
--- a/test/Hexagon/linux/LTO/LTOCommonSymbols/Inputs/script.t
+++ b/test/Hexagon/linux/LTO/LTOCommonSymbols/Inputs/script.t
@@ -6,5 +6,6 @@ SECTIONS {
 .allcommons : { *(COMMON) }
 .allnote : { *(.note*) }
 .comment : { *(.comment) }
+.hexagon.attributes : { *(.hexagon.attributes) }
 .unrecognized : { *(*) }
 }

--- a/test/Hexagon/linux/MoveCommonsToBSS/movecommon-to-bss.test
+++ b/test/Hexagon/linux/MoveCommonsToBSS/movecommon-to-bss.test
@@ -1,8 +1,8 @@
 #FIXME: How does this test checks that commons are moved to bss?
 # Test that commons are moved to bss, and commons appear at the end.
-RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o
-RUN: %clang %clangopts -c %p/Inputs/2.c -o %t2.o
-RUN: %link %linkopts %t1.o %t2.o -o %t.out 2>&1
+RUN: %clang %clangg0opts -c %p/Inputs/1.c -o %t1.o
+RUN: %clang %clangg0opts -c %p/Inputs/2.c -o %t2.o
+RUN: %link %linkg0opts %t1.o %t2.o -o %t.out 2>&1
 RUN: %readelf -s %t.out | %grep -E 'common|bss' | %filecheck %s
 
 #CHECK: {{[0-9]+}}: {{[x0-9a-z]+}}     4 OBJECT  GLOBAL DEFAULT    1 bss

--- a/test/Hexagon/linux/TLS/headers/headers.test
+++ b/test/Hexagon/linux/TLS/headers/headers.test
@@ -1,18 +1,18 @@
 # Test that correst program headers are generated for thread templates
 # .tbss .tdata and .data are considered in different combinations to
 # cover enough code and make sure all cases work.
-RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o
-RUN: %clang %clangopts -c %p/Inputs/2.c -o %t2.o
-RUN: %clang %clangopts -c %p/Inputs/3.c -o %t3.o
-RUN: %clang %clangopts -c %p/Inputs/4.c -o %t4.o
-RUN: %clang %clangopts -c %p/Inputs/5.c -o %t5.o
-RUN: %clang %clangopts -c %p/Inputs/6.c -o %t6.o
-RUN: %link %linkopts -mtriple hexagon-unknown-linux-elf -o %t1.out %t1.o --noinhibit-exec -G0 2>&1
-RUN: %link %linkopts -mtriple hexagon-unknown-linux-elf -o %t2.out %t2.o --noinhibit-exec -G0 2>&1
-RUN: %link %linkopts -mtriple hexagon-unknown-linux-elf -o %t3.out %t3.o --noinhibit-exec -G0 2>&1
-RUN: %link %linkopts -mtriple hexagon-unknown-linux-elf -o %t4.out %t4.o --noinhibit-exec -G0 2>&1
-RUN: %link %linkopts -mtriple hexagon-unknown-linux-elf -o %t5.out %t5.o --noinhibit-exec -G0 2>&1
-RUN: %link %linkopts -mtriple hexagon-unknown-linux-elf -o %t6.out %t6.o --noinhibit-exec -G0 2>&1
+RUN: %clang %clangg0opts -c %p/Inputs/1.c -o %t1.o
+RUN: %clang %clangg0opts -c %p/Inputs/2.c -o %t2.o
+RUN: %clang %clangg0opts -c %p/Inputs/3.c -o %t3.o
+RUN: %clang %clangg0opts -c %p/Inputs/4.c -o %t4.o
+RUN: %clang %clangg0opts -c %p/Inputs/5.c -o %t5.o
+RUN: %clang %clangg0opts -c %p/Inputs/6.c -o %t6.o
+RUN: %link %linkg0opts -mtriple hexagon-unknown-linux-elf -o %t1.out %t1.o --noinhibit-exec -G0 2>&1
+RUN: %link %linkg0opts -mtriple hexagon-unknown-linux-elf -o %t2.out %t2.o --noinhibit-exec -G0 2>&1
+RUN: %link %linkg0opts -mtriple hexagon-unknown-linux-elf -o %t3.out %t3.o --noinhibit-exec -G0 2>&1
+RUN: %link %linkg0opts -mtriple hexagon-unknown-linux-elf -o %t4.out %t4.o --noinhibit-exec -G0 2>&1
+RUN: %link %linkg0opts -mtriple hexagon-unknown-linux-elf -o %t5.out %t5.o --noinhibit-exec -G0 2>&1
+RUN: %link %linkg0opts -mtriple hexagon-unknown-linux-elf -o %t6.out %t6.o --noinhibit-exec -G0 2>&1
 # Check that the first load segment has offset that begins with 0.
 RUN: %readelf -l -W %t1.out | %filecheck %s --check-prefix="LOADPHDR"
 RUN: %readelf -l -S -s -W %t1.out |   %filecheck %s --check-prefix="ALL"

--- a/test/Hexagon/linux/alignSegments/alignSegment.test
+++ b/test/Hexagon/linux/alignSegments/alignSegment.test
@@ -1,5 +1,5 @@
-RUN: %clang %clangopts -c  %p/Inputs/1.c -o %t1.o
-RUN: %link %linkopts %t1.o -o %t2 -mtriple hexagon-unknown-linux -z max-page-size=4096
+RUN: %clang %clangg0opts -c  %p/Inputs/1.c -o %t1.o
+RUN: %link %linkg0opts %t1.o -o %t2 -mtriple hexagon-unknown-linux -z max-page-size=4096
 RUN: %readelf -l -W %t2 | %filecheck %s
 
 #CHECK:  LOAD           0x000000 {{.*}} 0x0008c 0x0008c R E 0x1000

--- a/test/Hexagon/linux/forceDynamic/forceDynamic.test
+++ b/test/Hexagon/linux/forceDynamic/forceDynamic.test
@@ -1,5 +1,5 @@
-RUN: %clang %clangopts -c  %p/Inputs/1.c -o %t1.o
-RUN: %link %linkopts --rosegment %t1.o -o %t2 -mtriple hexagon-unknown-linux --force-dynamic -z max-page-size=4096
+RUN: %clang %clangg0opts -c  %p/Inputs/1.c -o %t1.o
+RUN: %link %linkg0opts --rosegment %t1.o -o %t2 -mtriple hexagon-unknown-linux --force-dynamic -z max-page-size=4096
 RUN: %readelf -l -W %t2 | %filecheck %s
 
 #CHECK:  PHDR           0x000034 0x00400034 0x00400034 0x000e0 0x000e0 R E

--- a/test/Hexagon/linux/scommon/scommon.test
+++ b/test/Hexagon/linux/scommon/scommon.test
@@ -1,7 +1,7 @@
 # Check that common symbols when resolved are put in the proper section
-RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o
-RUN: %clang %clangopts -c %p/Inputs/2.c -o %t2.o
-RUN: %link %linkopts %t1.o %t2.o -o %t3.out -G0 -z max-page-size=4096
+RUN: %clang %clangg0opts -c %p/Inputs/1.c -o %t1.o
+RUN: %clang %clangg0opts -c %p/Inputs/2.c -o %t2.o
+RUN: %link %linkg0opts %t1.o %t2.o -o %t3.out -G0 -z max-page-size=4096
 RUN: %readelf -S %t3.out | %filecheck %s
 
 #CHECK:  [ 1] .bss            NOBITS        {{.*}} 000004


### PR DESCRIPTION
This commit fixes below failing tests:
 - LTOCommonSymbols.test
 - movecommon-to-bss.test
 - TLS/headers.test
 - alignSegment.test
 - forceDynamic.test
 - scommon.test