### PR TITLE
Improve build dashboard and musl github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
       - '.github/workflows/ci-win.yml'
       - '.github/workflows/picolibc-builder.yml'
       - '.github/workflows/nightly-test.yml'
+      - '.github/workflows/scripts/record_builds.py'
 
 jobs:
   build:

--- a/.github/workflows/nightly-musl-builder.yml
+++ b/.github/workflows/nightly-musl-builder.yml
@@ -3,6 +3,7 @@ name: Nightly builder for testing eld against musl-test-suite for x86_64
 on: 
   schedule:
       - cron: '0 2 * * *' # 2:00 AM
+  workflow_dispatch:     # Allows manual triggering
   pull_request:
     paths:
       - '.github/workflows/nightly-musl-builder.yml'

--- a/.github/workflows/scripts/record_builds.py
+++ b/.github/workflows/scripts/record_builds.py
@@ -160,14 +160,14 @@ def writeJSData(workflow, data):
             json.dump(data, file)
     except Exception as e:
         sys.exit("Unable to write build data: " + str(e))
-    print("\nBuild data emitted to " + workflow_file_name + "\n")
+    print("\nBuild data written to " + workflow_file_name + "\n")
 
 
 def emitJSData(args):
     workflow = args.workflow_build.lower()
     conn = get_connection()
     cursor = conn.cursor()
-    all_data = None
+    all_data = []
     all_states_data = []
     try:
         if args.workflow_build.lower() == "picolibc":
@@ -182,7 +182,7 @@ def emitJSData(args):
             )
         all_data = cursor.fetchall()
     except Exception as e:
-        sys.exit(
+        print(
             "Error fetching build status data from table " + workflow + ": " + str(e)
         )
 


### PR DESCRIPTION
This commit adds workflow_dispatch to musl workflow to allow manual triggering.
Build dashboard data recorder script updated to not exit while emitting JS data.