### PR TITLE
Add 'windows' feature to x86 lit config.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -199,10 +199,12 @@ if platform.system() == 'Windows':
     rm = which("rm") + " -rf"
     mkdir = which("mkdir") + " -p"
     grep = 'findstr'
+    config.available_features.add('windows')
 elif platform.system() == 'Linux':
     rm = 'rm -rf'
     mkdir = 'mkdir -p'
     grep = 'grep'
+    config.available_features.add('linux')
 
 if config.eld_option_name != "":
   config.available_features.add(config.eld_option_name)
@@ -270,10 +272,6 @@ if config.test_target == 'Hexagon':
     size = 'llvm-size'
     if config.has_zlib == "1":
         config.available_features.add('zlib')
-    if platform.system() == 'Windows':
-        config.available_features.add('windows')
-    elif platform.system() == 'Linux':
-        config.available_features.add('linux')
     #For Hexagon Linux.
     if 'hexagon-unknown-linux' in config.target_triple:
          clang ='clang'
@@ -306,7 +304,6 @@ if config.test_target == 'x86':
     nm = 'llvm-nm'
     objdump = 'llvm-objdump'
     dwarfdump = 'llvm-dwarfdump'
-    config.available_features.add('linux')
 
 if config.test_target == 'ARM':
     config.march = '-march=arm'
@@ -345,7 +342,6 @@ if config.test_target == 'AArch64':
     # Features for buildbot to XFAIL tests while they are being fixed.
     if platform.system() == 'Windows':
         config.available_features.add('aarch64-windows')
-        config.available_features.add('windows')
     elif platform.system() == 'Linux':
         config.available_features.add('aarch64-linux')
     if ('aarch64-windows' in config.available_features or
@@ -400,10 +396,6 @@ if config.test_target == 'RISCV64':
     nm = 'llvm-nm'
     objdump = 'llvm-objdump'
     dwarfdump = 'llvm-dwarfdump'
-    if platform.system() == 'Windows':
-        config.available_features.add('windows')
-    elif platform.system() == 'Linux':
-        config.available_features.add('linux')
 
 if config.test_target == 'RISCV':
     config.march = '-march=riscv32'
@@ -430,10 +422,6 @@ if config.test_target == 'RISCV':
     nm = 'llvm-nm'
     objdump = 'llvm-objdump'
     dwarfdump = 'llvm-dwarfdump'
-    if platform.system() == 'Windows':
-        config.available_features.add('windows')
-    elif platform.system() == 'Linux':
-        config.available_features.add('linux')
 
 cnot = which(cnot)
 clangxx = which(clangxx)


### PR DESCRIPTION
This patch adds the windows feature to the x86 lit config.  While other target configurations (Hexagon, ARM, AArch64, RISCV) properly add the windows feature based on platform.system(), the x86 section only added the linux feature unconditionally.