### PR TITLE
Disable windows tests on x86 temporarily.

### DIFF
--- a/test/x86_64/linux/DefaultImageBase/DefaultImageBase.test
+++ b/test/x86_64/linux/DefaultImageBase/DefaultImageBase.test
@@ -1,3 +1,4 @@
+#UNSUPPORTED: windows
 #---DefaultImageBase.test-----Executable--------#
 BEGIN_COMMENT
 # Test x86_64 default image address

--- a/test/x86_64/linux/EmulationSupport/EmulationOption.test
+++ b/test/x86_64/linux/EmulationSupport/EmulationOption.test
@@ -1,3 +1,4 @@
+#UNSUPPORTED: windows
 #---x86_64_Emulation.test----------------- Executable --------------------#
 
 BEGIN_COMMENT

--- a/test/x86_64/linux/relocGOTPCREL/relocGOTPCREL.test
+++ b/test/x86_64/linux/relocGOTPCREL/relocGOTPCREL.test
@@ -1,3 +1,4 @@
+#UNSUPPORTED: windows
 #--relocGOTPCRELStatic.test----------Executable--------#
 BEGIN_COMMENT
 # Test R_X86_64_GOTPCREL relocation type support.

--- a/test/x86_64/linux/relocPLT32Static/relocPLT32Static.test
+++ b/test/x86_64/linux/relocPLT32Static/relocPLT32Static.test
@@ -1,3 +1,4 @@
+#UNSUPPORTED: windows
 #--PLT32Static.test----------Executable--------#
 
 BEGIN_COMMENT

--- a/test/x86_64/linux/relocPLT32dynamic/relocPLT32dynamic.test
+++ b/test/x86_64/linux/relocPLT32dynamic/relocPLT32dynamic.test
@@ -1,3 +1,4 @@
+#UNSUPPORTED: windows
 #--relocPLT32dynamic.test-------Executable--#
 #BEGIN_COMMENT
 # Verifies R_X86_64_PLT32 relocations redirect external function calls


### PR DESCRIPTION
This patch disables windows tests that need emulation support on X86 temporarily.