### PR TITLE
Fix evaluation of non-dot assignments containing forward references

### DIFF
--- a/include/eld/Diagnostics/DiagVerbose.inc
+++ b/include/eld/Diagnostics/DiagVerbose.inc
@@ -167,3 +167,7 @@ DIAG(verbose_loaded_plugin_config, DiagnosticEngine::Verbose,
      "Initialized plugin config for %0")
 DIAG(verbose_infer_target, DiagnosticEngine::Verbose,
      "Inferred target : %0")
+DIAG(verbose_performing_layout_iteration, DiagnosticEngine::Verbose,
+     "Performing layout iteration %0")
+DIAG(verbose_eval_pending_assignments, DiagnosticEngine::Verbose,
+     "Evaluating pending assignments")

--- a/include/eld/Diagnostics/DiagnosticPrinter.h
+++ b/include/eld/Diagnostics/DiagnosticPrinter.h
@@ -47,6 +47,7 @@ public:
     TraceMergeStrings = 0x8000,
     TraceLinkerScript = 0x10000,
     TraceSymDef = 0x100000,
+    TracePendingAssignments = 0x200000
   };
 
   enum Verbose : uint16_t { None = 0x0, Default = 0x1 };
@@ -67,6 +68,8 @@ public:
   bool traceTrampolines() { return Trace & TraceTrampolines; }
 
   bool traceAssignments() { return Trace & TraceAssignments; }
+
+  bool tracePendingAssignments() { return Trace & TracePendingAssignments; }
 
   bool traceFiles() { return Trace & TraceFiles; }
 

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -688,7 +688,8 @@ defm trace
           "\t\t\t --trace=trampolines : trace trampolines\n"
           "\t\t\t --trace=wrap-symbols : trace symbol wrap options\n"
           "\t\t\t --trace=symdef : trace symbol resolution from symdef files\n"
-          "\t\t\t --trace=dynamic-linking : trace dynamic linking">,
+          "\t\t\t --trace=dynamic-linking : trace dynamic linking\n"
+          "\t\t\t --trace=pending-assignments : trace pending symbol assignments evaluation">,
       MetaVarName<"<trace-type>">,
       Group<grp_diagopts>;
 defm trace_symbol : smDashTwoWithOpt<"y", "trace-symbol", "trace_symbol",

--- a/include/eld/Script/Assignment.h
+++ b/include/eld/Script/Assignment.h
@@ -73,20 +73,26 @@ public:
 
   bool isDot() const;
 
-  // Does the assignment have any dot usage ?
+  // Does the assignment has any dot usage ?
   bool hasDot() const;
 
   static bool classof(const ScriptCommand *LinkerScriptCommand) {
     return LinkerScriptCommand->getKind() == ScriptCommand::ASSIGNMENT;
   }
 
+  /// Sets the expression context (location in the linker script)
+  /// and the assignment level.
   eld::Expected<void> activate(Module &CurModule) override;
 
   /// assign - evaluate the rhs and assign the result to lhs.
-  bool assign(Module &CurModule, const ELFSection *Section);
+  bool assign(Module &CurModule, const ELFSection *Section,
+              bool EvaluatePendingOnly);
 
   LDSymbol *symbol() const { return ThisSymbol; }
 
+  /// Returns all the symbols that might be referenced by the rhs of this
+  /// assignment. No expression evaluation is performed. Hence, this may return
+  /// more symbols than what is actually referenced at runtime.
   void getSymbols(std::vector<ResolveInfo *> &Symbols) const;
 
   /// Query functions on Assignment Kinds.
@@ -113,7 +119,9 @@ public:
 
   bool isAssert() const { return ThisType == ASSERT; }
 
-  // Retrieve the symbol names referred by the assignment expression
+  /// Returns the symbol names that might be referenced by the rhs of this
+  /// assignment. No expression evaluation is performed. Hence, this may return
+  /// names of more symbols than what is actually referenced at runtime.
   std::unordered_set<std::string> getSymbolNames() const;
 
   // Add all undefined references from assignmnent expressions

--- a/include/eld/SymbolResolver/NamePool.h
+++ b/include/eld/SymbolResolver/NamePool.h
@@ -111,6 +111,15 @@ public:
 
   bool getSymbolTracingRequested() const;
 
+  // --------------------- Linker Script Symbols ----------------
+  // Record a symbol that originates from a linker script / defsym.
+  void addScriptSymbol(ResolveInfo *RI) { ScriptSymbols.push_back(RI); }
+
+  // Return all symbols that originates from linker script / defsym.
+  const std::vector<ResolveInfo *> &getScriptSymbols() const {
+    return ScriptSymbols;
+  }
+
   /// --------------------- Symbol References and checks ----------------
   bool canSymbolsBeResolved(const ResolveInfo *, const ResolveInfo *) const;
   bool checkTLSTypes(const ResolveInfo *, const ResolveInfo *) const;
@@ -143,6 +152,9 @@ private:
   SymbolResolutionInfo SymbolResInfo;
   std::map<const ResolveInfo *, LDSymbol *> SharedLibsSymbols;
   PluginManager &PM;
+
+  // Symbols defined via linker scripts / defsym.
+  std::vector<ResolveInfo *> ScriptSymbols;
 };
 
 } // namespace eld

--- a/lib/Config/GeneralOptions.cpp
+++ b/lib/Config/GeneralOptions.cpp
@@ -230,6 +230,8 @@ eld::Expected<void> GeneralOptions::setTrace(const char *PTraceType) {
                   DiagEngine->getPrinter()->TraceDynamicLinking)
             .Case("linker-script", DiagEngine->getPrinter()->TraceLinkerScript)
             .Case("symdef", DiagEngine->getPrinter()->TraceSymDef)
+            .Case("pending-assignments",
+                  DiagEngine->getPrinter()->TracePendingAssignments)
             .Default(std::nullopt);
   }
   // Warn if trace category is unknown.

--- a/lib/Script/Assignment.cpp
+++ b/lib/Script/Assignment.cpp
@@ -19,6 +19,7 @@
 #include "eld/Readers/Section.h"
 #include "eld/Script/Expression.h"
 #include "eld/SymbolResolver/LDSymbol.h"
+#include "eld/Target/GNULDBackend.h"
 #include "llvm/Support/Casting.h"
 #include <cassert>
 
@@ -197,8 +198,8 @@ void Assignment::getSymbols(std::vector<ResolveInfo *> &Symbols) const {
   ExpressionToEvaluate->getSymbols(Symbols);
 }
 
