### PR TITLE
Fix crash due to missing thin archive member

### DIFF
--- a/include/eld/Diagnostics/DiagnosticEngine.h
+++ b/include/eld/Diagnostics/DiagnosticEngine.h
@@ -30,6 +30,12 @@
   if (!eldExp)                                                                 \
     return std::move(eldExp.error());
 
+#define DG_ELDEXP_REPORT_AND_RETURN_FALSE_IF_ERROR(DG, ELDExp)                 \
+  if (!ELDExp) {                                                               \
+    (DG).raiseDiagEntry(std::move(ELDExp.error()));                              \
+    return false;                                                              \
+  }
+
 /// If llvm::Error contains an error, then returns diagnostic entry
 /// created from llvm::Error; Otherwise does nothing.
 #define LLVMEXP_RETURN_DIAGENTRY_IF_ERROR(llvmExp)                             \

--- a/test/Common/standalone/ThinArchivesMissingMember/Inputs/1.c
+++ b/test/Common/standalone/ThinArchivesMissingMember/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/Common/standalone/ThinArchivesMissingMember/Inputs/main.c
+++ b/test/Common/standalone/ThinArchivesMissingMember/Inputs/main.c
@@ -1,0 +1,1 @@
+int main() { return 3; }

--- a/test/Common/standalone/ThinArchivesMissingMember/ThinArchiveMissingMember.test
+++ b/test/Common/standalone/ThinArchivesMissingMember/ThinArchiveMissingMember.test
@@ -1,0 +1,15 @@
+#---MissingMemberThinArchive.test--------------------- Executable ---------------------#
+#BEGIN_COMMENT
+# This test verifies that eld reports an error when the linker cannot locate a
+# thin archive member.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
+RUN: %clang %clangopts -o %t1.main.o %p/Inputs/main.c -c -ffunction-sections
+RUN: %ar cr %aropts --thin %t1.lib1.a %t1.1.o
+RUN: %rm %t1.1.o
+RUN: %not %link %linkopts -o %t1.main.out %t1.main.o %t1.lib1.a 2>&1 | %filecheck %s --check-prefix=ERROR
+#END_TEST
+
+ERROR: Fatal: LLVM: '{{.*}}1.o': No such file or directory
+


### PR DESCRIPTION
This commit fixes a linker crash caused when a thin archive member is missing. The root cause was that we were not reporting an eld::Expected error and hence it was being ignored, then later on, an assertion failure caused the crash.

Resolves #615