### PR TITLE
Add test for tracing symbol assignments

### DIFF
--- a/test/Common/standalone/linkerscript/TraceAssignments/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/TraceAssignments/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/Common/standalone/linkerscript/TraceAssignments/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/TraceAssignments/Inputs/script.t
@@ -1,0 +1,21 @@
+/* BEFORE_SECTIONS assignment */
+ABS1 = 0x1234;
+
+SECTIONS
+{
+  /* Place .text and emit assignments inside the output section */
+  .text :
+  {
+    *(.text*)
+    ABS2 = .;
+    ABS3 = .;
+  }
+
+  /* OUTPUT_SECTION(EPILOGUE) assignment */
+  .text : { }
+  ABS4 = .;
+}
+
+/* AFTER_SECTIONS assignment */
+ABS5 = 0x5678;
+

--- a/test/Common/standalone/linkerscript/TraceAssignments/TraceAssignments.test
+++ b/test/Common/standalone/linkerscript/TraceAssignments/TraceAssignments.test
@@ -1,0 +1,23 @@
+#---TraceAssignments.test------------------ Executable,LS ---------------------#
+#BEGIN_COMMENT
+# Validate tracing of symbol assignments with --trace=assignments.
+# Covers BEFORE_SECTIONS, INSIDE_OUTPUT_SECTION, OUTPUT_SECTION(EPILOGUE),
+# and AFTER_SECTIONS assignment trace lines to guard against regressions.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c -ffunction-sections %p/Inputs/1.c -o %t1.o
+RUN: %link %linkopts -o %t1.out %t1.o -T %p/Inputs/script.t --trace=assignments 2>&1 | %filecheck %s
+#END_TEST
+
+# Trace of BEFORE_SECTIONS assignment with decimal value and hex expression
+CHECK: BEFORE_SECTIONS >> ABS1(4660) = 0x1234;
+
+# Trace of assignments inside output section around .text contents
+CHECK: INSIDE_OUTPUT_SECTION >> ABS2({{[0-9]+}}) = .
+CHECK: INSIDE_OUTPUT_SECTION >> ABS3({{[0-9]+}}) = .
+
+# Trace of OUTPUT_SECTION(EPILOGUE) assignment at end of .text
+CHECK: OUTPUT_SECTION(EPILOGUE) >> ABS4({{[0-9]+}}) = .
+
+# Trace of AFTER_SECTIONS assignment with decimal value and hex expression
+CHECK: AFTER_SECTIONS >> ABS5(22136) = 0x5678;


### PR DESCRIPTION
This commit add tests for tracing symbol assignments.

Resolves #464