### PR TITLE
Make hexagon plugin test artifacts a dependency of check-eld target

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,14 @@ if(test_riscv GREATER -1)
   set(TEST_TARGETS "${TEST_TARGETS};RISCV64")
 endif()
 
+add_custom_target(PluginUnitTests)
+set_target_properties(PluginUnitTests PROPERTIES FOLDER
+  "plugin unit tests")
+
+function(add_plugin pluginname)
+  add_dependencies(PluginUnitTests ${pluginname})
+endfunction()
+
 # Set the depends list as a variable so that it can grow conditionally. NOTE:
 # Sync the substitutions in test/lit.cfg when adding to this list.
 set(TEST_DEPENDS
@@ -52,7 +60,7 @@ set(TEST_DEPENDS
     ${ELD_DEPENDS}
     ELDExpectedUsage
     LSParserVerifier
-    CommonPluginUnitTests)
+    PluginUnitTests)
 
 set(TARGET_NAME check-eld)
 add_custom_target(${TARGET_NAME})

--- a/test/Common/CMakeLists.txt
+++ b/test/Common/CMakeLists.txt
@@ -1,10 +1,2 @@
-add_custom_target(CommonPluginUnitTests)
-set_target_properties(CommonPluginUnitTests PROPERTIES FOLDER
-                                                       "plugin unit tests")
-
-function(add_common_plugin pluginname)
-  add_dependencies(CommonPluginUnitTests ${pluginname})
-endfunction()
-
 add_subdirectory(standalone)
 add_subdirectory(Plugin)

--- a/test/Common/Plugin/ActBeforePerformingLayout/CMakeLists.txt
+++ b/test/Common/Plugin/ActBeforePerformingLayout/CMakeLists.txt
@@ -18,4 +18,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(ActBeforePerformingLayoutPlugin)
+add_plugin(ActBeforePerformingLayoutPlugin)

--- a/test/Common/Plugin/ActBeforeRuleMatching/CMakeLists.txt
+++ b/test/Common/Plugin/ActBeforeRuleMatching/CMakeLists.txt
@@ -18,4 +18,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(ActBeforeRuleMatchingPlugin)
+add_plugin(ActBeforeRuleMatchingPlugin)

--- a/test/Common/Plugin/ActBeforeSectionMerging/CMakeLists.txt
+++ b/test/Common/Plugin/ActBeforeSectionMerging/CMakeLists.txt
@@ -18,4 +18,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(ActBeforeSectionMergingPlugin)
+add_plugin(ActBeforeSectionMergingPlugin)

--- a/test/Common/Plugin/ActBeforeWritingOutput/CMakeLists.txt
+++ b/test/Common/Plugin/ActBeforeWritingOutput/CMakeLists.txt
@@ -18,4 +18,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(ActBeforeWritingOutputPlugin)
+add_plugin(ActBeforeWritingOutputPlugin)

--- a/test/Common/Plugin/AddChunkToOutputInCreatingSections/CMakeLists.txt
+++ b/test/Common/Plugin/AddChunkToOutputInCreatingSections/CMakeLists.txt
@@ -17,4 +17,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(AddChunkToOutputCSPlugin)
+add_plugin(AddChunkToOutputCSPlugin)

--- a/test/Common/Plugin/AddPluginFileToReproduceTar/CMakeLists.txt
+++ b/test/Common/Plugin/AddPluginFileToReproduceTar/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(AddPluginFileToReproduceTar)
+add_plugin(AddPluginFileToReproduceTar)

--- a/test/Common/Plugin/AddPluginLinkStats/CMakeLists.txt
+++ b/test/Common/Plugin/AddPluginLinkStats/CMakeLists.txt
@@ -18,4 +18,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(AddPluginStats)
+add_plugin(AddPluginStats)

--- a/test/Common/Plugin/AddSectionAnnotations/CMakeLists.txt
+++ b/test/Common/Plugin/AddSectionAnnotations/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(AddSectionAnnotations)
+add_plugin(AddSectionAnnotations)

