### PR TITLE
x86_64: Implement GOTPLTN initialization

### DIFF
--- a/lib/Target/x86_64/x86_64GOT.cpp
+++ b/lib/Target/x86_64/x86_64GOT.cpp
@@ -15,3 +15,8 @@ x86_64GOTPLT0 *x86_64GOTPLT0::Create(ELFSection *O, Module *M) {
   x86_64GOTPLT0 *G = make<x86_64GOTPLT0>(O, M);
   return G;
 }
+
+x86_64GOTPLTN *x86_64GOTPLTN::Create(ELFSection *O, ResolveInfo *R) {
+  x86_64GOTPLTN *G = make<x86_64GOTPLTN>(O, R);
+  return G;
+}

--- a/lib/Target/x86_64/x86_64LDBackend.cpp
+++ b/lib/Target/x86_64/x86_64LDBackend.cpp
@@ -217,9 +217,8 @@ x86_64PLT *x86_64LDBackend::createPLT(ELFObjectFile *Obj, ResolveInfo *R) {
 
   // The relocation index is set before getContent() is called during
   // layout, as it is embedded directly in the PLT entry's instruction bytes.
-  if (x86_64PLTN *pltn = llvm::dyn_cast<x86_64PLTN>(P)) {
-    pltn->setRelocIndex(m_RelaPLTIndex);
-  }
+  x86_64PLTN *pltn = llvm::cast<x86_64PLTN>(P);
+  pltn->setRelocIndex(m_RelaPLTIndex);
 
   Relocation &rela_entry = *Obj->getRelaPLT()->createOneReloc();
   rela_entry.setType(llvm::ELF::R_X86_64_JUMP_SLOT);

--- a/lib/Target/x86_64/x86_64PLT.cpp
+++ b/lib/Target/x86_64/x86_64PLT.cpp
@@ -45,6 +45,10 @@ x86_64PLTN *x86_64PLTN::Create(eld::IRBuilder &I, x86_64GOT *G, ELFSection *O,
   x86_64PLTN *P = make<x86_64PLTN>(G, I, O, R, 16, 16);
   O->addFragmentAndUpdateSize(P);
 
+  // Link GOTPLTN to this PLT entry so it can compute its initial value
+  x86_64GOTPLTN *gotplt = llvm::cast<x86_64GOTPLTN>(G);
+  gotplt->setPLTEntry(P);
+
   // First instruction: jmpq *GOTPLTN(%rip)
   // Patches offset at PLTN+2 to reference GOTPLTN entry
   Relocation *r1 = Relocation::Create(llvm::ELF::R_X86_64_PC32, 32,

--- a/test/x86_64/linux/GOTPLTNStructure/GOTPLTNStructure.test
+++ b/test/x86_64/linux/GOTPLTNStructure/GOTPLTNStructure.test
@@ -1,0 +1,22 @@
+#--GOTPLTNStructure.test----------Executable (PIE)--------#
+#BEGIN_COMMENT
+# Verifies GOTPLTN entries point to PLT+6 (pushq instruction)
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.1.o
+RUN: %clang %clangopts -c %p/Inputs/2.c -o %t.2.o
+RUN: %link %linkopts -shared -o %t.lib2.so %t.2.o
+#The script fixes the address of .plt section
+RUN: %link %linkopts -T %p/Inputs/script_fixPLTaddress.t -o %t.out %t.1.o %t.lib2.so
+RUN: %readelf -x .got.plt %t.out | %filecheck %s
+
+# GOTPLT0 (24 bytes): .dynamic address + zeros
+CHECK: {{0x[0-9a-f]+}} 10034000 00000000
+CHECK-SAME: 00000000 00000000
+CHECK: {{0x[0-9a-f]+}} 00000000 00000000
+
+# First GOTPLTN: points to first PLT entry + 6
+CHECK-SAME: 96024000 00000000
+
+# Second GOTPLTN: points to second PLT entry + 6
+CHECK: {{0x[0-9a-f]+}} a6024000 00000000

--- a/test/x86_64/linux/GOTPLTNStructure/Inputs/1.c
+++ b/test/x86_64/linux/GOTPLTNStructure/Inputs/1.c
@@ -1,0 +1,3 @@
+int foo();
+int foo2();
+int bar() { return foo() + foo2(); }

--- a/test/x86_64/linux/GOTPLTNStructure/Inputs/2.c
+++ b/test/x86_64/linux/GOTPLTNStructure/Inputs/2.c
@@ -1,0 +1,2 @@
+int foo() { return 1; }
+int foo2() { return 2; }

--- a/test/x86_64/linux/GOTPLTNStructure/Inputs/script_fixPLTaddress.t
+++ b/test/x86_64/linux/GOTPLTNStructure/Inputs/script_fixPLTaddress.t
@@ -1,0 +1,7 @@
+#Need to fix the address of the .plt section as we are using absolute value checks to verify the correctness of GOTPLTN entries.
+#These absolute values are otherwise sensitive to get changed with updates made in future PRs
+SECTIONS {
+  .plt 0x400280 : {
+    *(.plt)
+  }
+}


### PR DESCRIPTION
Implement the GOTPLTN initialization required for the dynamic linking trampoline mechanism:

1. **Initial State**: GOTPLTN contains address of PLT entry + 6 (the `pushq` instruction)
2. **First Call**: Code jumps through GOTPLTN → lands at PLT entry + 6
3. **Resolution**: PLT entry pushes relocation index and jumps to PLT0
4. **Dynamic Linker**: Resolves symbol and updates GOTPLTN to point to actual function
5. **Subsequent Calls**: Jump through GOTPLTN directly to resolved function

Implementation Details:
- getContent() in x86_64GOTPLTN computes initial values so the GOTPLTN entries point to the pushq instruction of the corressponding PLTN entry
- setPLTEntry() in called in x86_64PLTN to link the GOTPLTN to the PLTN so it can compute the initial value

 Progress on #534 
 Fixes #568 
