### PR TITLE
Support for running x86_64 tests with musl-libc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
           path: pr-${{ env.PR_NUMBER }}/llvm-project/llvm/tools/eld
           fetch-depth: 0
 
+      - name: Setup musl environment
+        run: echo "/opt/musl/bin" >> $GITHUB_PATH
+
       - name: Check for non-doc changes
         id: file-check
         working-directory: pr-${{ env.PR_NUMBER }}/llvm-project/llvm/tools/eld

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -34,6 +34,15 @@ def which(cmdline):
   ret = ret.replace("\\", "/")
   return ' '.join([ret] + cmdline[1:])
 
+def has_musl():
+  """Check if musl-clang is available in PATH"""
+  musl_clang = lit.util.which('musl-clang', config.environment['PATH'])
+  if musl_clang is not None:
+    lit_config.note('musl-clang found at: {}'.format(musl_clang))
+    return True
+  lit_config.note('musl-clang not found in PATH, using default glibc')
+  return False
+
 # name: The name of this test suite.
 config.name = 'eld'
 
@@ -88,7 +97,7 @@ if eld_obj_root is not None:
     # Propagate PYTHON_EXECUTABLE into the environment
     config.environment['PYTHON_EXECUTABLE'] = getattr(config, 'python_executable',
                                                       '')
-
+    config.environment['LD']="eld"
 eld_src_root = getattr(config, 'eld_src_root', None)
 test_templates_dir = ""
 if eld_src_root is not None:
@@ -119,6 +128,10 @@ try:
     config.available_features.add('yaml')
 except ImportError:
     pass
+
+use_musl = has_musl()
+if use_musl:
+    config.available_features.add('musl')
 
 if ('RISCV64' in config.eld_targets_to_build or
      'AArch64' in config.eld_targets_to_build):
@@ -299,7 +312,13 @@ if config.test_target == 'Hexagon':
 
 if config.test_target == 'x86':
     config.march = ''
-    clang = 'clang -target x86_64-linux-gnu'
+    if use_musl:
+        clang = 'musl-clang'
+        lit_config.note('Using musl-clang for x86_64 tests')
+    else:
+        clang = 'clang -target x86_64-linux-gnu'
+        lit_config.note('Using standard clang with glibc for x86_64 tests')
+    
     clangxx = 'clang++'
     llvmmc = 'llvm-mc'
     readelf = 'llvm-readelf'

--- a/test/x86_64/linux/LinkWithMuslSupport/Inputs/1.c
+++ b/test/x86_64/linux/LinkWithMuslSupport/Inputs/1.c
@@ -1,0 +1,1 @@
+int main() { return 42; }

--- a/test/x86_64/linux/LinkWithMuslSupport/LinkWithMuslSupport.test
+++ b/test/x86_64/linux/LinkWithMuslSupport/LinkWithMuslSupport.test
@@ -1,0 +1,13 @@
+#--LinkWithMuslSupport.test----------Executable--------#
+BEGIN_COMMENT
+# Test linking of x86_64 with musl libc.
+# This test case should run only if musl is available
+#END_COMMENT
+
+REQUIRES: musl
+
+#START_TEST
+RUN: %clang %clangopts -static %p/Inputs/1.c -o %t.1.out
+RUN: %t.1.out; echo $? | %filecheck %s --check-prefix=EXITCODE
+EXITCODE: 42
+#END_TEST


### PR DESCRIPTION
## Summary

Enables x86_64 testing using musl-clang for linking using `%musl-clang` substitution and musl gating.

## Changes

- **CI**: Add `/opt/musl/bin` to `PATH` so `musl-clang` is found.
- **LIT**: Detect `musl-clang`, add `musl` feature; define `%musl-clang`.
- **Tests**: Add test that uses `%musl-clang` with `REQUIRES: musl` to link and run.
``