--- a/test/Common/Plugin/AddedSectionOverrides/CMakeLists.txt
+++ b/test/Common/Plugin/AddedSectionOverrides/CMakeLists.txt
@@ -16,4 +16,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(AddedSectionOverrides)
+add_plugin(AddedSectionOverrides)

--- a/test/Common/Plugin/AuxiliarySymbolName/CMakeLists.txt
+++ b/test/Common/Plugin/AuxiliarySymbolName/CMakeLists.txt
@@ -17,4 +17,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(AuxiliarySymbolNamePlugin)
+add_plugin(AuxiliarySymbolNamePlugin)

--- a/test/Common/Plugin/AuxiliarySymbolNameTrace/CMakeLists.txt
+++ b/test/Common/Plugin/AuxiliarySymbolNameTrace/CMakeLists.txt
@@ -18,4 +18,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(AuxiliarySymbolNameTracePlugin)
+add_plugin(AuxiliarySymbolNameTracePlugin)

--- a/test/Common/Plugin/BasicChunkMover/CMakeLists.txt
+++ b/test/Common/Plugin/BasicChunkMover/CMakeLists.txt
@@ -16,4 +16,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(BasicChunkMover)
+add_plugin(BasicChunkMover)

--- a/test/Common/Plugin/BasicLinkerScriptGenerator/CMakeLists.txt
+++ b/test/Common/Plugin/BasicLinkerScriptGenerator/CMakeLists.txt
@@ -18,4 +18,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(BasicLinkerScriptGenerator)
+add_plugin(BasicLinkerScriptGenerator)

--- a/test/Common/Plugin/CMakeLists.txt
+++ b/test/Common/Plugin/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Add HelloWorldPlugin as a test dependency!
-add_common_plugin(HelloWorldPlugin)
+add_plugin(HelloWorldPlugin)
 
 add_subdirectory(ActBeforeRuleMatching)
 add_subdirectory(ActBeforeSectionMerging)
@@ -82,4 +82,4 @@ add_subdirectory(VerifyChunkMoves)
 add_subdirectory(VirtualAddress)
 add_subdirectory(UPVisitSections)
 add_subdirectory(VisitSymbolHook)
-add_common_plugin(PluginSymbols)
+add_plugin(PluginSymbols)

--- a/test/Common/Plugin/ChangeSection/CMakeLists.txt
+++ b/test/Common/Plugin/ChangeSection/CMakeLists.txt
@@ -16,4 +16,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(TestChangeSection)
+add_plugin(TestChangeSection)

--- a/test/Common/Plugin/ChunkMovesInInvalidLinkStates/CMakeLists.txt
+++ b/test/Common/Plugin/ChunkMovesInInvalidLinkStates/CMakeLists.txt
@@ -18,4 +18,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(ChunkMovesInInvalidLinkStates)
+add_plugin(ChunkMovesInInvalidLinkStates)

--- a/test/Common/Plugin/DWARFInfo/CMakeLists.txt
+++ b/test/Common/Plugin/DWARFInfo/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(DWARFInfo)
+add_plugin(DWARFInfo)

--- a/test/Common/Plugin/DiscardedSections/CMakeLists.txt
+++ b/test/Common/Plugin/DiscardedSections/CMakeLists.txt
@@ -16,4 +16,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(TestDiscardedSections)
+add_plugin(TestDiscardedSections)

--- a/test/Common/Plugin/DoesRuleMatchWithSection/CMakeLists.txt
+++ b/test/Common/Plugin/DoesRuleMatchWithSection/CMakeLists.txt
@@ -18,4 +18,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(DoesRuleMatchWithSectionPlugin)
+add_plugin(DoesRuleMatchWithSectionPlugin)

--- a/test/Common/Plugin/DoesRuleMatchWithSectionSameRMName/CMakeLists.txt
+++ b/test/Common/Plugin/DoesRuleMatchWithSectionSameRMName/CMakeLists.txt
@@ -18,4 +18,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(DoesRuleMatchWithSectionSameRMName)
+add_plugin(DoesRuleMatchWithSectionSameRMName)

