### PR TITLE
Fix YAML package dependecy and search path related windows test failures

### DIFF
--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
     env:
       BASE_BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
-      
+
     steps:
       - name: Map Git usr/bin to a space-free drive and prepend to PATH
         shell: pwsh
@@ -55,6 +55,10 @@ jobs:
         working-directory: nightly/obj
         shell: bash
         run: cmake --build . --config Release
+
+      - name: Install PyYAML
+        shell: bash
+        run: python -m pip install pyyaml
 
       - name: Run tests
         working-directory: nightly/obj

--- a/test/Common/standalone/SearchPathTest/SearchPathErrorMessage.test
+++ b/test/Common/standalone/SearchPathTest/SearchPathErrorMessage.test
@@ -5,5 +5,5 @@
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.o
 RUN: %link %linkopts %t.o -L /a/b -o %t.test.out 2>&1 | %filecheck %s --check-prefix=MSG
-#MSG: Note: can not open search directory `{{[\(\)_A-Za-z0-9.\\/:]+}}a/b
+#MSG: Note: can not open search directory `{{.*}}{{[/\\]}}b
 #END_TEST


### PR DESCRIPTION
This patch fixes search path related errors and a YAML package dependecy error that occur while running windows tests in the nightly workflow.