### PR TITLE
Use -G0 in MagicSectionSymbols test

### DIFF
--- a/test/Common/standalone/MagicSectionSymbols/MagicSectionSymbols.test
+++ b/test/Common/standalone/MagicSectionSymbols/MagicSectionSymbols.test
@@ -3,9 +3,9 @@
 # This test checks that start and end symbols for magic sections .eh_frame and .eh_frame_hdr are defined by the linker
 #END_COMMENT
 #START_TEST
-RUN: %clang %clangopts -o %t.o -c %p/Inputs/1.c
-RUN: %link %linkopts -o %t1.out %t.o
-RUN: %link %linkopts -o %t2.out %t.o -T %p/Inputs/script.ld
+RUN: %clang %clangg0opts -o %t.o -c %p/Inputs/1.c
+RUN: %link %linkg0opts -o %t1.out %t.o
+RUN: %link %linkg0opts -o %t2.out %t.o -T %p/Inputs/script.ld
 RUN: %readelf -s %t1.out | %filecheck %s --check-prefix=NOSCRIPT
 RUN: %readelf -s %t2.out | %filecheck %s --check-prefix=SCRIPT
 #END_TEST


### PR DESCRIPTION
This commit modifies the MagicSectionSymbols test to use -G0 for compiling and linking. This is required to make the test pass for platforms that use different semantics for small data.