### PR TITLE
Re-evaluate OUTSIDE_SECTIONS assignments whenever layout resets

### DIFF
--- a/lib/Target/CreateProgramHeaders.hpp
+++ b/lib/Target/CreateProgramHeaders.hpp
@@ -168,6 +168,12 @@ bool GNULDBackend::createProgramHdrs() {
     noLoadSections.clear();
     resetNewSectionsAddedToLayout();
     enable_RELRO = true;
+
+    {
+      eld::RegisterTimer T("Evaluate Script Assignments", "Establish Layout",
+                           m_Module.getConfig().options().printTimingStats());
+      evaluateScriptAssignments(/*evaluateAsserts=*/false);
+    }
   };
 
   reset_state();

--- a/lib/Target/CreateScriptProgramHeaders.hpp
+++ b/lib/Target/CreateScriptProgramHeaders.hpp
@@ -81,6 +81,12 @@ bool GNULDBackend::createScriptProgramHdrs() {
     m_ImageStartVMA = vma;
     // Set initial dot symbol value.
     dotSymbol->setValue(vma);
+
+    {
+      eld::RegisterTimer T("Evaluate Script Assignments", "Establish Layout",
+                           m_Module.getConfig().options().printTimingStats());
+      evaluateScriptAssignments(/*evaluateAsserts=*/false);
+    }
   };
 
   reset_state();

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -3060,13 +3060,6 @@ bool GNULDBackend::layout() {
   // Clear the section table so that real sections can be inserted properly.
   m_Module.clearOutputSections();
 
-  // Evaluate defsym assignments.
-  {
-    eld::RegisterTimer T("Evaluate Script Assignments", "Establish Layout",
-                         m_Module.getConfig().options().printTimingStats());
-    evaluateScriptAssignments(false);
-  }
-
   // If partial link, we only set offsets, no addresses.
   if (isPartialLink) {
     if (!setOutputSectionOffset()) {

--- a/test/Common/standalone/linkerscript/IncorrectAssignmentInLayoutReiteration/IncorrectAssignmentInLayoutReiteration.test
+++ b/test/Common/standalone/linkerscript/IncorrectAssignmentInLayoutReiteration/IncorrectAssignmentInLayoutReiteration.test
@@ -1,0 +1,12 @@
+#---IncorrectAssignmentInLayoutReiteration.test------ LinkerScript ----------------#
+#BEGIN_COMMENT
+# Verify OUTSIDE_SECTIONS assignments are re-evaluated whenever layout resets.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t -Map %t1.1.map.txt
+RUN: %readelf -s %t1.1.out | %filecheck %s
+#END_TEST
+
+CHECK-DAG: {{0*100}}     0 NOTYPE  GLOBAL DEFAULT   ABS v
+CHECK-DAG: {{0*100}}     0 NOTYPE  GLOBAL DEFAULT   ABS u

--- a/test/Common/standalone/linkerscript/IncorrectAssignmentInLayoutReiteration/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/IncorrectAssignmentInLayoutReiteration/Inputs/1.c
@@ -1,0 +1,3 @@
+int foo() { return 1; }
+
+int val = 3;

--- a/test/Common/standalone/linkerscript/IncorrectAssignmentInLayoutReiteration/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/IncorrectAssignmentInLayoutReiteration/Inputs/script.t
@@ -1,0 +1,7 @@
+u = 0x100;
+SECTIONS {
+  v = u;
+  .text : { *(.text*) }
+  u = 0x300;
+  .data : { *(.data*) }
+}

--- a/test/Common/standalone/linkerscript/IncorrectAssignmentInLayoutReiterationWithPHDRS/IncorrectAssignmentInLayoutReiterationWithPHDRS.test
+++ b/test/Common/standalone/linkerscript/IncorrectAssignmentInLayoutReiterationWithPHDRS/IncorrectAssignmentInLayoutReiterationWithPHDRS.test
@@ -1,0 +1,13 @@
+#---IncorrectAssignmentInLayoutReiterationWithPHDRS.test-- LinkerScript -------------#
+#BEGIN_COMMENT
+# Verify OUTSIDE_SECTIONS assignments are re-evaluated when layout resets,
+# even when PHDRS is used.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t -Map %t1.1.map.txt
+RUN: %readelf -s %t1.1.out | %filecheck %s
+#END_TEST
+
+CHECK-DAG: {{0*100}}     0 NOTYPE  GLOBAL DEFAULT   ABS v
+CHECK-DAG: {{0*100}}     0 NOTYPE  GLOBAL DEFAULT   ABS u

--- a/test/Common/standalone/linkerscript/IncorrectAssignmentInLayoutReiterationWithPHDRS/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/IncorrectAssignmentInLayoutReiterationWithPHDRS/Inputs/1.c
@@ -1,0 +1,3 @@
+int foo() { return 1; }
+
+int val = 3;

--- a/test/Common/standalone/linkerscript/IncorrectAssignmentInLayoutReiterationWithPHDRS/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/IncorrectAssignmentInLayoutReiterationWithPHDRS/Inputs/script.t
@@ -1,0 +1,12 @@
+u = 0x100;
+PHDRS
+{
+  text PT_LOAD FLAGS(5);
+  data PT_LOAD FLAGS(6);
+}
+SECTIONS {
+  v = u;
+  .text : { *(.text*) } :text
+  u = 0x300;
+  .data : { *(.data*) } :data
+}


### PR DESCRIPTION
This commit updates the layout step to re-evaluate OUTSIDE_SECTIONS assignments whenever the layout is reset during layout iteration. This is important to ensure correctness of re-evaluation of SECTIONS assignments.

Resolves #468