### PR TITLE
Switch to the `.Cases({S0, S1, ...}, Value)` overload

### DIFF
--- a/lib/LinkerWrapper/HexagonLinkDriver.cpp
+++ b/lib/LinkerWrapper/HexagonLinkDriver.cpp
@@ -220,7 +220,7 @@ bool HexagonLinkDriver::processLLVMOptions(llvm::opt::InputArgList &Args) {
 bool HexagonLinkDriver::isValidEmulation(llvm::StringRef Emulation) {
   return llvm::StringSwitch<bool>(Emulation)
       .Cases("hexagonelf", "v68", "v69", "v71", "v71t", true)
-      .Cases("v73", "v75", "v77", "v79", "v81", "v83", "v85", "v87", "v89",
-             "v91", true)
+      .Cases({"v73", "v75", "v77", "v79", "v81", "v83", "v85", "v87", "v89",
+             "v91"}, true)
       .Default(false);
 }


### PR DESCRIPTION
Upstream llvm deprecated StringSwitch Cases with 6+ args in c4eaf56122d791d06c0a6f6be0224d8491d3beed.