### PR TITLE
Correctly store isQuoted info for tokens that are stored as StrToken

### DIFF
--- a/include/eld/Object/ScriptMemoryRegion.h
+++ b/include/eld/Object/ScriptMemoryRegion.h
@@ -83,6 +83,10 @@ public:
   // Retrieve the name of the memory region
   std::string getName() const;
 
+  // Retrieve the name of the memory region along with quotes if they were
+  // present in the linker scripts.
+  std::string getDecoratedName() const;
+
   // Check if the output section contains a VMA address specified by the
   // user for any override. If the VMA is within the memory region it will
   // be included, if not it will not be part of the image layout but not

--- a/include/eld/Script/MemoryDesc.h
+++ b/include/eld/Script/MemoryDesc.h
@@ -27,6 +27,12 @@ struct MemorySpec {
 
   const std::string getMemoryDescriptor() const { return Name->name(); }
 
+  /// Returns the memory descriptor along with quotes if they were
+  /// present in the input.
+  std::string getDecoratedMemoryDescriptor() const {
+    return Name->getDecoratedName();
+  }
+
   const std::string getMemoryAttributes() const {
     if (MemoryAttributesString)
       return MemoryAttributesString->name();

--- a/include/eld/Script/SymbolContainer.h
+++ b/include/eld/Script/SymbolContainer.h
@@ -24,6 +24,10 @@ public:
 
   llvm::StringRef getWildcardPatternAsString() const;
 
+  /// Returns wildcard pattern along with quotes if they were present in the
+  /// input.
+  std::string getDecoratedWildcardPattern() const;
+
   bool isEmpty() { return MMatchedSymbols.empty(); }
 
   void dump(llvm::raw_ostream &Ostream,

--- a/include/eld/ScriptParser/ScriptParser.h
+++ b/include/eld/ScriptParser/ScriptParser.h
@@ -217,6 +217,8 @@ private:
   /// '{' in between the pattern, as this case, would not be possible with
   /// LexState::Default.
   bool isValidSectionPattern(llvm::StringRef Pat);
+
+  StrToken *readName(llvm::StringRef Name);
 };
 } // namespace v2
 } // namespace eld

