### PR TITLE
Rename __end to ___end symbol to support picolibc

### DIFF
--- a/lib/Target/Hexagon/HexagonLDBackend.cpp
+++ b/lib/Target/Hexagon/HexagonLDBackend.cpp
@@ -331,7 +331,7 @@ void HexagonLDBackend::initTargetSymbols() {
   if (m_Module.getConfig().options().isSymbolTracingRequested() &&
       m_Module.getConfig().options().traceSymbol(SymbolName))
     config().raise(Diag::target_specific_symbol) << SymbolName;
-  SymbolName = "__end";
+  SymbolName = "___end";
   m_pEndOfImage = m_Module.getNamePool().findSymbol(SymbolName);
   if (!m_pEndOfImage)
     m_pEndOfImage =

--- a/lib/Target/Template/TemplateLDBackend.cpp
+++ b/lib/Target/Template/TemplateLDBackend.cpp
@@ -70,7 +70,7 @@ void TemplateLDBackend::initTargetSymbols() {
 
   m_pEndOfImage =
       m_Module.getIRBuilder()->addSymbol<IRBuilder::Force, IRBuilder::Resolve>(
-          m_Module.getInternalInput(Module::Script), "__end",
+          m_Module.getInternalInput(Module::Script), "___end",
           ResolveInfo::NoType, ResolveInfo::Define, ResolveInfo::Absolute,
           0x0, // size
           0x0, // value

--- a/lib/Target/x86_64/x86_64LDBackend.cpp
+++ b/lib/Target/x86_64/x86_64LDBackend.cpp
@@ -85,7 +85,7 @@ void x86_64LDBackend::initTargetSymbols() {
 
   m_pEndOfImage =
       m_Module.getIRBuilder()->addSymbol<IRBuilder::Force, IRBuilder::Resolve>(
-          m_Module.getInternalInput(Module::Script), "__end",
+          m_Module.getInternalInput(Module::Script), "___end",
           ResolveInfo::NoType, ResolveInfo::Define, ResolveInfo::Absolute,
           0x0, // size
           0x0, // value

--- a/test/Common/standalone/linkerscript/AllocAfterNonAllocSections/Inputs/script1.t
+++ b/test/Common/standalone/linkerscript/AllocAfterNonAllocSections/Inputs/script1.t
@@ -6,6 +6,6 @@ SECTIONS {
   .empty1 0 : { *(.empty1) }
   __start = .;
   .empty : { . = . + 1; }
-  ___end = .;
+  __end = .;
    /DISCARD/ : { *(.ARM.*) *(.*.attributes) }
 }

--- a/test/Common/standalone/linkerscript/AllocAfterNonAllocSections/Inputs/script2.t
+++ b/test/Common/standalone/linkerscript/AllocAfterNonAllocSections/Inputs/script2.t
@@ -10,6 +10,6 @@ SECTIONS {
   .empty1 0 : { *(.empty1) }
   __start = .;
   .empty : { . = . + 1; }
-  ___end = .;
+  __end = .;
    /DISCARD/ : { *(.ARM.*) *(.*.attributes) }
 }

--- a/test/Hexagon/standalone/EndOfImageSymbol/EndOfImageSymbol.test
+++ b/test/Hexagon/standalone/EndOfImageSymbol/EndOfImageSymbol.test
@@ -11,5 +11,5 @@ RUN: %link %linkopts %t1.o -o %t2.out.gc --gc-sections
 RUN: %readelf -s -W %t2.out.gc | %filecheck %s
 RUN: %link %linkopts %t1.o -o %t2.out.ls -T %p/Inputs/script.t --gc-sections
 RUN: %readelf -s -W %t2.out.ls | %filecheck %s
-#CHECK: {{[0-9a-f]+[1-9a-f]+}}    0 NOTYPE  GLOBAL DEFAULT  ABS __end
+#CHECK: {{[0-9a-f]+[1-9a-f]+}}    0 NOTYPE  GLOBAL DEFAULT  ABS ___end
 #END_TEST

--- a/test/Hexagon/standalone/EndOfImageSymbolGC/EndOfImageSymbolGC.test
+++ b/test/Hexagon/standalone/EndOfImageSymbolGC/EndOfImageSymbolGC.test
@@ -8,7 +8,7 @@
 RUN: %clang %clangopts -c %p/Inputs/fb.s -o %t1.o
 RUN: %link %linkopts %t1.o -e main --gc-sections -o %t2.out
 RUN: %dwarfdump -debug-frame %t2.out | %filecheck %s -check-prefix=EOI
-RUN: %link %linkopts %t1.o -e main --gc-sections -defsym __end=0 -o %t2.out.noeoi
+RUN: %link %linkopts %t1.o -e main --gc-sections -defsym ___end=0 -o %t2.out.noeoi
 RUN: %dwarfdump -debug-frame %t2.out.noeoi | %filecheck %s -check-prefix=NOEOI
 
 #EOI: 00000014 0000000c 00000000 FDE cie=00000000 pc=00000000...00000004

--- a/test/Hexagon/standalone/EndOfImageSymbolGCDynamicLibrary/EndOfImageSymbolGCDynamicLibrary.test
+++ b/test/Hexagon/standalone/EndOfImageSymbolGCDynamicLibrary/EndOfImageSymbolGCDynamicLibrary.test
@@ -8,5 +8,5 @@ RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o -fPIC -ffunction-sections -g
 RUN: %link %linkopts -shared %t1.o -e foo --gc-sections -o %t2.out -T %p/Inputs/script.t
 RUN: %nm -n %t2.out | %filecheck %s
 
-#CHECK: __end
+#CHECK: ___end
 #END_TEST


### PR DESCRIPTION
__end is used by picolibc as a marker for end of the heap.

Change the symbol to ___end.

Fixes #524