--- a/test/Common/Plugin/FindConfigFile/CMakeLists.txt
+++ b/test/Common/Plugin/FindConfigFile/CMakeLists.txt
@@ -14,4 +14,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(findconfig)
+add_plugin(findconfig)

--- a/test/Common/Plugin/GetEnv/CMakeLists.txt
+++ b/test/Common/Plugin/GetEnv/CMakeLists.txt
@@ -16,4 +16,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(GetEnvPlugin)
+add_plugin(GetEnvPlugin)

--- a/test/Common/Plugin/GetInputSectionDescription/CMakeLists.txt
+++ b/test/Common/Plugin/GetInputSectionDescription/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(GetInputSectionDescription)
+add_plugin(GetInputSectionDescription)

--- a/test/Common/Plugin/GetInputSectionHash/CMakeLists.txt
+++ b/test/Common/Plugin/GetInputSectionHash/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(GetInputSectionHash)
+add_plugin(GetInputSectionHash)

--- a/test/Common/Plugin/GetLinkerVersion/CMakeLists.txt
+++ b/test/Common/Plugin/GetLinkerVersion/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(GetLinkerVersion)
+add_plugin(GetLinkerVersion)

--- a/test/Common/Plugin/GetOutputSection/CMakeLists.txt
+++ b/test/Common/Plugin/GetOutputSection/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(GetOutputSection)
+add_plugin(GetOutputSection)

--- a/test/Common/Plugin/GetOutputSectionHash/CMakeLists.txt
+++ b/test/Common/Plugin/GetOutputSectionHash/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(GetOutputSectionHash)
+add_plugin(GetOutputSectionHash)

--- a/test/Common/Plugin/GetUses/CMakeLists.txt
+++ b/test/Common/Plugin/GetUses/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(findusessections)
+add_plugin(findusessections)

--- a/test/Common/Plugin/GetUsesSymbols/CMakeLists.txt
+++ b/test/Common/Plugin/GetUsesSymbols/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(findusessymbols)
+add_plugin(findusessymbols)

--- a/test/Common/Plugin/INIFile/CMakeLists.txt
+++ b/test/Common/Plugin/INIFile/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(INIFilePlugin)
+add_plugin(INIFilePlugin)

--- a/test/Common/Plugin/InputFilePluginAPIs/CMakeLists.txt
+++ b/test/Common/Plugin/InputFilePluginAPIs/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(InputFilePluginAPIs)
+add_plugin(InputFilePluginAPIs)

--- a/test/Common/Plugin/InputFiles/CMakeLists.txt
+++ b/test/Common/Plugin/InputFiles/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(InputFilePlugin)
+add_plugin(InputFilePlugin)

--- a/test/Common/Plugin/InputSectionAPIs/CMakeLists.txt
+++ b/test/Common/Plugin/InputSectionAPIs/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(InputSectionAPIs)
+add_plugin(InputSectionAPIs)

--- a/test/Common/Plugin/InputSpecAPITests/CMakeLists.txt
+++ b/test/Common/Plugin/InputSpecAPITests/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(InputSpecAPI)
+add_plugin(InputSpecAPI)

--- a/test/Common/Plugin/InvalidDiagnostics/CMakeLists.txt
+++ b/test/Common/Plugin/InvalidDiagnostics/CMakeLists.txt
@@ -17,4 +17,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(InvalidDiagnosticsPlugin)
+add_plugin(InvalidDiagnosticsPlugin)

--- a/test/Common/Plugin/InvalidStateOverrideLSRule/CMakeLists.txt
+++ b/test/Common/Plugin/InvalidStateOverrideLSRule/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(InvalidStateOverrideLSRule)
+add_plugin(InvalidStateOverrideLSRule)

--- a/test/Common/Plugin/IterateSectionsWithGC/CMakeLists.txt
+++ b/test/Common/Plugin/IterateSectionsWithGC/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(iteratesectionsgc)
+add_plugin(iteratesectionsgc)

