### PR TITLE
x86_64: Enable creation of .dynamic section

### DIFF
--- a/lib/Target/x86_64/CMakeLists.txt
+++ b/lib/Target/x86_64/CMakeLists.txt
@@ -7,7 +7,8 @@ llvm_add_library(
   x86_64Relocator.cpp
   x86_64RelocationCompute.cpp
   x86_64PLT.cpp
-  x86_64GOT.cpp)
+  x86_64GOT.cpp
+  x86_64ELFDynamic.cpp)
 
 add_subdirectory(TargetInfo)
 

--- a/lib/Target/x86_64/x86_64ELFDynamic.cpp
+++ b/lib/Target/x86_64/x86_64ELFDynamic.cpp
@@ -1,0 +1,19 @@
+//===- x86_64ELFDynamic.cpp----------------------------------------------===//
+// Part of the eld Project, under the BSD License
+// See https://github.com/qualcomm/eld/LICENSE.txt for license information.
+// SPDX-License-Identifier: BSD-3-Clause
+//===----------------------------------------------------------------------===//
+
+#include "x86_64ELFDynamic.h"
+#include "eld/Config/LinkerConfig.h"
+#include "eld/Target/ELFFileFormat.h"
+#include "eld/Target/GNULDBackend.h"
+
+using namespace eld;
+
+x86_64ELFDynamic::x86_64ELFDynamic(GNULDBackend &pParent, LinkerConfig &pConfig)
+    : ELFDynamic(pParent, pConfig) {}
+
+void x86_64ELFDynamic::reserveTargetEntries() {}
+
+void x86_64ELFDynamic::applyTargetEntries() {}

--- a/lib/Target/x86_64/x86_64ELFDynamic.h
+++ b/lib/Target/x86_64/x86_64ELFDynamic.h
@@ -1,0 +1,23 @@
+//===- x86_64ELFDynamic.h----------------------------------------------===//
+// Part of the eld Project, under the BSD License
+// See https://github.com/qualcomm/eld/LICENSE.txt for license information.
+// SPDX-License-Identifier: BSD-3-Clause
+//===----------------------------------------------------------------------===//
+
+#ifndef ELD_TARGET_X86_64_ELFDYNAMIC_H
+#define ELD_TARGET_X86_64_ELFDYNAMIC_H
+
+#include "eld/Target/ELFDynamic.h"
+
+namespace eld {
+
+class x86_64ELFDynamic : public ELFDynamic {
+public:
+  x86_64ELFDynamic(GNULDBackend &pParent, LinkerConfig &pConfig);
+
+private:
+  void reserveTargetEntries() override;
+  void applyTargetEntries() override;
+};
+} // namespace eld
+#endif

--- a/lib/Target/x86_64/x86_64LDBackend.h
+++ b/lib/Target/x86_64/x86_64LDBackend.h
@@ -12,6 +12,7 @@
 #include "eld/Readers/ELFSection.h"
 #include "eld/SymbolResolver/IRBuilder.h"
 #include "eld/Target/GNULDBackend.h"
+#include "x86_64ELFDynamic.h"
 #include "x86_64PLT.h"
 
 namespace eld {
@@ -55,7 +56,7 @@ public:
 
   uint64_t getValueForDiscardedRelocations(const Relocation *R) const override;
 
-  ELFDynamic *dynamic() override { return nullptr; }
+  x86_64ELFDynamic *dynamic() override;
 
   void doCreateProgramHdrs() override { return; }
 
@@ -88,6 +89,8 @@ public:
 
   void setDefaultConfigs() override;
 
+  void doPreLayout() override;
+
 private:
   /// getRelEntrySize - the size in BYTE of rela type relocation
   size_t getRelEntrySize() override { return 0; }
@@ -100,6 +103,7 @@ private:
 private:
   Relocator *m_pRelocator;
 
+  x86_64ELFDynamic *m_pDynamic;
   LDSymbol *m_pEndOfImage;
   llvm::DenseMap<ResolveInfo *, x86_64GOT *> m_GOTMap;
   llvm::DenseMap<ResolveInfo *, x86_64GOT *> m_GOTPLTMap;

--- a/lib/Target/x86_64/x86_64StandaloneInfo.h
+++ b/lib/Target/x86_64/x86_64StandaloneInfo.h
@@ -25,7 +25,9 @@ public:
     return 0;
   }
   void initializeAttributes(InputBuilder &pBuilder) override {
-    pBuilder.makeBStatic();
+    if (m_Config.codeGenType() == LinkerConfig::Object ||
+        m_Config.isCodeStatic())
+      pBuilder.makeBStatic();
   }
 };
 

--- a/test/x86_64/linux/InterpAndDynamicBasicTest/Inputs/1.c
+++ b/test/x86_64/linux/InterpAndDynamicBasicTest/Inputs/1.c
@@ -1,0 +1,1 @@
+int main() { return 0; }

--- a/test/x86_64/linux/InterpAndDynamicBasicTest/InterpAndDynamicBasic.test
+++ b/test/x86_64/linux/InterpAndDynamicBasicTest/InterpAndDynamicBasic.test
@@ -1,0 +1,17 @@
+#--InterpAndDynamicBasic.test----------Executable (PIE)--------#
+#BEGIN_COMMENT
+# Verify dynamic foundation emits interpreter and dynamic section.
+# - Builds a minimal PIE
+# - Checks PT_INTERP and PT_DYNAMIC exist
+# - Checks .interp and .dynamic sections present
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -fPIE -pie -c %p/Inputs/1.c -o %t.1.o
+RUN: %link %linkopts --force-dynamic -o %t.out %t.1.o
+# Basic presence of dynamic structures
+RUN: %readelf -l %t.out | %filecheck %s --check-prefix=PHDRS
+PHDRS: INTERP
+PHDRS: DYNAMIC
+RUN: %readelf -S %t.out | %filecheck %s --check-prefix=SECTS
+SECTS: .interp
+SECTS: .dynamic


### PR DESCRIPTION
Add x86_64ELFDynamic and wire it into the backend; instantiate in doPreLayout for dynamic outputs.
Adjust StandaloneInfo to not force static for dynamic/PIE, enabling .interp and .dynamic.
Add a lit test to verify presence of PT_INTERP/PT_DYNAMIC and .interp/.dynamic for a minimal PIE linked with --force-dynamic.

Fixes #534 