### PR TITLE
Divide OUTSIDE_SECTIONS into BEFORE_SECTIONS and AFTER_SECTIONS

### DIFF
--- a/include/eld/Script/Assignment.h
+++ b/include/eld/Script/Assignment.h
@@ -35,7 +35,8 @@ class ELFSection;
 class Assignment : public ScriptCommand {
 public:
   enum Level {
-    OUTSIDE_SECTIONS, // outside SECTIONS command
+    BEFORE_SECTIONS,  // Assignments before SECTIONS command
+    AFTER_SECTIONS,   // Assignments after SECTIONS command
     INPUT_SECTION,    // related to an input section
     SECTIONS_END
   };
@@ -90,8 +91,8 @@ public:
 
   /// Query functions on Assignment Kinds.
   bool isOutsideSections() const {
-    return AssignmentLevel == OUTSIDE_SECTIONS ||
-           AssignmentLevel == SECTIONS_END;
+    return AssignmentLevel == BEFORE_SECTIONS ||
+           AssignmentLevel == AFTER_SECTIONS;
   }
 
   bool isInsideOutputSection() const {

--- a/lib/Script/Assignment.cpp
+++ b/lib/Script/Assignment.cpp
@@ -74,8 +74,11 @@ void Assignment::dump(llvm::raw_ostream &Outs) const {
 
 void Assignment::trace(llvm::raw_ostream &Outs) const {
   switch (AssignmentLevel) {
-  case OUTSIDE_SECTIONS:
-    Outs << "OUTSIDE_SECTIONS   >>  ";
+  case BEFORE_SECTIONS:
+    Outs << "BEFORE_SECTIONS   >>  ";
+    break;
+  case AFTER_SECTIONS:
+    Outs << "AFTER_SECTIONS    >>  ";
     break;
   case INPUT_SECTION:
     Outs << "    INSIDE_OUTPUT_SECTION    >>  ";
@@ -95,7 +98,8 @@ void Assignment::dumpMap(llvm::raw_ostream &Ostream, bool Color,
                          bool UseNewLine, bool WithValues,
                          bool AddIndent) const {
   switch (AssignmentLevel) {
-  case OUTSIDE_SECTIONS: {
+  case BEFORE_SECTIONS:
+  case AFTER_SECTIONS: {
     if (Color)
       Ostream.changeColor(llvm::raw_ostream::GREEN);
     break;
@@ -170,7 +174,8 @@ eld::Expected<void> Assignment::activate(Module &CurModule) {
   ExpressionToEvaluate->setContext(getContext());
 
   switch (AssignmentLevel) {
-  case OUTSIDE_SECTIONS:
+  case BEFORE_SECTIONS:
+  case AFTER_SECTIONS:
     break;
 
   case INPUT_SECTION: {

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -3998,7 +3998,9 @@ MemoryRegion GNULDBackend::getFileOutputRegion(llvm::FileOutputBuffer &pBuffer,
 
 void GNULDBackend::evaluateScriptAssignments(bool evaluateAsserts) {
   for (auto &assign : m_Module.getScript().assignments()) {
-    if (assign->level() != Assignment::OUTSIDE_SECTIONS)
+    // Evaluate assignments outside SECTIONS both before and after layout.
+    if (!(assign->level() == Assignment::BEFORE_SECTIONS ||
+          assign->level() == Assignment::AFTER_SECTIONS))
       continue;
     if (shouldskipAssert(assign)) {
       if (m_Module.getPrinter()->isVerbose()) {


### PR DESCRIPTION
This commit divides Assignment::Level::OUTSIDE_SECTIONS into BEFORE_SECTIONS and AFTER_SECTIONS assignment level types. It does not change the evaluation order of the assignment. The actual evaluation order will be fixed in a separate patch.

Resolves #473