### PR TITLE
Add source assignment in symbol nodes

### DIFF
--- a/include/eld/Script/Expression.h
+++ b/include/eld/Script/Expression.h
@@ -331,6 +331,7 @@ private:
   Expression *getRightExpression() const override { return nullptr; }
 
   mutable LDSymbol *ThisSymbol = nullptr;
+  const Assignment *SourceAssignment = nullptr;
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -20,6 +20,7 @@
 #include "eld/Readers/ELFSection.h"
 #include "eld/Readers/SymDefReader.h"
 #include "eld/Script/Assignment.h"
+#include "eld/Script/Expression.h"
 #include "eld/Script/VersionScript.h"
 #include "eld/SymbolResolver/ResolveInfo.h"
 #include "eld/Target/ELFSegment.h"
@@ -824,6 +825,17 @@ public:
 
   const ResolveInfo *findAbsolutePLT(ResolveInfo *I) const;
 
+  const Assignment *getLatestAssignment(llvm::StringRef SymName) {
+    auto it = SymbolNameToLatestAssignment.find(SymName);
+    if (it != SymbolNameToLatestAssignment.end())
+      return it->getValue();
+    return nullptr;
+  }
+
+  void updateLatestAssignment(llvm::StringRef SymName, const Assignment *A) {
+    SymbolNameToLatestAssignment[SymName] = A;
+  }
+
 protected:
   virtual int numReservedSegments() const { return m_NumReservedSegments; }
 
@@ -1128,6 +1140,8 @@ protected:
   bool m_NeedEhdr = false;
 
   bool m_NeedPhdr = false;
+
+  llvm::StringMap<const Assignment *> SymbolNameToLatestAssignment;
 };
 
 } // namespace eld

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -1708,6 +1708,7 @@ bool ObjectLinker::addScriptSymbols() {
     // If there is a relocation to this symbol, the symbols contained in the
     // assignment also need to be considered as part of the list of symbols
     // that will be live.
+    // FIXME: Duplicate redundant addAssignment!
     if (Symbol)
       ThisModule->addAssignment(Symbol->resolveInfo()->name(), AssignCmd);
   }

--- a/lib/Script/Assignment.cpp
+++ b/lib/Script/Assignment.cpp
@@ -230,6 +230,9 @@ bool Assignment::assign(Module &CurModule, const ELFSection *Section) {
     ThisSymbol->setScriptValueDefined();
   }
 
+  auto &Backend = CurModule.getBackend();
+  Backend.updateLatestAssignment(Name, this);
+
   if (CurModule.getPrinter()->traceAssignments())
     trace(llvm::outs());
   return true;

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -3098,6 +3098,7 @@ bool GNULDBackend::layout() {
     return false;
   }
 
