### PR TITLE
Update musl and picolibc workflows to record build status data.

### DIFF
--- a/.github/workflows/BuildStatusDataRecorder/action.yaml
+++ b/.github/workflows/BuildStatusDataRecorder/action.yaml
@@ -1,0 +1,105 @@
+name: Record Workflow
+description: Record pre/post build data for dashboard
+
+inputs:
+  enabled:
+    description: "Turn workflow recording On/Off"
+    default: true
+  project:
+    description: "Project name for build workflow recording"
+    required: true
+  stage:
+    description: "Pre/post build"
+    required: false
+  workflow-name:
+    description: "Build workflow name"
+    required: true
+  record-mode:
+    description: "Build data record or update mode"
+    required: true
+  status:
+    description: "Build workflow pass/fail status"
+    required: true
+  run-id:
+    description: "Build workflow run-id"
+    required: true
+  arch-name:
+    description: "Workflow matrix build arch name"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Record ${{ inputs.stage }}build entry
+      if: ${{ inputs.enabled }} == "true"
+      shell: bash
+      run: |
+        cd ${{ inputs.project }}
+        DASH_DIR="$(mktemp -d)"
+        cp .github/workflows/scripts/record_builds.py ${DASH_DIR}/
+        git config --global user.name 'github-actions'
+        git config --global user.email 'github-actions@github.com'
+        # Switch to dashboard branch to access build-status.db
+        git fetch --all
+        git checkout dashboard
+        git reset --hard origin/dashboard
+        ls -l
+        : '
+        Multiple workflows and parallel matrix builds write to
+        build-status.db file. This causes race condition, stale DB or
+        git latest ref conflicts.
+        check_lock() is called throughout this workflow to make
+        sure build data is written to current DB file.
+        '
+        check_lock() {
+          FILE_PATH="data.lock"
+          # Checks for build data lock.
+          while [ -f "$FILE_PATH" ]; do
+            echo "Wait for data lock to be removed..."
+            sleep 10
+            git fetch --all
+            git reset --hard origin/dashboard
+            git pull
+            ls -l
+          done
+          echo "Data lock removed"
+        }
+        check_lock
+        # After data lock is released by other workflows, a lock is acquired for current workflow.
+        echo "Adding ${{ inputs.workflow-name }} ${{ inputs.arch-name }} data lock."
+        touch data.lock
+        git add .
+        git commit -m "Add data lock for ${{ inputs.workflow-name }} ${{ inputs.arch-name }} build status data to be written"
+        # Keep trying until a data lock is pushed successfully.
+        until git push -f origin HEAD:refs/heads/dashboard; do
+          sleep 5
+          check_lock
+          git fetch --all
+          git reset --hard origin/dashboard
+          touch data.lock
+          git add .
+          git commit -m "Add data lock for ${{ inputs.workflow-name }} ${{ inputs.arch-name }} build status data to be written"
+        done
+        # Record build status data for current workflow.
+        echo "Proceeding with data recording..."
+        cp ${DASH_DIR}/record_builds.py .
+        python record_builds.py --workflow ${{ inputs.workflow-name }} --${{ inputs.record-mode }} --${{ inputs.status }} --run-id ${{ inputs.run-id }} --arch ${{ inputs.arch-name }}
+        cp build-status.db ${DASH_DIR}/
+        rm -f record_builds.py
+        echo "Removing ${{ inputs.workflow-name }} ${{ inputs.arch-name }} data lock."
+        git rm -f data.lock
+        git add .
+        git commit -m "Add ${{ inputs.workflow-name }} ${{ inputs.arch-name }} build status data in DB"
+        # Keep trying until lock/conflicts are resolved and build data is pushed successfully.
+        until git push -f origin HEAD:refs/heads/dashboard; do
+          sleep 5
+          check_lock
+          git fetch --all
+          git reset --hard origin/dashboard
+          cp -f ${DASH_DIR}/build-status.db .
+          git rm -f data.lock
+          git add .
+          git commit -m "Add ${{ inputs.workflow-name }} ${{ matrix.arch.name }} build status data in DB"
+        done
+        rm -rf ${DASH_DIR}
+        git checkout -

