### PR TITLE
Fix NOCROSSREFS feature to work when there is no SECTIONS command

### DIFF
--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -2641,8 +2641,6 @@ void GNULDBackend::checkCrossReferencesHelper(InputFile *input) {
 }
 
 bool GNULDBackend::checkCrossReferences() {
-  if (!m_Module.getScript().linkerScriptHasSectionsCommand())
-    return true;
   eld::RegisterTimer T("Evaluate NOCROSSREFS", "Establish Layout",
                        m_Module.getConfig().options().printTimingStats());
   if (config().options().numThreads() <= 1 ||

--- a/test/Common/standalone/linkerscript/NoCrossRefs/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/NoCrossRefs/Inputs/1.c
@@ -1,4 +1,3 @@
-
 int common;
 extern int another_common;
 extern int z;

--- a/test/Common/standalone/linkerscript/NoCrossRefsDiscard/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/NoCrossRefsDiscard/Inputs/1.c
@@ -1,0 +1,3 @@
+int z = 1;
+int foo()  { return z; }
+int bar() { return foo(); }

--- a/test/Common/standalone/linkerscript/NoCrossRefsDiscard/Inputs/script.discard.t
+++ b/test/Common/standalone/linkerscript/NoCrossRefsDiscard/Inputs/script.discard.t
@@ -1,0 +1,4 @@
+NOCROSSREFS(.text .data)
+SECTIONS {
+  /DISCARD/ : { *(.data) *(.rodata*) }
+}

--- a/test/Common/standalone/linkerscript/NoCrossRefsDiscard/NoCrossRefsDiscard.test
+++ b/test/Common/standalone/linkerscript/NoCrossRefsDiscard/NoCrossRefsDiscard.test
@@ -1,0 +1,8 @@
+#---NoCrossRefsDiscard.test-------------------- Executable,LS -----------------#
+# Validate NOCROSSREFS feature when the section violating cross-reference
+# is discarded by /DISCARD/.
+
+RUN: %clang %clangg0opts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections -fdata-sections
+RUN: %link %linkg0opts -o %t1.1.out %t1.1.o -T %p/Inputs/script.discard.t 2>&1 | %filecheck %s --check-prefix=DISCARD --allow-empty
+
+DISCARD-NOT: prohibited cross reference

--- a/test/Common/standalone/linkerscript/NoCrossRefsNoSections/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/NoCrossRefsNoSections/Inputs/1.c
@@ -1,0 +1,3 @@
+int u = 11;
+int foo()  { return u; }
+int bar() { return foo(); }

--- a/test/Common/standalone/linkerscript/NoCrossRefsNoSections/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/NoCrossRefsNoSections/Inputs/script.t
@@ -1,0 +1,1 @@
+NOCROSSREFS(.text .data)

--- a/test/Common/standalone/linkerscript/NoCrossRefsNoSections/NoCrossRefsNoSections.test
+++ b/test/Common/standalone/linkerscript/NoCrossRefsNoSections/NoCrossRefsNoSections.test
@@ -1,0 +1,6 @@
+#---NoCrossRefsNoSections.test------------------ Executable,LS ---------------#
+# Validate that NOCROSSREFS reports cross-references even without SECTIONS.
+RUN: %clang %clangg0opts -o %t1.1.o -c %p/Inputs/1.c -ffunction-sections -fdata-sections
+RUN: %not %link %linkg0opts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t 2>&1 | %filecheck %s --check-prefix=CHECK
+
+CHECK: Error: {{.*}}1.o{{.*}} prohibited cross reference from .text to `foo'


### PR DESCRIPTION
This commit fixes NOCROSSREFS feature to work when there is no SECTIONS command by removing a redundant condition that caused NOCROSSREFS checks to be skipped if there is no SECTIONS command.

Resolves #451