### PR TITLE
x86_64: Add support for running x86_64 tests with musl-libc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
           path: pr-${{ env.PR_NUMBER }}/llvm-project/llvm/tools/eld
           fetch-depth: 0
 
+      - name: Setup musl environment
+        run: echo "/opt/musl/bin" >> $GITHUB_PATH
+
       - name: Check for non-doc changes
         id: file-check
         working-directory: pr-${{ env.PR_NUMBER }}/llvm-project/llvm/tools/eld

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -478,6 +478,14 @@ git = which(git)
 lsparserverifier = which(lsparserverifier)
 dirname = which(dirname)
 
+# Detect musl-clang
+muslclang = which('musl-clang')
+if 'Not Found' not in muslclang:
+    config.available_features.add('musl')
+    muslclang = ' '.join(['env LD=eld', muslclang])
+else:
+    muslclang = None
+
 # Set target-wise path where tests should be run.
 config.test_exec_root = os.path.join(config.test_exec_root, config.eld_targets_to_build)
 
@@ -526,6 +534,10 @@ lit_config.note('using cmake: {}'.format(cmake))
 lit_config.note('using git: {}'.format(git))
 lit_config.note('using dirname: {}'.format(dirname))
 lit_config.note('using test templates directory: {}'.format(test_templates_dir))
+if muslclang is not None:
+    lit_config.note('using musl-clang: {}'.format(muslclang))
+else:
+    lit_config.note('musl-clang not found - tests with REQUIRES: musl will be skipped')
 
 # Add substitutions.
 config.substitutions.append( ("%xlen", str(xlen)))
@@ -597,3 +609,5 @@ config.substitutions.append( ("%lsparserverifier", lsparserverifier) )
 config.substitutions.append( ("%mcpu","".join(mcpu)) )
 config.substitutions.append( ("%dirname","".join(dirname)) )
 config.substitutions.append( ("%emulation","".join(config.emulation)) )
+if muslclang is not None:
+    config.substitutions.append( ("%musl-clang","".join(muslclang)) )

--- a/test/x86_64/linux/LinkWithMuslSupport/Inputs/1.c
+++ b/test/x86_64/linux/LinkWithMuslSupport/Inputs/1.c
@@ -1,0 +1,1 @@
+int main() { return 42; }

--- a/test/x86_64/linux/LinkWithMuslSupport/LinkWithMuslSupport.test
+++ b/test/x86_64/linux/LinkWithMuslSupport/LinkWithMuslSupport.test
@@ -1,0 +1,10 @@
+REQUIRES: musl
+#--LinkWithMuslSupport.test----------Executable--------#
+BEGIN_COMMENT
+# Test linking of x86_64 with musl libc.
+#END_COMMENT
+#START_TEST
+RUN: %musl-clang %clangopts -static %p/Inputs/1.c -o %t.1.out
+RUN: %t.1.out; echo $? | %filecheck %s --check-prefix=EXITCODE
+EXITCODE: 42
+#END_TEST


### PR DESCRIPTION
## Summary

Enables x86_64 testing using musl-clang for linking using `%musl-clang` substitution and musl gating.

## Changes

- **CI**: Add `/opt/musl/bin` to `PATH` so `musl-clang` is found.
- **LIT**: Detect `musl-clang`, add `musl` feature; define `%musl-clang`.
- **Tests**: Add test that uses `%musl-clang` with `REQUIRES: musl` to link and run.

Fixes #534