### PR TITLE
x86_64: Fix PLTN stub instructions

### DIFF
--- a/lib/Target/x86_64/x86_64LDBackend.h
+++ b/lib/Target/x86_64/x86_64LDBackend.h
@@ -105,6 +105,10 @@ private:
 
   x86_64ELFDynamic *m_pDynamic;
   LDSymbol *m_pEndOfImage;
+  // Tracks .rela.plt entry index
+  // m_RelaPLTIndex starts at 0 for the first function PLT entry
+  uint32_t m_RelaPLTIndex = 0;
+
   llvm::DenseMap<ResolveInfo *, x86_64GOT *> m_GOTMap;
   llvm::DenseMap<ResolveInfo *, x86_64GOT *> m_GOTPLTMap;
   llvm::DenseMap<ResolveInfo *, x86_64PLT *> m_PLTMap;

--- a/lib/Target/x86_64/x86_64PLT.h
+++ b/lib/Target/x86_64/x86_64PLT.h
@@ -58,20 +58,48 @@ public:
                             ResolveInfo *R, bool HasNow);
 };
 
+/** \class x86_64PLTN
+ *  \brief per-function PLT entry.
+ *
+ *  Each external function gets a PLTN entry.
+ *  On first call, the dynamic linker resolves the symbol and updates the
+ *  corresponding GOTPLTN entry. Subsequent calls jump directly to the function.
+ *
+ *  The relocation index embedded in the pushq instruction tells the dynamic
+ *  linker which .rela.plt entry corresponds to this function.
+ */
 class x86_64PLTN : public x86_64PLT {
 public:
   x86_64PLTN(x86_64GOT *G, eld::IRBuilder &I, ELFSection *P, ResolveInfo *R,
              uint32_t Align, uint32_t Size)
-      : x86_64PLT(PLT::PLTN, I, G, P, R, Align, Size) {}
+      : x86_64PLT(PLT::PLTN, I, G, P, R, Align, Size), m_RelocIndex(0) {}
 
   virtual ~x86_64PLTN() {}
 
+
+  // The relocation index must match the position in .rela.plt so the
+  // dynamic linker can find the correct relocation entry when resolving
+  // this function on first call.
+  void setRelocIndex(uint32_t index) { m_RelocIndex = index; }
+
   virtual llvm::ArrayRef<uint8_t> getContent() const override {
-    return x86_64_plt1;
+    memcpy(m_Content, x86_64_plt1, sizeof(x86_64_plt1));
+
+    uint32_t index = m_RelocIndex;
+    m_Content[7] = index & 0xFF;
+    m_Content[8] = (index >> 8) & 0xFF;
+    m_Content[9] = (index >> 16) & 0xFF;
+    m_Content[10] = (index >> 24) & 0xFF;
+
+    return llvm::ArrayRef<uint8_t>(m_Content, sizeof(m_Content));
   }
 
   static x86_64PLTN *Create(eld::IRBuilder &I, x86_64GOT *G, ELFSection *O,
                             ResolveInfo *R, bool HasNow);
+
+private:
+  uint32_t m_RelocIndex; // Position in .rela.plt for dynamic linker lookup
+  mutable uint8_t m_Content[16];
 };
 
 } // namespace eld

