### PR TITLE
[NFC] Remove empty ScriptCommand subclasses destructors

### DIFF
--- a/include/eld/Script/Assignment.h
+++ b/include/eld/Script/Assignment.h
@@ -47,7 +47,7 @@ public:
   Assignment(Level AssignmentLevel, Type AssignmentType, std::string Symbol,
              Expression *ScriptExpression);
 
-  ~Assignment();
+
 
   Level level() const { return AssignmentLevel; }
 

--- a/include/eld/Script/EntryCmd.h
+++ b/include/eld/Script/EntryCmd.h
@@ -28,7 +28,7 @@ class Module;
 class EntryCmd : public ScriptCommand {
 public:
   EntryCmd(const std::string &PEntry);
-  ~EntryCmd();
+
 
   void dump(llvm::raw_ostream &Outs) const override;
 

--- a/include/eld/Script/ExternCmd.h
+++ b/include/eld/Script/ExternCmd.h
@@ -26,7 +26,7 @@ class Module;
 class ExternCmd : public ScriptCommand {
 public:
   ExternCmd(StringList &PExtern);
-  ~ExternCmd();
+
 
   void dump(llvm::raw_ostream &Outs) const override;
 

--- a/include/eld/Script/GroupCmd.h
+++ b/include/eld/Script/GroupCmd.h
@@ -26,7 +26,7 @@ class GroupCmd : public ScriptCommand {
 public:
   GroupCmd(const LinkerConfig &Config, StringList &PStringList,
            const Attribute &Attr, ScriptFile &PScriptFile);
-  ~GroupCmd();
+
 
   void dump(llvm::raw_ostream &Outs) const override;
 

--- a/include/eld/Script/IncludeCmd.h
+++ b/include/eld/Script/IncludeCmd.h
@@ -18,7 +18,7 @@ class IncludeCmd : public ScriptCommand {
 public:
   IncludeCmd(const std::string FileName, bool IsOptional);
 
-  ~IncludeCmd() {};
+
 
   void dump(llvm::raw_ostream &Outs) const override;
 

--- a/include/eld/Script/InputCmd.h
+++ b/include/eld/Script/InputCmd.h
@@ -26,7 +26,7 @@ class InputCmd : public ScriptCommand {
 public:
   InputCmd(const LinkerConfig &Config, StringList &PStringList,
            const Attribute &Attr, ScriptFile &PScriptFile);
-  ~InputCmd();
+
 
   void dump(llvm::raw_ostream &Outs) const override;
 

--- a/include/eld/Script/InputSectDesc.h
+++ b/include/eld/Script/InputSectDesc.h
@@ -135,7 +135,7 @@ public:
   InputSectDesc(ScriptCommand::Kind Kind, uint32_t ID, Policy Policy,
                 const Spec &Spec, OutputSectDesc &OutputDesc);
 
-  ~InputSectDesc();
+
 
   Policy policy() const { return InputSpecPolicy; }
 

--- a/include/eld/Script/MemoryCmd.h
+++ b/include/eld/Script/MemoryCmd.h
@@ -25,7 +25,7 @@ struct MemorySpec;
 class MemoryCmd : public ScriptCommand {
 public:
   MemoryCmd();
-  ~MemoryCmd();
+
 
   size_t size() const { return MemoryDescriptors.size(); }
 

--- a/include/eld/Script/MemoryDesc.h
+++ b/include/eld/Script/MemoryDesc.h
@@ -55,7 +55,7 @@ class MemoryDesc : public ScriptCommand {
 public:
   MemoryDesc(const MemorySpec &PSpec);
 
-  ~MemoryDesc();
+
 
   static bool classof(const ScriptCommand *LinkerScriptCommand) {
     return LinkerScriptCommand->isMemoryDesc();

--- a/include/eld/Script/NameSpec.h
+++ b/include/eld/Script/NameSpec.h
@@ -28,7 +28,7 @@ class NameSpec : public InputToken {
 public:
   explicit NameSpec(const std::string &PName, bool PAsNeeded);
 
-  ~NameSpec() {}
+
 
   static bool classof(const InputToken *ThisInputToken) {
     return ThisInputToken->type() == InputToken::NameSpec;

--- a/include/eld/Script/NoCrossRefsCmd.h
+++ b/include/eld/Script/NoCrossRefsCmd.h
@@ -22,7 +22,7 @@ class Module;
 class NoCrossRefsCmd : public ScriptCommand {
 public:
   NoCrossRefsCmd(StringList &PExtern, size_t PId);
-  ~NoCrossRefsCmd();
+
 
   void dump(llvm::raw_ostream &Outs) const override;
 

--- a/include/eld/Script/OutputArchCmd.h
+++ b/include/eld/Script/OutputArchCmd.h
@@ -21,7 +21,7 @@ class Module;
 class OutputArchCmd : public ScriptCommand {
 public:
   OutputArchCmd(const std::string &PArch);
-  ~OutputArchCmd();
+
 
   void dump(llvm::raw_ostream &Outs) const override;
 

--- a/include/eld/Script/OutputCmd.h
+++ b/include/eld/Script/OutputCmd.h
@@ -22,7 +22,7 @@ class OutputCmd : public ScriptCommand {
 public:
   OutputCmd(const std::string &POutputFile);
 
-  ~OutputCmd();
+
 
   void dump(llvm::raw_ostream &Outs) const override;
 

--- a/include/eld/Script/OutputFormatCmd.h
+++ b/include/eld/Script/OutputFormatCmd.h
@@ -35,7 +35,7 @@ public:
   OutputFormatCmd(const std::string &PFormat);
   OutputFormatCmd(const std::string &PDefault, const std::string &PBig,
                   const std::string &PLittle);
-  ~OutputFormatCmd();
+
 
   const_iterator begin() const { return OutputFormatList.begin(); }
   iterator begin() { return OutputFormatList.begin(); }

--- a/include/eld/Script/OutputSectDesc.h
+++ b/include/eld/Script/OutputSectDesc.h
@@ -273,7 +273,7 @@ public:
 
 public:
   OutputSectDesc(const std::string &PName);
-  ~OutputSectDesc();
+
 
   const_iterator begin() const { return OutputSectionCommands.begin(); }
   iterator begin() { return OutputSectionCommands.begin(); }

--- a/include/eld/Script/PhdrDesc.h
+++ b/include/eld/Script/PhdrDesc.h
@@ -59,7 +59,7 @@ class PhdrDesc : public ScriptCommand {
 public:
   PhdrDesc(const PhdrSpec &PSpec);
 
-  ~PhdrDesc();
+
 
   static bool classof(const ScriptCommand *LinkerScriptCommand) {
     return LinkerScriptCommand->getKind() == ScriptCommand::PHDR_DESC;

--- a/include/eld/Script/PhdrsCmd.h
+++ b/include/eld/Script/PhdrsCmd.h
@@ -24,7 +24,7 @@ class PhdrDesc;
 class PhdrsCmd : public ScriptCommand {
 public:
   PhdrsCmd();
-  ~PhdrsCmd();
+
 
   size_t size() const { return MPhdrs.size(); }
 

--- a/include/eld/Script/RegionAlias.h
+++ b/include/eld/Script/RegionAlias.h
@@ -32,7 +32,7 @@ class RegionAlias : public ScriptCommand {
 public:
   explicit RegionAlias(const StrToken *Alias, const StrToken *Region);
 
-  ~RegionAlias();
+
 
   void dump(llvm::raw_ostream &Outs) const override;
 

--- a/include/eld/Script/ScriptCommand.h
+++ b/include/eld/Script/ScriptCommand.h
@@ -58,7 +58,7 @@ public:
   ScriptCommand(Kind PKind)
       : ScriptFileKind(PKind), ParentScriptCommand(nullptr) {}
 
-  virtual ~ScriptCommand() = 0;
+  virtual ~ScriptCommand() {};
 
   virtual void dump(llvm::raw_ostream &Outs) const = 0;
 

--- a/include/eld/Script/SearchDirCmd.h
+++ b/include/eld/Script/SearchDirCmd.h
@@ -30,7 +30,7 @@ class Module;
 class SearchDirCmd : public ScriptCommand {
 public:
   SearchDirCmd(const std::string &PPath);
-  ~SearchDirCmd();
+
 
   void dump(llvm::raw_ostream &Outs) const override;
 

--- a/include/eld/Script/SectionsCmd.h
+++ b/include/eld/Script/SectionsCmd.h
@@ -35,7 +35,7 @@ public:
 
 public:
   SectionsCmd();
-  ~SectionsCmd();
+
 
   const_iterator begin() const { return ThisSectionCommands.begin(); }
   iterator begin() { return ThisSectionCommands.begin(); }

--- a/lib/Script/Assignment.cpp
+++ b/lib/Script/Assignment.cpp
@@ -34,7 +34,7 @@ Assignment::Assignment(Level AssignmentLevel, Type AssignmentType,
       ExpressionValue(0), Name(Symbol), ExpressionToEvaluate(ScriptExpression),
       ThisSymbol(nullptr) {}
 
-Assignment::~Assignment() {}
+
 
 void Assignment::dump(llvm::raw_ostream &Outs) const {
   bool CloseParen = true;

--- a/lib/Script/EntryCmd.cpp
+++ b/lib/Script/EntryCmd.cpp
@@ -23,7 +23,7 @@ using namespace eld;
 EntryCmd::EntryCmd(const std::string &PEntry)
     : ScriptCommand(ScriptCommand::ENTRY), EntrySymbol(PEntry) {}
 
-EntryCmd::~EntryCmd() {}
+
 
 void EntryCmd::dump(llvm::raw_ostream &Outs) const {
   Outs << "ENTRY(" << EntrySymbol << ")";

--- a/lib/Script/ExternCmd.cpp
+++ b/lib/Script/ExternCmd.cpp
@@ -21,7 +21,7 @@ using namespace eld;
 ExternCmd::ExternCmd(StringList &PExtern)
     : ScriptCommand(ScriptCommand::EXTERN), ExternSymbolList(PExtern) {}
 
-ExternCmd::~ExternCmd() {}
+
 
 void ExternCmd::dump(llvm::raw_ostream &Outs) const {
   for (auto &E : ExternSymbolList)

--- a/lib/Script/GroupCmd.cpp
+++ b/lib/Script/GroupCmd.cpp
@@ -27,7 +27,7 @@ GroupCmd::GroupCmd(const LinkerConfig &Config, StringList &PStringList,
     : ScriptCommand(ScriptCommand::GROUP), ThisStringList(PStringList),
       ThisBuilder(Config, Attribute), ThisScriptFile(ScriptFile) {}
 
-GroupCmd::~GroupCmd() {}
+
 
 void GroupCmd::dump(llvm::raw_ostream &Outs) const {
   Outs << "GROUP(";

--- a/lib/Script/InputCmd.cpp
+++ b/lib/Script/InputCmd.cpp
@@ -27,7 +27,7 @@ InputCmd::InputCmd(const LinkerConfig &Config, StringList &PStringList,
     : ScriptCommand(ScriptCommand::INPUT), ThisStringList(PStringList),
       ThisBuilder(Config, Attribute), ThisScriptFile(ScriptFile) {}
 
-InputCmd::~InputCmd() {}
+
 
 void InputCmd::dump(llvm::raw_ostream &Outs) const {
   Outs << "INPUT(";

--- a/lib/Script/InputSectDesc.cpp
+++ b/lib/Script/InputSectDesc.cpp
@@ -43,7 +43,7 @@ InputSectDesc::InputSectDesc(ScriptCommand::Kind Kind, uint32_t ID,
   InputSpec.initialize(Spec);
 }
 
-InputSectDesc::~InputSectDesc() {}
+
 
 void InputSectDesc::dump(llvm::raw_ostream &Outs) const { dumpMap(Outs); }
 

--- a/lib/Script/MemoryCmd.cpp
+++ b/lib/Script/MemoryCmd.cpp
@@ -15,7 +15,7 @@ using namespace eld;
 //===----------------------------------------------------------------------===//
 MemoryCmd::MemoryCmd() : ScriptCommand(ScriptCommand::MEMORY) {}
 
-MemoryCmd::~MemoryCmd() {}
+
 
 void MemoryCmd::dump(llvm::raw_ostream &Outs) const {
   Outs << "MEMORY\n{\n";

--- a/lib/Script/MemoryDesc.cpp
+++ b/lib/Script/MemoryDesc.cpp
@@ -19,7 +19,7 @@ using namespace eld;
 MemoryDesc::MemoryDesc(const MemorySpec &PSpec)
     : ScriptCommand(ScriptCommand::MEMORY_DESC), InputSpec(PSpec) {}
 
-MemoryDesc::~MemoryDesc() {}
+
 
 void MemoryDesc::dump(llvm::raw_ostream &Outs) const {
   Outs << InputSpec.getMemoryDescriptor();

--- a/lib/Script/NoCrossRefsCmd.cpp
+++ b/lib/Script/NoCrossRefsCmd.cpp
@@ -19,7 +19,7 @@ NoCrossRefsCmd::NoCrossRefsCmd(StringList &PSections, size_t ID)
     : ScriptCommand(ScriptCommand::NOCROSSREFS), ThisSectionions(PSections),
       CurID(ID) {}
 
-NoCrossRefsCmd::~NoCrossRefsCmd() {}
+
 
 void NoCrossRefsCmd::dump(llvm::raw_ostream &Outs) const {
   Outs << "NOCROSSREFS(";

--- a/lib/Script/OutputArchCmd.cpp
+++ b/lib/Script/OutputArchCmd.cpp
@@ -15,7 +15,7 @@ using namespace eld;
 OutputArchCmd::OutputArchCmd(const std::string &PArch)
     : ScriptCommand(ScriptCommand::OUTPUT_ARCH), OutputArch(PArch) {}
 
-OutputArchCmd::~OutputArchCmd() {}
+
 
 void OutputArchCmd::dump(llvm::raw_ostream &Outs) const {
   Outs << "OUTPUT_ARCH(" << OutputArch << ")\n";

--- a/lib/Script/OutputCmd.cpp
+++ b/lib/Script/OutputCmd.cpp
@@ -18,7 +18,7 @@ using namespace eld;
 OutputCmd::OutputCmd(const std::string &POutputFile)
     : ScriptCommand(ScriptCommand::OUTPUT), OutputFileName(POutputFile) {}
 
-OutputCmd::~OutputCmd() {}
+
 
 void OutputCmd::dump(llvm::raw_ostream &Outs) const {
   Outs << "OUTPUT(" << OutputFileName << ")\n";

--- a/lib/Script/OutputFormatCmd.cpp
+++ b/lib/Script/OutputFormatCmd.cpp
@@ -33,7 +33,7 @@ OutputFormatCmd::OutputFormatCmd(const std::string &PDefault,
   OutputFormatList.push_back(PLittle);
 }
 
-OutputFormatCmd::~OutputFormatCmd() {}
+
 
 void OutputFormatCmd::dump(llvm::raw_ostream &Outs) const {
   Outs << "OUTPUT_FORMAT(";

--- a/lib/Script/OutputSectDesc.cpp
+++ b/lib/Script/OutputSectDesc.cpp
@@ -43,7 +43,7 @@ OutputSectDesc::OutputSectDesc(const std::string &PName)
   OutputSectDescEpilog.FillExpression = nullptr;
 }
 
-OutputSectDesc::~OutputSectDesc() {}
+
 
 void OutputSectDesc::dump(llvm::raw_ostream &Outs) const {
   Outs << Name << "\t";

--- a/lib/Script/PhdrDesc.cpp
+++ b/lib/Script/PhdrDesc.cpp
@@ -19,7 +19,7 @@ using namespace eld;
 PhdrDesc::PhdrDesc(const PhdrSpec &PSpec)
     : ScriptCommand(ScriptCommand::PHDR_DESC), InputSpec(PSpec) {}
 
-PhdrDesc::~PhdrDesc() {}
+
 
 void PhdrDesc::dump(llvm::raw_ostream &Outs) const {
   Outs << InputSpec.name();

--- a/lib/Script/PhdrsCmd.cpp
+++ b/lib/Script/PhdrsCmd.cpp
@@ -15,7 +15,7 @@ using namespace eld;
 //===----------------------------------------------------------------------===//
 PhdrsCmd::PhdrsCmd() : ScriptCommand(ScriptCommand::PHDRS) {}
 
-PhdrsCmd::~PhdrsCmd() {}
+
 
 void PhdrsCmd::dump(llvm::raw_ostream &Outs) const {
   Outs << "PHDRS\n{\n";

--- a/lib/Script/RegionAlias.cpp
+++ b/lib/Script/RegionAlias.cpp
@@ -17,7 +17,7 @@ RegionAlias::RegionAlias(const StrToken *Alias, const StrToken *Region)
     : ScriptCommand(ScriptCommand::REGION_ALIAS), MemoryAliasName(Alias),
       MemoryRegionName(Region) {}
 
-RegionAlias::~RegionAlias() {}
+
 
 void RegionAlias::dump(llvm::raw_ostream &Outs) const {
   Outs << "REGION_ALIAS";

--- a/lib/Script/ScriptCommand.cpp
+++ b/lib/Script/ScriptCommand.cpp
@@ -23,7 +23,7 @@ using namespace eld;
 //===----------------------------------------------------------------------===//
 // ScriptCommand
 //===----------------------------------------------------------------------===//
-ScriptCommand::~ScriptCommand() {}
+
 void ScriptCommand::dumpMap(llvm::raw_ostream &Ostream, bool Color,
                             bool UseNewLine, bool WithValues,
                             bool AddIndent) const {

--- a/lib/Script/SearchDirCmd.cpp
+++ b/lib/Script/SearchDirCmd.cpp
@@ -23,7 +23,7 @@ using namespace eld;
 SearchDirCmd::SearchDirCmd(const std::string &PPath)
     : ScriptCommand(ScriptCommand::SEARCH_DIR), MPath(PPath) {}
 
-SearchDirCmd::~SearchDirCmd() {}
+
 
 void SearchDirCmd::dump(llvm::raw_ostream &Outs) const {
   Outs << "SEARCH_DIR(\"" << MPath << "\");\n";

--- a/lib/Script/SectionsCmd.cpp
+++ b/lib/Script/SectionsCmd.cpp
@@ -22,7 +22,7 @@ using namespace eld;
 //===----------------------------------------------------------------------===//
 SectionsCmd::SectionsCmd() : ScriptCommand(ScriptCommand::SECTIONS) {}
 
-SectionsCmd::~SectionsCmd() {}
+
 
 void SectionsCmd::dump(llvm::raw_ostream &Outs) const {
   Outs << "SECTIONS\n{\n";


### PR DESCRIPTION
Empty destructors are not required because they have the same effect as the default destructors.