### PR TITLE
Add missing cstdint includes

### DIFF
--- a/include/eld/Plugin/PluginOp.h
+++ b/include/eld/Plugin/PluginOp.h
@@ -7,6 +7,7 @@
 #ifndef ELD_PLUGIN_PLUGINOP_H
 #define ELD_PLUGIN_PLUGINOP_H
 
+#include <cstdint>
 #include <string>
 
 namespace eld::plugin {

--- a/include/eld/PluginAPI/DWARF.h
+++ b/include/eld/PluginAPI/DWARF.h
@@ -9,6 +9,7 @@
 #define ELD_PLUGINAPI_DWARF_H
 
 #include "Defines.h"
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/include/eld/PluginAPI/DiagnosticEntry.h
+++ b/include/eld/PluginAPI/DiagnosticEntry.h
@@ -7,6 +7,7 @@
 #ifndef ELD_PLUGINAPI_DIAGNOSTIC_ENTRY_H
 #define ELD_PLUGINAPI_DIAGNOSTIC_ENTRY_H
 #include "Defines.h"
+#include <cstdint>
 #include <limits>
 #include <string>
 #include <vector>

--- a/include/eld/PluginAPI/LinkerScript.h
+++ b/include/eld/PluginAPI/LinkerScript.h
@@ -8,6 +8,7 @@
 #define ELD_PLUGINAPI_LINKERSCRIPT_H
 
 #include "Defines.h"
+#include <cstdint>
 #include <ostream>
 #include <string>
 #include <vector>

--- a/include/eld/Support/Utils.h
+++ b/include/eld/Support/Utils.h
@@ -6,6 +6,7 @@
 #ifndef ELD_SUPPORT_UTILS_H
 #define ELD_SUPPORT_UTILS_H
 
+#include <cstdint>
 #include <string>
 
 namespace eld {


### PR DESCRIPTION
Adds the missing `cstdint` headers, without which building `eld` with `llvm` using `LLVM_EXTERNAL_PROJECTS` fails.

Fixes #446