--- a/lib/Target/x86_64/x86_64Relocator.cpp
+++ b/lib/Target/x86_64/x86_64Relocator.cpp
@@ -177,8 +177,6 @@ void x86_64Relocator::scanLocalReloc(InputFile &pInputFile, Relocation &pReloc,
 void x86_64Relocator::scanGlobalReloc(InputFile &pInputFile, Relocation &pReloc,
                                       eld::IRBuilder &pBuilder,
                                       ELFSection &pSection, CopyRelocs &) {
-  assert(config().codeGenType() == LinkerConfig::Exec &&
-         "scanGlobalReloc currently only supports static executables");
 
   ELFObjectFile *Obj = llvm::dyn_cast<ELFObjectFile>(&pInputFile);
   // rsym - The relocation target symbol
@@ -186,6 +184,9 @@ void x86_64Relocator::scanGlobalReloc(InputFile &pInputFile, Relocation &pReloc,
 
   switch (pReloc.type()) {
   case llvm::ELF::R_X86_64_PLT32: {
+    if (config().isCodeStatic()) {
+      return;
+    }
     std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
     // Absolute relocation type, symbol may needs PLT entry or
     // dynamic relocation entry

--- a/test/x86_64/linux/PLTNStructure/Inputs/1.c
+++ b/test/x86_64/linux/PLTNStructure/Inputs/1.c
@@ -1,0 +1,3 @@
+int foo();
+int foo2();
+int bar() { return foo() + foo2(); }

--- a/test/x86_64/linux/PLTNStructure/Inputs/2.c
+++ b/test/x86_64/linux/PLTNStructure/Inputs/2.c
@@ -1,0 +1,2 @@
+int foo() { return 1; }
+int foo2() { return 2; }

--- a/test/x86_64/linux/PLTNStructure/PLTNStructure.test
+++ b/test/x86_64/linux/PLTNStructure/PLTNStructure.test
@@ -1,0 +1,34 @@
+#--PLTNStructure.test----------Executable (PIE)--------#
+#BEGIN_COMMENT
+# Verifies PLTN structure:
+# - First instruction references GOTPLTN
+# - Second instruction embeds relocation index (0, 1, ...)
+# - Third instruction references PLT0
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.1.o
+RUN: %clang %clangopts -c %p/Inputs/2.c -o %t.2.o
+RUN: %link %linkopts -shared -o %t.lib2.so %t.2.o
+RUN: %link %linkopts -o %t.out %t.1.o %t.lib2.so
+RUN: (%readelf -S %t.out; %objdump -d %t.out) | %filecheck %s
+
+# Capture section addresses
+CHECK: .plt PROGBITS [[#%x,PLT0_ADDR:]]
+CHECK: .got.plt PROGBITS [[#%x,GOTPLT_ADDR:]]
+CHECK: <.plt>:
+
+# First PLTN entry (index 0)
+# jmpq *GOTPLTN(%rip) - GOTPLTN at GOTPLT+0x18 (after 24-byte GOTPLT0)
+CHECK: [[#PLT0_ADDR+0x10]]: ff 25 {{[0-9a-f ]+}} jmpq{{.*}}# 0x[[#GOTPLT_ADDR+0x18]]
+# pushq $0x0 - relocation index 0
+CHECK-NEXT: {{[0-9a-f]+}}: 68 00 00 00 00
+# jmpq PLT0 - jump to PLT0 for symbol resolution
+CHECK-NEXT: {{[0-9a-f]+}}: e9 {{[0-9a-f ]+}} jmp{{.*}} 0x[[#PLT0_ADDR]]
+
+# Second PLTN entry (index 1)
+# jmpq *GOTPLTN(%rip) - GOTPLTN at GOTPLT+0x20 (GOTPLT0 + first GOTPLTN)
+CHECK: [[#PLT0_ADDR+0x20]]: ff 25 {{[0-9a-f ]+}} jmpq{{.*}}# 0x[[#GOTPLT_ADDR+0x20]]
+# pushq $0x1 - relocation index 1
+CHECK-NEXT: {{[0-9a-f]+}}: 68 01 00 00 00
+# jmpq PLT0 - jump to PLT0 for symbol resolution
+CHECK-NEXT: {{[0-9a-f]+}}: e9 {{[0-9a-f ]+}} jmp{{.*}} 0x[[#PLT0_ADDR]]


### PR DESCRIPTION
This implementation enables standard x86_64 lazy binding where:
1. On first call, PLTN jumps through GOTPLTN (which initially points back into the PLT)
2. Control returns to PLTN, which pushes its relocation index and jumps to PLT0
3. PLT0 invokes the dynamic linker with the index, allowing it to resolve the symbol
4. Dynamic linker updates GOTPLTN to point to the actual function
5. Subsequent calls jump directly to the resolved function

PLTN stub structure:
- First instruction of PLTN stub refers to the corresponding GOTPLTN entry
- The second instruction pushes the relocation index onto the stack
- The third instruction jumps to PLT0 to invoke the dynamic linker

Implementation Details:
- The first and third instructions are patched using R_X86_64_PC32 relocations that are resolved at link time itself
- Added 'm_RelaPLTIndex' counter to track sequential PLT entry positions. x86_64PLTN stores and embeds this in the second instruction
- Added a static linking guard in 'scanGlobalReloc' for R_86_64_PLT32 in static executables to prevent unnecessary PLT creation for such symbols.

Fixes #534 