### PR TITLE
Update github workflows to continue if build dashboard step fails.

### DIFF
--- a/.github/workflows/nightly-musl-builder.yml
+++ b/.github/workflows/nightly-musl-builder.yml
@@ -44,13 +44,14 @@ jobs:
       - name: Record pre-build entry
         run: |
           cd llvm-project/llvm/tools/eld
-          git branch
           DASH_DIR="$(mktemp -d)"
           cp .github/workflows/scripts/record_builds.py ${DASH_DIR}/
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@github.com'
           git fetch --all
           git checkout dashboard
+          git fetch origin
+          git reset --hard origin/dashboard
           cp ${DASH_DIR}/record_builds.py .
           python record_builds.py --workflow musl --record --fail --run-id ${{github.run_id}}
           rm -f record_builds.py
@@ -59,6 +60,8 @@ jobs:
           git push -f origin HEAD:refs/heads/dashboard
           rm -rf ${DASH_DIR}
           git checkout -
+          git branch
+        continue-on-error: true
 
       - name: Configure ELD Build
         run: |
@@ -132,14 +135,14 @@ jobs:
       - name: Update build entry
         run: |
           cd llvm-project/llvm/tools/eld
-          git branch
           DASH_DIR="$(mktemp -d)"
           cp .github/workflows/scripts/record_builds.py ${DASH_DIR}/
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@github.com'
           git fetch --all
           git checkout dashboard
-          git pull
+          git fetch origin
+          git reset --hard origin/dashboard
           cp ${DASH_DIR}/record_builds.py .
           python record_builds.py --workflow musl --update --pass --run-id ${{github.run_id}}
           rm -f record_builds.py
@@ -148,3 +151,4 @@ jobs:
           git push -f origin HEAD:refs/heads/dashboard
           rm -rf ${DASH_DIR}
           git checkout -
+        continue-on-error: true

--- a/.github/workflows/picolibc-builder.yml
+++ b/.github/workflows/picolibc-builder.yml
@@ -65,13 +65,14 @@ jobs:
       - name: Record pre-build entry
         run: |
           cd llvm-project/llvm/tools/eld
-          git branch
           DASH_DIR="$(mktemp -d)"
           cp .github/workflows/scripts/record_builds.py ${DASH_DIR}/
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@github.com'
           git fetch --all
           git checkout dashboard
+          git fetch origin
+          git reset --hard origin/dashboard
           cp ${DASH_DIR}/record_builds.py .
           python record_builds.py --workflow picolibc --record --fail --run-id ${{github.run_id}} --arch ${{ matrix.arch.name }}
           rm -f record_builds.py
@@ -80,6 +81,8 @@ jobs:
           git push -f origin HEAD:refs/heads/dashboard
           rm -rf ${DASH_DIR}
           git checkout -
+          git branch
+        continue-on-error: true
 
       - name: Configure LLVM toolchain for ${{ matrix.arch.name }}
         run: |
@@ -233,14 +236,14 @@ jobs:
       - name: Update build entry
         run: |
           cd llvm-project/llvm/tools/eld
-          git branch
           DASH_DIR="$(mktemp -d)"
           cp .github/workflows/scripts/record_builds.py ${DASH_DIR}/
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@github.com'
           git fetch --all
           git checkout dashboard
-          git pull
+          git fetch origin
+          git reset --hard origin/dashboard
           cp ${DASH_DIR}/record_builds.py .
           python record_builds.py --workflow picolibc --update --pass --run-id ${{github.run_id}} --arch ${{ matrix.arch.name }}
           rm -f record_builds.py
@@ -249,3 +252,4 @@ jobs:
           git push -f origin HEAD:refs/heads/dashboard
           rm -rf ${DASH_DIR}
           git checkout -
+        continue-on-error: true

--- a/.github/workflows/update-build-dashboard-data.yml
+++ b/.github/workflows/update-build-dashboard-data.yml
@@ -38,3 +38,4 @@ jobs:
             git add .
             git commit -m "Update build status data for dashboard"
             git push -f origin HEAD:refs/heads/documentation
+        continue-on-error: true


### PR DESCRIPTION
This commit updates the picolibc, musl and hourly build dashboard workflows to continue if the build data recording/updating/publishing step fails.

Closes #560