--- a/lib/LayoutMap/TextLayoutPrinter.cpp
+++ b/lib/LayoutMap/TextLayoutPrinter.cpp
@@ -220,14 +220,14 @@ void TextLayoutPrinter::printMemoryRegions(GNULDBackend const &Backend,
   if (!OS->epilog().hasRegion())
     return;
 
-  std::string VMARegionName = OS->epilog().region().getName();
+  std::string VMARegionName = OS->epilog().region().getDecoratedName();
   std::optional<std::string> LMARegionName;
   // If LMA is set on the output section those sections are not
   // added to the default LMA region which is nothing but the
   // alias VMA region
   if (!OS->prolog().hasLMA()) {
     if (OS->epilog().hasLMARegion())
-      LMARegionName = OS->epilog().lmaRegion().getName();
+      LMARegionName = OS->epilog().lmaRegion().getDecoratedName();
     else
       LMARegionName = VMARegionName;
   }
@@ -961,7 +961,7 @@ void TextLayoutPrinter::printExternList(Module &CurModule, bool UseColor) {
     for (const SymbolContainer *SymContainer :
          llvm::cast<ExternCmd>(Cmd)->getSymbolContainers()) {
       outputStream() << "Pattern: "
-                     << SymContainer->getWildcardPatternAsString() << "\n";
+                     << SymContainer->getDecoratedWildcardPattern() << "\n";
 
       SymContainer->dump(outputStream(), GetDecoratedPath);
     }

--- a/lib/Object/ScriptMemoryRegion.cpp
+++ b/lib/Object/ScriptMemoryRegion.cpp
@@ -226,6 +226,12 @@ std::string ScriptMemoryRegion::getName() const {
   return getMemoryDesc()->getMemorySpec()->getMemoryDescriptor();
 }
 
+std::string ScriptMemoryRegion::getDecoratedName() const {
+  return getMemoryDesc()
+      ->getMemorySpec()
+      ->getDecoratedMemoryDescriptor();
+}
+
 bool ScriptMemoryRegion::containsVMA(uint64_t Addr) const {
   uint64_t Origin = getOrigin().value();
   uint64_t Length = getLength().value();

--- a/lib/Script/MemoryDesc.cpp
+++ b/lib/Script/MemoryDesc.cpp
@@ -22,7 +22,7 @@ MemoryDesc::MemoryDesc(const MemorySpec &PSpec)
 
 
 void MemoryDesc::dump(llvm::raw_ostream &Outs) const {
-  Outs << InputSpec.getMemoryDescriptor();
+  Outs << InputSpec.getDecoratedMemoryDescriptor();
   Outs << " " << InputSpec.getMemoryAttributes();
   Outs << " ORIGIN = ";
   InputSpec.getOrigin()->dump(Outs);

--- a/lib/Script/ScriptFile.cpp
+++ b/lib/Script/ScriptFile.cpp
@@ -541,7 +541,7 @@ ScriptFile::createWildCardPattern(StrToken *S, WildcardPattern::SortPolicy P,
 
 WildcardPattern *ScriptFile::createWildCardPattern(
     llvm::StringRef S, WildcardPattern::SortPolicy P, ExcludeFiles *E) {
-  StrToken *Tok = createStrToken(S.str());
+  StrToken *Tok = createParserStr(S);
   return createWildCardPattern(Tok, P, E);
 }
 

--- a/lib/Script/SymbolContainer.cpp
+++ b/lib/Script/SymbolContainer.cpp
@@ -28,3 +28,7 @@ void SymbolContainer::dump(
 llvm::StringRef SymbolContainer::getWildcardPatternAsString() const {
   return MStrToken.name();
 }
+
+std::string SymbolContainer::getDecoratedWildcardPattern() const {
+  return MStrToken.getDecoratedName();
+}

--- a/test/Common/standalone/linkerscript/PreserveQuotes/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/PreserveQuotes/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/Common/standalone/linkerscript/PreserveQuotes/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/PreserveQuotes/Inputs/script.t
@@ -1,0 +1,16 @@
+MEMORY {
+  "RAM REGION" : ORIGIN = 0x1000, LENGTH = 0x3000
+}
+
+REGION_ALIAS("RAM ALIAS", "RAM REGION")
+
+SECTIONS {
+  .foo (0x1000) : {
+    *(.text.foo)
+    *(.text)
+    *(.ARM.exidx)
+  } >"RAM REGION"
+  . = 0x2000;
+  .bar : { *(.text.bar) } >"RAM ALIAS"
+  .data (0x2000) : { *(.data) } >"RAM REGION"
+}

--- a/test/Common/standalone/linkerscript/PreserveQuotes/PreserveQuotes.test
+++ b/test/Common/standalone/linkerscript/PreserveQuotes/PreserveQuotes.test
@@ -1,0 +1,21 @@
+#---PreserveQuotes.test--------------------- Executable,LS------------------#
+#BEGIN_COMMENT
+# This test checks that the linker preserves quotes in the linker script for
+# some selected commands.
+# Quotes are only preserved for some of the linker script commands. These commands
+# includes:
+#   - NOCROSSREFS
+#   - MEMORY
+#   - REGION_ALIAS
+#END_COMMENT
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c
+RUN: %link -MapStyle txt %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t -Map %t1.1.map.txt
+RUN: %filecheck %s < %t1.1.map.txt
+
+CHECK: # Output Section and Layout
+CHECK: # MEMORY
+CHECK: #{
+CHECK: #       "RAM REGION"  ORIGIN = 0x1000 ,  LENGTH = 0x3000
+CHECK: #}
+CHECK: .foo {{.*}}
+CHECK: Memory : ["RAM REGION", "RAM REGION"]


### PR DESCRIPTION
This commit modifies the script parser to properly store isQuoted information wherever tokens are stored as StrToken objects.

Resolves #441 