### PR TITLE
Fix FileCheck pattern for AbsoluteSymbolRelocation

### DIFF
--- a/test/Hexagon/standalone/AbsoluteSymbolRelocation/abssymbolrelocation.test
+++ b/test/Hexagon/standalone/AbsoluteSymbolRelocation/abssymbolrelocation.test
@@ -2,4 +2,4 @@
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o %clangg0opts
 RUN: %link %linkopts %t1.o -o %t2.out
 RUN: %readelf -x .data %t2.out | %filecheck %s
-#CHECK-NOT: 00000000
+#CHECK-NOT: {{^0x[0-9a-f]+}}{{[[:space:]]+}}00000000


### PR DESCRIPTION
Update abssymbolrelocation.test to avoid false negatives when matching readelf output. The previous CHECK-NOT pattern excluded "00000000" globally, which can incorrectly match the address column in Hexagon binaries. The new regex anchors to the data column, ensuring we only forbid zero-initialized relocation values while allowing zero addresses.