--- a/test/Common/Plugin/LayoutWrapperTests/APIsForBinaryMapTest/CMakeLists.txt
+++ b/test/Common/Plugin/LayoutWrapperTests/APIsForBinaryMapTest/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(APIsForBinaryMapTest)
+add_plugin(APIsForBinaryMapTest)

--- a/test/Common/Plugin/LayoutWrapperTests/LayoutHeaderTest/CMakeLists.txt
+++ b/test/Common/Plugin/LayoutWrapperTests/LayoutHeaderTest/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(LayoutHeaderTest)
+add_plugin(LayoutHeaderTest)

--- a/test/Common/Plugin/LinkMode/CMakeLists.txt
+++ b/test/Common/Plugin/LinkMode/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(LinkMode)
+add_plugin(LinkMode)

--- a/test/Common/Plugin/LinkerPluginVersion/CMakeLists.txt
+++ b/test/Common/Plugin/LinkerPluginVersion/CMakeLists.txt
@@ -12,7 +12,7 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(LinkerPluginVersion)
+add_plugin(LinkerPluginVersion)
 
 if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
@@ -27,4 +27,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(LinkerPluginNoVersion)
+add_plugin(LinkerPluginNoVersion)

--- a/test/Common/Plugin/MatchIslandSections/CMakeLists.txt
+++ b/test/Common/Plugin/MatchIslandSections/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(matchislandsections)
+add_plugin(matchislandsections)

--- a/test/Common/Plugin/MatchIslandSectionsAndGetSymbolsDefinedInSection/CMakeLists.txt
+++ b/test/Common/Plugin/MatchIslandSectionsAndGetSymbolsDefinedInSection/CMakeLists.txt
@@ -14,4 +14,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(matchislandsectionsgetsymbols)
+add_plugin(matchislandsectionsgetsymbols)

--- a/test/Common/Plugin/MissingINIFile/CMakeLists.txt
+++ b/test/Common/Plugin/MissingINIFile/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(missinginifile)
+add_plugin(missinginifile)

--- a/test/Common/Plugin/MultithreadedDiagnostics/CMakeLists.txt
+++ b/test/Common/Plugin/MultithreadedDiagnostics/CMakeLists.txt
@@ -19,4 +19,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(TestMultithreadedDiagnostics)
+add_plugin(TestMultithreadedDiagnostics)

--- a/test/Common/Plugin/NoSectionOverrides/CMakeLists.txt
+++ b/test/Common/Plugin/NoSectionOverrides/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(nosectionoverrides)
+add_plugin(nosectionoverrides)

--- a/test/Common/Plugin/NullFileSize/CMakeLists.txt
+++ b/test/Common/Plugin/NullFileSize/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(nullfilesize)
+add_plugin(nullfilesize)

--- a/test/Common/Plugin/OrderChunks/CMakeLists.txt
+++ b/test/Common/Plugin/OrderChunks/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(OrderChunks)
+add_plugin(OrderChunks)

--- a/test/Common/Plugin/OutputChunkIterator/CMakeLists.txt
+++ b/test/Common/Plugin/OutputChunkIterator/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(outputchunkiterator)
+add_plugin(outputchunkiterator)

--- a/test/Common/Plugin/OutputChunkIteratorMoveBetweenSections/CMakeLists.txt
+++ b/test/Common/Plugin/OutputChunkIteratorMoveBetweenSections/CMakeLists.txt
@@ -14,4 +14,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(outputchunkiteratormovebetweensections)
+add_plugin(outputchunkiteratormovebetweensections)

--- a/test/Common/Plugin/OutputChunkIteratorSymbols/CMakeLists.txt
+++ b/test/Common/Plugin/OutputChunkIteratorSymbols/CMakeLists.txt
@@ -14,4 +14,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(outputchunkiteratorsymbols)
+add_plugin(outputchunkiteratorsymbols)

--- a/test/Common/Plugin/OutputSectionAddRules/CMakeLists.txt
+++ b/test/Common/Plugin/OutputSectionAddRules/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(outputsectionaddrules)
+add_plugin(outputsectionaddrules)

