### PR TITLE
[NFC] Remove Input::releaseMemory

### DIFF
--- a/include/eld/Input/ArchiveFile.h
+++ b/include/eld/Input/ArchiveFile.h
@@ -111,12 +111,7 @@ public:
 
   void setNoExport(bool NoExport = true) { BNoExport = NoExport; }
 
-  /// ------------------------Release Memory ---------------------------
-  void releaseMemory(bool IsVerbose = false);
-
   virtual ~ArchiveFile() = default;
-
-  bool isAlreadyReleased() const;
 
   size_t getLoadedMemberCount() const;
 

--- a/include/eld/Input/BitcodeFile.h
+++ b/include/eld/Input/BitcodeFile.h
@@ -53,11 +53,6 @@ public:
 
   std::unique_ptr<llvm::lto::InputFile> takeLTOInputFile();
 
-  /// Release Memory
-  bool canReleaseMemory() const;
-
-  void releaseMemory(bool IsVerbose = false);
-
   // --------- Comdat Table -------------------------
   bool findIfKeptComdat(int Index) const {
     if (Index == -1) /* Not a part of group */

--- a/include/eld/Input/Input.h
+++ b/include/eld/Input/Input.h
@@ -144,11 +144,6 @@ public:
 
   void setName(std::string N) { Name = N; }
 
-  /// -----------------------Release Memory-------------------------
-  void releaseMemory(bool IsVerbose = false);
-
-  bool isAlreadyReleased() const { return IsReleased; }
-
   /// --------------------- WildcardPattern ------------------------
   void addFileMatchedPattern(const WildcardPattern *W, bool R) {
     FilePatternMap[W] = R;
@@ -201,7 +196,6 @@ protected:
   uint64_t ResolvedPathHash = 0;
   uint64_t MemberNameHash = 0;
   InputType Type = Default; // The type of input file.
-  bool IsReleased = false;
   bool TraceMe = false;
   llvm::DenseMap<const WildcardPattern *, bool> FilePatternMap;
   llvm::DenseMap<const WildcardPattern *, bool> MemberPatternMap;

--- a/lib/Input/ArchiveFile.cpp
+++ b/lib/Input/ArchiveFile.cpp
@@ -82,17 +82,6 @@ Input *ArchiveFile::createMemberInput(llvm::StringRef MemberName,
   return Inp;
 }
 
-void ArchiveFile::releaseMemory(bool IsVerbose) {
-  if (isELFArchive())
-    return;
-  if (I)
-    I->releaseMemory(IsVerbose);
-}
-
-bool ArchiveFile::isAlreadyReleased() const {
-  return I && I->isAlreadyReleased();
-}
-
 // Returns all members of the archive file.
 const std::vector<Input *> &ArchiveFile::getAllMembers() const {
   ASSERT(AFI, "AFI must not be null!");

--- a/lib/Input/Input.cpp
+++ b/lib/Input/Input.cpp
@@ -12,14 +12,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "eld/Config/LinkerConfig.h"
-#include "eld/Diagnostics/DiagnosticPrinter.h"
 #include "eld/Input/InputFile.h"
 #include "eld/Input/InputTree.h"
 #include "eld/Script/WildcardPattern.h"
-#include "eld/Support/INIReader.h"
 #include "eld/Support/MsgHandling.h"
 #include "llvm/ADT/Hashing.h"
-#include "llvm/Object/ELFObjectFile.h"
 #include "llvm/Support/FileSystem.h"
 #include <filesystem>
 
@@ -165,18 +162,7 @@ llvm::StringRef Input::getFileContents() const {
   return MemArea->getContents();
 }
 
-void Input::releaseMemory(bool IsVerbose) {
-  if (IsVerbose)
-    DiagEngine->raise(Diag::release_file) << decoratedPath();
-  IsReleased = true;
-}
-
-Input::~Input() {
-  if (isArchiveMember())
-    return;
-  releaseMemory(false);
-  IF = nullptr;
-}
+Input::~Input() { IF = nullptr; }
 
 void Input::addMemberMatchedPattern(const WildcardPattern *W, bool R) {
   MemberPatternMap[W] = R;

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -252,8 +252,6 @@ bool ObjectLinker::readInputs(const std::vector<Node *> &InputVector) {
       ThisModule->setFailure(true);
       return false;
     }
-    if (Input->isAlreadyReleased())
-      continue;
     if (!readAndProcessInput(Input, MPostLtoPhase))
       return false;
     if (Input->getInputFile()->getKind() == InputFile::GNULinkerScriptKind) {
@@ -3244,10 +3242,6 @@ bool ObjectLinker::insertPostLTOELF() {
         BitcodeObject = (*Obj);
         BitcodeObj = Obj;
       }
-      // Release memory with Any Bitcode files.
-      BitcodeFile *BCFile = llvm::dyn_cast<eld::BitcodeFile>(*Obj);
-      if (BCFile && BCFile->canReleaseMemory())
-        BCFile->releaseMemory(ThisModule->getPrinter()->isVerbose());
     }
   }
 
@@ -3416,8 +3410,6 @@ void ObjectLinker::addInputFileToTar(InputFile *Ipt, MappingFile::Kind K) {
 
 bool ObjectLinker::readAndProcessInput(Input *Input, bool IsPostLto) {
   if (Input->isInternal())
-    return true;
-  if (Input->isAlreadyReleased())
     return true;
   if (!Input->getSize())
     ThisConfig.raise(Diag::input_file_has_zero_size) << Input->decoratedPath();

--- a/test/Common/LTO/EmbeddedBCVerbose/EmbeddedBCVerbose.test
+++ b/test/Common/LTO/EmbeddedBCVerbose/EmbeddedBCVerbose.test
@@ -10,4 +10,3 @@ RUN: %clang %embedclangopts -c -fembed-bitcode %p/Inputs/1.c -o %t1.1.o
 RUN: %link %linkopts  -flto -o %t.out %t1.1.o --verbose=1 2>&1 | %filecheck %s
 
 CHECK: Verbose: Using embedded bitcode section from file
-CHECK-DAG:  Release memory for file

--- a/test/Common/LTO/WholeArchiveLTO/wholeArchiveLTO.test
+++ b/test/Common/LTO/WholeArchiveLTO/wholeArchiveLTO.test
@@ -3,10 +3,8 @@
 RUN: %clang %clangopts -c %p/Inputs/main.c -flto -o %t1.main.o
 RUN: %clang %clangopts -c %p/Inputs/foo.c -o %t2.foo.o
 RUN: %ar %aropts cr %t1.libfoo.a %t2.foo.o
-RUN: %link %linkopts --whole-archive %t1.main.o %t1.libfoo.a --no-whole-archive -e main -o %t2.out --verbose 2>&1 | %filecheck %s -check-prefix=RELEASEMEM
+RUN: %link %linkopts --whole-archive %t1.main.o %t1.libfoo.a --no-whole-archive -e main -o %t2.out
 RUN: %readelf -s %t2.out | %filecheck %s
-
-#RELEASEMEM: Release memory for file {{.*}}main.o
 
 #CHECK: {{[0-9a-f]+}}: {{[0-9a-f]+}}    {{[0-9a-f]+}} FUNC    GLOBAL DEFAULT    {{[0-9a-f]+}} main
 #CHECK: {{[0-9a-f]+}}: {{[0-9a-f]+}}    {{[0-9a-f]+}} FUNC    GLOBAL DEFAULT    {{[0-9a-f]+}} foo


### PR DESCRIPTION
This function does not actually release any memory.

Fixes #73.