-bool Assignment::assign(Module &CurModule, const ELFSection *Section) {
-
+bool Assignment::assign(Module &CurModule, const ELFSection *Section,
+                        bool EvaluatePendingOnly) {
   if (Section && !Section->isAlloc() && isDot()) {
     CurModule.getConfig().raise(Diag::error_dot_lhs_in_non_alloc)
         << std::string(Section->name())
@@ -207,7 +208,11 @@ bool Assignment::assign(Module &CurModule, const ELFSection *Section) {
   }
 
   // evaluate, commit, then get the result of the expression
-  auto Result = ExpressionToEvaluate->evaluateAndRaiseError();
+  std::optional<uint64_t> Result;
+  if (EvaluatePendingOnly)
+    Result = ExpressionToEvaluate->evaluatePendingAndRaiseError();
+  else
+    Result = ExpressionToEvaluate->evaluateAndRaiseError();
   if (!Result)
     return false;
   ExpressionValue = *Result;
@@ -216,13 +221,23 @@ bool Assignment::assign(Module &CurModule, const ELFSection *Section) {
     return false;
 
   LDSymbol *Sym = CurModule.getNamePool().findSymbol(Name);
+  // ASSERT(Sym, "Sym must exist!");
+  // FIXME: Why is it okay for the Sym to be nullptr?
   if (Sym != nullptr) {
     ThisSymbol = Sym;
     ThisSymbol->setValue(ExpressionValue);
     ThisSymbol->setScriptValueDefined();
+    GNULDBackend &Backend = CurModule.getBackend();
+    const ResolveInfo *RI = ThisSymbol->resolveInfo();
+    if (ExpressionToEvaluate->hasPendingEvaluation())
+      Backend.addPartiallyEvaluatedSymbol(RI);
+    else
+      Backend.removePartiallyEvaluatedSymbol(RI);
   }
 
-  if (CurModule.getPrinter()->traceAssignments())
+  auto DP = CurModule.getPrinter();
+  if (DP->traceAssignments() ||
+      (EvaluatePendingOnly && DP->tracePendingAssignments()))
     trace(llvm::outs());
   return true;
 }

--- a/lib/Script/Expression.cpp
+++ b/lib/Script/Expression.cpp
@@ -63,7 +63,7 @@ eld::Expected<uint64_t> Expression::evaluateAndReturnError() {
   // This is unfortunate, but hopefully context for expressions will be set
   // during parsing.
   ASSERT(!MContext.empty(), "Context not set for expression");
-  auto Result = eval();
+  auto Result = eval(/*EvaluatePendingOnly=*/false);
   if (!Result)
     return addContextToDiagEntry(std::move(Result.error()), MContext);
   commit();
@@ -72,7 +72,7 @@ eld::Expected<uint64_t> Expression::evaluateAndReturnError() {
 
 std::optional<uint64_t> Expression::evaluateAndRaiseError() {
   ASSERT(!MContext.empty(), "Context not set for expression");
-  auto Result = eval();
+  auto Result = eval(/*EvaluatePendingOnly=*/false);
   if (!Result) {
     // Even if evaluation fails, set the result (to zero) as
     // we don't expect the caller to exit due to this error.
@@ -85,10 +85,34 @@ std::optional<uint64_t> Expression::evaluateAndRaiseError() {
   return Result.value();
 }
 
-eld::Expected<uint64_t> Expression::eval() {
-  auto V = evalImpl();
-  if (V)
+std::optional<uint64_t> Expression::evaluatePendingAndRaiseError() {
+  ASSERT(!MContext.empty(), "Context not set for expression");
+  auto Result = eval(/*EvaluatePendingOnly=*/true);
+  if (!Result) {
+    // Even if evaluation fails, set the result (to zero) as
+    // we don't expect the caller to exit due to this error.
+    ThisModule.getConfig().raiseDiagEntry(
+        addContextToDiagEntry(std::move(Result.error()), MContext));
+    commit();
+    return {};
+  }
+  commit();
+  return Result.value();
+}
+
+eld::Expected<uint64_t> Expression::eval(bool EvaluatePendingOnly) {
+  if (shouldReuseResult(EvaluatePendingOnly)) {
+    return result();
+  }
+  HasPendingEvaluation = false;
+  auto V = evalImpl(EvaluatePendingOnly);
+  if (V) {
     EvaluatedValue = V.value();
+    visitExpression([this](Expression &E) {
+      if (E.hasPendingEvaluation())
+        HasPendingEvaluation = true;
+    });
+  }
   return V;
 }
 
@@ -132,8 +156,7 @@ bool Symbol::hasDot() const {
   return ThisSymbol == ThisModule.getDotSymbol();
 }
 
-eld::Expected<uint64_t> Symbol::evalImpl() {
-
+eld::Expected<uint64_t> Symbol::evalImpl(bool EvaluatePendingOnly) {
   if (!ThisSymbol)
     ThisSymbol = ThisModule.getNamePool().findSymbol(Name);
 
@@ -152,6 +175,13 @@ eld::Expected<uint64_t> Symbol::evalImpl() {
            "using a symbol that points to a non allocatable section!");
     return Section->addr() + FragRef->getOutputOffset(ThisModule);
   }
+
+  GNULDBackend &Backend = ThisModule.getBackend();
+  if (ThisSymbol->scriptDefined() &&
+      (!ThisSymbol->scriptValueDefined() ||
+       Backend.isPartiallyEvaluated(ThisSymbol->resolveInfo())))
+    HasPendingEvaluation = true;
+
   return ThisSymbol->value();
 }
 
@@ -184,7 +214,10 @@ void Integer::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> Integer::evalImpl() { return ExpressionValue; }
+eld::Expected<uint64_t> Integer::evalImpl(bool IsReevaluation) {
+  return ExpressionValue;
+}
+
 void Integer::getSymbols(std::vector<ResolveInfo *> &Symbols) {}
 
 void Integer::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {}
@@ -208,12 +241,12 @@ void Add::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> Add::evalImpl() {
+eld::Expected<uint64_t> Add::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Left = LeftExpression.eval();
+  auto Left = LeftExpression.eval(EvaluatePendingOnly);
   if (!Left)
     return Left;
-  auto Right = RightExpression.eval();
+  auto Right = RightExpression.eval(EvaluatePendingOnly);
   if (!Right)
     return Right;
   if (!ThisModule.getScript().phdrsSpecified() &&
@@ -262,16 +295,17 @@ void Subtract::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> Subtract::evalImpl() {
+eld::Expected<uint64_t> Subtract::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Left = LeftExpression.eval();
+  auto Left = LeftExpression.eval(EvaluatePendingOnly);
   if (!Left)
     return Left;
-  auto Right = RightExpression.eval();
+  auto Right = RightExpression.eval(EvaluatePendingOnly);
   if (!Right)
     return Right;
   return Left.value() - Right.value();
 }
+
 void Subtract::getSymbols(std::vector<ResolveInfo *> &Symbols) {
   LeftExpression.getSymbols(Symbols);
   RightExpression.getSymbols(Symbols);
@@ -302,12 +336,12 @@ void Modulo::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> Modulo::evalImpl() {
+eld::Expected<uint64_t> Modulo::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Left = LeftExpression.eval();
+  auto Left = LeftExpression.eval(EvaluatePendingOnly);
   if (!Left)
     return Left;
-  auto Right = RightExpression.eval();
+  auto Right = RightExpression.eval(EvaluatePendingOnly);
   if (!Right)
     return Right;
   if (Right.value() == 0) {
@@ -353,12 +387,12 @@ void Multiply::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> Multiply::evalImpl() {
+eld::Expected<uint64_t> Multiply::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Left = LeftExpression.eval();
+  auto Left = LeftExpression.eval(EvaluatePendingOnly);
   if (!Left)
     return Left;
-  auto Right = RightExpression.eval();
+  auto Right = RightExpression.eval(EvaluatePendingOnly);
   if (!Right)
     return Right;
   return Left.value() * Right.value();
@@ -396,12 +430,12 @@ void Divide::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> Divide::evalImpl() {
+eld::Expected<uint64_t> Divide::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Left = LeftExpression.eval();
+  auto Left = LeftExpression.eval(EvaluatePendingOnly);
   if (!Left)
     return Left;
-  auto Right = RightExpression.eval();
+  auto Right = RightExpression.eval(EvaluatePendingOnly);
   if (!Right)
     return Right;
   if (Right.value() == 0) {
@@ -440,7 +474,7 @@ void SizeOf::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   }
   Outs << ")";
 }
-eld::Expected<uint64_t> SizeOf::evalImpl() {
+eld::Expected<uint64_t> SizeOf::evalImpl(bool EvaluatePendingOnly) {
 
   if (Name.size() && Name[0] == ':') {
     // If the name is a segment and we don't have PHDR's. SIZEOF on segment will
@@ -505,7 +539,7 @@ void SizeOfHeaders::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   }
 }
 
-eld::Expected<uint64_t> SizeOfHeaders::evalImpl() {
+eld::Expected<uint64_t> SizeOfHeaders::evalImpl(bool EvaluatePendingOnly) {
   uint64_t Offset = 0;
   std::vector<ELFSection *> Sections;
   if (!getTargetBackend().isEhdrNeeded())
@@ -535,7 +569,7 @@ void Addr::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   }
   Outs << "\")";
 }
-eld::Expected<uint64_t> Addr::evalImpl() {
+eld::Expected<uint64_t> Addr::evalImpl(bool EvaluatePendingOnly) {
   // As the section table is populated only during PostLayout, we have to
   // go the other way around to access the section. This is because size of
   // empty
@@ -572,7 +606,7 @@ void LoadAddr::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   }
   Outs << ")";
 }
-eld::Expected<uint64_t> LoadAddr::evalImpl() {
+eld::Expected<uint64_t> LoadAddr::evalImpl(bool EvaluatePendingOnly) {
   // As the section table is populated only during PostLayout, we have to
   // go the other way around to access the section. This is because size of
   // empty
@@ -601,7 +635,7 @@ void OffsetOf::dump(llvm::raw_ostream &Outs, bool WithValues) const {
     Outs.write_hex(resultOrZero());
   }
 }
-eld::Expected<uint64_t> OffsetOf::evalImpl() {
+eld::Expected<uint64_t> OffsetOf::evalImpl(bool EvaluatePendingOnly) {
   // As the section table is populated only during PostLayout, we have to
   // go the other way around to access the section. This is because size of
   // empty
@@ -622,8 +656,10 @@ void OffsetOf::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {}
 /// Ternary
 void Ternary::commit() {
   ConditionExpression.commit();
-  LeftExpression.commit();
-  RightExpression.commit();
+  if (ConditionExpression.result())
+    LeftExpression.commit();
+  else
+    RightExpression.commit();
   Expression::commit();
 }
 void Ternary::dump(llvm::raw_ostream &Outs, bool WithValues) const {
@@ -637,11 +673,12 @@ void Ternary::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> Ternary::evalImpl() {
-  auto Cond = ConditionExpression.eval();
+eld::Expected<uint64_t> Ternary::evalImpl(bool EvaluatePendingOnly) {
+  auto Cond = ConditionExpression.eval(EvaluatePendingOnly);
   if (!Cond)
     return Cond;
-  return Cond.value() ? LeftExpression.eval() : RightExpression.eval();
+  return Cond.value() ? LeftExpression.eval(EvaluatePendingOnly)
+                      : RightExpression.eval(EvaluatePendingOnly);
 }
 
 void Ternary::getSymbols(std::vector<ResolveInfo *> &Symbols) {
@@ -688,12 +725,12 @@ void AlignExpr::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   AlignmentExpression.dump(Outs, WithValues);
   Outs << ")";
 }
-eld::Expected<uint64_t> AlignExpr::evalImpl() {
+eld::Expected<uint64_t> AlignExpr::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Expr = ExpressionToEvaluate.eval();
+  auto Expr = ExpressionToEvaluate.eval(EvaluatePendingOnly);
   if (!Expr)
     return Expr;
-  auto Align = AlignmentExpression.eval();
+  auto Align = AlignmentExpression.eval(EvaluatePendingOnly);
   if (!Align)
     return Align;
   uint64_t Value = Expr.value();
@@ -731,7 +768,7 @@ void AlignOf::getSymbols(std::vector<ResolveInfo *> &Symbols) {}
 
 void AlignOf::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {}
 
-eld::Expected<uint64_t> AlignOf::evalImpl() {
+eld::Expected<uint64_t> AlignOf::evalImpl(bool EvaluatePendingOnly) {
   // As the section table is populated only during PostLayout, we have to
   // go the other way around to access the section. This is because size of
   // empty
@@ -758,8 +795,8 @@ void Absolute::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   ExpressionToEvaluate.dump(Outs, WithValues);
   Outs << ")";
 }
-eld::Expected<uint64_t> Absolute::evalImpl() {
-  return ExpressionToEvaluate.eval();
+eld::Expected<uint64_t> Absolute::evalImpl(bool EvaluatePendingOnly) {
+  return ExpressionToEvaluate.eval(EvaluatePendingOnly);
 }
 void Absolute::getSymbols(std::vector<ResolveInfo *> &Symbols) {
   ExpressionToEvaluate.getSymbols(Symbols);
@@ -788,11 +825,11 @@ void ConditionGT::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> ConditionGT::evalImpl() {
-  auto Left = LeftExpression.eval();
+eld::Expected<uint64_t> ConditionGT::evalImpl(bool EvaluatePendingOnly) {
+  auto Left = LeftExpression.eval(EvaluatePendingOnly);
   if (!Left)
     return Left;
-  auto Right = RightExpression.eval();
+  auto Right = RightExpression.eval(EvaluatePendingOnly);
   if (!Right)
     return Right;
   return Left.value() > Right.value();
@@ -829,12 +866,12 @@ void ConditionLT::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> ConditionLT::evalImpl() {
+eld::Expected<uint64_t> ConditionLT::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Left = LeftExpression.eval();
+  auto Left = LeftExpression.eval(EvaluatePendingOnly);
   if (!Left)
     return Left;
-  auto Right = RightExpression.eval();
+  auto Right = RightExpression.eval(EvaluatePendingOnly);
   if (!Right)
     return Right;
   return Left.value() < Right.value();
@@ -871,12 +908,12 @@ void ConditionEQ::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> ConditionEQ::evalImpl() {
+eld::Expected<uint64_t> ConditionEQ::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Left = LeftExpression.eval();
+  auto Left = LeftExpression.eval(EvaluatePendingOnly);
   if (!Left)
     return Left;
-  auto Right = RightExpression.eval();
+  auto Right = RightExpression.eval(EvaluatePendingOnly);
   if (!Right)
     return Right;
   return Left.value() == Right.value();
@@ -913,12 +950,12 @@ void ConditionGTE::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> ConditionGTE::evalImpl() {
+eld::Expected<uint64_t> ConditionGTE::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Left = LeftExpression.eval();
+  auto Left = LeftExpression.eval(EvaluatePendingOnly);
   if (!Left)
     return Left;
-  auto Right = RightExpression.eval();
+  auto Right = RightExpression.eval(EvaluatePendingOnly);
   if (!Right)
     return Right;
   return Left.value() >= Right.value();
@@ -955,12 +992,12 @@ void ConditionLTE::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> ConditionLTE::evalImpl() {
+eld::Expected<uint64_t> ConditionLTE::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Left = LeftExpression.eval();
+  auto Left = LeftExpression.eval(EvaluatePendingOnly);
   if (!Left)
     return Left;
-  auto Right = RightExpression.eval();
+  auto Right = RightExpression.eval(EvaluatePendingOnly);
   if (!Right)
     return Right;
   return Left.value() <= Right.value();
@@ -997,12 +1034,12 @@ void ConditionNEQ::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> ConditionNEQ::evalImpl() {
+eld::Expected<uint64_t> ConditionNEQ::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Left = LeftExpression.eval();
+  auto Left = LeftExpression.eval(EvaluatePendingOnly);
   if (!Left)
     return Left;
-  auto Right = RightExpression.eval();
+  auto Right = RightExpression.eval(EvaluatePendingOnly);
   if (!Right)
     return Right;
   return Left.value() != Right.value();
@@ -1033,9 +1070,9 @@ void Complement::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   Outs << Name;
   ExpressionToEvaluate.dump(Outs, WithValues);
 }
-eld::Expected<uint64_t> Complement::evalImpl() {
+eld::Expected<uint64_t> Complement::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Expr = ExpressionToEvaluate.eval();
+  auto Expr = ExpressionToEvaluate.eval(EvaluatePendingOnly);
   if (!Expr)
     return Expr;
   return ~Expr.value();
@@ -1061,8 +1098,8 @@ void UnaryPlus::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   Outs << Name;
   ExpressionToEvaluate.dump(Outs, WithValues);
 }
-eld::Expected<uint64_t> UnaryPlus::evalImpl() {
-  return ExpressionToEvaluate.eval();
+eld::Expected<uint64_t> UnaryPlus::evalImpl(bool EvaluatePendingOnly) {
+  return ExpressionToEvaluate.eval(EvaluatePendingOnly);
 }
 void UnaryPlus::getSymbols(std::vector<ResolveInfo *> &Symbols) {
   ExpressionToEvaluate.getSymbols(Symbols);
@@ -1084,9 +1121,9 @@ void UnaryMinus::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   Outs << "-";
   ExpressionToEvaluate.dump(Outs, WithValues);
 }
-eld::Expected<uint64_t> UnaryMinus::evalImpl() {
+eld::Expected<uint64_t> UnaryMinus::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Expr = ExpressionToEvaluate.eval();
+  auto Expr = ExpressionToEvaluate.eval(EvaluatePendingOnly);
   if (!Expr)
     return Expr;
   return -Expr.value();
@@ -1111,9 +1148,9 @@ void UnaryNot::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   Outs << Name;
   ExpressionToEvaluate.dump(Outs, WithValues);
 }
-eld::Expected<uint64_t> UnaryNot::evalImpl() {
+eld::Expected<uint64_t> UnaryNot::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Expr = ExpressionToEvaluate.eval();
+  auto Expr = ExpressionToEvaluate.eval(EvaluatePendingOnly);
   if (!Expr)
     return Expr;
   return !Expr.value();
@@ -1133,7 +1170,7 @@ void Constant::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   // format output for operator
   Outs << "CONSTANT(" << Name << ")";
 }
-eld::Expected<uint64_t> Constant::evalImpl() {
+eld::Expected<uint64_t> Constant::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
   switch (type()) {
   case Expression::MAXPAGESIZE:
@@ -1162,7 +1199,7 @@ void SegmentStart::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   ExpressionToEvaluate.dump(Outs, WithValues);
   Outs << ")";
 }
-eld::Expected<uint64_t> SegmentStart::evalImpl() {
+eld::Expected<uint64_t> SegmentStart::evalImpl(bool EvaluatePendingOnly) {
   GeneralOptions::AddressMapType &AddressMap =
       ThisModule.getConfig().options().addressMap();
   GeneralOptions::AddressMapType::const_iterator Addr;
@@ -1178,7 +1215,7 @@ eld::Expected<uint64_t> SegmentStart::evalImpl() {
 
   if (Addr != AddressMap.end())
     return Addr->getValue();
-  return ExpressionToEvaluate.eval();
+  return ExpressionToEvaluate.eval(EvaluatePendingOnly);
 }
 void SegmentStart::getSymbols(std::vector<ResolveInfo *> &Symbols) {}
 
@@ -1211,8 +1248,8 @@ void AssertCmd::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   ExpressionToEvaluate.dump(Outs, WithValues);
   Outs << ", \"" << AssertionMessage << "\")";
 }
-eld::Expected<uint64_t> AssertCmd::evalImpl() {
-  auto Expr = ExpressionToEvaluate.eval();
+eld::Expected<uint64_t> AssertCmd::evalImpl(bool EvaluatePendingOnly) {
+  auto Expr = ExpressionToEvaluate.eval(EvaluatePendingOnly);
   if (!Expr)
     return Expr;
   return Expr.value() != 0;
@@ -1246,12 +1283,12 @@ void RightShift::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> RightShift::evalImpl() {
+eld::Expected<uint64_t> RightShift::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Left = LeftExpression.eval();
+  auto Left = LeftExpression.eval(EvaluatePendingOnly);
   if (!Left)
     return Left;
-  auto Right = RightExpression.eval();
+  auto Right = RightExpression.eval(EvaluatePendingOnly);
   if (!Right)
     return Right;
   return Left.value() >> Right.value();
@@ -1290,12 +1327,12 @@ void LeftShift::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> LeftShift::evalImpl() {
+eld::Expected<uint64_t> LeftShift::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Left = LeftExpression.eval();
+  auto Left = LeftExpression.eval(EvaluatePendingOnly);
   if (!Left)
     return Left;
-  auto Right = RightExpression.eval();
+  auto Right = RightExpression.eval(EvaluatePendingOnly);
   if (!Right)
     return Right;
   return Left.value() << Right.value();
@@ -1333,12 +1370,12 @@ void BitwiseOr::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> BitwiseOr::evalImpl() {
+eld::Expected<uint64_t> BitwiseOr::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Left = LeftExpression.eval();
+  auto Left = LeftExpression.eval(EvaluatePendingOnly);
   if (!Left)
     return Left;
-  auto Right = RightExpression.eval();
+  auto Right = RightExpression.eval(EvaluatePendingOnly);
   if (!Right)
     return Right;
   return Left.value() | Right.value();
@@ -1376,12 +1413,12 @@ void BitwiseXor::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> BitwiseXor::evalImpl() {
+eld::Expected<uint64_t> BitwiseXor::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Left = LeftExpression.eval();
+  auto Left = LeftExpression.eval(EvaluatePendingOnly);
   if (!Left)
     return Left;
-  auto Right = RightExpression.eval();
+  auto Right = RightExpression.eval(EvaluatePendingOnly);
   if (!Right)
     return Right;
   return Left.value() ^ Right.value();
@@ -1419,12 +1456,12 @@ void BitwiseAnd::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> BitwiseAnd::evalImpl() {
+eld::Expected<uint64_t> BitwiseAnd::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Left = LeftExpression.eval();
+  auto Left = LeftExpression.eval(EvaluatePendingOnly);
   if (!Left)
     return Left;
-  auto Right = RightExpression.eval();
+  auto Right = RightExpression.eval(EvaluatePendingOnly);
   if (!Right)
     return Right;
   return Left.value() & Right.value();
@@ -1449,7 +1486,7 @@ void Defined::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   // format output for operator
   Outs << "DEFINED(" << Name << ")";
 }
-eld::Expected<uint64_t> Defined::evalImpl() {
+eld::Expected<uint64_t> Defined::evalImpl(bool EvaluatePendingOnly) {
   const LDSymbol *Symbol = ThisModule.getNamePool().findSymbol(Name);
   if (Symbol == nullptr)
     return 0;
@@ -1486,11 +1523,11 @@ void DataSegmentAlign::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   CommonPageSize.dump(Outs, WithValues);
   Outs << ")";
 }
-eld::Expected<uint64_t> DataSegmentAlign::evalImpl() {
-  auto MaxPageSize = this->MaxPageSize.eval();
+eld::Expected<uint64_t> DataSegmentAlign::evalImpl(bool EvaluatePendingOnly) {
+  auto MaxPageSize = this->MaxPageSize.eval(EvaluatePendingOnly);
   if (!MaxPageSize)
     return MaxPageSize;
-  auto CommonPageSize = this->CommonPageSize.eval();
+  auto CommonPageSize = this->CommonPageSize.eval(EvaluatePendingOnly);
   if (!CommonPageSize)
     return CommonPageSize;
   uint64_t Dot = ThisModule.getDotSymbol()->value();
@@ -1528,14 +1565,14 @@ void DataSegmentRelRoEnd::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   RightExpression.dump(Outs, WithValues);
   Outs << ")";
 }
-eld::Expected<uint64_t> DataSegmentRelRoEnd::evalImpl() {
-  auto CommonPageSize = this->CommonPageSize.eval();
+eld::Expected<uint64_t> DataSegmentRelRoEnd::evalImpl(bool EvaluatePendingOnly) {
+  auto CommonPageSize = this->CommonPageSize.eval(EvaluatePendingOnly);
   if (!CommonPageSize)
     return CommonPageSize;
-  auto Expr1 = LeftExpression.eval();
+  auto Expr1 = LeftExpression.eval(EvaluatePendingOnly);
   if (!Expr1)
     return Expr1;
-  auto Expr2 = RightExpression.eval();
+  auto Expr2 = RightExpression.eval(EvaluatePendingOnly);
   if (!Expr2)
     return Expr2;
   uint64_t Value = Expr1.value() + Expr2.value();
@@ -1569,9 +1606,9 @@ void DataSegmentEnd::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   ExpressionToEvaluate.dump(Outs, WithValues);
   Outs << ")";
 }
-eld::Expected<uint64_t> DataSegmentEnd::evalImpl() {
+eld::Expected<uint64_t> DataSegmentEnd::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Expr = ExpressionToEvaluate.eval();
+  auto Expr = ExpressionToEvaluate.eval(EvaluatePendingOnly);
   if (!Expr)
     return Expr;
   return Expr.value() != 0; // TODO: What does this do?
@@ -1606,12 +1643,12 @@ void Max::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> Max::evalImpl() {
+eld::Expected<uint64_t> Max::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Left = LeftExpression.eval();
+  auto Left = LeftExpression.eval(EvaluatePendingOnly);
   if (!Left)
     return Left;
-  auto Right = RightExpression.eval();
+  auto Right = RightExpression.eval(EvaluatePendingOnly);
   if (!Right)
     return Right;
 
@@ -1648,12 +1685,12 @@ void Min::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> Min::evalImpl() {
+eld::Expected<uint64_t> Min::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Left = LeftExpression.eval();
+  auto Left = LeftExpression.eval(EvaluatePendingOnly);
   if (!Left)
     return Left;
-  auto Right = RightExpression.eval();
+  auto Right = RightExpression.eval(EvaluatePendingOnly);
   if (!Right)
     return Right;
   return Left.value() < Right.value() ? Left.value() : Right.value();
@@ -1683,7 +1720,7 @@ void Fill::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   ExpressionToEvaluate.dump(Outs, WithValues);
   Outs << ")";
 }
-eld::Expected<uint64_t> Fill::evalImpl() { return ExpressionToEvaluate.eval(); }
+eld::Expected<uint64_t> Fill::evalImpl(bool EvaluatePendingOnly) { return ExpressionToEvaluate.eval(EvaluatePendingOnly); }
 
 void Fill::getSymbols(std::vector<ResolveInfo *> &Symbols) {
   ExpressionToEvaluate.getSymbols(Symbols);
@@ -1709,8 +1746,8 @@ void Log2Ceil::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   Outs << ")";
 }
 
-eld::Expected<uint64_t> Log2Ceil::evalImpl() {
-  auto Val = ExpressionToEvaluate.eval();
+eld::Expected<uint64_t> Log2Ceil::evalImpl(bool EvaluatePendingOnly) {
+  auto Val = ExpressionToEvaluate.eval(EvaluatePendingOnly);
   if (!Val)
     return Val;
   return llvm::Log2_64_Ceil(std::max(Val.value(), UINT64_C(1)));
@@ -1753,12 +1790,12 @@ void LogicalOp::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> LogicalOp::evalImpl() {
+eld::Expected<uint64_t> LogicalOp::evalImpl(bool EvaluatePendingOnly) {
   // evaluate sub expressions
-  auto Left = LeftExpression.eval();
+  auto Left = LeftExpression.eval(EvaluatePendingOnly);
   if (!Left)
     return Left;
-  auto Right = RightExpression.eval();
+  auto Right = RightExpression.eval(EvaluatePendingOnly);
   if (!Right)
     return Right;
   if (isLogicalAnd())
@@ -1795,7 +1832,7 @@ void QueryMemory::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   Outs << ")";
 }
 
-eld::Expected<uint64_t> QueryMemory::evalImpl() {
+eld::Expected<uint64_t> QueryMemory::evalImpl(bool EvaluatePendingOnly) {
   auto Region = ThisModule.getScript().getMemoryRegion(Name);
   if (!Region)
     return std::move(Region.error());
@@ -1818,7 +1855,7 @@ void NullExpression::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   Outs << Name;
 }
 
-eld::Expected<uint64_t> NullExpression::evalImpl() {
+eld::Expected<uint64_t> NullExpression::evalImpl(bool EvaluatePendingOnly) {
   return std::make_unique<plugin::DiagnosticEntry>(
       Diag::internal_error_null_expression, std::vector<std::string>{});
 }

--- a/lib/SymbolResolver/IRBuilder.cpp
+++ b/lib/SymbolResolver/IRBuilder.cpp
@@ -547,6 +547,9 @@ LDSymbol *IRBuilder::addSymbol<IRBuilder::Force, IRBuilder::Unresolve>(
                                     Desc, /*isBitcode=*/false});
   }
 
+  if (Input && Input->isLinkerScript())
+    ThisModule.getNamePool().addScriptSymbol(OutputSym->resolveInfo());
+
   return OutputSym;
 }
 
@@ -626,6 +629,10 @@ LDSymbol *IRBuilder::addSymbol<IRBuilder::Force, IRBuilder::Resolve>(
     OutputSym->setFragmentRef(CurFragmentRef);
     OutputSym->setValue(Value, false);
   }
+
+  // If symbol originates from a linker script, record it in NamePool.
+  if (Input && Input->isLinkerScript())
+    ThisModule.getNamePool().addScriptSymbol(Result.Info);
 
   return OutputSym;
 }

--- a/lib/Target/CreateProgramHeaders.hpp
+++ b/lib/Target/CreateProgramHeaders.hpp
@@ -150,6 +150,8 @@ bool GNULDBackend::createProgramHdrs() {
     outBegin = script.sectionMap().begin();
     outEnd = script.sectionMap().end();
     out = outBegin;
+    resetScriptSymbols();
+    resetPartiallyEvalAssignmentsAndSymbols();
     prev_flag = 0;
     prev = nullptr;
     prevOut = nullptr;
@@ -693,6 +695,8 @@ bool GNULDBackend::createProgramHdrs() {
     }
     ++out;
   }
+
+  evaluatePendingAssignments();
 
   if (dynamic && dynamic->size()) {
     ELFSegment *dyn_seg = make<ELFSegment>(llvm::ELF::PT_DYNAMIC,

--- a/lib/Target/CreateScriptProgramHeaders.hpp
+++ b/lib/Target/CreateScriptProgramHeaders.hpp
@@ -64,6 +64,8 @@ bool GNULDBackend::createScriptProgramHdrs() {
     outBegin = script.sectionMap().begin();
     outEnd = script.sectionMap().end();
     out = outBegin;
+    resetScriptSymbols();
+    resetPartiallyEvalAssignmentsAndSymbols();
     disconnect_lma_vma = false;
     last_seen_alloc_section = nullptr;
     is_previous_start_of_segment = false;
@@ -386,6 +388,8 @@ bool GNULDBackend::createScriptProgramHdrs() {
 
     ++out;
   }
+
+  evaluatePendingAssignments();
 
   for (auto &seg : elfSegmentTable()) {
     // Handle empty segments

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/ForwardReference.test
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/ForwardReference.test
@@ -1,0 +1,16 @@
+#---ForwardReference.test----------------------- Executable,LS --------------------#
+#BEGIN_COMMENT
+# This test checks that the linker performs correct expression evaluation
+# when the expression contains a forward-reference.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts  -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.ForwardReference.t
+RUN: %readelf -s %t1.1.out 2>&1 | %filecheck %s
+RUN: %link %linkopts -o %t1.1.phdr.out %t1.1.o -T %p/Inputs/script.ForwardReference.phdr.t
+RUN: %readelf -s %t1.1.phdr.out 2>&1 | %filecheck %s
+#END_TEST
+
+CHECK-DAG: [[VALUE:[0-9a-f]+]] {{.*}} ABS u
+CHECK-DAG: [[VALUE]] {{.*}} ABS v
+

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/ForwardReferenceProvideSymbol.test
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/ForwardReferenceProvideSymbol.test
@@ -1,0 +1,20 @@
+#---ForwardReferenceProvideSymbol.test----------------------- Executable,LS --------------------#
+#BEGIN_COMMENT
+# This test checks that the linker performs correct expression evaluation
+# when the expression contains a forward-reference of a PROVIDE symbol.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
+RUN: %link %linkopts -o %t1.1.out %t1.1.o \
+RUN:   -T %p/Inputs/script.ForwardReferenceProvideSymbol.t
+RUN: %readelf -s %t1.1.out 2>&1 | %filecheck %s
+RUN: %link %linkopts -o %t1.1.phdr.out %t1.1.o \
+RUN:   -T %p/Inputs/script.ForwardReferenceProvideSymbol.phdr.t
+RUN: %readelf -s %t1.1.phdr.out 2>&1 | %filecheck %s
+#END_TEST
+
+CHECK-DAG: : [[#%x, START:]] {{.*}} start
+CHECK-DAG: : [[#%x, END:]] {{.*}} end
+CHECK-DAG: : {{0+}}[[#%x, V: END - START]] {{.*}} ABS v
+CHECK-DAG: : {{0+}}[[#%x, V + 0x10]] {{.*}} ABS u
+

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/2.c
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/2.c
@@ -1,0 +1,11 @@
+int fn();
+
+int foo() { return 11; }
+
+int bar() { return 13; }
+
+int baz() { return fn(); }
+
+int main() {
+  return baz();
+}

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.ForwardReference.phdr.t
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.ForwardReference.phdr.t
@@ -1,0 +1,13 @@
+PHDRS {
+  A PT_LOAD;
+}
+
+SECTIONS {
+  u = v;
+  FOO (0x1000): {
+    start = .;
+    *(.text.foo)
+    end = .;
+  } :A
+  v = end - start;
+}

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.ForwardReference.t
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.ForwardReference.t
@@ -1,0 +1,9 @@
+SECTIONS {
+  u = v;
+  FOO (0x1000): {
+    start = .;
+    *(.text.foo)
+    end = .;
+  }
+  v = end - start;
+}

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.ForwardReferenceProvideSymbol.phdr.t
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.ForwardReferenceProvideSymbol.phdr.t
@@ -1,0 +1,13 @@
+PHDRS {
+  A PT_LOAD;
+}
+
+SECTIONS {
+  u = v ? v + 0x10 : 0x20;
+  FOO (0x1000): {
+    start = .;
+    *(.text.foo)
+    end = .;
+  } :A
+  PROVIDE(v = end - start);
+}

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.ForwardReferenceProvideSymbol.t
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.ForwardReferenceProvideSymbol.t
@@ -1,0 +1,9 @@
+SECTIONS {
+  u = v ? v + 0x10 : 0x20;
+  FOO (0x1000): {
+    start = .;
+    *(.text.foo)
+    end = .;
+  }
+  PROVIDE(v = end - start);
+}

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.LayoutReset.phdr.t
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.LayoutReset.phdr.t
@@ -1,0 +1,24 @@
+PHDRS {
+  A PT_LOAD;
+  B PT_LOAD;
+}
+
+SECTIONS {
+  FOO (0x1000): {
+    fn = u;
+    u = bar;
+    *(.text.foo)
+  } :A
+
+  BAR : {
+    u = baz;
+    *(.text.bar)
+  } :B
+
+  BAZ : {
+    u = main;
+    *(.text.baz)
+  } :B
+
+  u = foo;
+}

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.LayoutReset.t
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.LayoutReset.t
@@ -1,0 +1,19 @@
+SECTIONS {
+  FOO (0x1000): {
+    fn = u;
+    u = bar;
+    *(.text.foo)
+  }
+
+  BAR : {
+    u = baz;
+    *(.text.bar)
+  }
+
+  BAZ : {
+    u = main;
+    *(.text.baz)
+  }
+
+  u = foo;
+}

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.RecursivePendingEvaluation.phdr.t
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.RecursivePendingEvaluation.phdr.t
@@ -1,0 +1,17 @@
+PHDRS {
+  A PT_LOAD;
+}
+
+SECTIONS {
+  FOO (0x1000) : {
+    fn = u;
+    u = v1;
+    *(.text.foo)
+  } :A
+  v1 = v2;
+  v2 = v3;
+  v3 = v4;
+  v4 = v5;
+  v5 = v6;
+  v6 = foo;
+}

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.RecursivePendingEvaluation.t
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/Inputs/script.RecursivePendingEvaluation.t
@@ -1,0 +1,13 @@
+SECTIONS {
+  FOO (0x1000) : {
+    fn = u;
+    u = v1;
+    *(.text.foo)
+  }
+  v1 = v2;
+  v2 = v3;
+  v3 = v4;
+  v4 = v5;
+  v5 = v6;
+  v6 = foo;
+}

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/LayoutResetForwardReference.test
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/LayoutResetForwardReference.test
@@ -1,0 +1,25 @@
+#---LayoutResetForwardReference.test----------------------- Executable,LS --------------------#
+#BEGIN_COMMENT
+# This test checks that the linker performs correct expression evaluation
+# when the expression contains a forward-reference, and the layout reset
+# during the layout may cause incorrect expression evaluation by incorrectly
+# providing intermediate values to pending assignments.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts  -o %t1.2.o %p/Inputs/2.c -c -ffunction-sections
+RUN: %link %linkopts -o %t1.2.out %t1.2.o -T %p/Inputs/script.LayoutReset.t \
+RUN:   --trace=pending-assignments --verbose 2>&1 | %filecheck %s
+RUN: %readelf -s %t1.2.out 2>&1 | %filecheck %s --check-prefix READELF
+RUN: %link %linkopts -o %t1.2.phdr.out %t1.2.o -T %p/Inputs/script.LayoutReset.phdr.t \
+RUN:   --trace=pending-assignments --verbose 2>&1 | %filecheck %s
+RUN: %readelf -s %t1.2.phdr.out 2>&1 | %filecheck %s --check-prefix READELF
+#END_TEST
+
+CHECK-DAG: Verbose: Performing layout iteration 0
+CHECK-DAG: Verbose: Evaluating pending assignments
+CHECK-DAG:     INSIDE_OUTPUT_SECTION    >>  fn(4096) = u(0x1000);
+
+READELF-DAG: {{0+}}1000 {{.*}} u
+READELF-DAG: {{0+}}1000 {{.*}} foo
+READELF-DAG: {{0+}}1000 {{.*}} fn
+

--- a/test/Common/standalone/linkerscript/ExpressionEvaluation/RecursivePendingEvaluation.test
+++ b/test/Common/standalone/linkerscript/ExpressionEvaluation/RecursivePendingEvaluation.test
@@ -1,0 +1,59 @@
+#---RecursivePendingEvaluation.test----------------------- Executable,LS --------------------#
+#BEGIN_COMMENT
+# This test checks that the linker performs correct expression evaluation
+# when there is a chain of forward reference expression such that
+# the pending assignments evaluation rounds needs several iterations
+# to resolve all the pending assignments.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts  -o %t1.2.o %p/Inputs/2.c -c -ffunction-sections
+RUN: %link %linkopts -o %t1.2.out %t1.2.o \
+RUN:   -T %p/Inputs/script.RecursivePendingEvaluation.t \
+RUN:  --trace=pending-assignments --verbose 2>&1 | %filecheck %s
+RUN: %readelf -s %t1.2.out 2>&1 | %filecheck %s --check-prefix READELF
+RUN: %link %linkopts -o %t1.2.phdr.out %t1.2.o \
+RUN:   -T %p/Inputs/script.RecursivePendingEvaluation.phdr.t \
+RUN:  --trace=pending-assignments --verbose 2>&1 | %filecheck %s
+RUN: %readelf -s %t1.2.phdr.out 2>&1 | %filecheck %s --check-prefix READELF
+#END_TEST
+
+CHECK-DAG: Verbose: Performing layout iteration 0
+CHECK: INSIDE_OUTPUT_SECTION    >>  fn(0) = u(0x0);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  u(0) = v1(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v1(0) = v2(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v2(0) = v3(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v3(0) = v4(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v4(0) = v5(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v5(4096) = v6(0x1000);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  fn(0) = u(0x0);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  u(0) = v1(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v1(0) = v2(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v2(0) = v3(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v3(0) = v4(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v4(4096) = v5(0x1000);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  fn(0) = u(0x0);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  u(0) = v1(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v1(0) = v2(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v2(0) = v3(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v3(4096) = v4(0x1000);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  fn(0) = u(0x0);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  u(0) = v1(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v1(0) = v2(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v2(4096) = v3(0x1000);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  fn(0) = u(0x0);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  u(0) = v1(0x0);
+CHECK:  OUTPUT_SECTION(EPILOGUE)   >>  v1(4096) = v2(0x1000);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  fn(0) = u(0x0);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  u(4096) = v1(0x1000);
+CHECK:    INSIDE_OUTPUT_SECTION    >>  fn(4096) = u(0x1000);
+
+READELF-DAG: {{0+}}1000 {{.*}} u
+READELF-DAG: {{0+}}1000 {{.*}} foo
+READELF-DAG: {{0+}}1000 {{.*}} fn
+READELF-DAG: {{0+}}1000 {{.*}} v1
+READELF-DAG: {{0+}}1000 {{.*}} v2
+READELF-DAG: {{0+}}1000 {{.*}} v3
+READELF-DAG: {{0+}}1000 {{.*}} v4
+READELF-DAG: {{0+}}1000 {{.*}} v5
+READELF-DAG: {{0+}}1000 {{.*}} v6
+


### PR DESCRIPTION
This commit fixes evaluation of non-dot assignments containing forward references. At a high-level, eld evaluates assignments in sequence and consequently the expressions containing forward references needs to be reevaluated when the forward reference value is computed for the correct computation results. For example:

```
u = v1;    // Assignment 1
v1 = v2;   // Assignment 2
v2 = 0xa;  // Assignment 3
```

eld evaluates the assignments in order, that is, the evaluation happens as: [Assignment 1, Assignment 2, Assignment 3]. If we follow this evaluation order, the symbols `u` and `v1` will have incorrect values because the value of `v2` is unknown when the assignments of `u` and `v1` are evaluated.

This commit fixes evaluation of non-dot assignments containing forward references by making the below two changes:

1) Assignments which cannot be completely evaluated during the
   sequential evaluation of expressions are marked as pending
   assignments. After the layout is done, but before the relaxation,
   these pending assignments are recursively reevaluated until there
   is no improvement in pending assignments or a MaxIteration limit is
   reached.

2) During a layout iteration, assignments may get evaluated multiple times
   as layout needs to reset itself based on a few conditions
   (new segment needs to be created, and so on...). It is important to reset
   the symbol if a layout gets reset. Let's
   see why it is important with the help of an example:

```
   SECTIONS {
     FOO : {
       u = v; // Assignment 1
       v = 0xa; // Assignment 2
       *(.text.foo)
     }
     BAR : {
       v = 0xb; // Assignment 3
     }
     v = 0xc; // Assignment 4
  }
```

The sequential assignment evaluation order is: [A1, A2, A3, A4]. When A1 is evaluated, `v` is not defined, hence we mark A1 as pending assignment. However, if the layout gets reset after evaluating A2, then A1 will be evaluated again, but this time, `v` is defined (from assignment 2 evaluation) and thus A1 can be completely evaluated. This is wrong because A1 should get the value from the assignment 4 instead of assignment 2!

We fix this issue by resetting the symbol values
whenever a layout is reset.

The same issue happens when the layout needs to be recomputed after a relaxation pass. And the same solution of resetting the the symbol values works for this case as well.

This commit also adds a new trace category 'pending-assignments' for tracing pending assignment evaluation.

Resolves #505