--- a/.github/workflows/nightly-musl-builder.yml
+++ b/.github/workflows/nightly-musl-builder.yml
@@ -30,27 +30,19 @@ jobs:
         with:
           path: llvm-project/llvm/tools/eld
 
-      - uses: ./llvm-project/llvm/tools/eld/.github/workflows/MuslBuilderBuildELD
+      - name: Record pre-build entry
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "pre-"
+          workflow-name: "musl"
+          record-mode: "record"
+          status: "fail"
+          run-id: ${{github.run_id}}
+          arch-name: "x86-64"
 
-      # - name: Record pre-build entry
-      #   shell: bash
-      #   run: |
-      #     cd llvm-project/llvm/tools/eld
-      #     git branch
-      #     DASH_DIR="$(mktemp -d)"
-      #     cp .github/workflows/scripts/record_builds.py ${DASH_DIR}/
-      #     git config --global user.name 'github-actions'
-      #     git config --global user.email 'github-actions@github.com'
-      #     git fetch --all
-      #     git checkout dashboard
-      #     cp ${DASH_DIR}/record_builds.py .
-      #     python record_builds.py --workflow musl --record --fail --run-id ${{github.run_id}} --arch x86-64
-      #     rm -f record_builds.py
-      #     git add .
-      #     git commit -m "Add musl build status data in DB"
-      #     git push -f origin HEAD:refs/heads/dashboard
-      #     rm -rf ${DASH_DIR}
-      #     git checkout -
+      - uses: ./llvm-project/llvm/tools/eld/.github/workflows/MuslBuilderBuildELD
 
       - name: Setup ELD Environment
         run: |
@@ -95,25 +87,17 @@ jobs:
 
           echo "Test results validated"
 
-      # - name: Update build entry
-      #   run: |
-      #     cd llvm-project/llvm/tools/eld
-      #     git branch
-      #     DASH_DIR="$(mktemp -d)"
-      #     cp .github/workflows/scripts/record_builds.py ${DASH_DIR}/
-      #     git config --global user.name 'github-actions'
-      #     git config --global user.email 'github-actions@github.com'
-      #     git fetch --all
-      #     git checkout dashboard
-      #     git pull
-      #     cp ${DASH_DIR}/record_builds.py .
-      #     python record_builds.py --workflow musl --update --pass --run-id ${{github.run_id}} --arch x86-64
-      #     rm -f record_builds.py
-      #     git add .
-      #     git commit -m "Add musl build status data in DB"
-      #     git push -f origin HEAD:refs/heads/dashboard
-      #     rm -rf ${DASH_DIR}
-      #     git checkout -
+      - name: Update build entry
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "post-"
+          workflow-name: "musl"
+          record-mode: "update"
+          status: "pass"
+          run-id: ${{github.run_id}}
+          arch-name: "x86-64"
 
   test-musl:
     strategy:
@@ -136,27 +120,19 @@ jobs:
         with:
           path: llvm-project/llvm/tools/eld
 
-      - uses: ./llvm-project/llvm/tools/eld/.github/workflows/MuslBuilderBuildELD
+      - name: Record pre-build entry
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "pre-"
+          workflow-name: "musl"
+          record-mode: "record"
+          status: "fail"
+          run-id: ${{github.run_id}}
+          arch-name: ${{ matrix.arch }}
 
-      # - name: Record pre-build entry
-      #   shell: bash
-      #   run: |
-      #     cd llvm-project/llvm/tools/eld
-      #     git branch
-      #     DASH_DIR="$(mktemp -d)"
-      #     cp .github/workflows/scripts/record_builds.py ${DASH_DIR}/
-      #     git config --global user.name 'github-actions'
-      #     git config --global user.email 'github-actions@github.com'
-      #     git fetch --all
-      #     git checkout dashboard
-      #     cp ${DASH_DIR}/record_builds.py .
-      #     python record_builds.py --workflow musl --record --fail --run-id ${{github.run_id}} --arch ${{ matrix.arch }}
-      #     rm -f record_builds.py
-      #     git add .
-      #     git commit -m "Add musl build status data in DB"
-      #     git push -f origin HEAD:refs/heads/dashboard
-      #     rm -rf ${DASH_DIR}
-      #     git checkout -
+      - uses: ./llvm-project/llvm/tools/eld/.github/workflows/MuslBuilderBuildELD
 
       - name: Install dependencies
         shell: bash