+  // FIXME: Adding more symbols this late can cause layout issues.
   {
     eld::RegisterTimer T("Define Magic Symbols", "Establish Layout",
                          m_Module.getConfig().options().printTimingStats());

--- a/test/Common/standalone/linkerscript/IncorrectAssignmentInLayoutReiteration/IncorrectAssignmentInLayoutReiteration.test
+++ b/test/Common/standalone/linkerscript/IncorrectAssignmentInLayoutReiteration/IncorrectAssignmentInLayoutReiteration.test
@@ -1,0 +1,14 @@
+#---IncorrectAssignmentInLayoutReiteration.test-------------------------Executable,LS----#
+#BEGIN_COMMENT
+# This test verifies that a reassignment during layout reiteration
+# does not cause incorrect evaluation of previously-correct assignments.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangg0opts -o %t.1.o %p/Inputs/1.c -c -ffunction-sections -fdata-sections
+RUN: %link %linkg0opts -o %t1.1.out %t.1.o -T %p/Inputs/script.t
+RUN: %readelf -s %t1.1.out 2>&1 | %filecheck %s --check-prefix=CHECK
+#END_TEST
+
+#CHECK-DAG: {{0*100}}     0 NOTYPE  GLOBAL DEFAULT   ABS v
+#CHECK-DAG: {{0*100}}     0 NOTYPE  GLOBAL DEFAULT   ABS u
+

--- a/test/Common/standalone/linkerscript/IncorrectAssignmentInLayoutReiteration/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/IncorrectAssignmentInLayoutReiteration/Inputs/1.c
@@ -1,0 +1,3 @@
+int foo() { return 1; }
+int val = 3;
+

--- a/test/Common/standalone/linkerscript/IncorrectAssignmentInLayoutReiteration/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/IncorrectAssignmentInLayoutReiteration/Inputs/script.t
@@ -1,0 +1,8 @@
+u = 0x100;
+SECTIONS {
+  v = u;
+  .text : { *(.text*) }
+  u = 0x300;
+  .data : { *(.data*) }
+}
+


### PR DESCRIPTION
## Prologue

This commit changes how symbol expression nodes gets evaluated for the absolute symbols.

Previously, symbol nodes of the absolute symbols were evaluated to the current value of the symbol. Let's see this with the help of an example:

```
u = 0x100;
SECTIONS {
  v = u; // u == 0x100
  .text : { *(.text*) }
  u = 0x200;
  .data : { *(.data*) }
  w = u + v; // u == 0x200; v == 0x100
  v = u; // u == 0x200
}
```

This works well for general case as we see above. However, during the layout step, we often have to stop in between and compute the layout from the beginning (when a new segment is inserted). Or we may need to recompute the layout due to trampolines/relaxations until the layout converges. Or we may need to recompute the layout because the user requested to do so. During the layout recomputation, we do not typically reevaluate all the assignmnts. In particular, the assignments above the SECTIONS command do not need to be recomputed.

Let's see a case where the current model fails. The above example requires a layout re-iteration because a new segment is inserted on seeing .data output section. Let's see the symbol values in assignments for this 2nd layout reiteration:

```
u = 0x100; (1) u == 0x100; (2) <not re-evaluated>
SECTIONS {
  v = u; // (1) u == 0x100; (2) u == 0x200 <--- Incorrect assignment evaluation
  .text : { *(.text*) }
  u = 0x200;
  .data : { *(.data*) }
  w = u + v; // (1) u == 0x200, v == 0x100; (2) u == 0x200, v == 0x200
  v = u; // (1) u == 0x200; (2) u == 0x200
}
```

Please note that 'v = u' is evaluated incorrectly in the 2nd evaluation because in the 2nd evaluation 'u = 0x100' is not re-evaluated (we do not re-evaluate assignments above SECTIONS) and the latest value of u is 0x200 from the previous layout iteration.

Now, we have broadly two solutions to fix this issue:

(1) Reset all absolute symbols to 0 and re-evaluate all linker script
    assignments on each layout reiteration.
(2) Improve symbol node evaluation mechanism such that it returns
    the correct value irrespective of the latest value of the symbol.

This PR goes with solution route (2) because the solution (1) can be more computationally expensive.

## Solution

We solve this problem by using the key observation that a symbol node value is not the value of the symbol, instead it is the result of an assignment node. Thus, we add a `Assignment *SourceAssignment` node to the `Symbol` expression node. This points to the assignment node whose result is the value of the Symbol node. Let's understand this with the help of an example:

```
/*A1*/ u = 0x100;
SECTIONS {
  /*A2*/ v = u; // u == A1.result == 0x100
  .text : { *(.text*) }
  /*A3*/ u = 0x200;
  .data : { *(.data*) }
  /*A4*/ w = u + v; // u == A3.result == 0x200; v == A2.result == 0x100
  /*A5*/ v = u; // u == A3.result == 0x200
}
```

In the 2nd iteration when A1 is skipped, A2 is still evaluated correctly because A.result is still 0x100 -- we do not use the latest value of symbol u. Instead, we use the latest value of the assignment A1.

Resolves #468