### PR TITLE
Fix windows failures due to missing '.exe' suffix and missing ~ in path

### DIFF
--- a/test/Common/standalone/PluginAPI/ELDExpected.test
+++ b/test/Common/standalone/PluginAPI/ELDExpected.test
@@ -3,7 +3,7 @@
 # This test checks the functioning of eld::Expected.
 #END_COMMENT
 #START_TEST
-RUN: %llvmobjroot/bin/tests/ELDExpectedUsage | %filecheck %s
+RUN: %llvmobjroot/bin/tests/ELDExpectedUsage%var | %filecheck %s
 #END_TEST
 #CHECK: e1.has_value(): 1
 #CHECK: e1.value(): 11

--- a/test/Common/standalone/PluginAPI/lit.local.cfg
+++ b/test/Common/standalone/PluginAPI/lit.local.cfg
@@ -1,0 +1,6 @@
+import platform
+
+if platform.system() == 'Windows':
+   config.substitutions.append(('%var', '.exe'))
+else:
+   config.substitutions.append(('%var', ''))

--- a/test/Hexagon/standalone/LTO/LTOConstructors/ltoconstructors.test
+++ b/test/Hexagon/standalone/LTO/LTOConstructors/ltoconstructors.test
@@ -1,10 +1,10 @@
 # Leave .ctors and .dtors in their original order as they cant be tracked.
-RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o 
-RUN: %clang %clangopts -c %p/Inputs/2.c -flto -o %t1.2.o 
-RUN: %clang %clangopts -c %p/Inputs/3.c  -o %t1.3.o 
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
+RUN: %clang %clangopts -c %p/Inputs/2.c -flto -o %t1.2.o
+RUN: %clang %clangopts -c %p/Inputs/3.c  -o %t1.3.o
 RUN: %link -MapStyle txt %linkopts %t1.1.o %t1.2.o %t1.3.o  -T %p/Inputs/script.t -Map %t2.out.map --trace=lto -flto-options=codegen="-use-ctors"
 RUN: %filecheck %s < %t2.out.map
 
-#CHECK: .ctors  {{[0-9xa-f]+}}    {{[0-9xa-f]+}}     {{[ -\(\)_A-Za-z0-9.\\/:]+}}1.o
-#CHECK: .ctors  {{[0-9xa-f]+}}    {{[0-9xa-f]+}}     {{[ -\(\)_A-Za-z0-9.\\/:]+}}lto
-#CHECK: .ctors  {{[0-9xa-f]+}}    {{[0-9xa-f]+}}     {{[ -\(\)_A-Za-z0-9.\\/:]+}}3.o
+#CHECK: .ctors  {{[0-9xa-f]+}}    {{[0-9xa-f]+}}     {{[ -\(\)_A-Za-z0-9.~\\/:]+}}1.o
+#CHECK: .ctors  {{[0-9xa-f]+}}    {{[0-9xa-f]+}}     {{[ -\(\)_A-Za-z0-9.~\\/:]+}}lto
+#CHECK: .ctors  {{[0-9xa-f]+}}    {{[0-9xa-f]+}}     {{[ -\(\)_A-Za-z0-9.~\\/:]+}}3.o


### PR DESCRIPTION
This patch fixes windows nightly failures that were caused due to incorrect lit conditions and incorrect location of the binary being used.