### PR TITLE
[NFC] Switch to the `.Cases({S0, S1, ...}, Value)` overload

### DIFF
--- a/lib/Target/Hexagon/HexagonEmulation.cpp
+++ b/lib/Target/Hexagon/HexagonEmulation.cpp
@@ -24,7 +24,7 @@ static bool ELDEmulateHexagonELF(LinkerScript &pScript, LinkerConfig &pConfig) {
   llvm::StringRef Emulation = pConfig.options().getEmulation();
   if (!Emulation.empty()) {
     llvm::StringRef flag = llvm::StringSwitch<StringRef>(Emulation)
-                               .Cases("v68", "hexagonelf", "hexagonv68")
+                               .Cases({"v68", "hexagonelf"}, "hexagonv68")
                                .Case("v69", "hexagonv69")
                                .Case("v71", "hexagonv71")
                                .Case("v71t", "hexagonv71t")


### PR DESCRIPTION
Upstream llvm deprecated StringSwitch Cases to use initializer_list

Seems to have another occurence of this.