--- a/test/Common/Plugin/OutputSectionsBeforePerformingLayout/CMakeLists.txt
+++ b/test/Common/Plugin/OutputSectionsBeforePerformingLayout/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(OutputSectionsBeforePerformingLayout)
+add_plugin(OutputSectionsBeforePerformingLayout)

--- a/test/Common/Plugin/PartialPendingSectionOverrides/CMakeLists.txt
+++ b/test/Common/Plugin/PartialPendingSectionOverrides/CMakeLists.txt
@@ -18,4 +18,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(TestPartialPendingSectionOverrides)
+add_plugin(TestPartialPendingSectionOverrides)

--- a/test/Common/Plugin/PendingAndNoSectionOverrides/CMakeLists.txt
+++ b/test/Common/Plugin/PendingAndNoSectionOverrides/CMakeLists.txt
@@ -18,4 +18,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(TestPendingAndNoSectionOverrides)
+add_plugin(TestPendingAndNoSectionOverrides)

--- a/test/Common/Plugin/PendingRuleInsertions/CMakeLists.txt
+++ b/test/Common/Plugin/PendingRuleInsertions/CMakeLists.txt
@@ -16,4 +16,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(CreateRules)
+add_plugin(CreateRules)

--- a/test/Common/Plugin/PendingSectionOverrides/CMakeLists.txt
+++ b/test/Common/Plugin/PendingSectionOverrides/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(pendingsectionoverrides)
+add_plugin(pendingsectionoverrides)

--- a/test/Common/Plugin/PluginCommandLineOptions/CMakeLists.txt
+++ b/test/Common/Plugin/PluginCommandLineOptions/CMakeLists.txt
@@ -17,4 +17,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(PluginCommandLineOptions)
+add_plugin(PluginCommandLineOptions)

--- a/test/Common/Plugin/PluginCommandLineOptionsErrors/InvalidPrefixAndEmptyOpt/CMakeLists.txt
+++ b/test/Common/Plugin/PluginCommandLineOptionsErrors/InvalidPrefixAndEmptyOpt/CMakeLists.txt
@@ -17,4 +17,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(InvalidPrefixAndEmptyOpt)
+add_plugin(InvalidPrefixAndEmptyOpt)

--- a/test/Common/Plugin/PluginDiagCrash/CMakeLists.txt
+++ b/test/Common/Plugin/PluginDiagCrash/CMakeLists.txt
@@ -16,4 +16,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(PluginDiagCrash)
+add_plugin(PluginDiagCrash)

--- a/test/Common/Plugin/PluginDiagnostics/CMakeLists.txt
+++ b/test/Common/Plugin/PluginDiagnostics/CMakeLists.txt
@@ -16,4 +16,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(TestPluginDiagnostics)
+add_plugin(TestPluginDiagnostics)

--- a/test/Common/Plugin/RMSectNameInDiag/CMakeLists.txt
+++ b/test/Common/Plugin/RMSectNameInDiag/CMakeLists.txt
@@ -16,4 +16,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(RMSectNameInDiagPlugin)
+add_plugin(RMSectNameInDiagPlugin)

--- a/test/Common/Plugin/RemoveChunks/CMakeLists.txt
+++ b/test/Common/Plugin/RemoveChunks/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(removechunks)
+add_plugin(removechunks)

--- a/test/Common/Plugin/ReproduceOnCrash/CMakeLists.txt
+++ b/test/Common/Plugin/ReproduceOnCrash/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(LinkerCrashPlugin)
+add_plugin(LinkerCrashPlugin)

--- a/test/Common/Plugin/ReproducerWithFindConfigFile/CMakeLists.txt
+++ b/test/Common/Plugin/ReproducerWithFindConfigFile/CMakeLists.txt
@@ -14,4 +14,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(ReproducerWithFindConfigFile)
+add_plugin(ReproducerWithFindConfigFile)

--- a/test/Common/Plugin/ReproducerWithFindConfigFileAbsolutePath/CMakeLists.txt
+++ b/test/Common/Plugin/ReproducerWithFindConfigFileAbsolutePath/CMakeLists.txt
@@ -14,4 +14,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(ReproducerWithFindConfigFileAbsolutePath)
+add_plugin(ReproducerWithFindConfigFileAbsolutePath)