@@ -215,22 +191,14 @@ jobs:
           FileCheck --check-prefixes=COUNT ${ELD_SOURCE_DIR}/test/musl/${{ matrix.arch }}/test-failures.txt < src/REPORT
           echo "Test results validated"
 
-      # - name: Update build entry
-      #   run: |
-      #     cd llvm-project/llvm/tools/eld
-      #     git branch
-      #     DASH_DIR="$(mktemp -d)"
-      #     cp .github/workflows/scripts/record_builds.py ${DASH_DIR}/
-      #     git config --global user.name 'github-actions'
-      #     git config --global user.email 'github-actions@github.com'
-      #     git fetch --all
-      #     git checkout dashboard
-      #     git pull
-      #     cp ${DASH_DIR}/record_builds.py .
-      #     python record_builds.py --workflow musl --update --pass --run-id ${{github.run_id}} --arch ${{ matrix.arch }}
-      #     rm -f record_builds.py
-      #     git add .
-      #     git commit -m "Add musl build status data in DB"
-      #     git push -f origin HEAD:refs/heads/dashboard
-      #     rm -rf ${DASH_DIR}
-      #     git checkout -
+      - name: Update build entry
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "post-"
+          workflow-name: "musl"
+          record-mode: "update"
+          status: "pass"
+          run-id: ${{github.run_id}}
+          arch-name: ${{ matrix.arch }}

--- a/.github/workflows/picolibc-builder.yml
+++ b/.github/workflows/picolibc-builder.yml
@@ -72,23 +72,16 @@ jobs:
 
       - name: Record pre-build entry
         if: github.event_name == 'schedule'
-        run: |
-          cd llvm-project/llvm/tools/eld
-          git branch
-          DASH_DIR="$(mktemp -d)"
-          cp .github/workflows/scripts/record_builds.py ${DASH_DIR}/
-          git config --global user.name 'github-actions'
-          git config --global user.email 'github-actions@github.com'
-          git fetch --all
-          git checkout dashboard
-          cp ${DASH_DIR}/record_builds.py .
-          python record_builds.py --workflow picolibc --record --fail --run-id ${{github.run_id}} --arch ${{ matrix.arch.name }}
-          rm -f record_builds.py
-          git add .
-          git commit -m "Add picolibc build status data in DB"
-          git push -f origin HEAD:refs/heads/dashboard
-          rm -rf ${DASH_DIR}
-          git checkout -
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "pre-"
+          workflow-name: "picolibc"
+          record-mode: "record"
+          status: "fail"
+          run-id: ${{github.run_id}}
+          arch-name: ${{ matrix.arch.name }}
 
       - name: Configure LLVM toolchain for ${{ matrix.arch.name }}
         run: |
@@ -242,21 +235,13 @@ jobs:
 
       - name: Update build entry
         if: github.event_name == 'schedule'
-        run: |
-          cd llvm-project/llvm/tools/eld
-          git branch
-          DASH_DIR="$(mktemp -d)"
-          cp .github/workflows/scripts/record_builds.py ${DASH_DIR}/
-          git config --global user.name 'github-actions'
-          git config --global user.email 'github-actions@github.com'
-          git fetch --all
-          git checkout dashboard
-          git pull
-          cp ${DASH_DIR}/record_builds.py .
-          python record_builds.py --workflow picolibc --update --pass --run-id ${{github.run_id}} --arch ${{ matrix.arch.name }}
-          rm -f record_builds.py
-          git add .
-          git commit -m "Add picolibc build status data in DB"
-          git push -f origin HEAD:refs/heads/dashboard
-          rm -rf ${DASH_DIR}
-          git checkout -
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "post-"
+          workflow-name: "picolibc"
+          record-mode: "update"
+          status: "pass"
+          run-id: ${{github.run_id}}
+          arch-name: ${{ matrix.arch.name }}


### PR DESCRIPTION
Github Workflows updated to record build status data for picolibc
and musl builds using BuildStatusDataRecorder github composite action.
A file lock is also used to eliminate race condition in
updating the DB file.