### PR TITLE
improve memory usage diagnostics

### DIFF
--- a/include/eld/Diagnostics/DiagLDScript.inc
+++ b/include/eld/Diagnostics/DiagLDScript.inc
@@ -76,7 +76,7 @@ DIAG(fatal_modulo_by_zero, DiagnosticEngine::Fatal,
 DIAG(error_experimental_not_supported, DiagnosticEngine::Error,
      "Linker has only experimental support for handling %0")
 DIAG(error_memory_region_exceeded_limit, DiagnosticEngine::Error,
-     "Memory region %0 exceeded limit while adding section %1")
+     "Memory region %0 exceeded limit while adding section %1 : overflowed by 0x%2 bytes")
 DIAG(error_memory_region_empty, DiagnosticEngine::Error,
      "Missing name for memory region, name cannot be empty")
 DIAG(error_duplicate_memory_region, DiagnosticEngine::Error,

--- a/include/eld/Object/ScriptMemoryRegion.h
+++ b/include/eld/Object/ScriptMemoryRegion.h
@@ -33,7 +33,7 @@ public:
 
   void addOutputSectionLMA(const OutputSectionEntry *O);
 
-  eld::Expected<void> verifyMemoryUsage(LinkerConfig &Config);
+  void verifyMemoryUsage(LinkerConfig &Config);
 
   eld::Expected<uint64_t> getOrigin() const;
 
@@ -66,6 +66,7 @@ public:
   void clearMemoryRegion() {
     MOutputSections.clear();
     CurrentCursor.reset();
+    DiagOverflows.clear();
     FirstOutputSectionExceededLimit = nullptr;
   }
 
@@ -109,6 +110,7 @@ private:
   uint32_t AttrInvertedNegFlags = 0;
   std::optional<uint64_t> CurrentCursor;
   const OutputSectionEntry *FirstOutputSectionExceededLimit = nullptr;
+  std::vector<std::unique_ptr<plugin::DiagnosticEntry>> DiagOverflows;
 };
 
 } // end namespace eld

--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -910,7 +910,7 @@ private:
   // ----------------------- MEMORY Support --------------------
   void clearMemoryRegions();
 
-  eld::Expected<void> verifyMemoryRegions();
+  void verifyMemoryRegions();
 
   eld::Expected<void> printMemoryRegionsUsage();
 

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -3977,11 +3977,7 @@ bool GNULDBackend::relax() {
   printMemoryRegionsUsage();
 
   // Verify memory regions
-  eld::Expected<void> E = verifyMemoryRegions();
-  if (!E) {
-    config().raiseDiagEntry(std::move(E.error()));
-    return config().getDiagEngine()->diagnose();
-  }
+  verifyMemoryRegions();
 
   return config().getDiagEngine()->diagnose();
 }
@@ -4870,12 +4866,9 @@ void GNULDBackend::clearMemoryRegions() {
     M->clearMemoryRegion();
 }
 
-eld::Expected<void> GNULDBackend::verifyMemoryRegions() {
-  for (auto &M : m_Module.getLinkerScript().getMemoryRegions()) {
-    eld::Expected<void> E = M->verifyMemoryUsage(config());
-    ELDEXP_RETURN_DIAGENTRY_IF_ERROR(E);
-  }
-  return eld::Expected<void>();
+void GNULDBackend::verifyMemoryRegions() {
+  for (auto &M : m_Module.getLinkerScript().getMemoryRegions())
+    M->verifyMemoryUsage(config());
 }
 
 bool GNULDBackend::assignMemoryRegions() {

--- a/test/Common/standalone/linkerscript/MEMORY/OverflowMemoryRegion/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/MEMORY/OverflowMemoryRegion/Inputs/script.t
@@ -1,5 +1,5 @@
 MEMORY {
-  b1 (rx) : ORIGIN = 100, LENGTH = 30
+  b1 (rx) : ORIGIN = 100, LENGTH = 4
 }
 SECTIONS {
   . = 0x2000;

--- a/test/Common/standalone/linkerscript/MEMORY/OverflowMemoryRegion/OverflowMemoryRegion.test
+++ b/test/Common/standalone/linkerscript/MEMORY/OverflowMemoryRegion/OverflowMemoryRegion.test
@@ -11,7 +11,10 @@ RUN: -T %p/Inputs/script.t -o %t2.out -Map %t1.map \
 RUN: 2>&1 | %filecheck %s
 RUN: %filecheck %s -check-prefix=MAP < %t1.map
 #END_TEST
-#CHECK: Memory region b1 exceeded limit while adding section
+#CHECK: Error: Memory region b1 exceeded limit while adding section .t1 : overflowed by 0x{{[a-f0-9]+}} bytes
+#CHECK: Error: Memory region b1 exceeded limit while adding section .t2 : overflowed by 0x{{[a-f0-9]+}} bytes
+#CHECK: Error: Memory region b1 exceeded limit while adding section .t3 : overflowed by 0x{{[a-f0-9]+}} bytes
+#CHECK: Error: Memory region b1 exceeded limit while adding section .t4 : overflowed by 0x{{[a-f0-9]+}} bytes
 #MAP: .t1 {{.*}} {{.*}} # Offset: {{.*}}, LMA: {{.*}}, Alignment: {{.*}}, Flags: SHF_ALLOC|SHF_EXECINSTR, Type: SHT_PROGBITS, Memory : [b1, b1]
 #MAP: .t2 {{.*}} {{.*}} # Offset: {{.*}}, LMA: {{.*}}, Alignment: {{.*}}, Flags: SHF_ALLOC|SHF_EXECINSTR, Type: SHT_PROGBITS, Memory : [b1, b1]
 #MAP: .t3 {{.*}} {{.*}} # Offset: {{.*}}, LMA: {{.*}}, Alignment: {{.*}}, Flags: SHF_ALLOC|SHF_EXECINSTR, Type: SHT_PROGBITS, Memory : [b1, b1]


### PR DESCRIPTION
This PR supports both the requirements below

* Enhance the MEMORY region overflow error reporting in linkers (like lld or bfd) by including the number of bytes by which the region was overflowed.

* When reporting MEMORY region overflow errors, lld typically identifies the first section that contributes to the overflow, and may also list additional non-empty sections in the region

Resolves #486
Resolves #487