--- a/test/Common/Plugin/RuleMatchingSectNameMap/CMakeLists.txt
+++ b/test/Common/Plugin/RuleMatchingSectNameMap/CMakeLists.txt
@@ -16,4 +16,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(RuleMatchingSectNameMap)
+add_plugin(RuleMatchingSectNameMap)

--- a/test/Common/Plugin/RuleMatchingSectNameMapErrors/RMSectNameMapAlreadySet/CMakeLists.txt
+++ b/test/Common/Plugin/RuleMatchingSectNameMapErrors/RMSectNameMapAlreadySet/CMakeLists.txt
@@ -16,4 +16,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(RMSectNameMapAlreadySet)
+add_plugin(RMSectNameMapAlreadySet)

--- a/test/Common/Plugin/RuleMatchingSectNameMapErrors/RMSectNameMapEmptyInputFile/CMakeLists.txt
+++ b/test/Common/Plugin/RuleMatchingSectNameMapErrors/RMSectNameMapEmptyInputFile/CMakeLists.txt
@@ -18,4 +18,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(RMSectNameMapEmptyInputFile)
+add_plugin(RMSectNameMapEmptyInputFile)

--- a/test/Common/Plugin/SearchDiagnosticsPlugin/CMakeLists.txt
+++ b/test/Common/Plugin/SearchDiagnosticsPlugin/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(SearchDiagnosticsPlugin)
+add_plugin(SearchDiagnosticsPlugin)

--- a/test/Common/Plugin/SectionTypes/CMakeLists.txt
+++ b/test/Common/Plugin/SectionTypes/CMakeLists.txt
@@ -17,4 +17,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(SectionTypes)
+add_plugin(SectionTypes)

--- a/test/Common/Plugin/TarWriterTests/TarWriterNotNullTerminatedTest/CMakeLists.txt
+++ b/test/Common/Plugin/TarWriterTests/TarWriterNotNullTerminatedTest/CMakeLists.txt
@@ -14,4 +14,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(TarWriterNotNullTerminatedTest)
+add_plugin(TarWriterNotNullTerminatedTest)

--- a/test/Common/Plugin/TarWriterTests/TarWriterOverwriteTest/CMakeLists.txt
+++ b/test/Common/Plugin/TarWriterTests/TarWriterOverwriteTest/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(TarWriterOverwriteTest)
+add_plugin(TarWriterOverwriteTest)

--- a/test/Common/Plugin/TarWriterTests/TarWriterReadOnlyTest/CMakeLists.txt
+++ b/test/Common/Plugin/TarWriterTests/TarWriterReadOnlyTest/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(TarWriterReadOnlyTest)
+add_plugin(TarWriterReadOnlyTest)

--- a/test/Common/Plugin/TarWriterTests/TarWriterTest/CMakeLists.txt
+++ b/test/Common/Plugin/TarWriterTests/TarWriterTest/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(TarWriterTest)
+add_plugin(TarWriterTest)

--- a/test/Common/Plugin/TarWriterTests/TarWriterUnwritablePathTest/CMakeLists.txt
+++ b/test/Common/Plugin/TarWriterTests/TarWriterUnwritablePathTest/CMakeLists.txt
@@ -14,4 +14,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(TarWriterUnwritablePathTest)
+add_plugin(TarWriterUnwritablePathTest)

--- a/test/Common/Plugin/TimingReport/CMakeLists.txt
+++ b/test/Common/Plugin/TimingReport/CMakeLists.txt
@@ -16,4 +16,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(TimingReportPlugin)
+add_plugin(TimingReportPlugin)

--- a/test/Common/Plugin/UPVisitSections/CMakeLists.txt
+++ b/test/Common/Plugin/UPVisitSections/CMakeLists.txt
@@ -16,4 +16,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(UPVisitSections)
+add_plugin(UPVisitSections)

