### PR TITLE
[Hexagon][NFC] Simplify compatibility checking

### DIFF
--- a/test/Hexagon/standalone/Diagnostics/MixedISA/MixedISA.s
+++ b/test/Hexagon/standalone/Diagnostics/MixedISA/MixedISA.s
@@ -1,0 +1,17 @@
+// Check that mixing v71t objects with other ISAs emits a warning
+// and that the warning can be supressed.
+
+nop
+
+// RUN: %llvm-mc -filetype=obj -triple=hexagon -mcpu=hexagonv71t %s -o %t.o
+// RUN: %llvm-mc -filetype=obj -triple=hexagon -mcpu=hexagonv73 %s -o %t2.o
+
+// RUN: %link %linkopts %t.o %t2.o -o %t.out 2>&1 | %filecheck %s --check-prefix=WA7173
+// RUN: %link %linkopts %t2.o %t.o -o %t2.out 2>&1 | %filecheck %s --check-prefix=WA7371
+
+// RUN: %link %linkopts --no-warn-mismatch %t.o %t2.o -o %t3.out 2>&1 \
+// RUN:  | %filecheck --allow-empty %s --check-prefix=NOWARN
+
+// WA7173: Warning: Mixing incompatible object file {{.*}} object file arch is hexagonv73, {{.*}}hexagonv71t
+// WA7371: Warning: Mixing incompatible object file {{.*}} object file arch is hexagonv71t, {{.*}} hexagonv73
+// NOWARN-NOT: Mixing incompatible object file


### PR DESCRIPTION
Compatibility logic was previously stored in a big table (with missing columns), but the compatibility logic is not that complicated: we only need to warn when mixing v71t with non-v71t.