### PR TITLE
x86_64: Implements dynamic relocation support for GOTPCREL data access

### DIFF
--- a/lib/Target/x86_64/x86_64LDBackend.cpp
+++ b/lib/Target/x86_64/x86_64LDBackend.cpp
@@ -128,7 +128,10 @@ void x86_64LDBackend::doPreLayout() {
   if (LinkerConfig::Object != config().codeGenType()) {
     getRelaPLT()->setSize(getRelaPLT()->getRelocations().size() *
                           getRelaEntrySize());
+    getRelaDyn()->setSize(getRelaDyn()->getRelocations().size() *
+                          getRelaEntrySize());
     m_Module.addOutputSection(getRelaPLT());
+    m_Module.addOutputSection(getRelaDyn());
   }
 }
 

--- a/test/x86_64/linux/DynamicDataCall/DynamicDataCall.test
+++ b/test/x86_64/linux/DynamicDataCall/DynamicDataCall.test
@@ -1,0 +1,27 @@
+#UNSUPPORTED: windows
+#--DynamicDataCall.test-------Executable--#
+#BEGIN_COMMENT
+#Verifies data accesses are handled correctly for dynamic linking scenarios.
+#For GOTPCREL-type relocations, the linker must create a GOT entry and emit a dynamic relocation
+#to fill the GOT entry if it cannot be resolved at link time.
+#This test verifies that:
+# - GLOB_DAT relocations are emitted for GOT entries of global preemptible symbols (from shared libraries)
+# - RELATIVE relocations are emitted for GOT entries of global non-preemptible symbols defined in the same executable
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -fPIC -o %t.1.o
+RUN: %clang %clangopts -c %p/Inputs/2.c -o %t.2.o
+RUN: %link %linkopts -shared -o %t.lib2.so %t.2.o
+RUN: %link %linkopts  -dynamic-linker /lib64/ld-linux-x86-64.so.2 -o %t.out %t.1.o %t.lib2.so
+RUN: %t.out; echo $? | %filecheck %s --check-prefix=EXITCODE
+RUN: %readelf -Sdr %t.out | %filecheck %s
+CHECK: .data PROGBITS [[#%x,DATA_SEC_ADDR:]]
+CHECK: .got PROGBITS [[#%x,GOT_ADDR:]]
+CHECK: Dynamic section
+CHECK: RELACOUNT
+CHECK-SAME: 1
+CHECK: .rela.dyn
+CHECK-DAG: [[#GOT_ADDR]]{{.*}}000000000008{{.*}}R_X86_64_RELATIVE{{.*}}[[#DATA_SEC_ADDR]]
+CHECK-DAG: [[#GOT_ADDR+0x8]]{{.*}}00000006{{.*}}R_X86_64_GLOB_DAT{{.*}}extern_var + 0
+CHECK-DAG: [[#GOT_ADDR+0x10]]{{.*}}00000006{{.*}}R_X86_64_GLOB_DAT{{.*}}extern_var2 + 0
+EXITCODE: 8

--- a/test/x86_64/linux/DynamicDataCall/Inputs/1.c
+++ b/test/x86_64/linux/DynamicDataCall/Inputs/1.c
@@ -1,0 +1,12 @@
+long global_var_non_premp = 1;
+extern long extern_var;
+extern long extern_var2;
+void _start() {
+  long u = global_var_non_premp + extern_var + extern_var2;
+  asm("movq $60, %%rax\n"
+      "movq %0, %%rdi\n"
+      "syscall\n"
+      :
+      : "r"(u)
+      : "%rax", "%rdi");
+}

--- a/test/x86_64/linux/DynamicDataCall/Inputs/2.c
+++ b/test/x86_64/linux/DynamicDataCall/Inputs/2.c
@@ -1,0 +1,2 @@
+long extern_var = 3;
+long extern_var2 = 4;


### PR DESCRIPTION
The x86_64 backend was creating GOT entries for GOTPCREL relocations but not 
emitting the necessary dynamic relocations. This prevented PIE executables and 
shared libraries from correctly accessing global data at runtime.

This PR introduces a unified GOT creation mechanism that:
1. Analyzes symbol preemptibility to determine relocation type
2. Emits R_X86_64_RELATIVE for non-preemptible symbols
3. Emits R_X86_64_GLOB_DAT for preemptible symbols
4. Handles both static and dynamic linking scenarios

### Key Changes
- `CreateGOT()`: Unified helper for GOT creation with dynamic relocation support
- `helper_DynRel_init()`: Creates and initializes dynamic relocations in .rela.dyn
- Updated scan phase to handle GOTPCREL for both local and global symbols
- Implemented DT_RELACOUNT emission for loader optimization

Progress on #534 
Fixes #600 