--- a/test/Common/Plugin/UnbalancedChunkMoves/CMakeLists.txt
+++ b/test/Common/Plugin/UnbalancedChunkMoves/CMakeLists.txt
@@ -16,4 +16,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(UnbalancedChunkMoves)
+add_plugin(UnbalancedChunkMoves)

--- a/test/Common/Plugin/UniversalPluginInitAndDestroy/CMakeLists.txt
+++ b/test/Common/Plugin/UniversalPluginInitAndDestroy/CMakeLists.txt
@@ -16,4 +16,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(UPInitAndDestroy)
+add_plugin(UPInitAndDestroy)

--- a/test/Common/Plugin/UniversalPluginInitError/CMakeLists.txt
+++ b/test/Common/Plugin/UniversalPluginInitError/CMakeLists.txt
@@ -16,4 +16,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(UPInitError)
+add_plugin(UPInitError)

--- a/test/Common/Plugin/UniversalPluginTextMapFile/CMakeLists.txt
+++ b/test/Common/Plugin/UniversalPluginTextMapFile/CMakeLists.txt
@@ -16,4 +16,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(UPTextMapFile)
+add_plugin(UPTextMapFile)

--- a/test/Common/Plugin/UsingBothUPAndNonUP/CMakeLists.txt
+++ b/test/Common/Plugin/UsingBothUPAndNonUP/CMakeLists.txt
@@ -20,5 +20,5 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(UP)
-add_common_plugin(NonUP)
+add_plugin(UP)
+add_plugin(NonUP)

--- a/test/Common/Plugin/VerboseDiagnostics/CMakeLists.txt
+++ b/test/Common/Plugin/VerboseDiagnostics/CMakeLists.txt
@@ -16,4 +16,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(VerboseDiagnostics)
+add_plugin(VerboseDiagnostics)

--- a/test/Common/Plugin/VerifyChunkMoves/CMakeLists.txt
+++ b/test/Common/Plugin/VerifyChunkMoves/CMakeLists.txt
@@ -16,4 +16,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(VerifyChunkMoves)
+add_plugin(VerifyChunkMoves)

--- a/test/Common/Plugin/VirtualAddress/CMakeLists.txt
+++ b/test/Common/Plugin/VirtualAddress/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(copy)
+add_plugin(copy)

--- a/test/Common/Plugin/VisitSymbolHook/CMakeLists.txt
+++ b/test/Common/Plugin/VisitSymbolHook/CMakeLists.txt
@@ -16,4 +16,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(VisitSymbolHookPlugin)
+add_plugin(VisitSymbolHookPlugin)

--- a/test/Common/standalone/EmitMapFileEvenInCrash/CMakeLists.txt
+++ b/test/Common/standalone/EmitMapFileEvenInCrash/CMakeLists.txt
@@ -18,4 +18,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
   set(BUILD_SHARED_LIBS ${bsl})
 endif()
 
-add_common_plugin(CrashPlugin)
+add_plugin(CrashPlugin)

--- a/test/Hexagon/Plugin/CMakeLists.txt
+++ b/test/Hexagon/Plugin/CMakeLists.txt
@@ -1,10 +1,3 @@
-add_custom_target(PluginUnitTests)
-set_target_properties(PluginUnitTests PROPERTIES FOLDER "plugin unit tests")
-
-function(add_plugin pluginname)
-  add_dependencies(PluginUnitTests ${pluginname})
-endfunction()
-
 add_subdirectory(AllOutSectAddresses)
 add_subdirectory(ChangeSymbol)
 add_subdirectory(ConfigFile)

--- a/test/Hexagon/Plugin/LayoutWrapperTest/PaddingTest/CMakeLists.txt
+++ b/test/Hexagon/Plugin/LayoutWrapperTest/PaddingTest/CMakeLists.txt
@@ -13,4 +13,4 @@ if(NOT CYGWIN AND LLVM_ENABLE_PIC)
 
 endif()
 
-add_common_plugin(PaddingTest)
+add_plugin(PaddingTest)


### PR DESCRIPTION
This commit makes the hexagon plugin test artifacts a depedency of check-eld targets.

Resolves #460