### PR TITLE
[NFC] Remove `Assignment::level::OUTPUT_SECTION`

### DIFF
--- a/include/eld/Object/OutputSectionEntry.h
+++ b/include/eld/Object/OutputSectionEntry.h
@@ -97,12 +97,6 @@ public:
 
   void append(RuleContainer *PInput) { MInputList.push_back(PInput); }
 
-  sym_iterator symBegin() { return MSymbolAssignments.begin(); }
-  sym_iterator symEnd() { return MSymbolAssignments.end(); }
-
-  const SymbolAssignments &symAssignments() const { return MSymbolAssignments; }
-  SymbolAssignments &symAssignments() { return MSymbolAssignments; }
-
   const SymbolAssignments &sectionsEndAssignments() const {
     return MSectionEndAssignments;
   }
@@ -115,8 +109,6 @@ public:
     MSectionEndAssignments = Out->sectionEndAssignments();
     Out->sectionEndAssignments().clear();
   }
-
-  bool hasAssignments() const { return (MSymbolAssignments.size() > 0); }
 
   // A section may be part of multiple segments, this only returns the
   // segment where the section would get loaded.
@@ -217,7 +209,6 @@ private:
   size_t MOrder;
   bool MBIsDiscard;
   InputList MInputList;
-  SymbolAssignments MSymbolAssignments;
   SymbolAssignments MSectionEndAssignments;
   RuleContainer *FirstNonEmptyRule;
   RuleContainer *MLastRule;

--- a/include/eld/Script/Assignment.h
+++ b/include/eld/Script/Assignment.h
@@ -36,7 +36,6 @@ class Assignment : public ScriptCommand {
 public:
   enum Level {
     OUTSIDE_SECTIONS, // outside SECTIONS command
-    OUTPUT_SECTION,   // related to an output section
     INPUT_SECTION,    // related to an input section
     SECTIONS_END
   };
@@ -93,10 +92,6 @@ public:
   bool isOutsideSections() const {
     return AssignmentLevel == OUTSIDE_SECTIONS ||
            AssignmentLevel == SECTIONS_END;
-  }
-
-  bool isOutsideOutputSection() const {
-    return AssignmentLevel == OUTPUT_SECTION;
   }
 
   bool isInsideOutputSection() const {

--- a/lib/LinkerWrapper/LinkerScript.cpp
+++ b/lib/LinkerWrapper/LinkerScript.cpp
@@ -440,8 +440,10 @@ bool plugin::Script::Assignment::isGlobal() const {
   return m_Assignment->isOutsideSections();
 }
 
+// FIXME: This should return true when the assignment level
+// is SECTIONS_END or OUTSIDE_SECTIONS.
 bool plugin::Script::Assignment::isOutsideOutputSection() const {
-  return m_Assignment->isOutsideOutputSection();
+  return false;
 }
 
 bool plugin::Script::Assignment::isInsideOutputSection() const {

--- a/lib/Script/Assignment.cpp
+++ b/lib/Script/Assignment.cpp
@@ -77,9 +77,6 @@ void Assignment::trace(llvm::raw_ostream &Outs) const {
   case OUTSIDE_SECTIONS:
     Outs << "OUTSIDE_SECTIONS   >>  ";
     break;
-  case OUTPUT_SECTION:
-    Outs << "  OUTPUT_SECTION(PROLOGUE)   >>  ";
-    break;
   case INPUT_SECTION:
     Outs << "    INSIDE_OUTPUT_SECTION    >>  ";
     break;
@@ -103,11 +100,7 @@ void Assignment::dumpMap(llvm::raw_ostream &Ostream, bool Color,
       Ostream.changeColor(llvm::raw_ostream::GREEN);
     break;
   }
-  case OUTPUT_SECTION: {
-    if (Color)
-      Ostream.changeColor(llvm::raw_ostream::CYAN);
-    break;
-  }
+
   case INPUT_SECTION: {
     if (Color)
       Ostream.changeColor(llvm::raw_ostream::YELLOW);
@@ -179,12 +172,6 @@ eld::Expected<void> Assignment::activate(Module &CurModule) {
   switch (AssignmentLevel) {
   case OUTSIDE_SECTIONS:
     break;
-
-  case OUTPUT_SECTION: {
-    SectionMap::reference Out = Script.sectionMap().back();
-    Out->symAssignments().push_back(this);
-    break;
-  }
 
   case INPUT_SECTION: {
     OutputSectionEntry::reference In = Script.sectionMap().back()->back();

--- a/lib/Script/ScriptFile.cpp
+++ b/lib/Script/ScriptFile.cpp
@@ -298,7 +298,7 @@ void ScriptFile::addAssignment(const std::string &SymbolName,
       OutputSectionDescription->pushBack(NewAssignment);
     } else {
       NewAssignment =
-          make<Assignment>(Assignment::OUTPUT_SECTION, AssignmentType,
+          make<Assignment>(Assignment::Level::SECTIONS_END, AssignmentType,
                            SymbolName, ScriptExpression);
       NewAssignment->setInputFileInContext(getContext());
       NewAssignment->setParent(getParent());

--- a/lib/Script/SectionsCmd.cpp
+++ b/lib/Script/SectionsCmd.cpp
@@ -86,11 +86,8 @@ eld::Expected<void> SectionsCmd::activate(Module &CurModule) {
       break;
     case ScriptCommand::OUTPUT_SECT_DESC: {
       if (!Assignments.empty()) {
-        iterator Assign, AssignEnd = Assignments.end();
-        for (Assign = Assignments.begin(); Assign != AssignEnd; ++Assign) {
-          llvm::cast<Assignment>(*Assign)->setLevel(Assignment::SECTIONS_END);
-          (*Assign)->activate(CurModule);
-        }
+        for (auto *Assign : Assignments)
+          Assign->activate(CurModule);
         Assignments.clear();
       }
       eld::Expected<void> E = (*It)->activate(CurModule);


### PR DESCRIPTION
This commit removes Assignment::level::OUTPUT_SECTION and the related codes that were storing and using assignments of type OUTPUT_SECTION. The Assignment::level::OUTPUT_SECTION is never being used. All assignments of type OUTPUT_SECTION were getting converted to level::SECTIONS_END later, and the assignments that are inside an output section are of type Assignment::level::INPUT_SECTION.

This commit also modifies to
`plugin::Script::Assignment::isOutsideOutputSection()` to unconditionally return false to maintain the existing behavior.

Resolves #462