### PR TITLE
[ARM] Report unencodable imm for R_ARM_ALU_PC_G0

### DIFF
--- a/include/eld/Diagnostics/DiagRelocations.inc
+++ b/include/eld/Diagnostics/DiagRelocations.inc
@@ -54,6 +54,8 @@ DIAG(not_aligned, DiagnosticEngine::Warning,
 DIAG(reloc_truncated, DiagnosticEngine::Warning,
      "Relocation `%0' for symbol `%1' referred from `%2' and defined in `%3' "
      "is truncated to fit relocation field")
+DIAG(error_unencodable_imm, DiagnosticEngine::Error,
+     "%0: unencodable immediate %1 for relocation '%2' referencing '%3'")
 DIAG(undef_sym_visibility, DiagnosticEngine::Error,
      "%0: relocation %1 against undefined %3 symbol `%2' cannot be used when "
      "making %4")

--- a/include/eld/Readers/Relocation.h
+++ b/include/eld/Readers/Relocation.h
@@ -147,6 +147,8 @@ public:
 
   bool issueOverflow(Relocator &) const;
 
+  bool issueUnencodableImmediate(Relocator &R, int64_t Imm) const;
+
 private:
   /// m_pSymInfo - resolved symbol info of relocation target symbol
   ResolveInfo *m_pSymInfo;

--- a/include/eld/Target/Relocator.h
+++ b/include/eld/Target/Relocator.h
@@ -40,7 +40,7 @@ public:
   typedef Relocation::Size Size;
 
 public:
-  enum Result { OK, BadReloc, Overflow, Unsupport, Unknown };
+  enum Result { OK, BadReloc, Overflow, BadImm, Unsupport, Unknown };
 
   /** \enum ReservedEntryType
    *  \brief The reserved entry type of reserved space in ResolveInfo.

--- a/test/ARM/FromLLD/arm-adr-err-long.s
+++ b/test/ARM/FromLLD/arm-adr-err-long.s
@@ -27,7 +27,7 @@ _start:
  .inst 0xe24f0008 // sub r0, pc, #8
  .inst 0xe2400004 // sub r0, r0, #4
  .reloc 0, R_ARM_ALU_PC_G0, dat1
-// CHECK: Error: Relocation overflow when applying relocation `R_ARM_ALU_PC_G0' for symbol `dat1' referred from {{.*}}.s.tmp.o[.text.1] symbol defined in {{.*}}.s.tmp.o[.text.0]
+// CHECK: Error: {{.*}}.o:(.text.1): unencodable immediate 7340040 for relocation 'R_ARM_ALU_PC_G0' referencing 'dat1
 // FIXME .reloc 4, R_ARM_ALU_PC_G1, dat1
 
  .inst 0xe24f1008 // sub r1, pc, #8
@@ -42,7 +42,7 @@ _start:
  .inst 0xe2400004 // sub r0, r0, #4
  .inst 0xe2400000 // sub r0, r0, #0
  .reloc 20, R_ARM_ALU_PC_G0, dat1
-// CHECK: Error: Relocation overflow when applying relocation `R_ARM_ALU_PC_G0' for symbol `dat1' referred from {{.*}}.s.tmp.o[.text.1] symbol defined in {{.*}}.s.tmp.o[.text.0]
+// CHECK: Error: {{.*}}.o:(.text.1+0x14): unencodable immediate 7340060 for relocation 'R_ARM_ALU_PC_G0'
 // FIXME .reloc 24, R_ARM_ALU_PC_G1, dat1
 // FIXME .reloc 28, R_ARM_ALU_PC_G2, dat1
 

--- a/test/ARM/FromLLD/arm-adr-err.s
+++ b/test/ARM/FromLLD/arm-adr-err.s
@@ -14,11 +14,11 @@ low:
  .global _start
  .type _start, %function
 _start:
-// CHECK: Relocation overflow when applying relocation `R_ARM_ALU_PC_G0' for symbol `low' referred from {{.*}}.s.tmp.o[.os1] symbol defined in {{.*}}.s.tmp.o[.os0]
+// CHECK: Error: {{.*}}.o:(.os1): unencodable immediate 1031 for relocation 'R_ARM_ALU_PC_G0' referencing 'low'
 /// adr r0, low
  .inst 0xe24f0008
  .reloc 0, R_ARM_ALU_PC_G0, low
-// CHECK: Relocation overflow when applying relocation `R_ARM_ALU_PC_G0' for symbol `unaligned' referred from {{.*}}.s.tmp.o[.os1] symbol defined in {{.*}}.s.tmp.o[.os2]
+// Error: {{.*}}o:(.os1+0x4): unencodable immediate 1013 for relocation 'R_ARM_ALU_PC_G0' referencing 'unaligned'
 /// adr r1, unaligned
  .inst 0xe24f1008
  .reloc 4, R_ARM_ALU_PC_G0, unaligned


### PR DESCRIPTION
Report unencodable immediate errors instead of
overflows for R_ARM_ALU_PC_G0. The encoding space
is sparse rather than simply bounded, so this
diagnostic makes more sense than "overflow".
This matches the lld diagnostic.