### PR TITLE
Remove LD_LIBRARY_PATH env variable from lit test environment

### DIFF
--- a/test/Common/standalone/PluginAPI/CMakeLists.txt
+++ b/test/Common/standalone/PluginAPI/CMakeLists.txt
@@ -4,3 +4,4 @@ target_include_directories(ELDExpectedUsage
 target_link_libraries(ELDExpectedUsage PRIVATE LW)
 set_target_properties(ELDExpectedUsage PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                                                   ${CMAKE_BINARY_DIR}/bin/tests)
+set_target_properties(ELDExpectedUsage PROPERTIES INSTALL_RPATH "\$ORIGIN/../../lib")

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -78,9 +78,6 @@ if eld_obj_root is not None:
     llvm_libs_dir = getattr(config, 'llvm_libs_dir', None)
     if not llvm_libs_dir:
         lit_config.fatal('No LLVM libs dir set!')
-    path = os.path.pathsep.join((llvm_libs_dir,
-                                 config.environment.get('LD_LIBRARY_PATH','')))
-    config.environment['LD_LIBRARY_PATH'] = path
 
     # Propagate LLVM_SRC_ROOT into the environment.
     config.environment['LLVM_SRC_ROOT'] = getattr(config, 'llvm_src_root', '')


### PR DESCRIPTION
This commit removes LD_LIBRARY_PATH envirionment variable from lit test environment. The primary motivation for this change is that LD_LIBRARY_PATH is not helpful / required for running tests and instead can cause issues if the the host clang depends dynamically on LLVM/clang dependencies.