### PR TITLE
Emit text map-file even when the link crashes

### DIFF
--- a/include/eld/LayoutMap/TextLayoutPrinter.h
+++ b/include/eld/LayoutMap/TextLayoutPrinter.h
@@ -84,6 +84,8 @@ public:
   /// called before section-merging.
   void printRuleMatchingInfo(Module &Module);
 
+  void flush();
+
 private:
   void printChangeOutputSectionInfo(const ELFSection *S) const;
 

--- a/lib/LayoutMap/TextLayoutPrinter.cpp
+++ b/lib/LayoutMap/TextLayoutPrinter.cpp
@@ -1346,9 +1346,16 @@ void TextLayoutPrinter::printLayout(eld::Module &Module) {
   }
 }
 
-TextLayoutPrinter::~TextLayoutPrinter() {
-  if (Buffer)
+void TextLayoutPrinter::flush() {
+  if (Buffer) {
     (*LayoutFile) << Buffer->str();
+    Buffer->str().clear();
+    (*LayoutFile).flush();
+  }
+}
+
+TextLayoutPrinter::~TextLayoutPrinter() {
+  flush();
 }
 
 void TextLayoutPrinter::clearInputRecords() {

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -1571,6 +1571,15 @@ void GnuLdDriver::defaultSignalHandler(void *cookie) {
   else if (!DiagEngine->isUsable()) {
     DiagEngineUsable = false;
   }
+
+  TextLayoutPrinter *printer = ThisModule->getTextMapPrinter();
+  if (printer) {
+    printer->printMapFile(*ThisModule);
+    // We have to explicitly flush because in the case of crash, objects
+    // are not freed, and we write the map-file to disk during destruction.
+    printer->flush();
+  }
+
   std::string commandLine = "";
   for (auto arg : ThisModule->getConfig().options().args()) {
     if (arg) {

--- a/test/Common/CMakeLists.txt
+++ b/test/Common/CMakeLists.txt
@@ -1,2 +1,10 @@
+add_custom_target(CommonPluginUnitTests)
+set_target_properties(CommonPluginUnitTests PROPERTIES FOLDER
+                                                       "plugin unit tests")
+
+function(add_common_plugin pluginname)
+  add_dependencies(CommonPluginUnitTests ${pluginname})
+endfunction()
+
 add_subdirectory(standalone)
 add_subdirectory(Plugin)

--- a/test/Common/Plugin/CMakeLists.txt
+++ b/test/Common/Plugin/CMakeLists.txt
@@ -1,11 +1,3 @@
-add_custom_target(CommonPluginUnitTests)
-set_target_properties(CommonPluginUnitTests PROPERTIES FOLDER
-                                                       "plugin unit tests")
-
-function(add_common_plugin pluginname)
-  add_dependencies(CommonPluginUnitTests ${pluginname})
-endfunction()
-
 # Add HelloWorldPlugin as a test dependency!
 add_common_plugin(HelloWorldPlugin)
 

--- a/test/Common/standalone/CMakeLists.txt
+++ b/test/Common/standalone/CMakeLists.txt
@@ -1,2 +1,3 @@
+add_subdirectory(EmitMapFileEvenInCrash)
 add_subdirectory(PluginAPI)
 add_subdirectory(SymbolResolutionReport)

--- a/test/Common/standalone/EmitMapFileEvenInCrash/CMakeLists.txt
+++ b/test/Common/standalone/EmitMapFileEvenInCrash/CMakeLists.txt
@@ -1,0 +1,21 @@
+set(SOURCES CrashPlugin.cpp)
+
+if(NOT CYGWIN AND LLVM_ENABLE_PIC)
+  set(SHARED_LIB_SOURCES ${SOURCES})
+
+  set(bsl ${BUILD_SHARED_LIBS})
+
+  set(BUILD_SHARED_LIBS ON)
+
+  add_llvm_library(CrashPlugin ${SHARED_LIB_SOURCES} LINK_LIBS
+                   LW)
+
+  set_target_properties(
+    CrashPlugin
+    PROPERTIES LIBRARY_OUTPUT_DIRECTORY
+               "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/test")
+
+  set(BUILD_SHARED_LIBS ${bsl})
+endif()
+
+add_common_plugin(CrashPlugin)

--- a/test/Common/standalone/EmitMapFileEvenInCrash/CrashPlugin.cpp
+++ b/test/Common/standalone/EmitMapFileEvenInCrash/CrashPlugin.cpp
@@ -1,0 +1,15 @@
+#include "PluginVersion.h"
+#include "LinkerPlugin.h"
+#include <cassert>
+#include <iostream>
+
+class ActBeforeRuleMatchingPlugin : public eld::plugin::LinkerPlugin {
+public:
+  ActBeforeRuleMatchingPlugin()
+      : eld::plugin::LinkerPlugin("ActBeforeRuleMatchingPlugin") {}
+  void ActBeforeWritingOutput() override {
+    assert(false && "CrashPlugin caused a crash!");
+  }
+};
+
+ELD_REGISTER_PLUGIN(ActBeforeRuleMatchingPlugin)

--- a/test/Common/standalone/EmitMapFileEvenInCrash/EmitMapFileEvenInCrash.test
+++ b/test/Common/standalone/EmitMapFileEvenInCrash/EmitMapFileEvenInCrash.test
@@ -1,0 +1,18 @@
+#---EmitMapFileEvenInCrash.test----------------------- Executable,LS --------------------#
+#BEGIN_COMMENT
+# This test verifies that the linker emits map-file even when the link crashes
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
+RUN: %not %link %linkopts -o %t1.1.out %t1.1.o -L%libsdir/test --plugin-config \
+RUN:   %p/Inputs/PluginConfig.yaml -Map %t1.1.map || true
+RUN: %filecheck %s < %t1.1.map
+#END_TEST
+
+CHECK: Linker based on
+CHECK: Linker Plugin Information
+CHECK: Linker Plugins
+CHECK: CrashPlugin
+CHECK: Output Section and Layout
+CHECK: .text.foo
+CHECK: .text.bar

--- a/test/Common/standalone/EmitMapFileEvenInCrash/Inputs/1.c
+++ b/test/Common/standalone/EmitMapFileEvenInCrash/Inputs/1.c
@@ -1,0 +1,2 @@
+int foo() { return 1; }
+int bar() { return 3; }

--- a/test/Common/standalone/EmitMapFileEvenInCrash/Inputs/PluginConfig.yaml
+++ b/test/Common/standalone/EmitMapFileEvenInCrash/Inputs/PluginConfig.yaml
@@ -1,0 +1,4 @@
+GlobalPlugins:
+  - Type: LinkerPlugin
+    Name: CrashPlugin
+    Library: CrashPlugin


### PR DESCRIPTION
This commit modifies the signal handler to emit text map-file if it is requested by the user.

Resolves #425