### PR TITLE
Emit memory reports to debug link time memory usage

### DIFF
--- a/Plugins/HelloWorldPlugin/HelloWorldPlugin.cpp
+++ b/Plugins/HelloWorldPlugin/HelloWorldPlugin.cpp
@@ -12,6 +12,9 @@
 
 class DLL_A_EXPORT HelloWorldPlugin : public eld::plugin::LinkerPlugin {
 public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
+public:
   HelloWorldPlugin() : eld::plugin::LinkerPlugin("HelloWorldPlugin") {}
 
   void Init(const std::string &options) override {}

--- a/include/eld/BranchIsland/BranchIsland.h
+++ b/include/eld/BranchIsland/BranchIsland.h
@@ -34,6 +34,9 @@ class Relocation;
  */
 class BranchIsland {
 public:
+  static std::string getTypeName() { return "BranchIsland"; }
+
+public:
   typedef std::vector<Relocation *> RelocationListType;
   typedef RelocationListType::iterator reloc_iterator;
 

--- a/include/eld/BranchIsland/BranchIslandFactory.h
+++ b/include/eld/BranchIsland/BranchIslandFactory.h
@@ -32,6 +32,9 @@ class FragmentRef;
  */
 class BranchIslandFactory {
 public:
+  static std::string getTypeName() { return "BranchIslandFactory"; }
+
+public:
   BranchIslandFactory(bool UseAddends, LinkerConfig &Config);
 
   ~BranchIslandFactory();

--- a/include/eld/BranchIsland/StubFactory.h
+++ b/include/eld/BranchIsland/StubFactory.h
@@ -32,6 +32,9 @@ class IRBuilder;
  */
 class StubFactory {
 public:
+  static std::string getTypeName() { return "StubFactory"; }
+
+public:
   typedef std::vector<Stub *> StubVector;
   StubFactory(Stub *TargetStub);
   StubFactory();

--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -44,6 +44,9 @@ class ZOption;
  */
 class GeneralOptions {
 public:
+  static std::string getTypeName() { return "GeneralOptions"; }
+
+public:
   typedef llvm::StringMap<std::string> SymbolRenameMap;
 
   typedef llvm::StringMap<uint64_t> AddressMapType;
@@ -834,6 +837,16 @@ public:
   void setTimingStatsFile(std::string StatsFile) {
     TimingStatsFile = StatsFile;
   }
+  //--------------------Memory Report--------------------------------
+  // --print-memory-report
+  bool showMemoryReport() const { return PrintMemoryReport; }
+
+  void setPrintMemoryReport() { PrintMemoryReport = true; }
+
+  // --emit-memory-report <file>
+  std::string getMemoryReportFile() const { return MemoryReportFile; }
+
+  void setMemoryReportFile(std::string F) { MemoryReportFile = F; }
   //--------------------Plugin Config--------------------------------
   void addPluginConfig(const std::string &Config) {
     PluginConfig.push_back(Config);
@@ -1233,6 +1246,7 @@ private:
   bool BExecuteOnly = false;              // --execute-only
   bool BPrintTimeStats = false;           // --print-stats
   bool BPrintAllUserPluginTimeStats = false;
+  bool PrintMemoryReport = false;         // --print-memory-report
   bool BDemangle = true;                  // --demangle-style
   bool ValidateArchOpts = false;          // check -mabi with backend
   bool DisableGuardForWeakUndefs = false; // hexagon specific option to
@@ -1265,7 +1279,8 @@ private:
   std::string Filter;
   std::string MapFile; // Mapfile
   std::string TarFile; // --reproduce output tarfile name
-  std::string TimingStatsFile;
+  std::string TimingStatsFile;           // --emit-timing-stats
+  std::string MemoryReportFile;          // --emit-memory-report
   std::string MappingFileName;           // --Mapping-file
   std::string MappingDumpFile;           // --dump-mapping-file
   std::string ResponseDumpFile;          // --dump-response-file

--- a/include/eld/Config/LinkerConfig.h
+++ b/include/eld/Config/LinkerConfig.h
@@ -35,6 +35,9 @@ class DiagnosticEngine;
 class SearchDirs;
 class LinkerConfig {
 public:
+  static std::string getTypeName() { return "LinkerConfig"; }
+
+public:
   enum CodeGenType { Unknown, Object, DynObj, Exec, External, Binary };
 
   /** \enum CodePosition
@@ -75,6 +78,8 @@ public:
   enum SymDefStyle { Default, Provide, UnknownSymDefStyle };
 
   struct WarnOptions {
+  public:
+    static std::string getTypeName() { return "WarnOptions"; }
     std::optional<bool> EnableAllWarnings;
     std::optional<bool> EnableLinkerScriptWarnings;
     std::optional<bool> EnableZeroSizedSectionsWarnings;
@@ -88,6 +93,8 @@ public:
   };
 
   struct MappingFileInfo {
+  public:
+    static std::string getTypeName() { return "MappingFileInfo"; }
     std::unordered_map<std::string, std::string> StringMapKeyToValue;
 
     void addStringMapEntry(llvm::StringRef Key, llvm::StringRef Value) {

--- a/include/eld/Config/TargetOptions.h
+++ b/include/eld/Config/TargetOptions.h
@@ -27,6 +27,9 @@ class LinkerScript;
  */
 class TargetOptions {
 public:
+  static std::string getTypeName() { return "TargetOptions"; }
+
+public:
   enum Endian { Little, Big, Unknown };
 
 public:

--- a/include/eld/Core/CommandLine.h
+++ b/include/eld/Core/CommandLine.h
@@ -12,6 +12,9 @@ namespace eld {
 
 struct CommandLine {
 public:
+  static std::string getTypeName() { return "CommandLine"; }
+
+public:
   typedef enum { Flag, Option, MultiValueOption } CmdType;
 
   CommandLine(CmdType Type) : T(Type) {}
@@ -23,6 +26,8 @@ private:
 };
 
 struct Flags : public CommandLine {
+public:
+  static std::string getTypeName() { return "Flags"; }
   Flags(const std::string &Opt, bool Flag)
       : CommandLine(CmdType::Flag), Option(Opt), Flag(Flag) {}
 
@@ -39,6 +44,8 @@ private:
 };
 
 struct Options : public CommandLine {
+public:
+  static std::string getTypeName() { return "Options"; }
   Options(const std::string &Opt, const std::string &Arg)
       : CommandLine(CmdType::Option), Option(Opt), Argument(Arg) {}
 
@@ -55,6 +62,8 @@ private:
 };
 
 struct MultiValueOption : public CommandLine {
+public:
+  static std::string getTypeName() { return "MultiValueOption"; }
   MultiValueOption(const std::string &Opt, const std::vector<std::string> &Arg)
       : CommandLine(CmdType::MultiValueOption), Option(Opt), ArgumentList(Arg) {
   }

--- a/include/eld/Core/Linker.h
+++ b/include/eld/Core/Linker.h
@@ -41,6 +41,9 @@ class ObjectLinker;
  */
 class Linker {
 public:
+  static std::string getTypeName() { return "Linker"; }
+
+public:
   enum UnresolvedPolicy {
     NotSet = 0x0,
     IgnoreAll = 0x1,

--- a/include/eld/Core/LinkerScript.h
+++ b/include/eld/Core/LinkerScript.h
@@ -56,6 +56,9 @@ class SymbolContainer;
 
 class Phdrs {
 public:
+  static std::string getTypeName() { return "Phdrs"; }
+
+public:
   Phdrs(const PhdrSpec &PPhdrDesc) {
     ScriptSpec.Name = PPhdrDesc.Name;
     ScriptSpec.ThisType = PPhdrDesc.ThisType;
@@ -77,6 +80,9 @@ private:
  *
  */
 class LinkerScript {
+public:
+  static std::string getTypeName() { return "LinkerScript"; }
+
 public:
   typedef std::vector<Assignment *> Assignments;
   typedef std::vector<ChangeOutputSectionPluginOp *> OverrideSectionMatchT;

--- a/include/eld/Core/Module.h
+++ b/include/eld/Core/Module.h
@@ -72,6 +72,9 @@ class ScriptSymbol;
  */
 class Module {
 public:
+  static std::string getTypeName() { return "Module"; }
+
+public:
   typedef enum {
     Attributes,
     BitcodeSections,

--- a/include/eld/Diagnostics/Diagnostic.h
+++ b/include/eld/Diagnostics/Diagnostic.h
@@ -26,6 +26,9 @@ namespace eld {
  */
 class Diagnostic {
 public:
+  static std::string getTypeName() { return "Diagnostic"; }
+
+public:
   Diagnostic(DiagnosticEngine &PEngine);
 
   ~Diagnostic();

--- a/include/eld/Diagnostics/DiagnosticEngine.h
+++ b/include/eld/Diagnostics/DiagnosticEngine.h
@@ -90,6 +90,9 @@ using DiagnosticEntry = plugin::DiagnosticEntry;
  */
 class DiagnosticEngine {
 public:
+  static std::string getTypeName() { return "DiagnosticEngine"; }
+
+public:
   enum Severity {
     // None must be 0 because currently 0 severity value represent
     // no severity at all.
@@ -161,6 +164,9 @@ public:
   };
 
   struct State {
+  public:
+    static std::string getTypeName() { return "State"; }
+
   public:
     State() = default;
     ~State() {}
@@ -282,6 +288,8 @@ private:
 };
 
 class Diag {
+public:
+  static std::string getTypeName() { return "Diag"; }
   static DiagnosticEngine::DiagIDType Counter;
 
 public:

--- a/include/eld/Diagnostics/DiagnosticInfos.h
+++ b/include/eld/Diagnostics/DiagnosticInfos.h
@@ -32,8 +32,14 @@ class DiagnosticEngine;
  */
 class DiagnosticInfos {
 public:
+  static std::string getTypeName() { return "DiagnosticInfos"; }
+
+public:
   /// Stores custom diagnostic info
   class CustomDiagInfo {
+  public:
+    static std::string getTypeName() { return "CustomDiagInfo"; }
+
   public:
     CustomDiagInfo(const std::string &PFormatStr) : FormatStr(PFormatStr) {}
     llvm::StringRef getDescription() const { return FormatStr; }

--- a/include/eld/Diagnostics/DiagnosticPrinter.h
+++ b/include/eld/Diagnostics/DiagnosticPrinter.h
@@ -28,6 +28,9 @@ namespace eld {
  */
 class DiagnosticPrinter {
 public:
+  static std::string getTypeName() { return "DiagnosticPrinter"; }
+
+public:
   enum TraceType {
     TraceFiles = 0x1,
     TraceTrampolines = 0x2,

--- a/include/eld/Diagnostics/MsgHandler.h
+++ b/include/eld/Diagnostics/MsgHandler.h
@@ -48,6 +48,9 @@ namespace eld {
  */
 class MsgHandler {
 public:
+  static std::string getTypeName() { return "MsgHandler"; }
+
+public:
   MsgHandler(DiagnosticEngine &PEngine, std::unique_lock<std::timed_mutex> Lock);
   ~MsgHandler();
 

--- a/include/eld/Driver/ARMLinkDriver.h
+++ b/include/eld/Driver/ARMLinkDriver.h
@@ -21,6 +21,9 @@ class DiagnosticEngine;
 // Create OptTable class for parsing actual command line arguments
 class OPT_ARMLinkOptTable : public llvm::opt::GenericOptTable {
 public:
+  static std::string getTypeName() { return "OPT_ARMLinkOptTable"; }
+
+public:
   enum {
     INVALID = 0,
 #define OPTION(PREFIXES_OFFSET, PREFIXED_NAME_OFFSET, ID, KIND, GROUP, ALIAS,  \
@@ -35,6 +38,9 @@ public:
 };
 
 class ARMLinkDriver : public GnuLdDriver {
+public:
+  static std::string getTypeName() { return "ARMLinkDriver"; }
+
 public:
   static ARMLinkDriver *Create(eld::LinkerConfig &C,
                                std::string InferredArchFromProgramName);

--- a/include/eld/Driver/Driver.h
+++ b/include/eld/Driver/Driver.h
@@ -29,6 +29,9 @@ class GnuLdDriver;
 
 class DLL_A_EXPORT Driver {
 public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
+public:
   Driver(DriverFlavor F = DriverFlavor::Invalid);
 
   bool setDriverFlavorAndInferredArchFromLinkCommand(

--- a/include/eld/Driver/GnuLdDriver.h
+++ b/include/eld/Driver/GnuLdDriver.h
@@ -36,6 +36,9 @@ class LinkerScript;
 // Create OptTable class for parsing actual command line arguments
 class OPT_GnuLdOptTable : public llvm::opt::GenericOptTable {
 public:
+  static std::string getTypeName() { return "OPT_GnuLdOptTable"; }
+
+public:
   enum {
     INVALID = 0,
 #define OPTION(PREFIXES_OFFSET, PREFIXED_NAME_OFFSET, ID, KIND, GROUP, ALIAS,  \
@@ -50,6 +53,9 @@ public:
 };
 
 class DLL_A_EXPORT GnuLdDriver {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
 public:
   static GnuLdDriver *Create(eld::LinkerConfig &C, DriverFlavor F,
                              std::string InferredArchFromProgramName);
@@ -159,6 +165,8 @@ protected:
   }
 
   void setDriverFlavor(DriverFlavor F) { m_DriverFlavor = F; }
+
+  bool emitMemoryReport() const;
 
 private:
   // Raise diag entry for trace.

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -6,11 +6,11 @@
 
 include "llvm/Option/OptParser.td"
 
-//===----------------------------------------------------------------------===//
-/// Utility Functions
-//===----------------------------------------------------------------------===//
-// Single and multiple dash options combined
-multiclass smDash<string opt1, string opt2, string help> {
+    //===----------------------------------------------------------------------===//
+    /// Utility Functions
+    //===----------------------------------------------------------------------===//
+    // Single and multiple dash options combined
+    multiclass smDash<string opt1, string opt2, string help> {
   // Option
   def "" : Separate<["-"], opt1>, HelpText<help>;
   def opt1_eq : Joined<["-"], opt1 #"=">, Alias<!cast<Option>(opt1)>;
@@ -73,9 +73,10 @@ multiclass mDashEq<string opt1, string realopt, string help> {
 
 // --<option>,--<option>=
 multiclass EEq<string name, string help> {
-  def NAME: Separate<["--"], name>;
-  def NAME # _eq: Joined<["--"], name # "=">, Alias<!cast<Separate>(NAME)>,
-    HelpText<help>;
+  def NAME : Separate<["--"], name>;
+  def NAME #_eq : Joined<["--"], name #"=">,
+                  Alias<!cast<Separate>(NAME)>,
+                  HelpText<help>;
 }
 
 // Support -<option>,-<option>=
@@ -98,17 +99,18 @@ multiclass
 }
 
 // Support -<option>=,--<option>=
-multiclass smDashOnlyEq<string opt1, string realopt, string help> {
-  def "" : Joined<["-"], opt1 #"=">, HelpText<help>;
-  def opt1_eq : Joined<["--"], opt1 #"=">, Alias<!cast<Option>(realopt)>;
+multiclass smDashOnlyEq<string opt1, string realopt, string help>{
+  def "" : Joined<["-"], opt1 #"=">,
+  HelpText<help>;
+def opt1_eq : Joined<["--"], opt1 #"=">, Alias<!cast<Option>(realopt)>;
 }
 
 // Support -<option>=,--<option>= aliases
 multiclass smDashOnlyEqAlias<string opt1, string realopt, string help> {
-  def "" : Joined<["-"], opt1#"=">,
+  def "" : Joined<["-"], opt1 #"=">,
            Alias<!cast<Option>(realopt)>,
            HelpText<help>;
-  def opt1_eq : Joined<["--"], opt1#"=">,
+  def opt1_eq : Joined<["--"], opt1 #"=">,
                 Alias<!cast<Option>(realopt)>,
                 HelpText<help>;
 }
@@ -122,7 +124,7 @@ defm output_file : smDashTwoWithOpt<"o", "output", "output_file",
                    MetaVarName<"<outputfile>">,
                    Group<grp_general>;
 defm sysroot : smDash<"sysroot", "sysroot", "Set the system root">,
-              MetaVarName<"<sysroot-path>">,
+               MetaVarName<"<sysroot-path>">,
                Group<grp_general>;
 def version : Flag<["--"], "version">,
               HelpText<"Print the Linker version">,
@@ -138,7 +140,7 @@ defm build_id_val
     : smDashOnlyEq<
           "build-id", "build_id_val",
           "Request creation of \".note.gnu.build-id\" ELF note section">,
-           MetaVarName<"fast/md5/sha1/tree/uuid/0x<hexstring>/none">,
+      MetaVarName<"fast/md5/sha1/tree/uuid/0x<hexstring>/none">,
       Group<grp_general>;
 
 //===----------------------------------------------------------------------===//
@@ -253,7 +255,7 @@ defm exclude_libs : mDashEq<"exclude-libs", "exclude_libs",
                     MetaVarName<"<libs>">,
                     Group<grp_scriptopts>;
 def unique_output_sections
-    : Flag<["-", "--"], "unique-output-sections">,
+    : Flag<[ "-", "--" ], "unique-output-sections">,
       HelpText<"Place each input section in a unique output section">,
       Group<grp_scriptopts>;
 def global_merge_non_alloc_strings
@@ -270,7 +272,8 @@ def enable_overlap_checks
       Group<grp_scriptopts>;
 def print_memory_usage
     : Flag<["--"], "print-memory-usage">,
-      HelpText<"Print memory usage when MEMORY linker script directive is used">,
+      HelpText<
+          "Print memory usage when MEMORY linker script directive is used">,
       Group<grp_scriptopts>;
 
 //===----------------------------------------------------------------------===//
@@ -281,8 +284,8 @@ def relocatable : Flag<["-"], "r">,
                   HelpText<"Create relocatable object file">,
                   Group<grp_kind>;
 def static_link : Flag<["-"], "static">,
-             HelpText<"Create static executable">,
-             Group<grp_kind>;
+                  HelpText<"Create static executable">,
+                  Group<grp_kind>;
 def dynamic : Flag<["-"], "dynamic">,
               HelpText<"Create dynamic executable (default)">,
               Group<grp_kind>;
@@ -293,8 +296,8 @@ def pie : Flag<["-"], "pie">,
           HelpText<"Create PIE executable">,
           Group<grp_kind>;
 def no_pie : Flag<["-"], "no-pie">,
-          HelpText<"Do not create a PIE executable">,
-          Group<grp_kind>;
+             HelpText<"Do not create a PIE executable">,
+             Group<grp_kind>;
 def picexec : Flag<["--"], "pic-executable">,
               Group<grp_kind>,
               HelpText<"Create PIE executable">,
@@ -343,11 +346,10 @@ def namespec : Joined<["--"], "library=">,
                MetaVarName<"<namespec>">,
                HelpText<"library to use">,
                Group<grp_main>;
-defm library_path
-    : mDashEq<"library-path", "library_path",
-              "Path to search for libraries or linker scripts">,
-      MetaVarName<"<path>">,
-      Group<grp_main>;
+defm library_path : mDashEq<"library-path", "library_path",
+                            "Path to search for libraries or linker scripts">,
+                    MetaVarName<"<path>">,
+                    Group<grp_main>;
 defm Y : smDash<"Y", "Y", "Add path to the default library search path">,
          MetaVarName<"<path>">,
          Group<grp_main>;
@@ -370,17 +372,17 @@ defm init : smDash<"init", "init", "Specify an initializer function">,
 defm fini : smDash<"fini", "fini", "Specify a finalizer function">,
             MetaVarName<"<symbol>">,
             Group<grp_main>;
-def whole_archive : Flag<["-", "--"], "whole-archive">,
+def whole_archive : Flag<[ "-", "--" ], "whole-archive">,
                     HelpText<"Force load of all members in a static library">,
                     Group<grp_main>;
 def no_whole_archive
-    : Flag<["-", "--"], "no-whole-archive">,
+    : Flag<[ "-", "--" ], "no-whole-archive">,
       HelpText<"Restores the default behavior of loading archive members">,
       Group<grp_main>;
 def nostdlib : Flag<["-"], "nostdlib">,
                HelpText<"Disable default search path for libraries">,
                Group<grp_main>;
-def emit_relocs : Flag<["-", "--"], "emit-relocs">,
+def emit_relocs : Flag<[ "-", "--" ], "emit-relocs">,
                   HelpText<"Make Emit relocs behave just like GNU.">,
                   Group<grp_main>;
 def omagic
@@ -411,20 +413,19 @@ defm dynamic_linker : smDashWithOpt<"dynamic-linker", "dynamic_linker",
                                     "Set the path to the dynamic linker">,
                       MetaVarName<"<path>">,
                       Group<grp_dynlibexec>;
-defm rpath : smDash<"rpath", "rpath",
-                    "Add a path to the runtime library search path">,
-             MetaVarName<"<path>">,
-             Group<grp_dynlibexec>;
-defm rpath_link
-    : dashEqWithOpt<"rpath-link", "rpath-link", "rpath_link",
-                    "Specifies the path to search">,
+defm rpath
+    : smDash<"rpath", "rpath", "Add a path to the runtime library search path">,
       MetaVarName<"<path>">,
       Group<grp_dynlibexec>;
-def export_dynamic : Flag<["-", "--"], "export-dynamic">,
+defm rpath_link : dashEqWithOpt<"rpath-link", "rpath-link", "rpath_link",
+                                "Specifies the path to search">,
+                  MetaVarName<"<path>">,
+                  Group<grp_dynlibexec>;
+def export_dynamic : Flag<[ "-", "--" ], "export-dynamic">,
                      HelpText<"Add all symbols to the dynamic symbol table"
                               " when creating executables">,
                      Group<grp_dynlibexec>;
-def force_dynamic : Flag<["-", "--"], "force-dynamic">,
+def force_dynamic : Flag<[ "-", "--" ], "force-dynamic">,
                     HelpText<"Build executable as a force dynamic executable">,
                     Group<grp_dynlibexec>;
 def alias_export_dynamic : Flag<["-"], "E">,
@@ -439,21 +440,21 @@ defm export_dynamic_symbol
                     "Export specified symbol to dynamic symbol table">,
       MetaVarName<"<symbol>">,
       Group<grp_dynlibexec>;
-def no_dynamic_linker : Flag<["-", "--"], "no-dynamic-linker">,
-                     HelpText<"The program does not need a dynamic linker"
-                              " when creating static PIE executables">,
-                     Group<grp_dynlibexec>;
+def no_dynamic_linker : Flag<[ "-", "--" ], "no-dynamic-linker">,
+                        HelpText<"The program does not need a dynamic linker"
+                                 " when creating static PIE executables">,
+                        Group<grp_dynlibexec>;
 
 //===----------------------------------------------------------------------===//
 /// Dynamic Library Options
 //===----------------------------------------------------------------------===//
 def grp_dynlib : OptionGroup<"opts">, HelpText<"DYNAMIC LIBRARY OPTIONS">;
-def soname : Joined<["-", "--"], "soname=">,
+def soname : Joined<[ "-", "--" ], "soname=">,
              HelpText<"Set the internal DT_SONAME field to the specified name">,
              MetaVarName<"<name>">,
              Group<grp_dynlib>;
 def soname_separate
-    : Separate<["-", "--"], "soname">,
+    : Separate<[ "-", "--" ], "soname">,
       HelpText<"Set the internal DT_SONAME field to the specified name">,
       Alias<soname>,
       MetaVarName<"<name>">,
@@ -517,14 +518,14 @@ def u_alias : Joined<["--"], "undefined=">,
               MetaVarName<"<symbol>">,
               Group<grp_resolveropt>,
               Alias<u>;
-def start_group : Flag<["-", "--"], "start-group">,
+def start_group : Flag<[ "-", "--" ], "start-group">,
                   HelpText<"Start a group">,
                   Group<grp_resolveropt>;
 def alias_start_group : Flag<["-"], "(">,
                         HelpText<"Start a group">,
                         Group<grp_resolveropt>,
                         Alias<start_group>;
-def end_group : Flag<["-", "--"], "end-group">,
+def end_group : Flag<[ "-", "--" ], "end-group">,
                 HelpText<"End a group">,
                 Group<grp_resolveropt>;
 def alias_end_group : Flag<["-"], ")">,
@@ -539,13 +540,15 @@ def no_as_needed : Flag<["--"], "no-as-needed">,
                    HelpText<"This option restores the default behavior"
                             " of adding DT_NEEDED entries">,
                    Group<grp_resolveropt>;
-def push_state : Flag<["--"], "push-state">,
-                 HelpText<"Save current input handling flags (as-needed, whole-archive, etc)">,
-                 Group<grp_resolveropt>;
+def push_state
+    : Flag<["--"], "push-state">,
+      HelpText<
+          "Save current input handling flags (as-needed, whole-archive, etc)">,
+      Group<grp_resolveropt>;
 def pop_state : Flag<["--"], "pop-state">,
                 HelpText<"Restore previously saved input handling flags">,
                 Group<grp_resolveropt>;
-def allow_shlib_undefs : Flag<["-", "--"], "allow-shlib-undefined">,
+def allow_shlib_undefs : Flag<[ "-", "--" ], "allow-shlib-undefined">,
                          HelpText<"Allow undefined symbols from dynamic"
                                   " library when creating executables">,
                          Group<grp_resolveropt>;
@@ -562,7 +565,7 @@ defm defsym : smDash<"defsym", "defsym",
               MetaVarName<"symbol=<expression>">,
               Group<grp_resolveropt>;
 def no_undefined
-    : Flag<["-", "--"], "no-undefined">,
+    : Flag<[ "-", "--" ], "no-undefined">,
       HelpText<"Report unresolved symbol references from regular object files">,
       Group<grp_resolveropt>;
 def warn_once : Flag<["--"], "warn-once">,
@@ -576,10 +579,11 @@ defm unresolved_symbols
           "report-all(Default), ignore-in-object-files, ignore-in-shared-libs">,
       MetaVarName<"<option>">,
       Group<grp_scriptopts>;
-defm sort_section : EEq<"sort-section",
-                       "Sort sections. Options available are name , alignment">,
-                       MetaVarName<"<sort_section>">,
-                        Group<grp_scriptopts>;
+defm sort_section
+    : EEq<"sort-section",
+          "Sort sections. Options available are name , alignment">,
+      MetaVarName<"<sort_section>">,
+      Group<grp_scriptopts>;
 
 //===----------------------------------------------------------------------===//
 /// Symbol options
@@ -641,12 +645,14 @@ def dp : Flag<["-"], "dp">,
          HelpText<"Assign space to common symbols">,
          Alias<d>;
 def sort_common : Flag<["--"], "sort-common">,
-         HelpText<"sort common symbols by alignment">,
-         Group<grp_symbolopts>;
-defm sort_common_val : smDashOnlyEq<"sort-common", "sort_common_val",
-                       "Sort common symbols by ascdending/descending order of alignment">,
-                       MetaVarName<"<option>">,
-                        Group<grp_symbolopts>;
+                  HelpText<"sort common symbols by alignment">,
+                  Group<grp_symbolopts>;
+defm sort_common_val
+    : smDashOnlyEq<
+          "sort-common", "sort_common_val",
+          "Sort common symbols by ascdending/descending order of alignment">,
+      MetaVarName<"<option>">,
+      Group<grp_symbolopts>;
 
 //===----------------------------------------------------------------------===//
 /// Diagnostic options
@@ -678,15 +684,15 @@ defm trace
       MetaVarName<"<trace-type>">,
       Group<grp_diagopts>;
 defm trace_symbol : smDashTwoWithOpt<"y", "trace-symbol", "trace_symbol",
-                                  "Trace a particular symbol">,
+                                     "Trace a particular symbol">,
                     MetaVarName<"<symbol>">,
                     Group<grp_diagopts>;
 def trace_lto : Flag<["--"], "trace-lto">,
                 HelpText<"Trace stages of lto">,
                 Group<grp_diagopts>;
 def trace_linker_script : Flag<["--"], "trace-linker-script">,
-                HelpText<"Trace stages of linker script processing">,
-                Group<grp_diagopts>;
+                          HelpText<"Trace stages of linker script processing">,
+                          Group<grp_diagopts>;
 defm trace_section : smDashWithOpt<"trace-section", "trace_section",
                                    "Show metadata about a particular section">,
                      MetaVarName<"<section_name>">,
@@ -696,7 +702,8 @@ defm trace_reloc : smDashWithOpt<"trace-reloc", "trace_reloc",
                    MetaVarName<"<relocation>">,
                    Group<grp_diagopts>;
 defm trace_merge_strings
-    : smDashWithOpt<"trace-merge-strings", "trace_merge_strings",
+    : smDashWithOpt<
+          "trace-merge-strings", "trace_merge_strings",
           "Emit diagnostics describing how strings were merged. Options: "
           "all(default), allocatable_sections, <output section (regex)>">,
       MetaVarName<"<option>">,
@@ -709,7 +716,7 @@ defm verify_options : smDashWithOpt<"verify-options", "verify_options",
 def dash_t : Flag<["-"], "t">,
              HelpText<"Print all files processed by the linker">,
              Group<grp_diagopts>;
-def cref : Flag<["-", "--"], "cref">,
+def cref : Flag<[ "-", "--" ], "cref">,
            HelpText<"Print the references for a symbol or section">,
            Group<grp_diagopts>;
 defm emit_timing_stats : mDashEq<"emit-timing-stats", "emit_timing_stats",
@@ -719,23 +726,24 @@ defm emit_timing_stats : mDashEq<"emit-timing-stats", "emit_timing_stats",
                          Group<grp_diagopts>;
 
 def emit_timing_stats_in_output
-    : Flag<["-", "--"], "emit-timing-stats-in-output">,
+    : Flag<[ "-", "--" ], "emit-timing-stats-in-output">,
       HelpText<"Insert link-time stats in section .note.qc.timing">,
       Group<grp_diagopts>;
 
-defm time_region : mDashEq<"time-region", "time_region",
-                   "Emit time statistics for specified region of linker operation ">,
-                            MetaVarName<"<region>">,
-                             Group<grp_diagopts>;
+defm time_region
+    : mDashEq<"time-region", "time_region",
+              "Emit time statistics for specified region of linker operation ">,
+      MetaVarName<"<region>">,
+      Group<grp_diagopts>;
 
 def print_timing_stats
-    : Flag<["-", "--"], "print-timing-stats">,
+    : Flag<[ "-", "--" ], "print-timing-stats">,
       HelpText<"Print time statistics of various linker operatons to console">,
       Group<grp_diagopts>;
 defm gc_cref : mDashEq<"gc-cref", "gc_cref",
                        "Print the references for a symbol or section when "
                        "garbage collection is enabled">,
-              MetaVarName<"<symbol/section>">,
+               MetaVarName<"<symbol/section>">,
                Group<grp_diagopts>;
 def verbose : Flag<["--"], "verbose">,
               HelpText<"Enable verbose output">,
@@ -768,7 +776,7 @@ defm error_style
 defm color : smDash<"color", "color", "Enable color output for diagnostics">,
              MetaVarName<"<on/off>">,
              Group<grp_diagopts>;
-def opt_record_file : Flag<["-", "--"], "opt-record-file">,
+def opt_record_file : Flag<[ "-", "--" ], "opt-record-file">,
                       HelpText<"Create diagnostic yaml file">,
                       Group<grp_diagopts>;
 defm display_hotness
@@ -782,55 +790,63 @@ def summary : Flag<["--"], "summary">,
               HelpText<"Display linker run summary at the end">,
               Group<grp_diagopts>;
 def fatal_internal_errors : Flag<["--"], "fatal-internal-errors">,
-                     HelpText<"Enable fatal internal errors">,
-                     Group<grp_diagopts>;
+                            HelpText<"Enable fatal internal errors">,
+                            Group<grp_diagopts>;
 def no_fatal_internal_errors : Flag<["--"], "no-fatal-internal-errors">,
-                     HelpText<"Disable fatal internal errors">,
-                     Group<grp_diagopts>;
+                               HelpText<"Disable fatal internal errors">,
+                               Group<grp_diagopts>;
 defm error_limit
-    : mDashEq<"error-limit", "error_limit",
-              "Maximum number of errors to emit before stopping (0 = no limit)">,
+    : mDashEq<
+          "error-limit", "error_limit",
+          "Maximum number of errors to emit before stopping (0 = no limit)">,
       MetaVarName<"<max-error-number>">,
       Group<grp_diagopts>;
-defm warn_limit
-    : mDashEq<"warn-limit", "warn_limit",
-              "Maximum number of warnings to emit (0 = no limit)">,
-      MetaVarName<"<maxwarnings>">,
+defm warn_limit : mDashEq<"warn-limit", "warn_limit",
+                          "Maximum number of warnings to emit (0 = no limit)">,
+                  MetaVarName<"<maxwarnings>">,
+                  Group<grp_diagopts>;
+def W
+    : Joined<["-"], "W">,
+      MetaVarName<"<warn-type>">,
+      HelpText<"Print warnings which are OFF by default\n"
+               "\t\t\t -Wall : print all warnings\n"
+               "\t\t\t -W[no]linker-script : display warnings detected"
+               " while parsing linker scripts\n"
+               "\t\t\t -W[no]attribute-mix : display a warning if object files"
+               " of RISC-V with different attributes are being linked\n"
+               "\t\t\t -W[no-]archive-file : display warnings detected while "
+               "reading archive files\n"
+               "\t\t\t -W[no-]linker-script-memory : display warnings detected "
+               "while "
+               "processing linker script memory command\n"
+               "\t\t\t -W[no-]bad-dot-assignments : display warnings for bad "
+               "dot assignments\n"
+               "\t\t\t -W[no-]error : treat warnings as errors\n"
+               "\t\t\t -Wwhole-archive : display a warning when whole-archive "
+               "is enabled for any archive file\n"
+               "\t\t\t -W[no-]osabi : display a warning when linking objects "
+               "with different values for OS/ABI\n">,
       Group<grp_diagopts>;
-def W : Joined<["-"], "W">,
-        MetaVarName<"<warn-type>">,
-        HelpText<"Print warnings which are OFF by default\n"
-             "\t\t\t -Wall : print all warnings\n"
-             "\t\t\t -W[no]linker-script : display warnings detected"
-             " while parsing linker scripts\n"
-             "\t\t\t -W[no]attribute-mix : display a warning if object files"
-             " of RISC-V with different attributes are being linked\n"
-             "\t\t\t -W[no-]archive-file : display warnings detected while "
-             "reading archive files\n"
-             "\t\t\t -W[no-]linker-script-memory : display warnings detected while "
-             "processing linker script memory command\n"
-             "\t\t\t -W[no-]bad-dot-assignments : display warnings for bad "
-             "dot assignments\n"
-             "\t\t\t -W[no-]error : treat warnings as errors\n"
-             "\t\t\t -Wwhole-archive : display a warning when whole-archive "
-             "is enabled for any archive file\n"
-             "\t\t\t -W[no-]osabi : display a warning when linking objects "
-             "with different values for OS/ABI\n"
-            >,
-        Group<grp_diagopts>;
+def print_memory_report : Flag<["--"], "print-memory-report">,
+                          HelpText<"Print linker memory allocation report ">,
+                          Group<grp_diagopts>;
+defm emit_memory_report : mDashEq<"emit-memory-report", "emit_memory_report",
+                                  "Emit linker memory allocation report">,
+                          MetaVarName<"<filename>">,
+                          Group<grp_diagopts>;
 
 //===----------------------------------------------------------------------===//
 /// Optimization options
 //===----------------------------------------------------------------------===//
 def grp_optimizationopts : OptionGroup<"opts">,
                            HelpText<"OPTIMIZATION OPTIONS">;
-def gc_sections : Flag<["-", "--"], "gc-sections">,
+def gc_sections : Flag<[ "-", "--" ], "gc-sections">,
                   HelpText<"Enable garbage collection">,
                   Group<grp_optimizationopts>;
-def no_gc_sections : Flag<["-", "--"], "no-gc-sections">,
+def no_gc_sections : Flag<[ "-", "--" ], "no-gc-sections">,
                      HelpText<"Disable garbage collection">,
                      Group<grp_optimizationopts>;
-def print_gc_sections : Flag<["-", "--"], "print-gc-sections">,
+def print_gc_sections : Flag<[ "-", "--" ], "print-gc-sections">,
                         HelpText<"Print sections that are garbage collected">,
                         Group<grp_optimizationopts>;
 def eh_frame_hdr
@@ -849,13 +865,14 @@ def no_trampolines : Flag<["--"], "no-trampolines">,
 //===----------------------------------------------------------------------===//
 def grp_extendedopts : OptionGroup<"opts">, HelpText<"Extended Options">;
 defm dash_z
-    : dashEqWithJoinedOpt<
-          "z", "z", "dash_z",
-          "Extended Options or Non standard options.\n\t\t\t Available options are:\n"
-          "\t\t\t-z=combreloc : Combines multiple reloc sections and sorts them to make dynamic"
-          "symbol lookup caching\n"
-          "\t\t\t-z=now : Enables immediate binding\n"
-          "\t\t\t-z=nocopyreloc : Disables Copy Relocation">,
+    : dashEqWithJoinedOpt<"z", "z", "dash_z",
+                          "Extended Options or Non standard options.\n\t\t\t "
+                          "Available options are:\n"
+                          "\t\t\t-z=combreloc : Combines multiple reloc "
+                          "sections and sorts them to make dynamic"
+                          "symbol lookup caching\n"
+                          "\t\t\t-z=now : Enables immediate binding\n"
+                          "\t\t\t-z=nocopyreloc : Disables Copy Relocation">,
       MetaVarName<"<extended-opts>">,
       Group<grp_extendedopts>;
 def no_align_segments : Flag<["--"], "no-align-segments">,
@@ -883,7 +900,7 @@ def rosegment
 defm copy_farcalls_from_file
     : smDashWithOpt<"copy-farcalls-from-file", "copy_farcalls_from_file",
                     "Copy far calls instead of using trampolines">,
-                    MetaVarName<"<filename>">,
+      MetaVarName<"<filename>">,
       Group<grp_extendedopts>;
 defm no_reuse_trampolines_file
     : smDashWithOpt<"no-reuse-trampolines-file", "no_reuse_trampolines_file",
@@ -891,7 +908,7 @@ defm no_reuse_trampolines_file
       MetaVarName<"<filename>">,
       Group<grp_extendedopts>;
 def use_old_style_trampoline_name
-    : Flag<["--"],"use-old-style-trampoline-name">,
+    : Flag<["--"], "use-old-style-trampoline-name">,
       HelpText<"Use old style of naming trampolines">,
       Group<grp_extendedopts>;
 def no_emit_relocs : Flag<[ "-", "--" ], "no-emit-relocs">,
@@ -910,20 +927,22 @@ def allow_bss_conversion
 defm reproduce : smDash<"reproduce", "reproduce",
                         "Write a tar file containing input files and command "
                         "line options to inspect and re-link">,
-                  MetaVarName<"<tarfilename>">,
+                 MetaVarName<"<tarfilename>">,
                  Group<grp_extendedopts>;
-defm reproduce_compressed : smDashWithOpt<"reproduce-compressed", "reproduce_compressed",
-                                   "Write compressed tar file in zlib format "
-                                   "containing input files and command line "
-                                   "options to inspect and re-link.">,
-                            MetaVarName<"<tarfilename>">,
-                            Group<grp_extendedopts>;
-defm reproduce_on_fail : smDashWithOpt<"reproduce-on-fail", "reproduce_on_fail",
-                                   "Write reproduce tar file when link fails"
-                                   "containing input files and command line "
-                                   "options to inspect and re-link.">,
-                            MetaVarName<"<tarfilename>">,
-                            Group<grp_extendedopts>;
+defm reproduce_compressed
+    : smDashWithOpt<"reproduce-compressed", "reproduce_compressed",
+                    "Write compressed tar file in zlib format "
+                    "containing input files and command line "
+                    "options to inspect and re-link.">,
+      MetaVarName<"<tarfilename>">,
+      Group<grp_extendedopts>;
+defm reproduce_on_fail
+    : smDashWithOpt<"reproduce-on-fail", "reproduce_on_fail",
+                    "Write reproduce tar file when link fails"
+                    "containing input files and command line "
+                    "options to inspect and re-link.">,
+      MetaVarName<"<tarfilename>">,
+      Group<grp_extendedopts>;
 defm mapping_file : smDashWithOpt<"mapping-file", "mapping_file",
                                   "Reproduce link using a mapping file">,
                     MetaVarName<"<INI-file>">,
@@ -935,13 +954,11 @@ defm dump_mapping_file : smDashWithOpt<"dump-mapping-file", "dump_mapping_file",
 defm dump_response_file
     : smDashWithOpt<"dump-response-file", "dump_response_file",
                     "Dump response file to output file">,
-                    MetaVarName<"<outputfilename>">,
+      MetaVarName<"<outputfilename>">,
       Group<grp_extendedopts>;
-def about :
-     Flag<["--"], "about">,
-      HelpText<"Emit detailed information about the linker">,
-      Group<grp_extendedopts>;
-
+def about : Flag<["--"], "about">,
+            HelpText<"Emit detailed information about the linker">,
+            Group<grp_extendedopts>;
 
 //===----------------------------------------------------------------------===//
 /// Map file
@@ -1017,14 +1034,14 @@ def no_allow_shlib_undefs
       Group<grp_compatorignoredopts>;
 defm plugin_gnu
     : smDashWithOpt<"plugin", "plugin_gnu", "Specify a plugin file">,
-    MetaVarName<"<pluginfile>">,
+      MetaVarName<"<pluginfile>">,
       Group<grp_compatorignoredopts>;
 defm plugin_opt
     : smDashWithOpt<"plugin-opt", "plugin_opt", "Specify plugin options">,
       MetaVarName<"<plugin-opt>">,
       Group<grp_compatorignoredopts>;
 def thin_archive_rule_matching_compatibility
-    : Flag<["-", "--"], "thin-archive-rule-matching-compatibility">,
+    : Flag<[ "-", "--" ], "thin-archive-rule-matching-compatibility">,
       HelpText<"Provides rule-matching compatibility when fat archives are\n"
                "\t\t\tconverted to thin archives">,
       Group<grp_compatorignoredopts>;
@@ -1033,7 +1050,7 @@ def thin_archive_rule_matching_compatibility
 /// LTO options
 //===----------------------------------------------------------------------===//
 def grp_ltooptions : OptionGroup<"opts">, HelpText<"LTO Options">;
-def flto : Flag<["-", "--"], "flto">,
+def flto : Flag<[ "-", "--" ], "flto">,
            HelpText<"Enable LTO if a Bitcode file is present.">,
            Group<grp_ltooptions>;
 defm flto_options
@@ -1041,17 +1058,17 @@ defm flto_options
                     "Specify various options with LTO">,
       MetaVarName<"<option>">,
       Group<grp_ltooptions>;
-def flto_use_as : Flag<["-", "--"], "flto-use-as">,
+def flto_use_as : Flag<[ "-", "--" ], "flto-use-as">,
                   HelpText<"Use the standalone assembler instead of the "
                            "integrated assembler for LTO">,
                   Group<grp_ltooptions>;
-def save_temps : Flag<["-", "--"], "save-temps">,
+def save_temps : Flag<[ "-", "--" ], "save-temps">,
                  HelpText<"Save the temporary files produced by LTO">,
                  Group<grp_ltooptions>;
 defm save_temps_EQ : smDashOnlyEq<"save-temps", "save_temps_EQ",
-                 "Save the temporary files produced by LTO">,
-                 MetaVarName<"<filename>">,
-                 Group<grp_ltooptions>;
+                                  "Save the temporary files produced by LTO">,
+                     MetaVarName<"<filename>">,
+                     Group<grp_ltooptions>;
 defm exclude_lto_filelist
     : smDashWithOpt<"exclude-lto-filelist", "exclude_lto_filelist",
                     "Specify a list of files that are to be disregarded while "
@@ -1084,7 +1101,7 @@ defm plugin_opt_sample_profile
 /// Linker speedup and control
 //===----------------------------------------------------------------------===//
 def grp_linktime : OptionGroup<"opts">, HelpText<"Link Time Speedup">;
-def threads : Flag<["-", "--"], "threads">,
+def threads : Flag<[ "-", "--" ], "threads">,
               HelpText<"Enable Threads at Link time">,
               Group<grp_linktime>;
 defm enable_threads
@@ -1092,7 +1109,7 @@ defm enable_threads
                    "make linker fully threaded, available options: all">,
       MetaVarName<"<option>">,
       Group<grp_linktime>;
-def no_threads : Flag<["-", "--"], "no-threads">,
+def no_threads : Flag<[ "-", "--" ], "no-threads">,
                  HelpText<"Disable Threads at Link time">,
                  Group<grp_linktime>;
 defm thread_count
@@ -1106,19 +1123,18 @@ defm thread_count
 //===----------------------------------------------------------------------===//
 def grp_otherlinker : OptionGroup<"opts">,
                       HelpText<"Features From other Linkers">;
-def symdef : Flag<["-", "--"], "symdef">,
+def symdef : Flag<[ "-", "--" ], "symdef">,
              HelpText<"Output SymDef file to console">,
              Group<grp_otherlinker>;
 defm symdef_file : mDashEq<"symdef-file", "symdef_file", "Emit SymDef file">,
                    MetaVarName<"<filename>">,
                    Group<grp_otherlinker>;
-defm symdef_style
-    : mDashEq<
-          "symdef-style", "symdef_style",
-          "Determine how to handle symbol resolution for symbols from symdef file, Options available are "
-          "provide">,
-      MetaVarName<"<style>">,
-      Group<grp_otherlinker>;
+defm symdef_style : mDashEq<"symdef-style", "symdef_style",
+                            "Determine how to handle symbol resolution for "
+                            "symbols from symdef file, Options available are "
+                            "provide">,
+                    MetaVarName<"<style>">,
+                    Group<grp_otherlinker>;
 defm R : smDash<"R", "just-symbols",
                 "Read symbol names and addresses from filename">,
          MetaVarName<"<filename>">,
@@ -1132,17 +1148,16 @@ defm plugin_config : mDashEq<"plugin-config", "plugin_config",
                              "Specify a plugin configuration">,
                      MetaVarName<"<config-file>">,
                      Group<grp_pluginopts>;
-def noDefaultPlugins
-    : Flag<["--"], "no-default-plugins">,
-      HelpText<"Allow no plugins to be implicitly loaded">,
-      Group<grp_pluginopts>;
+def noDefaultPlugins : Flag<["--"], "no-default-plugins">,
+                       HelpText<"Allow no plugins to be implicitly loaded">,
+                       Group<grp_pluginopts>;
 
 //===----------------------------------------------------------------------===//
 /// Other Features
 //===----------------------------------------------------------------------===//
 def grp_miscfeatures : OptionGroup<"otherfeatures">, HelpText<"Misc Features">;
 def allow_incompatible_section_mix
-    : Flag<["-", "--"], "allow-incompatible-section-mix">,
+    : Flag<[ "-", "--" ], "allow-incompatible-section-mix">,
       HelpText<"Allow incompatible section mix">,
       Group<grp_miscfeatures>;
 
@@ -1150,10 +1165,10 @@ def allow_incompatible_section_mix
 /// Help!
 //===----------------------------------------------------------------------===//
 def grp_help : OptionGroup<"opts">, HelpText<"Help!">;
-def help : Flag<["--", "-"], "help">,
+def help : Flag<[ "--", "-" ], "help">,
            HelpText<"Print option help">,
            Group<grp_help>;
-def help_hidden : Flag<["--", "-"], "help-hidden">,
+def help_hidden : Flag<[ "--", "-" ], "help-hidden">,
                   HelpText<"Print hidden option help">,
                   Group<grp_help>;
 
@@ -1161,8 +1176,10 @@ def help_hidden : Flag<["--", "-"], "help-hidden">,
 /// Input formats!
 //===----------------------------------------------------------------------===//
 def grp_input_formats : OptionGroup<"opts">, HelpText<"Input Format">;
-defm input_format : smDashTwoWithOpt<"b", "format", "input_format",
-                      "Specify input format for inputs following this option.\n"
-                      "Supported values: binary,default">,
-                    MetaVarName<"<input-format>">,
-                    Group<grp_input_formats>;
+defm input_format
+    : smDashTwoWithOpt<
+          "b", "format", "input_format",
+          "Specify input format for inputs following this option.\n"
+          "Supported values: binary,default">,
+      MetaVarName<"<input-format>">,
+      Group<grp_input_formats>;

--- a/include/eld/Driver/HexagonLinkDriver.h
+++ b/include/eld/Driver/HexagonLinkDriver.h
@@ -16,6 +16,9 @@
 // Create OptTable class for parsing actual command line arguments
 class OPT_HexagonLinkOptTable : public llvm::opt::GenericOptTable {
 public:
+  static std::string getTypeName() { return "OPT_HexagonLinkOptTable"; }
+
+public:
   // Create enum with OPT_xxx values for each option in DarwinLdOptions.td
   enum {
     INVALID = 0,
@@ -31,6 +34,9 @@ public:
 };
 
 class HexagonLinkDriver : public GnuLdDriver {
+public:
+  static std::string getTypeName() { return "HexagonLinkDriver"; }
+
 public:
   static HexagonLinkDriver *Create(eld::LinkerConfig &C,
                                    std::string InferredArchFromProgramName);

--- a/include/eld/Driver/RISCVLinkDriver.h
+++ b/include/eld/Driver/RISCVLinkDriver.h
@@ -16,6 +16,9 @@
 // Create OptTable class for parsing actual command line arguments
 class OPT_RISCVLinkOptTable : public llvm::opt::GenericOptTable {
 public:
+  static std::string getTypeName() { return "OPT_RISCVLinkOptTable"; }
+
+public:
   enum {
     INVALID = 0,
 #define OPTION(PREFIXES_OFFSET, PREFIXED_NAME_OFFSET, ID, KIND, GROUP, ALIAS,  \
@@ -30,6 +33,9 @@ public:
 };
 
 class RISCVLinkDriver : public GnuLdDriver {
+public:
+  static std::string getTypeName() { return "RISCVLinkDriver"; }
+
 public:
   static RISCVLinkDriver *Create(eld::LinkerConfig &C,
                                  std::string InferredArchFromProgramName);

--- a/include/eld/Driver/x86_64LinkDriver.h
+++ b/include/eld/Driver/x86_64LinkDriver.h
@@ -18,6 +18,9 @@
 // Create OptTable class for parsing actual command line arguments
 class OPT_x86_64LinkOptTable : public llvm::opt::GenericOptTable {
 public:
+  static std::string getTypeName() { return "OPT_x86_64LinkOptTable"; }
+
+public:
   enum {
     INVALID = 0,
 #define OPTION(PREFIXES_OFFSET, PREFIXED_NAME_OFFSET, ID, KIND, GROUP, ALIAS,  \
@@ -32,6 +35,9 @@ public:
 };
 
 class x86_64LinkDriver : public GnuLdDriver {
+public:
+  static std::string getTypeName() { return "x86_64LinkDriver"; }
+
 public:
   static x86_64LinkDriver *Create(eld::LinkerConfig &C,
                                   std::string InferredArchFromProgramName);

--- a/include/eld/Fragment/BuildIDFragment.h
+++ b/include/eld/Fragment/BuildIDFragment.h
@@ -19,6 +19,10 @@ class LinkerConfig;
  */
 class BuildIDFragment : public Fragment {
 public:
+public:
+  static std::string getTypeName() { return "BuildIDFragment"; }
+
+public:
   enum BuildIDKind : uint8_t { NONE, FAST, MD5, UUID, SHA1, HEXSTRING };
 
   BuildIDFragment(ELFSection *O = nullptr);

--- a/include/eld/Fragment/EhFrameFragment.h
+++ b/include/eld/Fragment/EhFrameFragment.h
@@ -22,6 +22,10 @@ class Relocation;
 
 class EhFramePiece {
 public:
+public:
+  static std::string getTypeName() { return "EhFramePiece"; }
+
+public:
   EhFramePiece(size_t Off, size_t Sz, Relocation *R, EhFrameSection *O)
       : MOffset(Off), ThisSize(Sz), MRelocation(R), MSection(O) {}
 
@@ -66,6 +70,10 @@ private:
 
 class FDEFragment : public Fragment {
 public:
+public:
+  static std::string getTypeName() { return "FDEFragment"; }
+
+public:
   FDEFragment(EhFramePiece &P, EhFrameSection *O);
 
   virtual ~FDEFragment();
@@ -96,6 +104,10 @@ private:
 };
 
 class CIEFragment : public Fragment {
+public:
+public:
+  static std::string getTypeName() { return "CIEFragment"; }
+
 public:
   CIEFragment(EhFramePiece &P, EhFrameSection *O);
 

--- a/include/eld/Fragment/EhFrameHdrFragment.h
+++ b/include/eld/Fragment/EhFrameHdrFragment.h
@@ -25,7 +25,14 @@ class Relocation;
 
 class EhFrameHdrFragment : public Fragment {
 public:
+public:
+  static std::string getTypeName() { return "EhFrameHdrFragment"; }
+
+public:
   struct FdeData {
+  public:
+  public:
+    static std::string getTypeName() { return "FdeData"; }
     uint32_t PcRel;
     uint32_t FdeVARel;
   };

--- a/include/eld/Fragment/FillFragment.h
+++ b/include/eld/Fragment/FillFragment.h
@@ -22,6 +22,10 @@ class LinkerConfig;
 
 class FillFragment : public Fragment {
 public:
+public:
+  static std::string getTypeName() { return "FillFragment"; }
+
+public:
   FillFragment(Module &M, uint64_t PValue, size_t PSize,
                ELFSection *O = nullptr, size_t PAlignment = 1);
 

--- a/include/eld/Fragment/Fragment.h
+++ b/include/eld/Fragment/Fragment.h
@@ -31,6 +31,10 @@ class ResolveInfo;
  */
 class Fragment {
 public:
+public:
+  static std::string getTypeName() { return "Fragment"; }
+
+public:
   /* Null means this fragment is removed */
   enum Type : uint8_t {
     Fillment,

--- a/include/eld/Fragment/FragmentRef.h
+++ b/include/eld/Fragment/FragmentRef.h
@@ -16,6 +16,7 @@
 
 #include "eld/Config/Config.h"
 #include "llvm/Support/DataTypes.h"
+#include <string>
 
 namespace eld {
 
@@ -31,6 +32,10 @@ class OutputSectionEntry;
  *
  */
 class FragmentRef {
+public:
+public:
+  static std::string getTypeName() { return "FragmentRef"; }
+
 public:
   typedef uint64_t Offset; // FIXME: use SizeTraits<T>::Offset
 

--- a/include/eld/Fragment/GNUHashFragment.h
+++ b/include/eld/Fragment/GNUHashFragment.h
@@ -63,6 +63,9 @@ private:
 
 private:
   struct SymbolData {
+  public:
+  public:
+    static std::string getTypeName() { return "SymbolData"; }
     ResolveInfo *R;
     uint32_t DynSymIndex;
     uint32_t Hash;

--- a/include/eld/Fragment/GOT.h
+++ b/include/eld/Fragment/GOT.h
@@ -20,6 +20,10 @@ class ResolveInfo;
 
 class GOT : public Fragment {
 public:
+public:
+  static std::string getTypeName() { return "GOT"; }
+
+public:
   // GOT Types.
   enum GOTType {
     Regular,  /* Regular GOT Slots */

--- a/include/eld/Fragment/MergeStringFragment.h
+++ b/include/eld/Fragment/MergeStringFragment.h
@@ -26,6 +26,9 @@ class OutputSectionEntry;
 /// this string and the input offset of the next string. Fragment Pointer could
 /// also be removed.
 struct MergeableString {
+public:
+public:
+  static std::string getTypeName() { return "MergeableString"; }
   MergeStringFragment *Fragment;
   llvm::StringRef String;
   uint32_t InputOffset;
@@ -45,6 +48,9 @@ struct MergeableString {
 /// MergeStringFrgament is a Fragment that manages MergeableStrings of a
 /// LDFileFormat::MergeStr input section.
 class MergeStringFragment : public Fragment {
+public:
+public:
+  static std::string getTypeName() { return "MergeStringFragment"; }
   std::vector<MergeableString *> Strings;
 
 public:

--- a/include/eld/Fragment/OutputSectDataFragment.h
+++ b/include/eld/Fragment/OutputSectDataFragment.h
@@ -13,6 +13,10 @@
 namespace eld {
 class OutputSectDataFragment : public Fragment {
 public:
+public:
+  static std::string getTypeName() { return "OutputSectDataFragment"; }
+
+public:
   OutputSectDataFragment(OutputSectData &OutSectData);
 
   ~OutputSectDataFragment() = default;

--- a/include/eld/Fragment/PLT.h
+++ b/include/eld/Fragment/PLT.h
@@ -22,6 +22,10 @@ class GOT;
 
 class PLT : public Fragment {
 public:
+public:
+  static std::string getTypeName() { return "PLT"; }
+
+public:
   // PLT Types.
   enum PLTType {
     PLT0, /* Lazy Binding PLT */

--- a/include/eld/Fragment/RegionFragment.h
+++ b/include/eld/Fragment/RegionFragment.h
@@ -26,6 +26,11 @@ class LinkerConfig;
 // Region fragment expression
 class RegionFragment : public Fragment {
 public:
+public:
+public:
+  static std::string getTypeName() { return "RegionFragment"; }
+
+public:
   RegionFragment(llvm::StringRef PRegion, ELFSection *O, Fragment::Type T,
                  uint32_t Align = 1);
 

--- a/include/eld/Fragment/RegionFragmentEx.h
+++ b/include/eld/Fragment/RegionFragmentEx.h
@@ -20,6 +20,10 @@ class LinkerConfig;
  */
 class RegionFragmentEx : public Fragment {
 public:
+public:
+  static std::string getTypeName() { return "RegionFragmentEx"; }
+
+public:
   RegionFragmentEx(const char *Data, size_t Sz, ELFSection *O = nullptr,
                    uint32_t Align = 1);
 

--- a/include/eld/Fragment/StringFragment.h
+++ b/include/eld/Fragment/StringFragment.h
@@ -18,6 +18,10 @@ class LinkerConfig;
  */
 class StringFragment : public Fragment {
 public:
+public:
+  static std::string getTypeName() { return "StringFragment"; }
+
+public:
   StringFragment(std::string Str, ELFSection *O = nullptr);
 
   ~StringFragment();

--- a/include/eld/Fragment/Stub.h
+++ b/include/eld/Fragment/Stub.h
@@ -31,10 +31,18 @@ class ResolveInfo;
 
 class Stub : public Fragment {
 public:
+public:
+  static std::string getTypeName() { return "Stub"; }
+
+public:
   typedef Relocation::DWord DWord;
   typedef Relocation::SWord SWord;
   typedef Relocation::Type Type;
   class Fixup {
+  public:
+  public:
+    static std::string getTypeName() { return "Fixup"; }
+
   public:
     Fixup(DWord POffset, SWord PAddend, Type PType)
         : MOffset(POffset), MAddend(PAddend), MType(PType) {}

--- a/include/eld/Fragment/TargetFragment.h
+++ b/include/eld/Fragment/TargetFragment.h
@@ -25,6 +25,10 @@ class GNULDBackend;
 
 class TargetFragment : public Fragment {
 public:
+public:
+  static std::string getTypeName() { return "TargetFragment"; }
+
+public:
   enum Kind : uint8_t {
     Attributes,
     GNUHash,

--- a/include/eld/Fragment/TimingFragment.h
+++ b/include/eld/Fragment/TimingFragment.h
@@ -14,6 +14,10 @@ class LinkerConfig;
 
 class TimingFragment : public Fragment {
 public:
+public:
+  static std::string getTypeName() { return "TimingFragment"; }
+
+public:
   TimingFragment(uint64_t BeginningOfTime, uint64_t Duration,
                  llvm::StringRef ModuleName, ELFSection *O);
 

--- a/include/eld/GarbageCollection/GarbageCollection.h
+++ b/include/eld/GarbageCollection/GarbageCollection.h
@@ -33,6 +33,9 @@ class GNULDBackend;
  */
 class GarbageCollection {
 public:
+  static std::string getTypeName() { return "GarbageCollection"; }
+
+public:
   typedef llvm::DenseSet<Section *> SectionListTy;
   typedef llvm::DenseSet<LDSymbol *> SymbolListTy;
   typedef llvm::DenseSet<Section *> SectionSetTy;
@@ -41,6 +44,9 @@ public:
    *  \brief Map the section to the list of sections which it can reach directly
    */
   class SectionReachedListMap {
+  public:
+    static std::string getTypeName() { return "SectionReachedListMap"; }
+
   public:
     SectionReachedListMap() {}
 

--- a/include/eld/Input/ArchiveFile.h
+++ b/include/eld/Input/ArchiveFile.h
@@ -25,8 +25,13 @@ struct ArchiveFileInfo;
 class DiagnosticPrinter;
 class ArchiveFile : public InputFile {
 public:
+  static std::string getTypeName() { return "ArchiveFile"; }
+
+public:
   // -----------Declare Types ----------------
   struct Symbol {
+  public:
+    static std::string getTypeName() { return "Symbol"; }
     enum SymbolStatus { Include, Exclude, Unknown };
 
     enum SymbolType { NoType, DefineData, DefineFunction, Common, Weak };

--- a/include/eld/Input/ArchiveFileInfo.h
+++ b/include/eld/Input/ArchiveFileInfo.h
@@ -15,6 +15,8 @@ namespace eld {
 // when an archive file is read multiple times. For instance, if an archive file
 // is repeated in the link command, then it is read multiple times.
 struct ArchiveFileInfo {
+public:
+  static std::string getTypeName() { return "ArchiveFileInfo"; }
   ArchiveFileInfo() = default;
   ~ArchiveFileInfo() = default;
   llvm::DenseMap<off_t, Input *> LazyLoadMemberMap;

--- a/include/eld/Input/ArchiveMemberInput.h
+++ b/include/eld/Input/ArchiveMemberInput.h
@@ -20,6 +20,9 @@ class DiagnosticPrinter;
 
 class ArchiveMemberInput : public Input {
 public:
+  static std::string getTypeName() { return "ArchiveMemberInput"; }
+
+public:
   explicit ArchiveMemberInput(DiagnosticEngine *DiagEngine,
                               ArchiveFile *ArchiveFile, llvm::StringRef Name,
                               MemoryArea *Data, off_t ChildOffset);

--- a/include/eld/Input/BinaryFile.h
+++ b/include/eld/Input/BinaryFile.h
@@ -18,6 +18,9 @@ namespace eld {
 /// output file.
 class BinaryFile : public ObjectFile {
 public:
+  static std::string getTypeName() { return "BinaryFile"; }
+
+public:
   BinaryFile(Input *I, DiagnosticEngine *DiagEngine);
 
   /// Casting support.

--- a/include/eld/Input/BitcodeFile.h
+++ b/include/eld/Input/BitcodeFile.h
@@ -38,6 +38,9 @@ class DiagnosticEngine;
  */
 class BitcodeFile : public ObjectFile {
 public:
+  static std::string getTypeName() { return "BitcodeFile"; }
+
+public:
   BitcodeFile(Input *I, DiagnosticEngine *DiagEngine);
 
   ~BitcodeFile();

--- a/include/eld/Input/ELDDirectory.h
+++ b/include/eld/Input/ELDDirectory.h
@@ -25,6 +25,9 @@ namespace eld {
  */
 class ELDDirectory {
 public:
+  static std::string getTypeName() { return "ELDDirectory"; }
+
+public:
   explicit ELDDirectory(llvm::StringRef PName, std::string SysRoot);
   virtual ~ELDDirectory();
 

--- a/include/eld/Input/ELFDynObjectFile.h
+++ b/include/eld/Input/ELFDynObjectFile.h
@@ -16,6 +16,9 @@ namespace eld {
  */
 class ELFDynObjectFile : public ELFFileBase {
 public:
+  static std::string getTypeName() { return "ELFDynObjectFile"; }
+
+public:
   ELFDynObjectFile(Input *I, DiagnosticEngine *DiagEngine);
 
   /// Casting support.

--- a/include/eld/Input/ELFExecutableFile.h
+++ b/include/eld/Input/ELFExecutableFile.h
@@ -17,6 +17,9 @@ namespace eld {
  */
 class ELFExecutableFile : public ELFFileBase {
 public:
+  static std::string getTypeName() { return "ELFExecutableFile"; }
+
+public:
   ELFExecutableFile(Input *I, DiagnosticEngine *DiagEngine);
 
   /// Casting support.

--- a/include/eld/Input/ELFFileBase.h
+++ b/include/eld/Input/ELFFileBase.h
@@ -21,6 +21,9 @@ class DiagnosticPrinter;
  */
 class ELFFileBase : public ObjectFile {
 public:
+  static std::string getTypeName() { return "ELFFileBase"; }
+
+public:
   ELFFileBase(Input *I, DiagnosticEngine *DiagEngine,
               InputFile::InputFileKind K)
       : ObjectFile(I, K, DiagEngine) {}

--- a/include/eld/Input/ELFObjectFile.h
+++ b/include/eld/Input/ELFObjectFile.h
@@ -22,6 +22,9 @@ class RelocMap;
  */
 class ELFObjectFile : public ELFFileBase {
 public:
+  static std::string getTypeName() { return "ELFObjectFile"; }
+
+public:
   ELFObjectFile(Input *I, DiagnosticEngine *DiagEngine);
 
   /// Casting support.

--- a/include/eld/Input/Input.h
+++ b/include/eld/Input/Input.h
@@ -41,6 +41,9 @@ class DiagnosticPrinter;
  */
 class Input {
 public:
+  static std::string getTypeName() { return "Input"; }
+
+public:
   enum InputType {
     Archive,       // This is used mainly by -Bstatic
     DynObj,        // This is used mainly by -Bdynamic

--- a/include/eld/Input/InputAction.h
+++ b/include/eld/Input/InputAction.h
@@ -30,6 +30,9 @@ class Input;
  */
 class InputAction {
 public:
+  static std::string getTypeName() { return "InputAction"; }
+
+public:
   enum InputActionKind {
     AddNeeded,
     AsNeeded,
@@ -78,6 +81,9 @@ private:
 /// InputFileAction
 class InputFileAction : public InputAction {
 public:
+  static std::string getTypeName() { return "InputFileAction"; }
+
+public:
   explicit InputFileAction(std::string Name, DiagnosticPrinter *Printer);
 
   explicit InputFileAction(std::string Name, InputAction::InputActionKind K,
@@ -108,6 +114,9 @@ protected:
 /// NamespecAction
 class NamespecAction : public InputAction {
 public:
+  static std::string getTypeName() { return "NamespecAction"; }
+
+public:
   NamespecAction(const std::string &PNamespec, DiagnosticPrinter *Printer);
 
   const std::string &namespec() const { return MNamespec; }
@@ -130,6 +139,9 @@ private:
 /// StartGroupAction
 class StartGroupAction : public InputAction {
 public:
+  static std::string getTypeName() { return "StartGroupAction"; }
+
+public:
   explicit StartGroupAction(DiagnosticPrinter *Printer);
 
   bool activate(InputBuilder &) override;
@@ -143,6 +155,9 @@ public:
 
 /// EndGroupAction
 class EndGroupAction : public InputAction {
+public:
+  static std::string getTypeName() { return "EndGroupAction"; }
+
 public:
   explicit EndGroupAction(DiagnosticPrinter *Printer);
 
@@ -158,6 +173,9 @@ public:
 /// WholeArchiveAction
 class WholeArchiveAction : public InputAction {
 public:
+  static std::string getTypeName() { return "WholeArchiveAction"; }
+
+public:
   explicit WholeArchiveAction(DiagnosticPrinter *Printer);
 
   bool activate(InputBuilder &) override;
@@ -171,6 +189,9 @@ public:
 
 /// NoWholeArchiveAction
 class NoWholeArchiveAction : public InputAction {
+public:
+  static std::string getTypeName() { return "NoWholeArchiveAction"; }
+
 public:
   explicit NoWholeArchiveAction(DiagnosticPrinter *Printer);
 
@@ -186,6 +207,9 @@ public:
 /// AsNeededAction
 class AsNeededAction : public InputAction {
 public:
+  static std::string getTypeName() { return "AsNeededAction"; }
+
+public:
   explicit AsNeededAction(DiagnosticPrinter *Printer);
 
   bool activate(InputBuilder &) override;
@@ -199,6 +223,9 @@ public:
 
 /// PushStateAction
 class PushStateAction : public InputAction {
+public:
+  static std::string getTypeName() { return "PushStateAction"; }
+
 public:
   explicit PushStateAction(DiagnosticPrinter *Printer);
 
@@ -214,6 +241,9 @@ public:
 /// PopStateAction
 class PopStateAction : public InputAction {
 public:
+  static std::string getTypeName() { return "PopStateAction"; }
+
+public:
   explicit PopStateAction(DiagnosticPrinter *Printer);
 
   bool activate(InputBuilder &) override;
@@ -227,6 +257,9 @@ public:
 
 /// NoAsNeededAction
 class NoAsNeededAction : public InputAction {
+public:
+  static std::string getTypeName() { return "NoAsNeededAction"; }
+
 public:
   explicit NoAsNeededAction(DiagnosticPrinter *Printer);
 
@@ -242,6 +275,9 @@ public:
 /// AddNeededAction
 class AddNeededAction : public InputAction {
 public:
+  static std::string getTypeName() { return "AddNeededAction"; }
+
+public:
   explicit AddNeededAction(DiagnosticPrinter *Printer);
 
   bool activate(InputBuilder &) override;
@@ -255,6 +291,9 @@ public:
 
 /// NoAddNeededAction
 class NoAddNeededAction : public InputAction {
+public:
+  static std::string getTypeName() { return "NoAddNeededAction"; }
+
 public:
   explicit NoAddNeededAction(DiagnosticPrinter *Printer);
 
@@ -270,6 +309,9 @@ public:
 /// BDynamicAction
 class BDynamicAction : public InputAction {
 public:
+  static std::string getTypeName() { return "BDynamicAction"; }
+
+public:
   explicit BDynamicAction(DiagnosticPrinter *Printer);
 
   bool activate(InputBuilder &) override;
@@ -284,6 +326,9 @@ public:
 /// BStaticAction
 class BStaticAction : public InputAction {
 public:
+  static std::string getTypeName() { return "BStaticAction"; }
+
+public:
   explicit BStaticAction(DiagnosticPrinter *Printer);
 
   bool activate(InputBuilder &) override;
@@ -297,6 +342,9 @@ public:
 
 /// DefSymAction
 class DefSymAction : public InputAction {
+public:
+  static std::string getTypeName() { return "DefSymAction"; }
+
 public:
   explicit DefSymAction(std::string PAssignment, DiagnosticPrinter *Printer);
 
@@ -317,6 +365,9 @@ private:
 /// InputFormatAction handles the processing of '--format|-b <input_format>'
 /// command-line options.
 class InputFormatAction : public InputAction {
+public:
+  static std::string getTypeName() { return "InputFormatAction"; }
+
 public:
   explicit InputFormatAction(const std::string &InputFormat,
                              DiagnosticPrinter *Printer);

--- a/include/eld/Input/InputBuilder.h
+++ b/include/eld/Input/InputBuilder.h
@@ -34,6 +34,9 @@ class DiagnosticEngine;
  *  InputBuilder build input tree and inputs.
  */
 class InputBuilder {
+public:
+  static std::string getTypeName() { return "InputBuilder"; }
+
 private:
   InputBuilder() = delete;
 

--- a/include/eld/Input/InputFile.h
+++ b/include/eld/Input/InputFile.h
@@ -23,6 +23,9 @@ class Input;
  */
 class InputFile {
 public:
+  static std::string getTypeName() { return "InputFile"; }
+
+public:
   enum InputFileKind {
     ELFObjFileKind,
     ELFDynObjFileKind,

--- a/include/eld/Input/InputTree.h
+++ b/include/eld/Input/InputTree.h
@@ -13,11 +13,16 @@
 #ifndef ELD_INPUT_INPUTTREE_H
 #define ELD_INPUT_INPUTTREE_H
 
+#include <string>
+
 namespace eld {
 
 class Input;
 
 class Node {
+public:
+  static std::string getTypeName() { return "Node"; }
+
 public:
   enum Kind { File, GroupStart, GroupEnd };
 
@@ -30,6 +35,9 @@ private:
 };
 
 class Attribute {
+public:
+  static std::string getTypeName() { return "Attribute"; }
+
 public:
   // -----  modifiers  ----- //
   void setWholeArchive() { WholeArchive = true; }
@@ -106,6 +114,9 @@ inline bool operator!=(const Attribute &PLhs, const Attribute &PRhs) {
 
 class FileNode : public Node {
 public:
+  static std::string getTypeName() { return "FileNode"; }
+
+public:
   FileNode(Input *I) : Node(Node::File), In(I) {}
 
   static bool classof(const Node *N) { return (N->kind() == Node::File); }
@@ -118,12 +129,18 @@ private:
 
 class GroupStart : public Node {
 public:
+  static std::string getTypeName() { return "GroupStart"; }
+
+public:
   GroupStart() : Node(Node::GroupStart) {}
 
   static bool classof(const Node *N) { return (N->kind() == Node::GroupStart); }
 };
 
 class GroupEnd : public Node {
+public:
+  static std::string getTypeName() { return "GroupEnd"; }
+
 public:
   GroupEnd() : Node(Node::GroupEnd) {}
 

--- a/include/eld/Input/InternalInputFile.h
+++ b/include/eld/Input/InternalInputFile.h
@@ -12,6 +12,9 @@ namespace eld {
 
 class InternalInputFile : public ObjectFile {
 public:
+  static std::string getTypeName() { return "InternalInputFile"; }
+
+public:
   InternalInputFile(Input *I, DiagnosticEngine *diagEngine)
       : ObjectFile(I, InputFile::InternalInputKind, diagEngine) {
     setUsed(true);

--- a/include/eld/Input/JustSymbolsAction.h
+++ b/include/eld/Input/JustSymbolsAction.h
@@ -16,6 +16,9 @@ class LinkerConfig;
 /// JustSymbolsAction
 class JustSymbolsAction : public InputFileAction {
 public:
+  static std::string getTypeName() { return "JustSymbolsAction"; }
+
+public:
   JustSymbolsAction(const std::string &FileName, const LinkerConfig &Config,
                     DiagnosticPrinter *DiagPrinter);
 

--- a/include/eld/Input/LinkerScriptFile.h
+++ b/include/eld/Input/LinkerScriptFile.h
@@ -24,6 +24,9 @@ class ScriptFile;
 
 class LinkerScriptFile : public InputFile {
 public:
+  static std::string getTypeName() { return "LinkerScriptFile"; }
+
+public:
   LinkerScriptFile(Input *I, DiagnosticEngine *DiagEngine);
 
   /// Casting support.

--- a/include/eld/Input/ObjectFile.h
+++ b/include/eld/Input/ObjectFile.h
@@ -18,6 +18,8 @@ namespace eld {
 // A hash function used to hash a pair.
 // Used to hash elfsection and addend to indentify local symbols uniquely
 struct HashPair {
+public:
+  static std::string getTypeName() { return "HashPair"; }
   template <class T1, class T2>
   size_t operator()(const std::pair<T1, T2> &P) const {
     return llvm::hash_combine(P.first, P.second);
@@ -35,6 +37,9 @@ class DiagnosticPrinter;
  *  that the rest of the linker can work with.
  */
 class ObjectFile : public InputFile {
+public:
+  static std::string getTypeName() { return "ObjectFile"; }
+
 public:
   /// Type of ELF file from the target triple encoded in the object file
   /// or by inspecting the ELF header

--- a/include/eld/Input/SearchDirs.h
+++ b/include/eld/Input/SearchDirs.h
@@ -35,6 +35,8 @@ class ELDDirectory;
  *  @see ELDDirectory.
  */
 class SearchDirs {
+public:
+  static std::string getTypeName() { return "SearchDirs"; }
   static const std::string MainExecutablePath;
 
 public:

--- a/include/eld/Input/SymDefFile.h
+++ b/include/eld/Input/SymDefFile.h
@@ -12,6 +12,9 @@ namespace eld {
 
 class SymDefFile : public InputFile {
 public:
+  static std::string getTypeName() { return "SymDefFile"; }
+
+public:
   SymDefFile(Input *I, DiagnosticEngine *DiagEngine);
 
   /// Casting support.

--- a/include/eld/Input/ZOption.h
+++ b/include/eld/Input/ZOption.h
@@ -23,6 +23,9 @@ namespace eld {
  */
 class ZOption {
 public:
+  static std::string getTypeName() { return "ZOption"; }
+
+public:
   enum ZOptionKind {
     CombReloc,
     CommPageSize,

--- a/include/eld/LayoutMap/LDYAML.h
+++ b/include/eld/LayoutMap/LDYAML.h
@@ -14,20 +14,28 @@
 namespace eld {
 namespace LDYAML {
 struct Header {
+public:
+  static std::string getTypeName() { return "Header"; }
   std::string Architecture;
   std::string Emulation;
   std::string AddressSize;
   llvm::yaml::Hex64 ABIPageSize;
 };
 struct Version {
+public:
+  static std::string getTypeName() { return "Version"; }
   std::string VendorVersion;
   std::string ELDVersion;
 };
 struct ArchiveRecord {
+public:
+  static std::string getTypeName() { return "ArchiveRecord"; }
   std::string Origin;
   std::string Referred;
 };
 struct Common {
+public:
+  static std::string getTypeName() { return "Common"; }
   std::string Name;
   llvm::yaml::Hex32 Size;
   std::string InputPath;
@@ -35,6 +43,8 @@ struct Common {
 };
 
 struct LinkStats {
+public:
+  static std::string getTypeName() { return "LinkStats"; }
   std::string Name;
   uint64_t Count;
 };
@@ -42,6 +52,8 @@ struct LinkStats {
 LLVM_YAML_STRONG_TYPEDEF(uint32_t, SymbolType)
 LLVM_YAML_STRONG_TYPEDEF(uint32_t, SymbolScope)
 struct Symbol {
+public:
+  static std::string getTypeName() { return "Symbol"; }
   std::string Name;
   SymbolType Type;
   SymbolScope Scope;
@@ -50,16 +62,22 @@ struct Symbol {
 };
 // Display Input file if it is used or not.
 struct InputFile {
+public:
+  static std::string getTypeName() { return "InputFile"; }
   virtual ~InputFile() {};
   virtual void mapping(llvm::yaml::IO &IO) = 0;
 };
 LLVM_YAML_STRONG_TYPEDEF(bool, InputUsed)
 struct RegularInput : public InputFile {
+public:
+  static std::string getTypeName() { return "RegularInput"; }
   virtual void mapping(llvm::yaml::IO &IO) override;
   std::string Name;
   InputUsed Used;
 };
 struct Archive : public InputFile {
+public:
+  static std::string getTypeName() { return "Archive"; }
   virtual void mapping(llvm::yaml::IO &IO) override;
   std::string Name;
   InputUsed Used;
@@ -68,6 +86,8 @@ struct Archive : public InputFile {
 LLVM_YAML_STRONG_TYPEDEF(uint32_t, Permissions)
 LLVM_YAML_STRONG_TYPEDEF(uint32_t, SectionType)
 struct Content {
+public:
+  static std::string getTypeName() { return "Content"; }
   enum Kind {
     Assignment,
     LinkerScriptRule,
@@ -80,6 +100,8 @@ struct Content {
   Kind ContentKind;
 };
 struct Assignment : public Content {
+public:
+  static std::string getTypeName() { return "Assignment"; }
   virtual void mapping(llvm::yaml::IO &IO) override;
   static bool classof(const Content *C) {
     return C->ContentKind == Kind::Assignment;
@@ -90,6 +112,8 @@ struct Assignment : public Content {
 };
 
 struct LinkerScriptRule : public Content {
+public:
+  static std::string getTypeName() { return "LinkerScriptRule"; }
   virtual void mapping(llvm::yaml::IO &IO) override;
   static bool classof(const Content *C) {
     return C->ContentKind == Kind::LinkerScriptRule;
@@ -98,6 +122,8 @@ struct LinkerScriptRule : public Content {
 };
 
 struct Padding : public Content {
+public:
+  static std::string getTypeName() { return "Padding"; }
   virtual void mapping(llvm::yaml::IO &IO) override;
   static bool classof(const Content *C) {
     return C->ContentKind == Kind::Padding;
@@ -107,6 +133,8 @@ struct Padding : public Content {
   llvm::yaml::Hex64 PaddingValue;
 };
 struct InputSection : public Content {
+public:
+  static std::string getTypeName() { return "InputSection"; }
   virtual void mapping(llvm::yaml::IO &IO) override;
   static bool classof(const Content *C) {
     return C->ContentKind == Kind::InputSection;
@@ -123,10 +151,14 @@ struct InputSection : public Content {
 };
 
 struct InputBitcodeSection : public InputSection {
+public:
+  static std::string getTypeName() { return "InputBitcodeSection"; }
   virtual void mapping(llvm::yaml::IO &IO) override;
   std::string BitcodeOrigin;
 };
 struct OutputSection : public Content {
+public:
+  static std::string getTypeName() { return "OutputSection"; }
   virtual void mapping(llvm::yaml::IO &IO) override;
   static bool classof(const Content *C) {
     return C->ContentKind == Kind::OutputSection;
@@ -141,12 +173,16 @@ struct OutputSection : public Content {
 };
 
 struct SimpleSymbol {
+public:
+  static std::string getTypeName() { return "SimpleSymbol"; }
   std::string Name;
   SymbolType Type;
   llvm::yaml::Hex64 Size;
 };
 
 struct Reuse {
+public:
+  static std::string getTypeName() { return "Reuse"; }
   std::string From;
   std::vector<SimpleSymbol> Symbols;
   std::string FromFile;
@@ -154,6 +190,8 @@ struct Reuse {
 };
 
 struct Trampoline {
+public:
+  static std::string getTypeName() { return "Trampoline"; }
   std::string Name;
   std::string From;
   std::vector<SimpleSymbol> FromSymbols;
@@ -167,6 +205,8 @@ struct Trampoline {
 };
 
 struct TrampolineInfo {
+public:
+  static std::string getTypeName() { return "TrampolineInfo"; }
   virtual void mapping(llvm::yaml::IO &IO);
   std::string OutputSectionName;
   std::vector<Trampoline> Trampolines;
@@ -174,12 +214,16 @@ struct TrampolineInfo {
 };
 
 struct CommandLineDefault {
+public:
+  static std::string getTypeName() { return "CommandLineDefault"; }
   std::string Name;
   std::string Value;
   std::string Description;
 };
 LLVM_YAML_STRONG_TYPEDEF(uint8_t, CodeGenType)
 struct DiscardedSection {
+public:
+  static std::string getTypeName() { return "DiscardedSection"; }
   virtual void mapping(llvm::yaml::IO &IO);
   std::string Name;
   SectionType Type;
@@ -195,6 +239,8 @@ struct DiscardedSection {
 LLVM_YAML_STRONG_TYPEDEF(uint32_t, SegmentType)
 LLVM_YAML_STRONG_TYPEDEF(uint32_t, SegmentPermissions)
 struct LoadRegion {
+public:
+  static std::string getTypeName() { return "LoadRegion"; }
   virtual void mapping(llvm::yaml::IO &IO);
   SegmentType Type;
   llvm::yaml::Hex64 VirtualAddress;
@@ -211,6 +257,8 @@ struct LoadRegion {
 
 // Cross Reference Table.
 struct CRef {
+public:
+  static std::string getTypeName() { return "CRef"; }
   virtual void mapping(llvm::yaml::IO &IO);
   std::string SymbolName;
   std::vector<std::string> FileRefs;
@@ -218,6 +266,8 @@ struct CRef {
 };
 
 struct Module {
+public:
+  static std::string getTypeName() { return "Module"; }
   Header ModuleHeader;
   Version ModuleVersion;
   std::vector<eld::LDYAML::ArchiveRecord> ArchiveRecords;
@@ -364,6 +414,8 @@ template <> struct MappingTraits<eld::LDYAML::TrampolineInfo> {
 };
 template <>
 struct MappingTraits<std::shared_ptr<eld::LDYAML::DiscardedSection>> {
+public:
+  static std::string getTypeName() { return "MappingTraits"; }
   static void
   mapping(IO &IO,
           std::shared_ptr<eld::LDYAML::DiscardedSection> &DiscardedSection);

--- a/include/eld/LayoutMap/LayoutInfo.h
+++ b/include/eld/LayoutMap/LayoutInfo.h
@@ -40,6 +40,8 @@ class Module;
 class Stats;
 
 struct LayoutFragmentInfo {
+public:
+  static std::string getTypeName() { return "LayoutFragmentInfo"; }
   LayoutFragmentInfo(InputFile *F, const ELFSection *Section)
       : ThisInputFile(F), ThisSection(Section) {}
 
@@ -70,6 +72,8 @@ struct LayoutFragmentInfo {
 };
 
 class LayoutInfo {
+public:
+  static std::string getTypeName() { return "LayoutInfo"; }
   static uint32_t LayoutDetail;
 
 public:
@@ -95,6 +99,8 @@ public:
   };
 
   struct Stats {
+  public:
+    static std::string getTypeName() { return "Stats"; }
     uint64_t NumElfObjectFiles = 0;
     uint64_t NumElfExecutableFiles = 0;
     uint64_t NumLinkerScripts = 0;
@@ -132,6 +138,8 @@ public:
   };
 
   struct InputSequenceT {
+  public:
+    static std::string getTypeName() { return "InputSequenceT"; }
     InputKindPrefix Prefix;
     Input *Input;
     std::string ArchFlag;
@@ -173,6 +181,8 @@ public:
 
   // Linker Script support
   struct ScriptInputT {
+  public:
+    static std::string getTypeName() { return "ScriptInputT"; }
     std::string Include;
     std::string Parent;
     bool Found = false;

--- a/include/eld/LayoutMap/LinkStats.h
+++ b/include/eld/LayoutMap/LinkStats.h
@@ -15,6 +15,9 @@ namespace eld {
 
 class LinkStats {
 public:
+  static std::string getTypeName() { return "LinkStats"; }
+
+public:
   enum Kind : uint8_t { None, Relaxation };
 
   LinkStats(llvm::StringRef Name, Kind K) : StatsName(Name), StatsKind(K) {}

--- a/include/eld/LayoutMap/TextLayoutPrinter.h
+++ b/include/eld/LayoutMap/TextLayoutPrinter.h
@@ -25,6 +25,9 @@ class LinkerConfig;
 
 class TextLayoutPrinter {
 public:
+  static std::string getTypeName() { return "TextLayoutPrinter"; }
+
+public:
   TextLayoutPrinter(LayoutInfo *ThisLayoutInfo);
 
   eld::Expected<void> init();

--- a/include/eld/LayoutMap/YamlLayoutPrinter.h
+++ b/include/eld/LayoutMap/YamlLayoutPrinter.h
@@ -18,12 +18,16 @@
 namespace eld {
 class LinkerConfig;
 struct CommandLineDefault {
+public:
+  static std::string getTypeName() { return "CommandLineDefault"; }
   std::string Name;
   std::string Value;
   llvm::StringRef Desc;
 };
 
 class YamlLayoutPrinter {
+public:
+  static std::string getTypeName() { return "YamlLayoutPrinter"; }
 
 public:
   YamlLayoutPrinter(LayoutInfo *layoutInfo);

--- a/include/eld/Object/GroupReader.h
+++ b/include/eld/Object/GroupReader.h
@@ -31,6 +31,9 @@ class Node;
  */
 class GroupReader {
 public:
+  static std::string getTypeName() { return "GroupReader"; }
+
+public:
   GroupReader(Module &PModule, ObjectLinker *ObjLinker);
 
   ~GroupReader();

--- a/include/eld/Object/ObjectBuilder.h
+++ b/include/eld/Object/ObjectBuilder.h
@@ -42,6 +42,9 @@ class SectionMap;
  */
 class ObjectBuilder {
 public:
+  static std::string getTypeName() { return "ObjectBuilder"; }
+
+public:
   ObjectBuilder(LinkerConfig &PConfig, Module &PTheModule);
 
   ELFSection *createSection(const std::string &PInputName,

--- a/include/eld/Object/ObjectLinker.h
+++ b/include/eld/Object/ObjectLinker.h
@@ -66,6 +66,9 @@ class ScriptReader;
  */
 class ObjectLinker {
 public:
+  static std::string getTypeName() { return "ObjectLinker"; }
+
+public:
   ObjectLinker(LinkerConfig &PConfig, Module &PModule);
 
   bool initialize();
@@ -335,6 +338,8 @@ public:
   bool isPostLTOPhase() const { return MPostLtoPhase; }
 
   struct SymbolStats {
+  public:
+    static std::string getTypeName() { return "SymbolStats"; }
     uint64_t Global = 0;
     uint64_t Local = 0;
     uint64_t Weak = 0;

--- a/include/eld/Object/OutputSectionEntry.h
+++ b/include/eld/Object/OutputSectionEntry.h
@@ -31,6 +31,9 @@ class SectionMap;
 
 class OutputSectionEntry {
 public:
+  static std::string getTypeName() { return "OutputSectionEntry"; }
+
+public:
   typedef std::vector<RuleContainer *> InputList;
   typedef std::vector<BranchIsland *>::iterator BranchIslandsIter;
   typedef InputList::iterator iterator;

--- a/include/eld/Object/RuleContainer.h
+++ b/include/eld/Object/RuleContainer.h
@@ -31,6 +31,9 @@ class SectionMap;
 
 class RuleContainer {
 public:
+  static std::string getTypeName() { return "RuleContainer"; }
+
+public:
   typedef std::vector<Assignment *> SymbolAssignments;
   typedef SymbolAssignments::iterator sym_iterator;
 

--- a/include/eld/Object/ScriptMemoryRegion.h
+++ b/include/eld/Object/ScriptMemoryRegion.h
@@ -20,6 +20,9 @@ class MemoryDesc;
 
 class ScriptMemoryRegion {
 public:
+  static std::string getTypeName() { return "ScriptMemoryRegion"; }
+
+public:
   enum MemoryAttributes {
     NoAttributes = 0,
     Write = 0x1,

--- a/include/eld/Object/SectionMap.h
+++ b/include/eld/Object/SectionMap.h
@@ -37,6 +37,9 @@ class Section;
  */
 class SectionMap {
 public:
+  static std::string getTypeName() { return "SectionMap"; }
+
+public:
   typedef std::pair<OutputSectionEntry *, RuleContainer *> mapping;
   typedef std::vector<OutputSectionEntry *> OutputSectionEntryDescList;
   typedef OutputSectionEntryDescList::const_iterator const_iterator;

--- a/include/eld/Plugin/PluginData.h
+++ b/include/eld/Plugin/PluginData.h
@@ -13,6 +13,9 @@ namespace eld {
 
 class PluginData {
 public:
+  static std::string getTypeName() { return "PluginData"; }
+
+public:
   explicit PluginData(uint32_t Key, void *Data, std::string Annotation);
 
   uint32_t getKey() const { return Key; }

--- a/include/eld/Plugin/PluginManager.h
+++ b/include/eld/Plugin/PluginManager.h
@@ -21,6 +21,9 @@ class Plugin;
 /// routines for calling a plugin hook for all plugins.
 class PluginManager {
 public:
+  static std::string getTypeName() { return "PluginManager"; }
+
+public:
   explicit PluginManager(const LinkerScript &LinkerScript,
                          DiagnosticEngine &DiagEngine, bool PrintTimingStats)
       : LS(LinkerScript), DE(DiagEngine),

--- a/include/eld/Plugin/PluginOp.h
+++ b/include/eld/Plugin/PluginOp.h
@@ -24,6 +24,9 @@ class OutputSectionEntry;
 
 class PluginOp {
 public:
+  static std::string getTypeName() { return "PluginOp"; }
+
+public:
   enum PluginOpType : uint8_t {
     ChangeOutputSection,
     AddChunk,
@@ -57,6 +60,9 @@ protected:
 
 class ChangeOutputSectionPluginOp : public PluginOp {
 public:
+  static std::string getTypeName() { return "ChangeOutputSectionPluginOp"; }
+
+public:
   ChangeOutputSectionPluginOp(plugin::LinkerWrapper *W, eld::ELFSection *S,
                               std::string OutputSection,
                               std::string Annotation);
@@ -86,6 +92,9 @@ private:
 
 class AddChunkPluginOp : public PluginOp {
 public:
+  static std::string getTypeName() { return "AddChunkPluginOp"; }
+
+public:
   AddChunkPluginOp(plugin::LinkerWrapper *W, RuleContainer *Rule,
                    eld::Fragment *F, std::string Annotation);
 
@@ -106,6 +115,9 @@ private:
 
 class RemoveChunkPluginOp : public PluginOp {
 public:
+  static std::string getTypeName() { return "RemoveChunkPluginOp"; }
+
+public:
   RemoveChunkPluginOp(plugin::LinkerWrapper *W, RuleContainer *Rule,
                       eld::Fragment *F, std::string Annotation);
 
@@ -125,6 +137,9 @@ private:
 };
 
 class UpdateChunksPluginOp : public PluginOp {
+public:
+  static std::string getTypeName() { return "UpdateChunksPluginOp"; }
+
 public:
   enum Type : uint8_t { Start, End };
 
@@ -150,6 +165,9 @@ private:
 
 class RemoveSymbolPluginOp : public PluginOp {
 public:
+  static std::string getTypeName() { return "RemoveSymbolPluginOp"; }
+
+public:
   RemoveSymbolPluginOp(plugin::LinkerWrapper *W, std::string Annotation,
                        const eld::ResolveInfo *S);
 
@@ -166,6 +184,9 @@ private:
 };
 
 class RelocationDataPluginOp : public PluginOp {
+public:
+  static std::string getTypeName() { return "RelocationDataPluginOp"; }
+
 public:
   RelocationDataPluginOp(plugin::LinkerWrapper *W, const eld::Relocation *R,
                          const std::string &Annotation = {});
@@ -185,6 +206,9 @@ private:
 
 class UpdateLinkStatsPluginOp : public PluginOp {
 public:
+  static std::string getTypeName() { return "UpdateLinkStatsPluginOp"; }
+
+public:
   UpdateLinkStatsPluginOp(plugin::LinkerWrapper *W, const std::string &StatName,
                           const std::string &Annotation);
 
@@ -197,6 +221,9 @@ private:
 };
 
 class UpdateRulePluginOp : public PluginOp {
+public:
+  static std::string getTypeName() { return "UpdateRulePluginOp"; }
+
 public:
   UpdateRulePluginOp(plugin::LinkerWrapper *W, RuleContainer *Rule,
                      eld::ELFSection *S, const std::string &Annotation);
@@ -215,6 +242,9 @@ private:
 };
 
 class ResetOffsetPluginOp : public PluginOp {
+public:
+  static std::string getTypeName() { return "ResetOffsetPluginOp"; }
+
 public:
   ResetOffsetPluginOp(plugin::LinkerWrapper *W, const OutputSectionEntry *O,
                       uint32_t OldOffset, const std::string &Annotation = {});

--- a/include/eld/PluginAPI/ControlFileSizePlugin.h
+++ b/include/eld/PluginAPI/ControlFileSizePlugin.h
@@ -13,6 +13,9 @@ namespace eld::plugin {
 
 class DLL_A_EXPORT ControlFileSizePlugin : public Plugin {
 public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
+public:
   /* Constructor */
   ControlFileSizePlugin(std::string Name)
       : Plugin(Plugin::ControlFileSize, Name) {}

--- a/include/eld/PluginAPI/ControlMemorySizePlugin.h
+++ b/include/eld/PluginAPI/ControlMemorySizePlugin.h
@@ -13,6 +13,9 @@ namespace eld::plugin {
 
 class DLL_A_EXPORT ControlMemorySizePlugin : public Plugin {
 public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
+public:
   /* Constructor */
   ControlMemorySizePlugin(std::string Name)
       : Plugin(Plugin::ControlMemorySize, Name) {}

--- a/include/eld/PluginAPI/DWARF.h
+++ b/include/eld/PluginAPI/DWARF.h
@@ -35,6 +35,8 @@ struct DLL_A_EXPORT InputFile;
 
 // A class that can parse information from debug sections in DWARF format
 struct DLL_A_EXPORT DWARFInfo {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
 
   explicit DWARFInfo(llvm::DWARFContext *DC);
 
@@ -62,6 +64,8 @@ private:
 
 // A class that can parse DWARF Compile Unit
 struct DLL_A_EXPORT DWARFUnit {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit DWARFUnit(llvm::DWARFUnit *Unit);
 
   ///
@@ -84,6 +88,8 @@ private:
 
 // A class that can parse DWARF Compile Unit
 struct DLL_A_EXPORT DWARFDie {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
 
   explicit DWARFDie(llvm::DWARFUnit *U, llvm::DWARFDebugInfoEntry *Entry);
 
@@ -276,6 +282,8 @@ private:
 
 /// Represents DWARF Attributes
 struct DLL_A_EXPORT DWARFAttribute {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
 
   /// Create a DWARFAttribute from llvm::DWARFAttribute
   explicit DWARFAttribute(const llvm::DWARFAttribute *Attribute);
@@ -300,6 +308,8 @@ private:
 
 /// The associated value for an attribute
 struct DLL_A_EXPORT DWARFValue {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit DWARFValue(const llvm::DWARFFormValue *V);
 
   /// If the value for this DWARF attribute is a string, return it. Otherwise

--- a/include/eld/PluginAPI/DiagnosticBuilder.h
+++ b/include/eld/PluginAPI/DiagnosticBuilder.h
@@ -42,6 +42,9 @@ namespace eld::plugin {
 /// \endcode
 class DLL_A_EXPORT DiagnosticBuilder {
 public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
+public:
   DiagnosticBuilder(eld::MsgHandler *msgHandler);
   /// DiagnosticBuilder should not be copied.
   /// If it is copied, then multiple DiagnosticBuilder object

--- a/include/eld/PluginAPI/DiagnosticEntry.h
+++ b/include/eld/PluginAPI/DiagnosticEntry.h
@@ -23,6 +23,9 @@ namespace eld::plugin {
 /// with a diagnostic ID is used.
 class DLL_A_EXPORT DiagnosticEntry {
 public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
+public:
   // The order of values in Severity enum should be from
   // least severe to most severe.
   enum class Severity { None, Verbose, Note, Warning, Error, Fatal };
@@ -82,6 +85,9 @@ private:
 /// entry.
 class DLL_A_EXPORT ErrorDiagnosticEntry : public DiagnosticEntry {
 public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
+public:
   ErrorDiagnosticEntry() = default;
   explicit ErrorDiagnosticEntry(DiagIDType id,
                                 const std::vector<std::string> &args)
@@ -93,6 +99,9 @@ public:
 /// WarningDiagnosticEntry subclass allows to easily create warning diagnostic
 /// entry.
 class DLL_A_EXPORT WarningDiagnosticEntry : public DiagnosticEntry {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
 public:
   WarningDiagnosticEntry() = default;
   explicit WarningDiagnosticEntry(DiagIDType id,
@@ -107,6 +116,9 @@ public:
 /// entry.
 class DLL_A_EXPORT FatalDiagnosticEntry : public DiagnosticEntry {
 public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
+public:
   FatalDiagnosticEntry() = default;
   explicit FatalDiagnosticEntry(DiagIDType id,
                                 const std::vector<std::string> &args)
@@ -118,6 +130,9 @@ public:
 /// VerboseDiagnosticEntry subclass allows to easily create verbose diagnostic
 /// entry.
 class DLL_A_EXPORT VerboseDiagnosticEntry : public DiagnosticEntry {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
 public:
   VerboseDiagnosticEntry() = default;
   explicit VerboseDiagnosticEntry(DiagIDType id,
@@ -131,6 +146,9 @@ public:
 /// NoteDiagnosticEntry subclass allows to easily create note diagnostic
 /// entry.
 class DLL_A_EXPORT NoteDiagnosticEntry : public DiagnosticEntry {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
 public:
   NoteDiagnosticEntry() = default;
   explicit NoteDiagnosticEntry(DiagIDType id,

--- a/include/eld/PluginAPI/Expected.h
+++ b/include/eld/PluginAPI/Expected.h
@@ -71,6 +71,9 @@ namespace eld {
 template <class T, class U = std::unique_ptr<plugin::DiagnosticEntry>>
 class Expected {
 public:
+  static std::string getTypeName() { return "Expected"; }
+
+public:
   Expected() = default;
   Expected(const Expected &) = default;
   Expected(Expected &&) noexcept = default;

--- a/include/eld/PluginAPI/LayoutADT.h
+++ b/include/eld/PluginAPI/LayoutADT.h
@@ -18,6 +18,8 @@ struct DLL_A_EXPORT LinkerConfig;
 struct DLL_A_EXPORT MapHeader;
 
 struct DLL_A_EXPORT MapHeader {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit MapHeader(const plugin::LinkerConfig &Config);
   std::string getVendorName() const;
   std::string getVendorVersion() const;
@@ -32,6 +34,8 @@ private:
 /// Padding details at section start, fragment and
 /// between rules.
 struct DLL_A_EXPORT Padding {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   uint64_t startOffset = 0;
   uint64_t size = 0;
   uint64_t fillValue = 0;

--- a/include/eld/PluginAPI/LayoutWrapper.h
+++ b/include/eld/PluginAPI/LayoutWrapper.h
@@ -25,6 +25,9 @@ struct OutputSection;
 /// layout data in a map file.
 class DLL_A_EXPORT LayoutWrapper {
 public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
+public:
   explicit LayoutWrapper(const LinkerWrapper &Linker);
 
   /// Get the map header.

--- a/include/eld/PluginAPI/LinkerPlugin.h
+++ b/include/eld/PluginAPI/LinkerPlugin.h
@@ -28,6 +28,9 @@ class LTOModule;
 
 class DLL_A_EXPORT LinkerPlugin : public PluginBase {
 public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
+public:
   LinkerPlugin(const std::string &name)
       : PluginBase(PluginBase::Type::LinkerPlugin, name) {}
 

--- a/include/eld/PluginAPI/LinkerPluginConfig.h
+++ b/include/eld/PluginAPI/LinkerPluginConfig.h
@@ -23,6 +23,9 @@ struct DLL_A_EXPORT Use;
 /// LinkerWrapper::RegisterReloc.
 class DLL_A_EXPORT LinkerPluginConfig {
 public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
+public:
   explicit LinkerPluginConfig(plugin::Plugin *);
 
   /// The Init callback hook is called before any relocation callback hook

--- a/include/eld/PluginAPI/LinkerScript.h
+++ b/include/eld/PluginAPI/LinkerScript.h
@@ -77,6 +77,8 @@ struct DLL_A_EXPORT Sections;
 /// \class ScriptCommand
 /// \brief Base class for all linker script commands.
 struct DLL_A_EXPORT ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   /// \enum CommmandKind - represents the kind of commands supported
   enum CommandKind : uint8_t {
     Assignment,
@@ -343,6 +345,8 @@ private:
 /// \class PHDRDescriptor
 /// \brief This class represents each segment and the corresponding members
 struct DLL_A_EXPORT PHDRDescriptor : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   /// Constructor
   explicit PHDRDescriptor(eld::PhdrDesc *PhdrDesc);
 
@@ -382,6 +386,8 @@ public:
 ///             [ FLAGS ( flags ) ] ;
 ///  }
 struct DLL_A_EXPORT PHDRS : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   /// Constructor
   explicit PHDRS(eld::PhdrsCmd *PhdrsCmd);
 
@@ -421,6 +427,8 @@ private:
 /// symbol *= expression ;
 /// symbol /= expression ;
 struct DLL_A_EXPORT Assignment : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit Assignment(eld::Assignment *Assignment);
 
   /// \returns true when used in a boolean expression.
@@ -462,6 +470,8 @@ public:
 ///
 /// \brief Specification :- represented by {
 struct DLL_A_EXPORT EnterScope : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit EnterScope(eld::EnterScopeCmd *EnterScope);
 
   /// \returns true when used in a boolean expression.
@@ -482,6 +492,8 @@ public:
 ///
 /// \brief Specification :- represented by }
 struct DLL_A_EXPORT ExitScope : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit ExitScope(eld::ExitScopeCmd *ExitScope);
 
   /// \returns true when used in a boolean expression.
@@ -522,6 +534,8 @@ public:
 /// * The address 0.
 
 struct DLL_A_EXPORT Entry : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit Entry(eld::EntryCmd *Entry);
 
   /// \returns true when used in a boolean expression.
@@ -548,6 +562,8 @@ public:
 /// may use EXTERN multiple times. This command has the same effect as the `-u'
 /// command-line option.
 struct DLL_A_EXPORT Extern : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit Extern(eld::ExternCmd *Extern);
 
   /// \returns true when used in a boolean expression.
@@ -574,6 +590,8 @@ public:
 /// are created.
 
 struct DLL_A_EXPORT Group : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit Group(eld::GroupCmd *Group);
 
   /// \returns true when used in a boolean expression.
@@ -600,6 +618,8 @@ public:
 /// deep You can place INCLUDE directives at the top level, in MEMORY or
 /// SECTIONS commands, or in output section descriptions
 struct DLL_A_EXPORT Include : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit Include(eld::IncludeCmd *Include);
 
   /// \returns true when used in a boolean expression.
@@ -646,6 +666,8 @@ public:
 /// If you use `INPUT (-lfile)', ld will transform the name to libfile.a, as
 /// with the command line argument `-l'.
 struct DLL_A_EXPORT Input : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit Input(eld::InputCmd *Input);
 
   /// \returns true when used in a boolean expression.
@@ -668,6 +690,8 @@ public:
 /// memory. You use input section descriptions to tell the linker how to map the
 /// input files into your memory layout.
 struct DLL_A_EXPORT InputSectionSpec : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit InputSectionSpec(eld::InputSectDesc *ISD);
 
   /// \returns true when used in a boolean expression.
@@ -717,6 +741,8 @@ public:
 /// names, not input section names.
 
 struct DLL_A_EXPORT NoCrossRefs : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit NoCrossRefs(eld::NoCrossRefsCmd *NoCrossRefs);
 
   /// \returns true when used in a boolean expression.
@@ -742,6 +768,8 @@ public:
 /// precedence. You can use the OUTPUT command to define a default name for the
 /// output file other than the usual default of a.out.
 struct DLL_A_EXPORT Output : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit Output(eld::OutputCmd *Output);
 
   /// \returns true when used in a boolean expression.
@@ -763,6 +791,8 @@ public:
 /// Specify a particular output machine architecture.
 
 struct DLL_A_EXPORT OutputArch : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit OutputArch(eld::OutputArchCmd *OutputArch);
 
   /// \returns true when used in a boolean expression.
@@ -783,6 +813,8 @@ public:
 /// OUTPUT_FORMAT ( name )
 /// Specify output format.
 struct DLL_A_EXPORT OutputFormat : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit OutputFormat(eld::OutputFormatCmd *OutputFormat);
 
   /// \returns true when used in a boolean expression.
@@ -813,6 +845,8 @@ public:
 ///        } [>region] [AT>lma_region] [:phdr :phdr ...] [=fillexp]
 
 struct DLL_A_EXPORT OutputSectionSpec : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit OutputSectionSpec(eld::OutputSectDesc *OSD);
 
   /// \returns true when used in a boolean expression.
@@ -848,6 +882,8 @@ public:
 /// PLUGIN_SECTION_MATCHER
 /// Handle all Linker plugins.
 struct DLL_A_EXPORT Plugin : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit Plugin(eld::PluginCmd *P);
 
   /// \returns true when used in a boolean expression.
@@ -874,6 +910,8 @@ public:
 /// command-line option are searched first.
 
 struct DLL_A_EXPORT SearchDir : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit SearchDir(eld::SearchDirCmd *SearchDir);
 
   /// \returns true when used in a boolean expression.
@@ -910,6 +948,8 @@ public:
 /// an output section description
 
 struct DLL_A_EXPORT Sections : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit Sections(eld::SectionsCmd *SectionsCmd);
 
   /// \returns true when used in a boolean expression.
@@ -939,6 +979,8 @@ public:
 /// bytes of data in an output section. These commands include BYTE, SHORT,
 /// LONG, QUAD and SQUAD.
 struct DLL_A_EXPORT OutputSectionData : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit OutputSectionData(eld::OutputSectData *OSD);
 
   /// \returns true if objects contains a command.
@@ -953,6 +995,8 @@ private:
 
 /// MEMORY command wrapper
 struct DLL_A_EXPORT Memory : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit Memory(eld::MemoryCmd *MemoryCmd);
 
   operator bool() const { return m_MemoryCmd != nullptr; }
@@ -967,6 +1011,8 @@ private:
 
 /// REGION_ALIAS command wrapper
 struct DLL_A_EXPORT RegionAlias : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit RegionAlias(eld::RegionAlias *RegionAliasCmd);
 
   operator bool() const { return m_RegionAlias != nullptr; }
@@ -982,6 +1028,8 @@ private:
 /// \brief Handle Linker Script and provide lookup of PHDRS, OutputSections and
 /// Rules
 struct DLL_A_EXPORT LinkerScript {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
 
   /// Constructor
   explicit LinkerScript(eld::LinkerScript *LinkerScript);

--- a/include/eld/PluginAPI/LinkerWrapper.h
+++ b/include/eld/PluginAPI/LinkerWrapper.h
@@ -82,6 +82,9 @@ using AuxiliarySymbolNameMap = std::unordered_map<uint64_t, std::string>;
 /// certain plugin interface types and link stages.
 class DLL_A_EXPORT LinkerWrapper {
 public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
+public:
 
   /// Link modes.
   enum LinkMode : uint8_t {
@@ -102,6 +105,8 @@ public:
   /// chunk: The added chunk
   /// rule: Rule to which it was added.
   struct DLL_A_EXPORT UnbalancedChunkMove {
+  public:
+    static std::string getTypeName() { return "DLL_A_EXPORT"; }
     Chunk chunk;
     LinkerScriptRule rule;
   };

--- a/include/eld/PluginAPI/OutputSectionIteratorPlugin.h
+++ b/include/eld/PluginAPI/OutputSectionIteratorPlugin.h
@@ -13,6 +13,9 @@ namespace eld::plugin {
 
 class DLL_A_EXPORT OutputSectionIteratorPlugin : public Plugin {
 public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
+public:
   /* Constructor */
   OutputSectionIteratorPlugin(std::string Name)
       : Plugin(Plugin::Type::OutputSectionIterator, Name) {}

--- a/include/eld/PluginAPI/PluginADT.h
+++ b/include/eld/PluginAPI/PluginADT.h
@@ -78,6 +78,8 @@ struct DLL_A_EXPORT LinkerConfig;
 /// chunk.
 
 struct DLL_A_EXPORT Chunk {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
 
   explicit Chunk(eld::Fragment *F) : m_Fragment(F) {}
 
@@ -113,6 +115,8 @@ struct DLL_A_EXPORT Chunk {
   /// Returns true if the chunks A and B originates
   /// from different input sections; Otherwise returns false.
   struct DEPRECATED DLL_A_EXPORT Compare final {
+  public:
+    static std::string getTypeName() { return "DEPRECATED"; }
     bool operator()(const Chunk &A, const Chunk &B) const;
   };
 
@@ -181,6 +185,8 @@ protected:
 /// strings. For a Chunk to be a MergeStringChunk, isMergeableString() must be
 /// true for that Chunk.
 struct DLL_A_EXPORT MergeStringChunk : public Chunk {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   MergeStringChunk(eld::Fragment *F) : Chunk(F) {}
 
   /// Return the strings contained in this Chunk in a vector
@@ -191,6 +197,8 @@ struct DLL_A_EXPORT MergeStringChunk : public Chunk {
 /// section that has the flags SHF_STRINGS & SHF_MERGE, and alignment and entry
 /// size of 1.
 struct DLL_A_EXPORT MergeableString {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit MergeableString(const eld::MergeableString *S);
   /// return the null-terminated string that this MergeableString represents.
   const char *getString() const;
@@ -238,6 +246,8 @@ private:
 /// If two LinkerScriptRule objects have the same underlying RuleContainer
 /// object, then both the objects represent the same rule.
 struct DLL_A_EXPORT LinkerScriptRule final {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
 
   enum State : uint8_t { Empty, NoChunk, DuplicateChunk, NotEmpty, Ok };
 
@@ -410,6 +420,8 @@ private:
 /// Segment is a handler for an ELF Segment. A Segment object can be used
 /// to inspect Segment properties and their associated OutputSections.
 struct DLL_A_EXPORT Segment final {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
 
   explicit Segment(eld::ELFSegment *S) : S(S) {}
 
@@ -481,6 +493,9 @@ private:
 /// cannot be represented in the default function call instruction.
 class DLL_A_EXPORT Stub {
 public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
+public:
   explicit Stub(const eld::BranchIsland *pBI) : BI(pBI) {}
 
   /// Returns the target symbol for the stub.
@@ -509,6 +524,8 @@ private:
 /// OutputSectionEntry object, then they both represent the same
 /// output section.
 struct DLL_A_EXPORT OutputSection final {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit OutputSection(eld::OutputSectionEntry *O) : m_OutputSection(O) {}
 
   /// Returns the name of the output section.
@@ -650,6 +667,8 @@ private:
 /// have the same underlying Section object, then they both represents the
 /// same section.
 struct DLL_A_EXPORT Section {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   // TODO: What do each of these types means? Where is SectionType used?
   enum SectionType : uint8_t { Default, Padding };
 
@@ -852,6 +871,8 @@ protected:
 /// Block represents output sections and their content.
 // TODO:
 struct DLL_A_EXPORT Block final {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   Block() : Data(nullptr), Size(0), Address(0), Alignment(1) {}
   const uint8_t *Data; ///< Data passed to the plugin
   uint32_t Size;       ///< Size of the data in bytes.
@@ -870,6 +891,8 @@ struct DLL_A_EXPORT Block final {
 /// If two Use objects have the same underlying relocation objects,
 /// then the two Use objects represents the same Use.
 struct DLL_A_EXPORT Use final {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   /// Symbol status.
   enum Status : uint8_t { Ok, SymbolDoesNotExist, Error };
   explicit Use(eld::Relocation *R) : m_Relocation(R) {}
@@ -966,6 +989,8 @@ private:
 /// Symbol objects have the same underlying ResolveInfo object, then
 /// they both represent the same symbol.
 struct DLL_A_EXPORT Symbol final {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
 
   enum Binding { Global = 0, Weak = 1, Local = 2 };
   enum Kind { Undefined = 0, Define = 1, Common = 2 };
@@ -1084,6 +1109,8 @@ private:
 /// INIFile represents an ini configuration file. It provides APIs
 /// to easily inspect and modify the INI configuration.
 struct DLL_A_EXPORT INIFile final {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
 
   enum ErrorCode { Success, FileDoesNotExist, ReadError, WriteError };
 
@@ -1174,6 +1201,9 @@ private:
 /// E.g. Adding data to a tar file using the plugin::TarWriter's
 /// addBufferToTar(eld::Expected<plugin::MemoryBuffer> buffer) function.
 class DLL_A_EXPORT MemoryBuffer final {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
 private:
   std::unique_ptr<eld::MemoryArea> getBuffer();
 
@@ -1221,6 +1251,8 @@ private:
 /// with. An InputFile object can be used to inspect input file properties,
 /// and contents.
 struct DLL_A_EXPORT InputFile {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit InputFile(eld::InputFile *I) : m_InputFile(I) {}
 
   /// Returns the file name of the input file if the object has an
@@ -1326,6 +1358,8 @@ private:
 
 /// An interface to represent a bitcode file to retrieve the LTO Input file.
 struct DLL_A_EXPORT BitcodeFile final : public InputFile {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
 
   explicit BitcodeFile(eld::BitcodeFile &F);
 
@@ -1336,6 +1370,8 @@ struct DLL_A_EXPORT BitcodeFile final : public InputFile {
 };
 
 struct DLL_A_EXPORT DynamicLibrary final {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   void *Handle;
   std::string Path;
 };
@@ -1343,6 +1379,8 @@ struct DLL_A_EXPORT DynamicLibrary final {
 /// PluginData provide a way for storing data and communicating between plugins.
 // TODO: Add a demo that shows the usage of PluginData.
 struct DLL_A_EXPORT PluginData final {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit PluginData(eld::PluginData *D) : m_Data(D) {}
 
   void *getData() const;
@@ -1373,6 +1411,8 @@ private:
 
 /// Plugin Profiling support
 struct DLL_A_EXPORT AutoTimer final {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit AutoTimer(llvm::Timer *T);
 
   /// Start Timer
@@ -1404,6 +1444,8 @@ private:
 };
 
 struct DLL_A_EXPORT Timer final {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   Timer(llvm::Timer *T);
 
   /// Start Timer
@@ -1439,6 +1481,8 @@ private:
 // FIXME: This class do not provide much functionality to handle
 // relocations.
 struct DLL_A_EXPORT RelocationHandler final {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
 
   RelocationHandler(eld::Relocator *R);
 
@@ -1479,6 +1523,9 @@ private:
 
 class DLL_A_EXPORT InputSymbol final {
 public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
+public:
   InputSymbol();
 
   InputSymbol(eld::LDSymbol *sym, std::string_view symName,
@@ -1515,6 +1562,8 @@ private:
 /// LinkerConfig houses functions for plugins to access linker configurations
 /// and options.
 struct DLL_A_EXPORT LinkerConfig {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit LinkerConfig(const eld::LinkerConfig &Config);
   std::string getTargetCPU() const;
   std::string getArchName() const;

--- a/include/eld/PluginAPI/PluginConfig.h
+++ b/include/eld/PluginAPI/PluginConfig.h
@@ -15,6 +15,8 @@ namespace eld {
 namespace LinkerPlugin {
 
 struct GlobalPlugin {
+public:
+  static std::string getTypeName() { return "GlobalPlugin"; }
   plugin::PluginBase::Type PluginType;
   std::string PluginName;
   std::string LibraryName;
@@ -22,6 +24,8 @@ struct GlobalPlugin {
 };
 
 struct OutputSectionPlugin {
+public:
+  static std::string getTypeName() { return "OutputSectionPlugin"; }
   plugin::PluginBase::Type PluginType;
   std::string OutputSection;
   std::string PluginName;
@@ -30,6 +34,8 @@ struct OutputSectionPlugin {
 };
 
 struct Config {
+public:
+  static std::string getTypeName() { return "Config"; }
   std::vector<eld::LinkerPlugin::GlobalPlugin> GlobalPlugins;
   std::vector<eld::LinkerPlugin::OutputSectionPlugin> OutputSectionPlugins;
 };

--- a/include/eld/PluginAPI/SectionIteratorPlugin.h
+++ b/include/eld/PluginAPI/SectionIteratorPlugin.h
@@ -13,6 +13,9 @@ namespace eld::plugin {
 
 class DLL_A_EXPORT SectionIteratorPlugin : public Plugin {
 public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
+public:
   /* Constructor */
   SectionIteratorPlugin(std::string Name)
       : Plugin(Plugin::Type::SectionIterator, Name) {}

--- a/include/eld/PluginAPI/SectionMatcherPlugin.h
+++ b/include/eld/PluginAPI/SectionMatcherPlugin.h
@@ -13,6 +13,9 @@ namespace eld::plugin {
 
 class DLL_A_EXPORT SectionMatcherPlugin : public Plugin {
 public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
+public:
   /* Constructor */
   SectionMatcherPlugin(std::string Name)
       : Plugin(Plugin::Type::SectionMatcher, Name) {}

--- a/include/eld/PluginAPI/SmallJSON.h
+++ b/include/eld/PluginAPI/SmallJSON.h
@@ -25,6 +25,9 @@ struct DLL_A_EXPORT SmallJSONValue;
 /// Arrays, boolean, floating point, integral, string, and null types
 struct DLL_A_EXPORT SmallJSONValue {
 public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
+public:
   /// Create a SmallJSONValue from a SmallJSONObject
   SmallJSONValue(SmallJSONObject &&Obj);
   /// Create a SmallJSONValue from SmallJSONArray
@@ -66,6 +69,8 @@ private:
 /// This class is append only. Items will appear in the order in which they were
 /// inserted
 struct DLL_A_EXPORT SmallJSONObject {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
 
 public:
   /// Move constructor
@@ -96,6 +101,8 @@ private:
 /// An append-only class represeting a heterogenous array of JSON values. Items
 /// are stored in insertion order.
 struct DLL_A_EXPORT SmallJSONArray {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
 
 public:
   /// Move constructor

--- a/include/eld/PluginAPI/TarWriter.h
+++ b/include/eld/PluginAPI/TarWriter.h
@@ -21,6 +21,8 @@ class LinkerWrapper;
 
 /// A utility class for creating tar archives
 class DLL_A_EXPORT TarWriter {
+public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
   explicit TarWriter(std::unique_ptr<llvm::TarWriter> TW);
 
 public:

--- a/include/eld/PluginAPI/ThreadPool.h
+++ b/include/eld/PluginAPI/ThreadPool.h
@@ -23,6 +23,9 @@ namespace eld::plugin {
 /// variable for some work to become available.
 class DLL_A_EXPORT ThreadPool {
 public:
+  static std::string getTypeName() { return "DLL_A_EXPORT"; }
+
+public:
   using TaskTy = std::function<void()>;
 
   explicit ThreadPool(uint32_t NumThreads);

--- a/include/eld/Readers/ArchiveParser.h
+++ b/include/eld/Readers/ArchiveParser.h
@@ -23,6 +23,9 @@ class ResolveInfo;
 
 class ArchiveParser final {
 public:
+  static std::string getTypeName() { return "ArchiveParser"; }
+
+public:
   explicit ArchiveParser(Module &module) : m_Module(module) {};
 
   // clang-format off
@@ -42,6 +45,8 @@ public:
   eld::Expected<uint32_t> parseFile(InputFile &inputFile) const;
 
   struct ArchiveSymbol {
+  public:
+    static std::string getTypeName() { return "ArchiveSymbol"; }
     uint64_t ChildOffset = 0;
     llvm::StringRef SymbolName;
 

--- a/include/eld/Readers/BinaryFileParser.h
+++ b/include/eld/Readers/BinaryFileParser.h
@@ -23,6 +23,9 @@ class Module;
 ///   '_binary_${FileName}_size'.
 class BinaryFileParser {
 public:
+  static std::string getTypeName() { return "BinaryFileParser"; }
+
+public:
   BinaryFileParser(Module &module) : m_Module(module) {}
 
   eld::Expected<void> parseFile(InputFile &inputFile);

--- a/include/eld/Readers/BitcodeReader.h
+++ b/include/eld/Readers/BitcodeReader.h
@@ -7,6 +7,8 @@
 #ifndef ELD_READERS_BITCODEREADER_H
 #define ELD_READERS_BITCODEREADER_H
 
+#include <string>
+
 namespace eld::plugin {
 class LinkerPlugin;
 }
@@ -17,6 +19,8 @@ class Module;
 class InputFile;
 
 class BitcodeReader {
+public:
+  static std::string getTypeName() { return "BitcodeReader"; }
 
 public:
   BitcodeReader(Module &);

--- a/include/eld/Readers/CommonELFSection.h
+++ b/include/eld/Readers/CommonELFSection.h
@@ -17,6 +17,9 @@ namespace eld {
 ///
 class CommonELFSection : public ELFSection {
 public:
+  static std::string getTypeName() { return "CommonELFSection"; }
+
+public:
   CommonELFSection(const std::string &Name, InputFile *I, uint32_t Align)
       : ELFSection(Section::Kind::CommonELF, LDFileFormat::Common, Name,
                    DefaultFlags, /*EntSize=*/0, Align, DefaultType, /*Info=*/0,

--- a/include/eld/Readers/ELFDynObjParser.h
+++ b/include/eld/Readers/ELFDynObjParser.h
@@ -20,6 +20,9 @@ class Module;
 /// process.
 class ELFDynObjParser {
 public:
+  static std::string getTypeName() { return "ELFDynObjParser"; }
+
+public:
   ELFDynObjParser(Module &);
 
   ~ELFDynObjParser();

--- a/include/eld/Readers/ELFExecObjParser.h
+++ b/include/eld/Readers/ELFExecObjParser.h
@@ -15,6 +15,9 @@ class ELFExecutableFileReader;
 
 class ELFExecObjParser {
 public:
+  static std::string getTypeName() { return "ELFExecObjParser"; }
+
+public:
   ELFExecObjParser(Module &);
 
   /// This function returns the machine information encoded in the ELF

--- a/include/eld/Readers/ELFReaderBase.h
+++ b/include/eld/Readers/ELFReaderBase.h
@@ -27,6 +27,9 @@ class Module;
 /// eld::Expected.
 class ELFReaderBase {
 public:
+  static std::string getTypeName() { return "ELFReaderBase"; }
+
+public:
   explicit ELFReaderBase(Module &module, InputFile &inputFile);
 
   // defaulted copy-constructor.

--- a/include/eld/Readers/ELFRelocObjParser.h
+++ b/include/eld/Readers/ELFRelocObjParser.h
@@ -20,6 +20,9 @@ class Module;
 /// process.
 class ELFRelocObjParser {
 public:
+  static std::string getTypeName() { return "ELFRelocObjParser"; }
+
+public:
   ELFRelocObjParser(Module &);
 
   /// This function returns the machine information encoded in the ELF

--- a/include/eld/Readers/ELFSection.h
+++ b/include/eld/Readers/ELFSection.h
@@ -29,6 +29,9 @@ class Section;
 
 class ELFSectionBase : public Section {
 public:
+  static std::string getTypeName() { return "ELFSectionBase"; }
+
+public:
   virtual ~ELFSectionBase() {}
 
   uint32_t getType() const { return Type; }
@@ -120,6 +123,9 @@ protected:
  *  abstraction of a section header entry for various file formats.
  */
 class ELFSection : public ELFSectionBase {
+public:
+  static std::string getTypeName() { return "ELFSection"; }
+
 public:
   explicit ELFSection(LDFileFormat::Kind ELFSectionKind,
                       const std::string &Name, uint32_t Flags, uint32_t EntSize,

--- a/include/eld/Readers/EhFrameHdrSection.h
+++ b/include/eld/Readers/EhFrameHdrSection.h
@@ -20,6 +20,9 @@ class EhFrameHdrFragment;
 
 class EhFrameHdrSection : public ELFSection {
 public:
+  static std::string getTypeName() { return "EhFrameHdrSection"; }
+
+public:
   EhFrameHdrSection(std::string Name, uint32_t pType, uint32_t pFlag,
                     uint32_t entSize, uint64_t pSize);
 

--- a/include/eld/Readers/EhFrameSection.h
+++ b/include/eld/Readers/EhFrameSection.h
@@ -25,6 +25,9 @@ class EhFramePiece;
 
 class EhFrameSection : public ELFSection {
 public:
+  static std::string getTypeName() { return "EhFrameSection"; }
+
+public:
   EhFrameSection(std::string Name, DiagnosticEngine *diagEngine, uint32_t pType,
                  uint32_t pFlag, uint32_t entSize, uint64_t pSize);
 

--- a/include/eld/Readers/ObjectReader.h
+++ b/include/eld/Readers/ObjectReader.h
@@ -21,12 +21,18 @@ class InputFile;
  *  formats.
  */
 class ObjectReader {
+public:
+  static std::string getTypeName() { return "ObjectReader"; }
+
 protected:
   ObjectReader() {}
 
 public:
   // Group Signature Info.
   class GroupSignatureInfo {
+  public:
+    static std::string getTypeName() { return "GroupSignatureInfo"; }
+
   public:
     GroupSignatureInfo(ResolveInfo *R, ELFSection *S)
         : m_Info(R), m_Section(S) {}

--- a/include/eld/Readers/Relocation.h
+++ b/include/eld/Readers/Relocation.h
@@ -29,6 +29,8 @@ class ELFSection;
 class ELFSegment;
 
 class Relocation {
+public:
+  static std::string getTypeName() { return "Relocation"; }
   static llvm::DenseMap<const Relocation *, FragmentRef *> m_RelocFragMap;
 
 public:

--- a/include/eld/Readers/Section.h
+++ b/include/eld/Readers/Section.h
@@ -21,6 +21,9 @@ class DiagnosticEngine;
 
 class Section {
 public:
+  static std::string getTypeName() { return "Section"; }
+
+public:
   enum Kind : uint8_t {
     Bitcode,
     CommonELF,

--- a/include/eld/Readers/SymDefReader.h
+++ b/include/eld/Readers/SymDefReader.h
@@ -17,6 +17,8 @@ class InputFile;
 class Module;
 
 class SymDefReader : public ObjectReader {
+public:
+  static std::string getTypeName() { return "SymDefReader"; }
 
 public:
   SymDefReader(Module &);

--- a/include/eld/Readers/TimingSection.h
+++ b/include/eld/Readers/TimingSection.h
@@ -21,6 +21,9 @@ class InputFile;
 
 class TimingSection : public ELFSection {
 public:
+  static std::string getTypeName() { return "TimingSection"; }
+
+public:
   explicit TimingSection(DiagnosticEngine *diagEngine,
                          llvm::StringRef SectionData, uint32_t sh_size,
                          uint32_t sh_flag, InputFile *iptFile);

--- a/include/eld/Readers/TimingSlice.h
+++ b/include/eld/Readers/TimingSlice.h
@@ -19,6 +19,9 @@ class DiagnosticEngine;
 // Represents the data of a single module in timing section
 class TimingSlice {
 public:
+  static std::string getTypeName() { return "TimingSlice"; }
+
+public:
   explicit TimingSlice(llvm::StringRef Slice, llvm::StringRef InputFileName,
                        DiagnosticEngine *DiagEngine);
 

--- a/include/eld/Script/Assignment.h
+++ b/include/eld/Script/Assignment.h
@@ -34,6 +34,9 @@ class ELFSection;
 
 class Assignment : public ScriptCommand {
 public:
+  static std::string getTypeName() { return "Assignment"; }
+
+public:
   enum Level {
     BEFORE_SECTIONS,  // Assignments before SECTIONS command
     AFTER_SECTIONS,   // Assignments after SECTIONS command

--- a/include/eld/Script/EnterScopeCmd.h
+++ b/include/eld/Script/EnterScopeCmd.h
@@ -21,6 +21,9 @@ class Module;
 
 class EnterScopeCmd : public ScriptCommand {
 public:
+  static std::string getTypeName() { return "EnterScopeCmd"; }
+
+public:
   EnterScopeCmd();
 
   eld::Expected<void> activate(Module &CurModule) override;

--- a/include/eld/Script/EntryCmd.h
+++ b/include/eld/Script/EntryCmd.h
@@ -27,6 +27,9 @@ class Module;
 
 class EntryCmd : public ScriptCommand {
 public:
+  static std::string getTypeName() { return "EntryCmd"; }
+
+public:
   EntryCmd(const std::string &PEntry);
 
 

--- a/include/eld/Script/ExcludeFiles.h
+++ b/include/eld/Script/ExcludeFiles.h
@@ -9,6 +9,7 @@
 
 #include "eld/Config/Config.h"
 #include <cstdint>
+#include <string>
 #include <vector>
 
 namespace eld {
@@ -21,7 +22,12 @@ class WildcardPattern;
 
 class ExcludePattern {
 public:
+  static std::string getTypeName() { return "ExcludePattern"; }
+
+public:
   struct Spec {
+  public:
+    static std::string getTypeName() { return "Spec"; }
     Spec(WildcardPattern *A, WildcardPattern *F)
         : ArchiveLibraryNamePattern(A), FileNamePattern(F) {}
     WildcardPattern *ArchiveLibraryNamePattern;
@@ -43,6 +49,9 @@ public:
 };
 
 class ExcludeFiles {
+public:
+  static std::string getTypeName() { return "ExcludeFiles"; }
+
 public:
   typedef std::vector<ExcludePattern *> ExcludeFileList;
   typedef ExcludeFileList::iterator iterator;

--- a/include/eld/Script/ExitScopeCmd.h
+++ b/include/eld/Script/ExitScopeCmd.h
@@ -21,6 +21,9 @@ class Module;
 
 class ExitScopeCmd : public ScriptCommand {
 public:
+  static std::string getTypeName() { return "ExitScopeCmd"; }
+
+public:
   ExitScopeCmd();
 
   eld::Expected<void> activate(Module &CurModule) override;

--- a/include/eld/Script/Expression.h
+++ b/include/eld/Script/Expression.h
@@ -30,6 +30,9 @@ class ScriptFile;
  */
 class Expression {
 public:
+  static std::string getTypeName() { return "Expression"; }
+
+public:
   enum Type {
     /* Operands */
     STRING,
@@ -315,6 +318,9 @@ private:
  */
 class Symbol : public Expression {
 public:
+  static std::string getTypeName() { return "Symbol"; }
+
+public:
   Symbol(Module &Module, std::string Name);
 
   // Casting support
@@ -338,6 +344,9 @@ private:
  *  \brief This class extends an Expression to an Integer operand.
  */
 class Integer : public Expression {
+public:
+  static std::string getTypeName() { return "Integer"; }
+
 public:
   Integer(Module &Module, std::string Name, uint64_t Value)
       : Expression(Name, Expression::INTEGER, Module, Value),
@@ -363,6 +372,9 @@ private:
  *  \brief This class extends an Expression to an Add operator.
  */
 class Add : public Expression {
+public:
+  static std::string getTypeName() { return "Add"; }
+
 public:
   Add(Module &Module, Expression &Left, Expression &Right)
       : Expression("+", Expression::ADD, Module), LeftExpression(Left),
@@ -391,6 +403,9 @@ private:
  */
 class Subtract : public Expression {
 public:
+  static std::string getTypeName() { return "Subtract"; }
+
+public:
   Subtract(Module &Module, Expression &Left, Expression &Right)
       : Expression("-", Expression::SUBTRACT, Module), LeftExpression(Left),
         RightExpression(Right) {}
@@ -417,6 +432,9 @@ private:
  *  \brief This class extends an Expression to a Modulus operator.
  */
 class Modulo : public Expression {
+public:
+  static std::string getTypeName() { return "Modulo"; }
+
 public:
   Modulo(Module &Module, Expression &Left, Expression &Right)
       : Expression("%", Expression::MODULO, Module), LeftExpression(Left),
@@ -445,6 +463,9 @@ private:
  */
 class Multiply : public Expression {
 public:
+  static std::string getTypeName() { return "Multiply"; }
+
+public:
   Multiply(Module &Module, Expression &Left, Expression &Right)
       : Expression("*", Expression::MULTIPLY, Module), LeftExpression(Left),
         RightExpression(Right) {}
@@ -471,6 +492,9 @@ private:
  *  \brief This class extends an Expression to a Divide operator.
  */
 class Divide : public Expression {
+public:
+  static std::string getTypeName() { return "Divide"; }
+
 public:
   Divide(Module &Module, Expression &Left, Expression &Right)
       : Expression("/", Expression::DIVIDE, Module), LeftExpression(Left),
@@ -499,6 +523,9 @@ private:
  */
 class SizeOf : public Expression {
 public:
+  static std::string getTypeName() { return "SizeOf"; }
+
+public:
   SizeOf(Module &Module, std::string Name);
 
   // Casting support
@@ -522,6 +549,9 @@ private:
  */
 class SizeOfHeaders : public Expression {
 public:
+  static std::string getTypeName() { return "SizeOfHeaders"; }
+
+public:
   SizeOfHeaders(Module &Module, ScriptFile *S);
 
   // Casting support
@@ -541,6 +571,9 @@ private:
  *  \brief This class extends an Expression to an OffsetOf operator.
  */
 class OffsetOf : public Expression {
+public:
+  static std::string getTypeName() { return "OffsetOf"; }
+
 public:
   OffsetOf(Module &Module, std::string Name)
       : Expression(Name, Expression::OFFSETOF, Module), ThisSection(nullptr) {}
@@ -569,6 +602,9 @@ private:
  */
 class Addr : public Expression {
 public:
+  static std::string getTypeName() { return "Addr"; }
+
+public:
   Addr(Module &Module, std::string Name)
       : Expression(Name, Expression::ADDR, Module), ThisSection(nullptr) {}
 
@@ -593,6 +629,9 @@ private:
  */
 class LoadAddr : public Expression {
 public:
+  static std::string getTypeName() { return "LoadAddr"; }
+
+public:
   LoadAddr(Module &Module, std::string Name);
 
   // Casting support
@@ -615,6 +654,9 @@ private:
  *  \brief This class extends an Expression to an AlignmentOf operator.
  */
 class AlignExpr : public Expression {
+public:
+  static std::string getTypeName() { return "AlignExpr"; }
+
 public:
   AlignExpr(Module &Module, const std::string &Context, Expression &Align,
             Expression &Expr)
@@ -651,6 +693,9 @@ private:
  */
 class AlignOf : public Expression {
 public:
+  static std::string getTypeName() { return "AlignOf"; }
+
+public:
   AlignOf(Module &Module, std::string Name)
       : Expression(Name, Expression::ALIGNOF, Module), ThisSection(nullptr) {}
   AlignOf(Module &Module, ELFSection *Sect)
@@ -677,6 +722,9 @@ private:
  *  \brief This class extends an Expression to an Absolute operator.
  */
 class Absolute : public Expression {
+public:
+  static std::string getTypeName() { return "Absolute"; }
+
 public:
   Absolute(Module &Module, Expression &Expr)
       : Expression("ABSOLUTE", Expression::ABSOLUTE, Module),
@@ -705,6 +753,9 @@ private:
  *  \brief This class extends an Expression to a Ternary operator.
  */
 class Ternary : public Expression {
+public:
+  static std::string getTypeName() { return "Ternary"; }
+
 public:
   Ternary(Module &Module, Expression &Cond, Expression &Left, Expression &Right)
       : Expression("?", Expression::TERNARY, Module), ConditionExpression(Cond),
@@ -737,6 +788,9 @@ private:
  */
 class ConditionGT : public Expression {
 public:
+  static std::string getTypeName() { return "ConditionGT"; }
+
+public:
   ConditionGT(Module &Module, Expression &Left, Expression &Right)
       : Expression(">", Expression::GT, Module), LeftExpression(Left),
         RightExpression(Right) {}
@@ -763,6 +817,9 @@ private:
  *  \brief This class extends an Expression to a LessThan operator.
  */
 class ConditionLT : public Expression {
+public:
+  static std::string getTypeName() { return "ConditionLT"; }
+
 public:
   ConditionLT(Module &Module, Expression &Left, Expression &Right)
       : Expression("<", Expression::LT, Module), LeftExpression(Left),
@@ -791,6 +848,9 @@ private:
  */
 class ConditionEQ : public Expression {
 public:
+  static std::string getTypeName() { return "ConditionEQ"; }
+
+public:
   ConditionEQ(Module &Module, Expression &Left, Expression &Right)
       : Expression("==", Expression::EQ, Module), LeftExpression(Left),
         RightExpression(Right) {}
@@ -817,6 +877,9 @@ private:
  *  \brief This class extends an Expression to a GreaterThanEqual operator.
  */
 class ConditionGTE : public Expression {
+public:
+  static std::string getTypeName() { return "ConditionGTE"; }
+
 public:
   ConditionGTE(Module &Module, Expression &Left, Expression &Right)
       : Expression(">=", Expression::GTE, Module), LeftExpression(Left),
@@ -847,6 +910,9 @@ private:
  */
 class ConditionLTE : public Expression {
 public:
+  static std::string getTypeName() { return "ConditionLTE"; }
+
+public:
   ConditionLTE(Module &Module, Expression &Left, Expression &Right)
       : Expression("<=", Expression::LTE, Module), LeftExpression(Left),
         RightExpression(Right) {}
@@ -876,6 +942,9 @@ private:
  */
 class ConditionNEQ : public Expression {
 public:
+  static std::string getTypeName() { return "ConditionNEQ"; }
+
+public:
   ConditionNEQ(Module &Module, Expression &Left, Expression &Right)
       : Expression("!=", Expression::NEQ, Module), LeftExpression(Left),
         RightExpression(Right) {}
@@ -903,6 +972,9 @@ private:
  */
 class Complement : public Expression {
 public:
+  static std::string getTypeName() { return "Complement"; }
+
+public:
   Complement(Module &Module, Expression &Expr)
       : Expression("~", Expression::COM, Module), ExpressionToEvaluate(Expr) {}
 
@@ -929,6 +1001,9 @@ private:
  *  \brief This class extends an Expression to a UnaryPlus operator.
  */
 class UnaryPlus : public Expression {
+public:
+  static std::string getTypeName() { return "UnaryPlus"; }
+
 public:
   UnaryPlus(Module &Module, Expression &Expr)
       : Expression("+", Expression::UNARYMINUS, Module),
@@ -958,6 +1033,9 @@ private:
  */
 class UnaryMinus : public Expression {
 public:
+  static std::string getTypeName() { return "UnaryMinus"; }
+
+public:
   UnaryMinus(Module &Module, Expression &Expr)
       : Expression("-", Expression::UNARYMINUS, Module),
         ExpressionToEvaluate(Expr) {}
@@ -986,6 +1064,9 @@ private:
  */
 class UnaryNot : public Expression {
 public:
+  static std::string getTypeName() { return "UnaryNot"; }
+
+public:
   UnaryNot(Module &Module, Expression &Expr)
       : Expression("!", Expression::UNARYNOT, Module),
         ExpressionToEvaluate(Expr) {}
@@ -1013,6 +1094,9 @@ private:
  */
 class Constant : public Expression {
 public:
+  static std::string getTypeName() { return "Constant"; }
+
+public:
   Constant(Module &Module, std::string Name, Type Type)
       : Expression(Name, Type, Module) {}
 
@@ -1036,6 +1120,9 @@ private:
  *  \brief This class extends an Expression to a SegmentStart operator.
  */
 class SegmentStart : public Expression {
+public:
+  static std::string getTypeName() { return "SegmentStart"; }
+
 public:
   SegmentStart(Module &Module, std::string Segment, Expression &Expr)
       : Expression("SEGMENT_START", Expression::SEGMENT_START, Module),
@@ -1068,6 +1155,9 @@ private:
  */
 class AssertCmd : public Expression {
 public:
+  static std::string getTypeName() { return "AssertCmd"; }
+
+public:
   AssertCmd(Module &Module, std::string Msg, Expression &Expr)
       : Expression("ASSERT", Expression::ASSERT, Module),
         ExpressionToEvaluate(Expr), AssertionMessage(Msg) {}
@@ -1098,6 +1188,9 @@ private:
  */
 class RightShift : public Expression {
 public:
+  static std::string getTypeName() { return "RightShift"; }
+
+public:
   RightShift(Module &Module, Expression &Left, Expression &Right)
       : Expression(">>", Expression::BITWISE_RS, Module), LeftExpression(Left),
         RightExpression(Right) {}
@@ -1126,6 +1219,9 @@ private:
  *  \brief This class extends an Expression to a Left Shift operator.
  */
 class LeftShift : public Expression {
+public:
+  static std::string getTypeName() { return "LeftShift"; }
+
 public:
   LeftShift(Module &Module, Expression &Left, Expression &Right)
       : Expression("<<", Expression::BITWISE_LS, Module), LeftExpression(Left),
@@ -1156,6 +1252,9 @@ private:
  */
 class BitwiseOr : public Expression {
 public:
+  static std::string getTypeName() { return "BitwiseOr"; }
+
+public:
   BitwiseOr(Module &Module, Expression &Left, Expression &Right)
       : Expression("|", Expression::BITWISE_OR, Module), LeftExpression(Left),
         RightExpression(Right) {}
@@ -1182,6 +1281,9 @@ private:
  *  \brief This class extends an Expression to a Bitwise And operator.
  */
 class BitwiseAnd : public Expression {
+public:
+  static std::string getTypeName() { return "BitwiseAnd"; }
+
 public:
   BitwiseAnd(Module &Module, Expression &Left, Expression &Right)
       : Expression("&", Expression::BITWISE_AND, Module), LeftExpression(Left),
@@ -1210,6 +1312,9 @@ private:
  */
 class BitwiseXor : public Expression {
 public:
+  static std::string getTypeName() { return "BitwiseXor"; }
+
+public:
   BitwiseXor(Module &Module, Expression &Left, Expression &Right)
       : Expression("^", Expression::BITWISE_XOR, Module), LeftExpression(Left),
         RightExpression(Right) {}
@@ -1237,6 +1342,9 @@ private:
  */
 class Defined : public Expression {
 public:
+  static std::string getTypeName() { return "Defined"; }
+
+public:
   Defined(Module &Module, std::string Name)
       : Expression(Name, Expression::DEFINED, Module) {}
 
@@ -1258,6 +1366,9 @@ private:
  *  \brief This class extends an Expression to a Data Segment Align operator.
  */
 class DataSegmentAlign : public Expression {
+public:
+  static std::string getTypeName() { return "DataSegmentAlign"; }
+
 public:
   DataSegmentAlign(Module &Module, Expression &MaxPageSize,
                    Expression &CommonPageSize)
@@ -1290,6 +1401,9 @@ private:
  * operator.
  */
 class DataSegmentRelRoEnd : public Expression {
+public:
+  static std::string getTypeName() { return "DataSegmentRelRoEnd"; }
+
 public:
   DataSegmentRelRoEnd(Module &Module, Expression &Expr1, Expression &Expr2)
       : Expression("DATA_SEGMENT_RELRO_END", Expression::DATA_SEGMENT_RELRO_END,
@@ -1325,6 +1439,9 @@ private:
  */
 class DataSegmentEnd : public Expression {
 public:
+  static std::string getTypeName() { return "DataSegmentEnd"; }
+
+public:
   DataSegmentEnd(Module &Module, Expression &Expr)
       : Expression("DATA_SEGMENT_END", Expression::DATA_SEGMENT_END, Module),
         ExpressionToEvaluate(Expr) {}
@@ -1354,6 +1471,9 @@ private:
  */
 class Max : public Expression {
 public:
+  static std::string getTypeName() { return "Max"; }
+
+public:
   Max(Module &Module, Expression &Left, Expression &Right)
       : Expression("MAX", Expression::MAX, Module), LeftExpression(Left),
         RightExpression(Right) {}
@@ -1381,6 +1501,9 @@ private:
  */
 class Min : public Expression {
 public:
+  static std::string getTypeName() { return "Min"; }
+
+public:
   Min(Module &Module, Expression &Left, Expression &Right)
       : Expression("MIN", Expression::MIN, Module), LeftExpression(Left),
         RightExpression(Right) {}
@@ -1406,6 +1529,9 @@ private:
  *  \brief This class extends an Expression to a Fill operator.
  */
 class Fill : public Expression {
+public:
+  static std::string getTypeName() { return "Fill"; }
+
 public:
   Fill(Module &Module, Expression &Expr)
       : Expression("FILL", Expression::FILL, Module),
@@ -1435,6 +1561,9 @@ private:
  */
 class Log2Ceil : public Expression {
 public:
+  static std::string getTypeName() { return "Log2Ceil"; }
+
+public:
   Log2Ceil(Module &Module, Expression &Expr)
       : Expression("LOG2CEIL", Expression::LOG2CEIL, Module),
         ExpressionToEvaluate(Expr) {}
@@ -1462,6 +1591,9 @@ private:
  *  \brief This class extends an Expression to a logical operator.
  */
 class LogicalOp : public Expression {
+public:
+  static std::string getTypeName() { return "LogicalOp"; }
+
 public:
   LogicalOp(Expression::Type Type, Module &Module, Expression &Left,
             Expression &Right)
@@ -1494,6 +1626,9 @@ private:
  */
 class QueryMemory : public Expression {
 public:
+  static std::string getTypeName() { return "QueryMemory"; }
+
+public:
   QueryMemory(Expression::Type Type, Module &Module, const std::string &Name);
 
   // Casting support
@@ -1519,6 +1654,9 @@ inline void alignAddress(uint64_t &PAddr, uint64_t AlignConstraint) {
 /// NullExpression represents an invalid expression. It is used as a sentinel
 /// expression when the linker script parser fails to parse an expression.
 class NullExpression : public Expression {
+public:
+  static std::string getTypeName() { return "NullExpression"; }
+
 public:
   NullExpression(Module &Module);
 

--- a/include/eld/Script/ExternCmd.h
+++ b/include/eld/Script/ExternCmd.h
@@ -25,6 +25,9 @@ class Module;
 
 class ExternCmd : public ScriptCommand {
 public:
+  static std::string getTypeName() { return "ExternCmd"; }
+
+public:
   ExternCmd(StringList &PExtern);
 
 

--- a/include/eld/Script/FileToken.h
+++ b/include/eld/Script/FileToken.h
@@ -26,6 +26,9 @@ namespace eld {
 
 class FileToken : public InputToken {
 public:
+  static std::string getTypeName() { return "FileToken"; }
+
+public:
   explicit FileToken(const std::string &PName, bool PAsNeeded);
 
   static bool classof(const InputToken *ThisInputToken) {

--- a/include/eld/Script/GroupCmd.h
+++ b/include/eld/Script/GroupCmd.h
@@ -24,6 +24,9 @@ class LinkerConfig;
 
 class GroupCmd : public ScriptCommand {
 public:
+  static std::string getTypeName() { return "GroupCmd"; }
+
+public:
   GroupCmd(const LinkerConfig &Config, StringList &PStringList,
            const Attribute &Attr, ScriptFile &PScriptFile);
 

--- a/include/eld/Script/IncludeCmd.h
+++ b/include/eld/Script/IncludeCmd.h
@@ -16,6 +16,9 @@ namespace eld {
 
 class IncludeCmd : public ScriptCommand {
 public:
+  static std::string getTypeName() { return "IncludeCmd"; }
+
+public:
   IncludeCmd(const std::string FileName, bool IsOptional);
 
 

--- a/include/eld/Script/InputCmd.h
+++ b/include/eld/Script/InputCmd.h
@@ -24,6 +24,9 @@ class LinkerConfig;
 
 class InputCmd : public ScriptCommand {
 public:
+  static std::string getTypeName() { return "InputCmd"; }
+
+public:
   InputCmd(const LinkerConfig &Config, StringList &PStringList,
            const Attribute &Attr, ScriptFile &PScriptFile);
 

--- a/include/eld/Script/InputSectDesc.h
+++ b/include/eld/Script/InputSectDesc.h
@@ -31,11 +31,16 @@ class WildcardPattern;
 
 class InputSectDesc : public ScriptCommand {
 public:
+  static std::string getTypeName() { return "InputSectDesc"; }
+
+public:
   /* Special rule markers that dictate whether a list of input sections should
    * be kept that are handled by the rule */
   enum Policy { Keep, NoKeep, SpecialNoKeep, SpecialKeep, Fixed, KeepFixed };
 
   struct Spec {
+  public:
+    static std::string getTypeName() { return "Spec"; }
     void initialize() {
       WildcardFilePattern = nullptr;
       InputArchiveMember = nullptr;

--- a/include/eld/Script/InputToken.h
+++ b/include/eld/Script/InputToken.h
@@ -23,6 +23,9 @@ namespace eld {
 
 class InputToken : public StrToken {
 public:
+  static std::string getTypeName() { return "InputToken"; }
+
+public:
   enum Type { Unknown, File, NameSpec };
 
 protected:

--- a/include/eld/Script/MemoryCmd.h
+++ b/include/eld/Script/MemoryCmd.h
@@ -24,6 +24,9 @@ struct MemorySpec;
 
 class MemoryCmd : public ScriptCommand {
 public:
+  static std::string getTypeName() { return "MemoryCmd"; }
+
+public:
   MemoryCmd();
 
 

--- a/include/eld/Script/MemoryDesc.h
+++ b/include/eld/Script/MemoryDesc.h
@@ -19,6 +19,8 @@ namespace eld {
  */
 
 struct MemorySpec {
+public:
+  static std::string getTypeName() { return "MemorySpec"; }
 
   MemorySpec(const StrToken *Name, const StrToken *Attributes,
              Expression *Origin, Expression *Length)
@@ -58,6 +60,9 @@ private:
  */
 
 class MemoryDesc : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "MemoryDesc"; }
+
 public:
   MemoryDesc(const MemorySpec &PSpec);
 

--- a/include/eld/Script/NameSpec.h
+++ b/include/eld/Script/NameSpec.h
@@ -26,6 +26,9 @@ namespace eld {
 
 class NameSpec : public InputToken {
 public:
+  static std::string getTypeName() { return "NameSpec"; }
+
+public:
   explicit NameSpec(const std::string &PName, bool PAsNeeded);
 
 

--- a/include/eld/Script/NoCrossRefsCmd.h
+++ b/include/eld/Script/NoCrossRefsCmd.h
@@ -21,6 +21,9 @@ class Module;
 
 class NoCrossRefsCmd : public ScriptCommand {
 public:
+  static std::string getTypeName() { return "NoCrossRefsCmd"; }
+
+public:
   NoCrossRefsCmd(StringList &PExtern, size_t PId);
 
 

--- a/include/eld/Script/OutputArchCmd.h
+++ b/include/eld/Script/OutputArchCmd.h
@@ -20,6 +20,9 @@ class Module;
 
 class OutputArchCmd : public ScriptCommand {
 public:
+  static std::string getTypeName() { return "OutputArchCmd"; }
+
+public:
   OutputArchCmd(const std::string &PArch);
 
 

--- a/include/eld/Script/OutputCmd.h
+++ b/include/eld/Script/OutputCmd.h
@@ -20,6 +20,9 @@ class Module;
 
 class OutputCmd : public ScriptCommand {
 public:
+  static std::string getTypeName() { return "OutputCmd"; }
+
+public:
   OutputCmd(const std::string &POutputFile);
 
 

--- a/include/eld/Script/OutputFormatCmd.h
+++ b/include/eld/Script/OutputFormatCmd.h
@@ -27,6 +27,9 @@ class Module;
 
 class OutputFormatCmd : public ScriptCommand {
 public:
+  static std::string getTypeName() { return "OutputFormatCmd"; }
+
+public:
   typedef std::vector<std::string> FormatList;
   typedef FormatList::const_iterator const_iterator;
   typedef FormatList::iterator iterator;

--- a/include/eld/Script/OutputSectData.h
+++ b/include/eld/Script/OutputSectData.h
@@ -41,6 +41,9 @@ class OutputSectDesc;
 /// special input section description is processed.
 class OutputSectData : public InputSectDesc {
 public:
+  static std::string getTypeName() { return "OutputSectData"; }
+
+public:
   enum OSDKind { None, Byte, Short, Long, Quad, Squad };
 
   /// Creates an OutputSectData object.

--- a/include/eld/Script/OutputSectDesc.h
+++ b/include/eld/Script/OutputSectDesc.h
@@ -33,6 +33,9 @@ class ScriptMemoryRegion;
 
 class OutputSectDesc : public ScriptCommand {
 public:
+  static std::string getTypeName() { return "OutputSectDesc"; }
+
+public:
   enum Type {
     LOAD, // ALLOC
     NOLOAD,
@@ -58,6 +61,8 @@ public:
   enum Constraint { NO_CONSTRAINT, ONLY_IF_RO, ONLY_IF_RW };
 
   struct Prolog {
+  public:
+    static std::string getTypeName() { return "Prolog"; }
     bool hasVMA() const { return OutputSectionVMA != nullptr; }
     const Expression &vma() const {
       assert(hasVMA());
@@ -176,6 +181,8 @@ public:
   };
 
   struct Epilog {
+  public:
+    static std::string getTypeName() { return "Epilog"; }
     bool hasRegion() const { return OutputSectionMemoryRegion != nullptr; }
     const eld::ScriptMemoryRegion &region() const {
       assert(hasRegion());

--- a/include/eld/Script/PhdrDesc.h
+++ b/include/eld/Script/PhdrDesc.h
@@ -19,6 +19,8 @@ namespace eld {
  */
 
 struct PhdrSpec {
+public:
+  static std::string getTypeName() { return "PhdrSpec"; }
 
   const std::string name() const { return Name->name(); }
 
@@ -56,6 +58,9 @@ struct PhdrSpec {
  */
 
 class PhdrDesc : public ScriptCommand {
+public:
+  static std::string getTypeName() { return "PhdrDesc"; }
+
 public:
   PhdrDesc(const PhdrSpec &PSpec);
 

--- a/include/eld/Script/PhdrsCmd.h
+++ b/include/eld/Script/PhdrsCmd.h
@@ -23,6 +23,9 @@ class PhdrDesc;
 
 class PhdrsCmd : public ScriptCommand {
 public:
+  static std::string getTypeName() { return "PhdrsCmd"; }
+
+public:
   PhdrsCmd();
 
 

--- a/include/eld/Script/Plugin.h
+++ b/include/eld/Script/Plugin.h
@@ -25,6 +25,9 @@ class Module;
 
 class Plugin {
 public:
+  static std::string getTypeName() { return "Plugin"; }
+
+public:
   explicit Plugin(plugin::Plugin::Type T, std::string Name, std::string R,
                   std::string O, bool Stats, bool DefaultPlugin,
                   Module &Module);
@@ -32,6 +35,8 @@ public:
   ~Plugin();
 
   struct CommandLineOptionSpec {
+  public:
+    static std::string getTypeName() { return "CommandLineOptionSpec"; }
     using OptionHandlerType =
         plugin::LinkerWrapper::CommandLineOptionHandlerType;
 
@@ -155,6 +160,9 @@ public:
   /// - A chunk that is removed must be put back into the image.
   /// - A chunk must not be added multiple times.
   class UnbalancedFragmentMoves {
+  public:
+    static std::string getTypeName() { return "UnbalancedFragmentMoves"; }
+
   public:
     using TrackingDataType = std::unordered_map<Fragment *, RuleContainer *>;
 

--- a/include/eld/Script/PluginCmd.h
+++ b/include/eld/Script/PluginCmd.h
@@ -23,6 +23,9 @@ class Plugin;
 
 class PluginCmd : public ScriptCommand {
 public:
+  static std::string getTypeName() { return "PluginCmd"; }
+
+public:
   explicit PluginCmd(plugin::Plugin::Type T, const std::string &Name,
                      const std::string &R, const std::string &O);
 

--- a/include/eld/Script/RegionAlias.h
+++ b/include/eld/Script/RegionAlias.h
@@ -30,6 +30,9 @@ class StrToken;
 
 class RegionAlias : public ScriptCommand {
 public:
+  static std::string getTypeName() { return "RegionAlias"; }
+
+public:
   explicit RegionAlias(const StrToken *Alias, const StrToken *Region);
 
 

--- a/include/eld/Script/ScriptAction.h
+++ b/include/eld/Script/ScriptAction.h
@@ -25,6 +25,9 @@ class LinkerConfig;
 /// ScriptAction
 class ScriptAction : public InputFileAction {
 public:
+  static std::string getTypeName() { return "ScriptAction"; }
+
+public:
   ScriptAction(const std::string &PFileName, ScriptFile::Kind PKind,
                const LinkerConfig &PConfig, DiagnosticPrinter *Printer);
 

--- a/include/eld/Script/ScriptCommand.h
+++ b/include/eld/Script/ScriptCommand.h
@@ -28,6 +28,9 @@ class InputFile;
  */
 class ScriptCommand {
 public:
+  static std::string getTypeName() { return "ScriptCommand"; }
+
+public:
   enum Kind {
     ASSERT,
     ASSIGNMENT,

--- a/include/eld/Script/ScriptFile.h
+++ b/include/eld/Script/ScriptFile.h
@@ -56,6 +56,9 @@ class ScriptSymbol;
 
 class ScriptFile {
 public:
+  static std::string getTypeName() { return "ScriptFile"; }
+
+public:
   enum Kind {
     LDScript,              // -T
     ScriptExpression,      // --defsym

--- a/include/eld/Script/ScriptReader.h
+++ b/include/eld/Script/ScriptReader.h
@@ -27,6 +27,9 @@ class GNULDBackend;
 
 class ScriptReader {
 public:
+  static std::string getTypeName() { return "ScriptReader"; }
+
+public:
   ScriptReader();
 
   ~ScriptReader();

--- a/include/eld/Script/ScriptSymbol.h
+++ b/include/eld/Script/ScriptSymbol.h
@@ -27,6 +27,9 @@ class ResolveInfo;
 
 class ScriptSymbol : public WildcardPattern {
 public:
+  static std::string getTypeName() { return "ScriptSymbol"; }
+
+public:
   explicit ScriptSymbol(const std::string &PString);
 
   eld::Expected<void> activate();

--- a/include/eld/Script/SearchDirCmd.h
+++ b/include/eld/Script/SearchDirCmd.h
@@ -29,6 +29,9 @@ class Module;
 
 class SearchDirCmd : public ScriptCommand {
 public:
+  static std::string getTypeName() { return "SearchDirCmd"; }
+
+public:
   SearchDirCmd(const std::string &PPath);
 
 

--- a/include/eld/Script/SectionsCmd.h
+++ b/include/eld/Script/SectionsCmd.h
@@ -27,6 +27,9 @@ class Module;
 
 class SectionsCmd : public ScriptCommand {
 public:
+  static std::string getTypeName() { return "SectionsCmd"; }
+
+public:
   typedef std::vector<ScriptCommand *> SectionCommands;
   typedef SectionCommands::const_iterator const_iterator;
   typedef SectionCommands::iterator iterator;

--- a/include/eld/Script/StrToken.h
+++ b/include/eld/Script/StrToken.h
@@ -24,6 +24,9 @@ namespace eld {
 
 class StrToken {
 public:
+  static std::string getTypeName() { return "StrToken"; }
+
+public:
   enum Kind { Unknown, String, Input, Wildcard };
 
   explicit StrToken(const std::string &PString, Kind K = StrToken::String);

--- a/include/eld/Script/StringList.h
+++ b/include/eld/Script/StringList.h
@@ -26,6 +26,9 @@ class StrToken;
 
 class StringList {
 public:
+  static std::string getTypeName() { return "StringList"; }
+
+public:
   typedef std::vector<StrToken *> Tokens;
   typedef Tokens::const_iterator const_iterator;
   typedef Tokens::iterator iterator;

--- a/include/eld/Script/SymbolContainer.h
+++ b/include/eld/Script/SymbolContainer.h
@@ -18,6 +18,9 @@ class Input;
 
 class SymbolContainer {
 public:
+  static std::string getTypeName() { return "SymbolContainer"; }
+
+public:
   explicit SymbolContainer(StrToken &Token);
 
   void addResolveInfo(const ResolveInfo *Info);

--- a/include/eld/Script/VersionScript.h
+++ b/include/eld/Script/VersionScript.h
@@ -29,6 +29,9 @@ scripts :-
 
 class VersionSymbol {
 public:
+  static std::string getTypeName() { return "VersionSymbol"; }
+
+public:
   typedef enum : uint8_t { Simple, Extern } VersionSymbolKind;
 
 public:
@@ -60,6 +63,9 @@ protected:
 };
 
 class VersionScriptBlock {
+public:
+  static std::string getTypeName() { return "VersionScriptBlock"; }
+
 public:
   typedef enum : uint8_t {
     Local,
@@ -98,6 +104,9 @@ protected:
 
 class LocalVersionScriptBlock : public VersionScriptBlock {
 public:
+  static std::string getTypeName() { return "LocalVersionScriptBlock"; }
+
+public:
   LocalVersionScriptBlock(class VersionScriptNode *N)
       : VersionScriptBlock(VersionScriptBlock::BlockKind::Local, N) {}
   void dump(llvm::raw_ostream &Ostream,
@@ -107,6 +116,9 @@ public:
 
 class GlobalVersionScriptBlock : public VersionScriptBlock {
 public:
+  static std::string getTypeName() { return "GlobalVersionScriptBlock"; }
+
+public:
   GlobalVersionScriptBlock(class VersionScriptNode *N)
       : VersionScriptBlock(VersionScriptBlock::BlockKind::Global, N) {}
   void dump(llvm::raw_ostream &Ostream,
@@ -115,6 +127,9 @@ public:
 };
 
 class VersionScriptNode {
+public:
+  static std::string getTypeName() { return "VersionScriptNode"; }
+
 public:
   VersionScriptNode();
 
@@ -160,6 +175,9 @@ private:
 };
 
 class VersionScript {
+public:
+  static std::string getTypeName() { return "VersionScript"; }
+
 public:
   VersionScript(InputFile *Inp);
 

--- a/include/eld/Script/WildcardPattern.h
+++ b/include/eld/Script/WildcardPattern.h
@@ -33,6 +33,9 @@ class ExcludeFiles;
 
 class WildcardPattern : public StrToken {
 public:
+  static std::string getTypeName() { return "WildcardPattern"; }
+
+public:
   enum SortPolicy {
     SORT_NONE,
     SORT_BY_NAME,

--- a/include/eld/ScriptParser/ScriptLexer.h
+++ b/include/eld/ScriptParser/ScriptLexer.h
@@ -30,6 +30,9 @@ namespace v2 {
 
 class ScriptLexer {
 public:
+  static std::string getTypeName() { return "ScriptLexer"; }
+
+public:
   enum class LexState {
     Default,
     Expr
@@ -130,6 +133,8 @@ private:
 
 protected:
   struct Buffer {
+  public:
+    static std::string getTypeName() { return "Buffer"; }
     // The remaining content to parse and the filename.
     llvm::StringRef S, Filename;
     const char *Begin = nullptr;

--- a/include/eld/ScriptParser/ScriptParser.h
+++ b/include/eld/ScriptParser/ScriptParser.h
@@ -29,6 +29,9 @@ class ScriptLexer;
 
 class ScriptParser final : ScriptLexer {
 public:
+  static std::string getTypeName() { return "ScriptParser"; }
+
+public:
   ScriptParser(eld::LinkerConfig &Config, eld::ScriptFile &ScriptFile);
 
   void readLinkerScript();

--- a/include/eld/Support/INIReader.h
+++ b/include/eld/Support/INIReader.h
@@ -23,6 +23,9 @@ namespace eld {
 /// \brief Represents a particular section within an ini file
 class INIReaderSection {
 public:
+  static std::string getTypeName() { return "INIReaderSection"; }
+
+public:
   INIReaderSection(std::string SectionName) : sectionName(SectionName) {}
   ~INIReaderSection() = default;
 
@@ -55,6 +58,9 @@ private:
 /// \class INIReader`
 /// \brief An ini file reader
 class INIReader {
+public:
+  static std::string getTypeName() { return "INIReader"; }
+
 public:
   enum Kind {
     Comment,

--- a/include/eld/Support/INIWriter.h
+++ b/include/eld/Support/INIWriter.h
@@ -21,6 +21,9 @@ namespace eld {
 /// \brief Represents a particular section within an ini file
 class INISection {
 public:
+  static std::string getTypeName() { return "INISection"; }
+
+public:
   INISection() = default;
 
   ~INISection() = default;
@@ -48,6 +51,9 @@ private:
 /// \class INIWriter
 /// \brief ini file writer
 class INIWriter {
+public:
+  static std::string getTypeName() { return "INIWriter"; }
+
 public:
   INIWriter() = default;
 

--- a/include/eld/Support/MappingFile.h
+++ b/include/eld/Support/MappingFile.h
@@ -16,6 +16,9 @@ class InputFile;
 
 class MappingFile {
 public:
+  static std::string getTypeName() { return "MappingFile"; }
+
+public:
   enum Kind {
     ObjectFile,
     LinkerScript,

--- a/include/eld/Support/MappingFileReader.h
+++ b/include/eld/Support/MappingFileReader.h
@@ -18,6 +18,9 @@ namespace eld {
 /// \brief Reads a mapping.ini file and ensures it is only read once
 class MappingFileReader {
 public:
+  static std::string getTypeName() { return "MappingFileReader"; }
+
+public:
   MappingFileReader(std::string filename) {
     reader = std::make_unique<eld::INIReader>(filename);
   }

--- a/include/eld/Support/Memory.h
+++ b/include/eld/Support/Memory.h
@@ -30,35 +30,142 @@
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/StringSaver.h"
+#include "llvm/Support/raw_ostream.h"
+#include <atomic>
+#include <cstring> // For strstr, etc.
+#include <string>
+#include <string_view>
+#include <type_traits>
 #include <vector>
 
 namespace eld {
 
-// Use this arena if your object doesn't have a destructor.
 extern llvm::BumpPtrAllocator BAlloc;
 extern llvm::StringSaver Saver;
+
 void freeArena();
 
-// These two classes are hack to keep track of all
-// SpecificBumpPtrAllocator instances.
 struct SpecificAllocBase {
   SpecificAllocBase() { Instances.push_back(this); }
   virtual ~SpecificAllocBase() = default;
+
   virtual void reset() = 0;
+  virtual const char *typeName() const = 0;
+  virtual size_t sizeOfT() const = 0;
+  virtual size_t count() const = 0;
+  virtual size_t totalBytes() const = 0;
+  virtual void report(llvm::raw_ostream &OS) const = 0;
+
   static std::vector<SpecificAllocBase *> Instances;
 };
 
+// Detect presence of static T::getTypeName()
+template <typename T, typename = void>
+struct HasGetTypeName : std::false_type {};
+
+template <typename T>
+struct HasGetTypeName<T, std::void_t<decltype(T::getTypeName())>>
+    : std::true_type {};
+
+// --- Internal detail for getting type names without RTTI ---
+namespace detail {
+
+// Fallback: Parse type name from compiler-specific function signature macro
+template <typename T> std::string parseTypeNameFromSignature() {
+#if defined(__clang__) || defined(__GNUC__)
+  const char *signature = __PRETTY_FUNCTION__;
+  const char *start = strstr(signature, "T = ");
+  if (!start)
+    return "parsing_failed";
+  start += 4; // Move past "T = "
+  const char *end = strchr(start, ']');
+  if (!end)
+    return "parsing_failed";
+  return std::string(start, end - start);
+#elif defined(_MSC_VER)
+  const char *signature = __FUNCSIG__;
+  const char *start = strstr(signature, "parseTypeNameFromSignature<");
+  if (!start)
+    return "parsing_failed";
+  start += strlen("parseTypeNameFromSignature<");
+
+  // MSVC might add "class ", "struct ", etc.
+  if (strncmp(start, "class ", 6) == 0)
+    start += 6;
+  else if (strncmp(start, "struct ", 7) == 0)
+    start += 7;
+
+  // Find the matching '>' at the end
+  const char *end = strrchr(start, '>');
+  if (!end)
+    return "parsing_failed";
+
+  return std::string(start, end - start);
+#else
+  return "unsupported_compiler";
+#endif
+}
+
+// Resolve type name: prefer user-defined, then fallback to macro parsing
+template <typename T> std::string resolveTypeName() {
+  if constexpr (HasGetTypeName<T>::value) {
+    return T::getTypeName();
+  } else {
+    // Priority 2: Fallback to parsing compiler macros
+    return parseTypeNameFromSignature<T>();
+  }
+}
+
+} // namespace detail
+
 template <class T> struct SpecificAlloc : public SpecificAllocBase {
-  void reset() override { Alloc.DestroyAll(); }
+  // The constructor now uses the robust resolveTypeName helper
+  SpecificAlloc() : TypeName(detail::resolveTypeName<T>()) {}
+
+  void reset() override {
+    Alloc.DestroyAll();
+    Cnt.store(0, std::memory_order_relaxed);
+  }
+
+  void onAllocate() { Cnt.fetch_add(1, std::memory_order_relaxed); }
+
+  const char *typeName() const override { return TypeName.c_str(); }
+  size_t sizeOfT() const override { return sizeof(T); }
+  size_t count() const override { return Cnt.load(std::memory_order_relaxed); }
+  size_t totalBytes() const override { return count() * sizeof(T); }
+
+  void report(llvm::raw_ostream &OS) const override {
+    OS << "  - " << typeName() << ": count=" << count()
+       << ", sizeof(T)=" << sizeOfT() << "B"
+       << ", total=" << totalBytes() << "B\n";
+  }
+
   llvm::SpecificBumpPtrAllocator<T> Alloc;
+  std::string TypeName;
+  std::atomic<size_t> Cnt{0};
 };
 
-// Use this arena if your object has a destructor.
-// Your destructor will be invoked from freeArena().
+template <typename T> struct ArenaForType {
+  static SpecificAlloc<T> &getAlloc() {
+    static SpecificAlloc<T> Alloc;
+    return Alloc;
+  }
+
+  template <typename... U> static T *create(U &&...Args) {
+    auto &Alloc = getAlloc();
+    T *P = new (Alloc.Alloc.Allocate()) T(std::forward<U>(Args)...);
+    Alloc.onAllocate();
+    return P;
+  }
+};
+
 template <typename T, typename... U> T *make(U &&...Args) {
-  static SpecificAlloc<T> Alloc;
-  return new (Alloc.Alloc.Allocate()) T(std::forward<U>(Args)...);
+  return ArenaForType<T>::create(std::forward<U>(Args)...);
 }
+
+std::string formatBytes(size_t bytes);
+
+void dumpArenaReport(llvm::raw_ostream &OS);
 
 const char *getUninitBuffer(uint32_t Sz);
 

--- a/include/eld/Support/MemoryArea.h
+++ b/include/eld/Support/MemoryArea.h
@@ -28,6 +28,9 @@ class DiagnosticEngine;
  */
 class MemoryArea {
 public:
+  static std::string getTypeName() { return "MemoryArea"; }
+
+public:
   // Read a Input File.
   explicit MemoryArea(llvm::StringRef pFilename);
 

--- a/include/eld/Support/OutputTarWriter.h
+++ b/include/eld/Support/OutputTarWriter.h
@@ -30,6 +30,9 @@ class ProgressBar;
 /// output
 class OutputTarWriter {
 public:
+  static std::string getTypeName() { return "OutputTarWriter"; }
+
+public:
   /// Create an OutputTarWriter
   /// \param OutputPath where the tarball should be written
   /// \param doCompress Compressed Tar files

--- a/include/eld/Support/Path.h
+++ b/include/eld/Support/Path.h
@@ -41,6 +41,9 @@ const char dot = '.';
  */
 class Path {
 public:
+  static std::string getTypeName() { return "Path"; }
+
+public:
   Path();
   Path(const std::string &s);
   Path(const Path &pCopy);

--- a/include/eld/Support/ProgressBar.h
+++ b/include/eld/Support/ProgressBar.h
@@ -13,6 +13,9 @@
 
 namespace eld {
 class ProgressBar {
+public:
+  static std::string getTypeName() { return "ProgressBar"; }
+
 private:
   uint32_t ticks = 0;
   uint32_t total_ticks;

--- a/include/eld/Support/RegisterTimer.h
+++ b/include/eld/Support/RegisterTimer.h
@@ -14,6 +14,8 @@ namespace eld {
 class Input;
 
 class RegisterTimer : public llvm::NamedRegionTimer {
+public:
+  static std::string getTypeName() { return "RegisterTimer"; }
 
 public:
   // Params: Name -> Stats Description, Group -> Name of Sub-section in Linker
@@ -26,6 +28,9 @@ public:
 };
 
 class Timer {
+public:
+  static std::string getTypeName() { return "Timer"; }
+
 public:
   // Generic timer.
   Timer(std::string Name, std::string Description = "", bool Enable = true);

--- a/include/eld/Support/Target.h
+++ b/include/eld/Support/Target.h
@@ -27,6 +27,8 @@ class GNULDBackend;
  *  \brief Target collects target specific information
  */
 struct Target {
+public:
+  static std::string getTypeName() { return "Target"; }
   typedef bool (*EmulationFnTy)(LinkerScript &, LinkerConfig &);
 
   typedef GNULDBackend *(*GNULDBackendCtorTy)(Module &);

--- a/include/eld/Support/TargetRegistry.h
+++ b/include/eld/Support/TargetRegistry.h
@@ -22,6 +22,9 @@
 namespace eld {
 
 class TargetRegistry {
+public:
+  static std::string getTypeName() { return "TargetRegistry"; }
+
 private:
   static std::vector<eld::Target *> TargetList;
 
@@ -56,6 +59,9 @@ public:
 };
 
 struct RegisterTarget {
+public:
+  static std::string getTypeName() { return "RegisterTarget"; }
+
 public:
   RegisterTarget(eld::Target &pTarget, llvm::StringRef Name, uint16_t Machine,
                  bool is64bit = false) {

--- a/include/eld/SymbolResolver/IRBuilder.h
+++ b/include/eld/SymbolResolver/IRBuilder.h
@@ -37,6 +37,9 @@ class LayoutInfo;
 
 class IRBuilder {
 public:
+  static std::string getTypeName() { return "IRBuilder"; }
+
+public:
   enum ObjectFormat { ELF, MachO, COFF };
 
   enum SymbolDefinePolicy { Force, AsReferred };

--- a/include/eld/SymbolResolver/LDSymbol.h
+++ b/include/eld/SymbolResolver/LDSymbol.h
@@ -24,6 +24,9 @@ class ELFSection;
 
 class LDSymbol {
 public:
+  static std::string getTypeName() { return "LDSymbol"; }
+
+public:
   // FIXME: use SizeTrait<32> or SizeTrait<64> instead of big type
   typedef ResolveInfo::SizeType SizeType;
   typedef uint64_t ValueType;

--- a/include/eld/SymbolResolver/NamePool.h
+++ b/include/eld/SymbolResolver/NamePool.h
@@ -42,6 +42,9 @@ class Input;
  */
 class NamePool {
 public:
+  static std::string getTypeName() { return "NamePool"; }
+
+public:
   explicit NamePool(eld::LinkerConfig &Config, PluginManager &Pm);
 
   ~NamePool();

--- a/include/eld/SymbolResolver/ResolveInfo.h
+++ b/include/eld/SymbolResolver/ResolveInfo.h
@@ -43,6 +43,9 @@ class LinkerConfig;
  */
 class ResolveInfo {
 public:
+  static std::string getTypeName() { return "ResolveInfo"; }
+
+public:
   typedef uint32_t SizeType;
 
   /** \enum Type

--- a/include/eld/SymbolResolver/Resolver.h
+++ b/include/eld/SymbolResolver/Resolver.h
@@ -33,6 +33,9 @@ class LinkerConfig;
  */
 class Resolver {
 public:
+  static std::string getTypeName() { return "Resolver"; }
+
+public:
   enum Action { Success, Warning, Abort, LastAction };
 
   /** \class Resolver::Result
@@ -42,6 +45,8 @@ public:
    *   - overriden, if true, the info is being overriden.
    */
   struct Result {
+  public:
+    static std::string getTypeName() { return "Result"; }
     ResolveInfo *Info;
     bool Existent;
     bool Overriden;

--- a/include/eld/SymbolResolver/StaticResolver.h
+++ b/include/eld/SymbolResolver/StaticResolver.h
@@ -27,6 +27,9 @@ class LinkerConfig;
  */
 class StaticResolver : public Resolver {
 public:
+  static std::string getTypeName() { return "StaticResolver"; }
+
+public:
   enum LinkAction {
     FAIL,   /* abort.  */
     NOACT,  /* no action.  */

--- a/include/eld/SymbolResolver/SymbolInfo.h
+++ b/include/eld/SymbolResolver/SymbolInfo.h
@@ -22,6 +22,9 @@ namespace eld {
 /// - Input file
 class SymbolInfo {
 public:
+  static std::string getTypeName() { return "SymbolInfo"; }
+
+public:
   SymbolInfo() = default;
   SymbolInfo(const InputFile *InputFile, size_t Size,
              ResolveInfo::Binding Binding, ResolveInfo::Type SymType,
@@ -71,6 +74,8 @@ public:
 
 private:
   struct SymbolInfoBitField {
+  public:
+    static std::string getTypeName() { return "SymbolInfoBitField"; }
     SymbolInfoBitField()
         : SymBinding(0), SymType(0), SymVisibility(0), SymSectIndexKind(0),
           IsBitcode(0) {}

--- a/include/eld/SymbolResolver/SymbolResolutionInfo.h
+++ b/include/eld/SymbolResolver/SymbolResolutionInfo.h
@@ -23,6 +23,9 @@ class Plugin;
 /// Stores information required for reporting symbol resolution.
 class SymbolResolutionInfo {
 public:
+  static std::string getTypeName() { return "SymbolResolutionInfo"; }
+
+public:
   SymbolResolutionInfo() {}
   using CandidatesType = std::vector<const LDSymbol *>;
   using CandidatesTableType = llvm::StringMap<CandidatesType>;

--- a/include/eld/Target/ARMEXIDXSection.h
+++ b/include/eld/Target/ARMEXIDXSection.h
@@ -16,11 +16,15 @@ class DiagnosticEngine;
 class RegionFragment;
 
 struct EXIDXEntry {
+public:
+  static std::string getTypeName() { return "EXIDXEntry"; }
   uint32_t InputOffset = -1;
   Fragment *Fragment = nullptr;
 };
 
 class ARMEXIDXSection : public ELFSection {
+public:
+  static std::string getTypeName() { return "ARMEXIDXSection"; }
   llvm::SmallVector<EXIDXEntry, 0> Entries;
 
 public:

--- a/include/eld/Target/ELFDynamic.h
+++ b/include/eld/Target/ELFDynamic.h
@@ -38,6 +38,9 @@ namespace elf_dynamic {
  *  section
  */
 class EntryIF {
+public:
+  static std::string getTypeName() { return "EntryIF"; }
+
 protected:
   EntryIF();
 
@@ -124,6 +127,9 @@ private:
  *  files.
  */
 class ELFDynamic {
+public:
+  static std::string getTypeName() { return "ELFDynamic"; }
+
 public:
   typedef std::vector<elf_dynamic::EntryIF *> EntryListType;
   typedef EntryListType::iterator iterator;

--- a/include/eld/Target/ELFFileFormat.h
+++ b/include/eld/Target/ELFFileFormat.h
@@ -19,6 +19,9 @@ namespace eld {
 
 class ELFFileFormat : public LDFileFormat {
 public:
+  static std::string getTypeName() { return "ELFFileFormat"; }
+
+public:
   ELFFileFormat();
 
   void initStdSections(Module &pModule, unsigned int pBitClass);
@@ -79,6 +82,8 @@ public:
 
 private:
   struct StringTableContents {
+  public:
+    static std::string getTypeName() { return "StringTableContents"; }
     std::string Strings = std::string(1, '\0');
     std::unordered_map<std::string, std::size_t> StringOffsets;
 

--- a/include/eld/Target/ELFSegment.h
+++ b/include/eld/Target/ELFSegment.h
@@ -32,6 +32,9 @@ struct PhdrSpec;
  */
 class ELFSegment {
 public:
+  static std::string getTypeName() { return "ELFSegment"; }
+
+public:
   typedef std::vector<OutputSectionEntry *> SectionList;
   typedef SectionList::iterator iterator;
   typedef SectionList::const_iterator const_iterator;

--- a/include/eld/Target/ELFSegmentFactory.h
+++ b/include/eld/Target/ELFSegmentFactory.h
@@ -27,6 +27,9 @@ class ELFSection;
  */
 class ELFSegmentFactory {
 public:
+  static std::string getTypeName() { return "ELFSegmentFactory"; }
+
+public:
   typedef std::vector<ELFSegment *> Segments;
   typedef Segments::const_iterator const_iterator;
   typedef Segments::iterator iterator;

--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -71,6 +71,9 @@ class TimingFragment;
  */
 class GNULDBackend {
 public:
+  static std::string getTypeName() { return "GNULDBackend"; }
+
+public:
   // Support for Fill Patterns.
   typedef struct PaddingT {
     Expression *Exp = nullptr;
@@ -79,6 +82,8 @@ public:
   } PaddingT;
 
   struct SectionOffset {
+  public:
+    static std::string getTypeName() { return "SectionOffset"; }
     ELFSection *sec = nullptr;
     uint64_t offset = 0;
   };

--- a/include/eld/Target/LDFileFormat.h
+++ b/include/eld/Target/LDFileFormat.h
@@ -24,6 +24,9 @@ class LinkerConfig;
  */
 class LDFileFormat {
 public:
+  static std::string getTypeName() { return "LDFileFormat"; }
+
+public:
   enum Kind : uint8_t {
     Common,
     Debug,

--- a/include/eld/Target/Relocator.h
+++ b/include/eld/Target/Relocator.h
@@ -33,6 +33,9 @@ class InputFile;
  */
 class Relocator {
 public:
+  static std::string getTypeName() { return "Relocator"; }
+
+public:
   typedef Relocation::Type Type;
   typedef Relocation::Address Address;
   typedef Relocation::DWord DWord;

--- a/include/eld/Target/TargetInfo.h
+++ b/include/eld/Target/TargetInfo.h
@@ -29,7 +29,12 @@ class Relocation;
  */
 class TargetInfo {
 public:
+  static std::string getTypeName() { return "TargetInfo"; }
+
+public:
   struct TargetRelocationType {
+  public:
+    static std::string getTypeName() { return "TargetRelocationType"; }
     Relocation::Type CopyRelocType;
   };
 

--- a/include/eld/Writers/ELFObjectWriter.h
+++ b/include/eld/Writers/ELFObjectWriter.h
@@ -33,6 +33,9 @@ class Output;
  */
 class ELFObjectWriter {
 public:
+  static std::string getTypeName() { return "ELFObjectWriter"; }
+
+public:
   ELFObjectWriter(Module &M);
 
   ~ELFObjectWriter();

--- a/include/eld/Writers/SymDefWriter.h
+++ b/include/eld/Writers/SymDefWriter.h
@@ -24,6 +24,9 @@ class LinkerConfig;
 
 class SymDefWriter {
 public:
+  static std::string getTypeName() { return "SymDefWriter"; }
+
+public:
   SymDefWriter(LinkerConfig &Config);
 
   eld::Expected<void> init();

--- a/lib/Diagnostics/DiagnosticInfos.cpp
+++ b/lib/Diagnostics/DiagnosticInfos.cpp
@@ -27,6 +27,9 @@ namespace {
 
 struct DiagStaticInfo {
 public:
+  static std::string getTypeName() { return "DiagStaticInfo"; }
+
+public:
   DiagnosticEngine::DiagIDType BaseDiagID;
   llvm::StringRef DescriptionStr;
 

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -85,6 +85,9 @@ namespace {
 static DiagnosticEngine *SDiagEngineForLto = nullptr;
 class PrepareDiagEngineForLTO {
 public:
+  static std::string getTypeName() { return "PrepareDiagEngineForLTO"; }
+
+public:
   PrepareDiagEngineForLTO(DiagnosticEngine *DiagEngine) {
     MMutex.lock();
     SDiagEngineForLto = DiagEngine;
@@ -1777,6 +1780,8 @@ void ObjectLinker::createRelocationSections() {
 
   // SectionName, contentPermissions, filepath
   struct SectionKey {
+  public:
+    static std::string getTypeName() { return "SectionKey"; }
     SectionKey() : Name(""), Type(-1) {}
 
     SectionKey(llvm::StringRef Name, int32_t Type) : Name(Name), Type(Type) {}
@@ -1787,6 +1792,8 @@ void ObjectLinker::createRelocationSections() {
   };
 
   struct SectionKeyInfo {
+  public:
+    static std::string getTypeName() { return "SectionKeyInfo"; }
     static SectionKey getEmptyKey() { return SectionKey(); }
     static SectionKey getTombstoneKey() { return SectionKey(); }
     static unsigned getHashValue(const SectionKey &K) {

--- a/lib/Script/Plugin.cpp
+++ b/lib/Script/Plugin.cpp
@@ -32,6 +32,8 @@
 using namespace eld;
 
 struct Running {
+public:
+  static std::string getTypeName() { return "Running"; }
   explicit Running(Plugin *P) : P(P) { P->setRunning(true); }
   ~Running() { P->setRunning(false); }
 

--- a/lib/Support/Memory.cpp
+++ b/lib/Support/Memory.cpp
@@ -13,6 +13,7 @@ using namespace eld;
 BumpPtrAllocator eld::BAlloc;
 StringSaver eld::Saver{BAlloc};
 std::vector<SpecificAllocBase *> eld::SpecificAllocBase::Instances;
+
 void eld::freeArena() {
   for (SpecificAllocBase *Alloc : llvm::reverse(SpecificAllocBase::Instances))
     Alloc->reset();
@@ -21,4 +22,45 @@ void eld::freeArena() {
 
 const char *eld::getUninitBuffer(uint32_t Sz) {
   return BAlloc.Allocate<char>(Sz);
+}
+
+// Format bytes using 1024-based units with a short suffix (B, KB, MB, GB, TB)
+std::string eld::formatBytes(size_t bytes) {
+  static constexpr const char *kUnits[] = {"B", "KB", "MB", "GB", "TB"};
+  double value = static_cast<double>(bytes);
+  size_t unit = 0;
+  while (value >= 1024.0 && unit < std::size(kUnits) - 1) {
+    value /= 1024.0;
+    ++unit;
+  }
+  char buf[64];
+  // Use 0 decimals for large values, 1 decimal otherwise
+  if (value >= 100.0 || unit == 0) {
+    std::snprintf(buf, sizeof(buf), "%.0f %s", value, kUnits[unit]);
+  } else {
+    std::snprintf(buf, sizeof(buf), "%.1f %s", value, kUnits[unit]);
+  }
+  return std::string(buf);
+}
+
+void eld::dumpArenaReport(llvm::raw_ostream &OS) {
+  // Copy and sort instances by total bytes (descending)
+  std::vector<SpecificAllocBase *> items = SpecificAllocBase::Instances;
+  std::sort(items.begin(), items.end(),
+            [](const SpecificAllocBase *a, const SpecificAllocBase *b) {
+              return a->totalBytes() > b->totalBytes();
+            });
+
+  size_t grandTotal = 0;
+  OS << "[eld] Arena allocation report by type (sorted by total bytes):\n";
+  for (auto *I : items) {
+    const size_t total = I->totalBytes();
+    OS << "  - " << I->typeName() << ": count=" << I->count()
+       << ", sizeof(T)=" << I->sizeOfT() << "B"
+       << ", total=" << total << "B"
+       << " (" << formatBytes(total) << ")\n";
+    grandTotal += total;
+  }
+  OS << "Grand total: " << grandTotal << "B"
+     << " (" << formatBytes(grandTotal) << ")\n";
 }

--- a/lib/Target/AArch64/AArch64ELFDynamic.h
+++ b/lib/Target/AArch64/AArch64ELFDynamic.h
@@ -19,6 +19,9 @@ namespace eld {
 
 class AArch64ELFDynamic : public ELFDynamic {
 public:
+  static std::string getTypeName() { return "AArch64ELFDynamic"; }
+
+public:
   AArch64ELFDynamic(GNULDBackend &pParent, LinkerConfig &pConfig);
   ~AArch64ELFDynamic();
 

--- a/lib/Target/AArch64/AArch64Errata843419Stub.h
+++ b/lib/Target/AArch64/AArch64Errata843419Stub.h
@@ -21,6 +21,9 @@ class IRBuilder;
 
 class AArch64Errata843419Stub : public Stub {
 public:
+  static std::string getTypeName() { return "AArch64Errata843419Stub"; }
+
+public:
   AArch64Errata843419Stub();
 
   AArch64Errata843419Stub(const uint32_t *pData, size_t pSize,

--- a/lib/Target/AArch64/AArch64ErrataFactory.h
+++ b/lib/Target/AArch64/AArch64ErrataFactory.h
@@ -25,6 +25,9 @@ class IRBuilder;
  */
 class AArch64ErrataFactory {
 public:
+  static std::string getTypeName() { return "AArch64ErrataFactory"; }
+
+public:
   AArch64ErrataFactory(Stub *targetStub);
 
   ~AArch64ErrataFactory();

--- a/lib/Target/AArch64/AArch64ErrataIslandFactory.h
+++ b/lib/Target/AArch64/AArch64ErrataIslandFactory.h
@@ -23,6 +23,9 @@ class Module;
  */
 class AArch64ErrataIslandFactory {
 public:
+  static std::string getTypeName() { return "AArch64ErrataIslandFactory"; }
+
+public:
   AArch64ErrataIslandFactory();
 
   ~AArch64ErrataIslandFactory();

--- a/lib/Target/AArch64/AArch64FarcallStub.h
+++ b/lib/Target/AArch64/AArch64FarcallStub.h
@@ -24,6 +24,9 @@ class ResolveInfo;
  */
 class AArch64FarcallStub : public Stub {
 public:
+  static std::string getTypeName() { return "AArch64FarcallStub"; }
+
+public:
   AArch64FarcallStub(bool pIsOutputPIC);
 
   ~AArch64FarcallStub();

--- a/lib/Target/AArch64/AArch64GOT.h
+++ b/lib/Target/AArch64/AArch64GOT.h
@@ -25,6 +25,9 @@ namespace eld {
 
 class AArch64GOT : public GOT {
 public:
+  static std::string getTypeName() { return "AArch64GOT"; }
+
+public:
   // Going to be used by GOTPLT0
   AArch64GOT(GOTType T, ELFSection *O, ResolveInfo *R, uint32_t Align,
              uint32_t Size)
@@ -74,6 +77,9 @@ private:
 
 class AArch64GOTPLT0 : public AArch64GOT {
 public:
+  static std::string getTypeName() { return "AArch64GOTPLT0"; }
+
+public:
   AArch64GOTPLT0(ELFSection *O, ResolveInfo *R)
       : AArch64GOT(GOT::GOTPLT0, O, R, 8, 24), Value() {
     std::memset(Value, 0, sizeof(Value));
@@ -95,6 +101,9 @@ private:
 };
 
 class AArch64GOTPLTN : public AArch64GOT {
+public:
+  static std::string getTypeName() { return "AArch64GOTPLTN"; }
+
 public:
   AArch64GOTPLTN(ELFSection *O, ResolveInfo *R)
       : AArch64GOT(GOT::GOTPLTN, O, R, 8, 8) {}
@@ -120,6 +129,9 @@ private:
 
 class AArch64TLSDESCGOT : public AArch64GOT {
 public:
+  static std::string getTypeName() { return "AArch64TLSDESCGOT"; }
+
+public:
   AArch64TLSDESCGOT(ELFSection *O, ResolveInfo *R)
       : AArch64GOT(GOT::TLS_DESC, O, R),
         Other(make<AArch64GOT>(GOT::TLS_DESC, O, R)) {}
@@ -137,6 +149,9 @@ private:
 };
 
 class AArch64IEGOT : public AArch64GOT {
+public:
+  static std::string getTypeName() { return "AArch64IEGOT"; }
+
 public:
   AArch64IEGOT(ELFSection *O, ResolveInfo *R) : AArch64GOT(GOT::TLS_LE, O, R) {}
 

--- a/lib/Target/AArch64/AArch64Info.h
+++ b/lib/Target/AArch64/AArch64Info.h
@@ -24,6 +24,9 @@ class GNULDBackend;
 
 class AArch64Info : public TargetInfo {
 public:
+  static std::string getTypeName() { return "AArch64Info"; }
+
+public:
   AArch64Info(LinkerConfig &pConfig);
 
   uint32_t machine() const override { return llvm::ELF::EM_AARCH64; }

--- a/lib/Target/AArch64/AArch64InsnHelpers.h
+++ b/lib/Target/AArch64/AArch64InsnHelpers.h
@@ -19,6 +19,9 @@ namespace eld {
 
 class AArch64InsnHelpers {
 public:
+  static std::string getTypeName() { return "AArch64InsnHelpers"; }
+
+public:
   typedef uint32_t InsnType;
 
   static constexpr int InsnSize = 4;

--- a/lib/Target/AArch64/AArch64LDBackend.h
+++ b/lib/Target/AArch64/AArch64LDBackend.h
@@ -34,6 +34,9 @@ class TargetInfo;
 ///
 class AArch64GNUInfoLDBackend : public GNULDBackend {
 public:
+  static std::string getTypeName() { return "AArch64GNUInfoLDBackend"; }
+
+public:
   AArch64GNUInfoLDBackend(Module &pModule, TargetInfo *pInfo);
   ~AArch64GNUInfoLDBackend();
 

--- a/lib/Target/AArch64/AArch64LinuxInfo.h
+++ b/lib/Target/AArch64/AArch64LinuxInfo.h
@@ -20,6 +20,9 @@ namespace eld {
 
 class AArch64LinuxInfo : public AArch64Info {
 public:
+  static std::string getTypeName() { return "AArch64LinuxInfo"; }
+
+public:
   AArch64LinuxInfo(LinkerConfig &config) : AArch64Info(config) {}
 
   uint64_t startAddr(bool linkerScriptHasSectionsCommand, bool isDynExec,

--- a/lib/Target/AArch64/AArch64NoteGNUPropertyFragment.h
+++ b/lib/Target/AArch64/AArch64NoteGNUPropertyFragment.h
@@ -21,6 +21,9 @@ class GNULDBackend;
 
 class AArch64NoteGNUPropertyFragment : public TargetFragment {
 public:
+  static std::string getTypeName() { return "AArch64NoteGNUPropertyFragment"; }
+
+public:
   AArch64NoteGNUPropertyFragment(ELFSection *O);
 
   virtual ~AArch64NoteGNUPropertyFragment();

--- a/lib/Target/AArch64/AArch64PLT.h
+++ b/lib/Target/AArch64/AArch64PLT.h
@@ -47,6 +47,9 @@ class IRBuilder;
 
 class AArch64PLT : public PLT {
 public:
+  static std::string getTypeName() { return "AArch64PLT"; }
+
+public:
   AArch64PLT(PLT::PLTType T, eld::IRBuilder &I, AArch64GOT *G, ELFSection *P,
              ResolveInfo *R, uint32_t Align, uint32_t Size)
       : PLT(T, G, P, R, Align, Size) {
@@ -60,6 +63,9 @@ public:
 };
 
 class AArch64PLT0 : public AArch64PLT {
+public:
+  static std::string getTypeName() { return "AArch64PLT0"; }
+
 public:
   AArch64PLT0(AArch64GOT *G, eld::IRBuilder &I, ELFSection *P, ResolveInfo *R,
               uint32_t Align, uint32_t Size)
@@ -76,6 +82,9 @@ public:
 };
 
 class AArch64PLTN : public AArch64PLT {
+public:
+  static std::string getTypeName() { return "AArch64PLTN"; }
+
 public:
   AArch64PLTN(AArch64GOT *G, eld::IRBuilder &I, ELFSection *P, ResolveInfo *R,
               uint32_t Align, uint32_t Size)

--- a/lib/Target/AArch64/AArch64Relocator.cpp
+++ b/lib/Target/AArch64/AArch64Relocator.cpp
@@ -105,6 +105,9 @@ typedef Relocator::Result (*ApplyFunctionType)(Relocation &pReloc,
 // the table entry of applying functions
 class ApplyFunctionEntry {
 public:
+  static std::string getTypeName() { return "ApplyFunctionEntry"; }
+
+public:
   ApplyFunctionEntry() {}
   ApplyFunctionEntry(ApplyFunctionType pFunc, const char *pName,
                      size_t pSize = 0)

--- a/lib/Target/AArch64/AArch64Relocator.h
+++ b/lib/Target/AArch64/AArch64Relocator.h
@@ -45,6 +45,9 @@ enum {
  */
 class AArch64Relocator : public Relocator {
 public:
+  static std::string getTypeName() { return "AArch64Relocator"; }
+
+public:
   AArch64Relocator(AArch64GNUInfoLDBackend &pParent, LinkerConfig &pConfig,
                    Module &pModule);
   ~AArch64Relocator();

--- a/lib/Target/ARM/ARMAttributeFragment.h
+++ b/lib/Target/ARM/ARMAttributeFragment.h
@@ -35,6 +35,8 @@ class Module;
 enum class ARMVFPArgKind { Default, Base, VFP, ToolChain };
 
 struct OutputARMAttributes {
+public:
+  static std::string getTypeName() { return "OutputARMAttributes"; }
   bool armHasBlx = false;
   bool armJ1J2BranchEncoding = false;
   bool armHasMovtMovw = false;
@@ -47,6 +49,9 @@ struct OutputARMAttributes {
 };
 
 class ARMAttributeFragment : public TargetFragment {
+public:
+  static std::string getTypeName() { return "ARMAttributeFragment"; }
+
 public:
   ARMAttributeFragment(ELFSection *O);
 

--- a/lib/Target/ARM/ARMELFDynamic.h
+++ b/lib/Target/ARM/ARMELFDynamic.h
@@ -22,6 +22,9 @@ namespace eld {
 
 class ARMELFDynamic : public ELFDynamic {
 public:
+  static std::string getTypeName() { return "ARMELFDynamic"; }
+
+public:
   ARMELFDynamic(GNULDBackend &pParent, LinkerConfig &pConfig);
   ~ARMELFDynamic();
 

--- a/lib/Target/ARM/ARMGOT.h
+++ b/lib/Target/ARM/ARMGOT.h
@@ -25,6 +25,9 @@ namespace eld {
 
 class ARMGOT : public GOT {
 public:
+  static std::string getTypeName() { return "ARMGOT"; }
+
+public:
   // Going to be used by GOTPLT0
   ARMGOT(GOTType T, ELFSection *O, ResolveInfo *R, uint32_t Align,
          uint32_t Size)
@@ -86,6 +89,9 @@ private:
 
 class ARMGOTPLT0 : public ARMGOT {
 public:
+  static std::string getTypeName() { return "ARMGOTPLT0"; }
+
+public:
   ARMGOTPLT0(ELFSection *O, ResolveInfo *R)
       : ARMGOT(GOT::GOTPLT0, O, R, 4, 12), Value() {
     std::memset(Value, 0, sizeof(Value));
@@ -107,6 +113,9 @@ private:
 };
 
 class ARMGOTPLTN : public ARMGOT {
+public:
+  static std::string getTypeName() { return "ARMGOTPLTN"; }
+
 public:
   ARMGOTPLTN(ELFSection *O, ResolveInfo *R)
       : ARMGOT(GOT::GOTPLTN, O, R, 4, 4) {}
@@ -132,6 +141,9 @@ private:
 
 class ARMGDGOT : public ARMGOT {
 public:
+  static std::string getTypeName() { return "ARMGDGOT"; }
+
+public:
   ARMGDGOT(ELFSection *O, ResolveInfo *R)
       : ARMGOT(GOT::TLS_GD, O, R), Other(make<ARMGOT>(GOT::TLS_GD, O, R)) {}
 
@@ -149,6 +161,9 @@ private:
 
 class ARMLDGOT : public ARMGOT {
 public:
+  static std::string getTypeName() { return "ARMLDGOT"; }
+
+public:
   ARMLDGOT(ELFSection *O, ResolveInfo *R)
       : ARMGOT(GOT::TLS_LD, O, R), Other(make<ARMGOT>(GOT::TLS_LD, O, R)) {}
 
@@ -165,6 +180,9 @@ private:
 };
 
 class ARMIEGOT : public ARMGOT {
+public:
+  static std::string getTypeName() { return "ARMIEGOT"; }
+
 public:
   ARMIEGOT(ELFSection *O, ResolveInfo *R) : ARMGOT(GOT::TLS_LE, O, R) {}
 

--- a/lib/Target/ARM/ARMInfo.h
+++ b/lib/Target/ARM/ARMInfo.h
@@ -21,6 +21,9 @@ namespace eld {
 
 class ARMInfo : public TargetInfo {
 public:
+  static std::string getTypeName() { return "ARMInfo"; }
+
+public:
   ARMInfo(LinkerConfig &pConfig) : TargetInfo(pConfig) {}
 
   uint32_t machine() const override { return llvm::ELF::EM_ARM; }

--- a/lib/Target/ARM/ARMLDBackend.h
+++ b/lib/Target/ARM/ARMLDBackend.h
@@ -36,6 +36,9 @@ class ARMAttributeFragment;
 ///
 class ARMGNULDBackend : public GNULDBackend {
 public:
+  static std::string getTypeName() { return "ARMGNULDBackend"; }
+
+public:
   // max branch offsets for ARM, THUMB, and THUMB2
   // @ref gold/arm.cc:99
   static const int32_t ARM_MAX_FWD_BRANCH_OFFSET = ((((1 << 23) - 1) << 2) + 8);

--- a/lib/Target/ARM/ARMPLT.h
+++ b/lib/Target/ARM/ARMPLT.h
@@ -49,6 +49,9 @@ class IRBuilder;
 
 class ARMPLT : public PLT {
 public:
+  static std::string getTypeName() { return "ARMPLT"; }
+
+public:
   ARMPLT(PLT::PLTType T, eld::IRBuilder &I, ARMGOT *G, ELFSection *P,
          ResolveInfo *R, uint32_t Align, uint32_t Size)
       : PLT(T, G, P, R, Align, Size) {
@@ -62,6 +65,9 @@ public:
 };
 
 class ARMPLT0 : public ARMPLT {
+public:
+  static std::string getTypeName() { return "ARMPLT0"; }
+
 public:
   ARMPLT0(ARMGOT *G, eld::IRBuilder &I, ELFSection *P, ResolveInfo *R,
           uint32_t Align, uint32_t Size)
@@ -78,6 +84,9 @@ public:
 };
 
 class ARMPLTN : public ARMPLT {
+public:
+  static std::string getTypeName() { return "ARMPLTN"; }
+
 public:
   ARMPLTN(ARMGOT *G, eld::IRBuilder &I, ELFSection *P, ResolveInfo *R,
           uint32_t Align, uint32_t Size)

--- a/lib/Target/ARM/ARMRelocator.cpp
+++ b/lib/Target/ARM/ARMRelocator.cpp
@@ -236,6 +236,8 @@ typedef Relocator::Result (*ApplyFunctionType)(Relocation &pReloc,
 
 // the table entry of applying functions
 struct ApplyFunctionTriple {
+public:
+  static std::string getTypeName() { return "ApplyFunctionTriple"; }
   ApplyFunctionType func;
   unsigned int type;
   const char *name;

--- a/lib/Target/ARM/ARMRelocator.h
+++ b/lib/Target/ARM/ARMRelocator.h
@@ -25,6 +25,9 @@ namespace eld {
  */
 class ARMRelocator : public Relocator {
 public:
+  static std::string getTypeName() { return "ARMRelocator"; }
+
+public:
   ARMRelocator(ARMGNULDBackend &pParent, LinkerConfig &pConfig,
                Module &pModule);
   ~ARMRelocator();

--- a/lib/Target/ARM/ARMToARMStub.h
+++ b/lib/Target/ARM/ARMToARMStub.h
@@ -27,6 +27,9 @@ class Module;
  */
 class ARMToARMStub : public Stub {
 public:
+  static std::string getTypeName() { return "ARMToARMStub"; }
+
+public:
   ARMToARMStub(uint32_t type, ARMGNULDBackend *Target);
 
   ~ARMToARMStub();

--- a/lib/Target/ARM/ARMToTHMStub.h
+++ b/lib/Target/ARM/ARMToTHMStub.h
@@ -25,6 +25,9 @@ class Module;
  */
 class ARMToTHMStub : public Stub {
 public:
+  static std::string getTypeName() { return "ARMToTHMStub"; }
+
+public:
   ARMToTHMStub(uint32_t type, ARMGNULDBackend *Target);
 
   ~ARMToTHMStub();

--- a/lib/Target/ARM/THMToARMStub.h
+++ b/lib/Target/ARM/THMToARMStub.h
@@ -26,6 +26,9 @@ class ResolveInfo;
  */
 class THMToARMStub : public Stub {
 public:
+  static std::string getTypeName() { return "THMToARMStub"; }
+
+public:
   THMToARMStub(uint32_t type, ARMGNULDBackend *Target);
 
   ~THMToARMStub();

--- a/lib/Target/ARM/THMToTHMStub.h
+++ b/lib/Target/ARM/THMToTHMStub.h
@@ -27,6 +27,9 @@ class Module;
  */
 class THMToTHMStub : public Stub {
 public:
+  static std::string getTypeName() { return "THMToTHMStub"; }
+
+public:
   THMToTHMStub(uint32_t type, ARMGNULDBackend *Target);
 
   ~THMToTHMStub();

--- a/lib/Target/Hexagon/HexagonAbsoluteStub.h
+++ b/lib/Target/Hexagon/HexagonAbsoluteStub.h
@@ -26,6 +26,9 @@ class ResolveInfo;
  */
 class HexagonAbsoluteStub : public Stub {
 public:
+  static std::string getTypeName() { return "HexagonAbsoluteStub"; }
+
+public:
   HexagonAbsoluteStub(bool pIsOutputPIC);
 
   ~HexagonAbsoluteStub();

--- a/lib/Target/Hexagon/HexagonAttributeFragment.h
+++ b/lib/Target/Hexagon/HexagonAttributeFragment.h
@@ -15,6 +15,9 @@ namespace eld {
 class ObjectFile;
 class HexagonAttributeFragment : public TargetFragment {
 public:
+  static std::string getTypeName() { return "HexagonAttributeFragment"; }
+
+public:
   HexagonAttributeFragment(ELFSection *O);
 
   ~HexagonAttributeFragment();

--- a/lib/Target/Hexagon/HexagonELFDynamic.h
+++ b/lib/Target/Hexagon/HexagonELFDynamic.h
@@ -19,6 +19,9 @@ enum {
 
 class HexagonELFDynamic : public ELFDynamic {
 public:
+  static std::string getTypeName() { return "HexagonELFDynamic"; }
+
+public:
   HexagonELFDynamic(GNULDBackend &pParent, LinkerConfig &pConfig);
   ~HexagonELFDynamic();
 

--- a/lib/Target/Hexagon/HexagonGOT.h
+++ b/lib/Target/Hexagon/HexagonGOT.h
@@ -19,6 +19,9 @@ namespace eld {
 
 class HexagonGOT : public GOT {
 public:
+  static std::string getTypeName() { return "HexagonGOT"; }
+
+public:
   // Going to be used by GOTPLT0
   HexagonGOT(GOTType T, ELFSection *O, ResolveInfo *R, uint32_t Align,
              uint32_t Size)
@@ -68,6 +71,9 @@ private:
 
 class HexagonGOTPLT0 : public HexagonGOT {
 public:
+  static std::string getTypeName() { return "HexagonGOTPLT0"; }
+
+public:
   HexagonGOTPLT0(ELFSection *O, ResolveInfo *R)
       : HexagonGOT(GOT::GOTPLT0, O, R, 4, 16) {}
 
@@ -87,6 +93,9 @@ private:
 
 class HexagonGOTPLTN : public HexagonGOT {
 public:
+  static std::string getTypeName() { return "HexagonGOTPLTN"; }
+
+public:
   HexagonGOTPLTN(ELFSection *O, ResolveInfo *R)
       : HexagonGOT(GOT::GOTPLTN, O, R, 4, 4) {}
 
@@ -98,6 +107,9 @@ public:
 };
 
 class HexagonGDGOT : public HexagonGOT {
+public:
+  static std::string getTypeName() { return "HexagonGDGOT"; }
+
 public:
   HexagonGDGOT(ELFSection *O, ResolveInfo *R)
       : HexagonGOT(GOT::TLS_GD, O, R),
@@ -117,6 +129,9 @@ private:
 
 class HexagonLDGOT : public HexagonGOT {
 public:
+  static std::string getTypeName() { return "HexagonLDGOT"; }
+
+public:
   HexagonLDGOT(ELFSection *O, ResolveInfo *R)
       : HexagonGOT(GOT::TLS_LD, O, R),
         Other(make<HexagonGOT>(GOT::TLS_LD, O, R)) {}
@@ -134,6 +149,9 @@ private:
 };
 
 class HexagonIEGOT : public HexagonGOT {
+public:
+  static std::string getTypeName() { return "HexagonIEGOT"; }
+
 public:
   HexagonIEGOT(ELFSection *O, ResolveInfo *R) : HexagonGOT(GOT::TLS_LE, O, R) {}
 

--- a/lib/Target/Hexagon/HexagonInfo.h
+++ b/lib/Target/Hexagon/HexagonInfo.h
@@ -16,6 +16,9 @@ namespace eld {
 
 class HexagonInfo : public TargetInfo {
 public:
+  static std::string getTypeName() { return "HexagonInfo"; }
+
+public:
   // This enumeration creates a mapping in the static array for every input
   // flag.
   enum TranslationCPU {

--- a/lib/Target/Hexagon/HexagonLDBackend.cpp
+++ b/lib/Target/Hexagon/HexagonLDBackend.cpp
@@ -63,6 +63,9 @@ namespace {
 static DiagnosticEngine *sDiagEngine = nullptr;
 class PrepareStaticDiagEngine {
 public:
+  static std::string getTypeName() { return "PrepareStaticDiagEngine"; }
+
+public:
   PrepareStaticDiagEngine(DiagnosticEngine *diagEngine) {
     m_Mutex.lock();
     sDiagEngine = diagEngine;

--- a/lib/Target/Hexagon/HexagonLDBackend.h
+++ b/lib/Target/Hexagon/HexagonLDBackend.h
@@ -29,6 +29,9 @@ class RegionFragmentEx;
 ///
 class HexagonLDBackend : public GNULDBackend {
 public:
+  static std::string getTypeName() { return "HexagonLDBackend"; }
+
+public:
   HexagonLDBackend(Module &pModule, HexagonInfo *pInfo);
 
   uint32_t machine() const;

--- a/lib/Target/Hexagon/HexagonLinuxInfo.h
+++ b/lib/Target/Hexagon/HexagonLinuxInfo.h
@@ -14,6 +14,9 @@ namespace eld {
 
 class HexagonLinuxInfo : public HexagonInfo {
 public:
+  static std::string getTypeName() { return "HexagonLinuxInfo"; }
+
+public:
   HexagonLinuxInfo(LinkerConfig &config) : HexagonInfo(config) {}
 
   uint64_t startAddr(bool linkerScriptHasSectionsCommand, bool isDynExec,

--- a/lib/Target/Hexagon/HexagonPLT.h
+++ b/lib/Target/Hexagon/HexagonPLT.h
@@ -41,6 +41,9 @@ class IRBuilder;
 
 class HexagonPLT : public PLT {
 public:
+  static std::string getTypeName() { return "HexagonPLT"; }
+
+public:
   HexagonPLT(PLT::PLTType T, eld::IRBuilder &I, HexagonGOT *G, ELFSection *P,
              ResolveInfo *R, uint32_t Align, uint32_t Size)
       : PLT(T, G, P, R, Align, Size) {}
@@ -51,6 +54,9 @@ public:
 };
 
 class HexagonPLT0 : public HexagonPLT {
+public:
+  static std::string getTypeName() { return "HexagonPLT0"; }
+
 public:
   HexagonPLT0(HexagonGOT *G, eld::IRBuilder &I, ELFSection *P, ResolveInfo *R,
               uint32_t Align, uint32_t Size)
@@ -67,6 +73,9 @@ public:
 };
 
 class HexagonPLTN : public HexagonPLT {
+public:
+  static std::string getTypeName() { return "HexagonPLTN"; }
+
 public:
   HexagonPLTN(HexagonGOT *G, eld::IRBuilder &I, ELFSection *P, ResolveInfo *R,
               uint32_t Align, uint32_t Size)

--- a/lib/Target/Hexagon/HexagonRelocationFunctions.h
+++ b/lib/Target/Hexagon/HexagonRelocationFunctions.h
@@ -9,6 +9,7 @@
 
 #include "HexagonLLVMExtern.h"
 #include "HexagonRelocator.h"
+#include <string>
 
 namespace eld {
 
@@ -66,6 +67,8 @@ typedef Relocator::Result (*ApplyFunctionType)(
     RelocationDescription &pRelocDesc);
 
 struct RelocationDescription {
+public:
+  static std::string getTypeName() { return "RelocationDescription"; }
   // The application function for the relocation.
   const ApplyFunctionType func;
   // The Relocation type, this is just kept for convenience when writing new

--- a/lib/Target/Hexagon/HexagonRelocator.h
+++ b/lib/Target/Hexagon/HexagonRelocator.h
@@ -27,6 +27,9 @@ class LinkerConfig;
  */
 class HexagonRelocator : public Relocator {
 public:
+  static std::string getTypeName() { return "HexagonRelocator"; }
+
+public:
   HexagonRelocator(HexagonLDBackend &pParent, LinkerConfig &pConfig,
                    Module &pModule);
   ~HexagonRelocator();

--- a/lib/Target/Hexagon/HexagonStandaloneInfo.h
+++ b/lib/Target/Hexagon/HexagonStandaloneInfo.h
@@ -16,6 +16,9 @@ namespace eld {
 
 class HexagonStandaloneInfo : public HexagonInfo {
 public:
+  static std::string getTypeName() { return "HexagonStandaloneInfo"; }
+
+public:
   HexagonStandaloneInfo(LinkerConfig &pConfig) : HexagonInfo(pConfig) {}
 
   uint64_t startAddr(bool linkerScriptHasSectionsCommand, bool isDynExec,

--- a/lib/Target/Hexagon/HexagonTLSStub.h
+++ b/lib/Target/Hexagon/HexagonTLSStub.h
@@ -30,6 +30,9 @@ class Module;
 //===----------------------------------------------------------------------===//
 class HexagonTLSStub : public TargetFragment {
 public:
+  static std::string getTypeName() { return "HexagonTLSStub"; }
+
+public:
   enum StubType { GD, GDtoIE, LDtoLE };
 
   HexagonTLSStub(StubType T, ELFSection *O, ResolveInfo *R, uint32_t Align,
@@ -59,6 +62,9 @@ private:
 
 class HexagonGDStub : public HexagonTLSStub {
 public:
+  static std::string getTypeName() { return "HexagonGDStub"; }
+
+public:
   HexagonGDStub(ELFSection *O, ResolveInfo *R)
       : HexagonTLSStub(HexagonTLSStub::GD, O, R, 4, 0) {};
 
@@ -72,6 +78,9 @@ public:
 };
 
 class HexagonGDIEStub : public HexagonTLSStub {
+public:
+  static std::string getTypeName() { return "HexagonGDIEStub"; }
+
 public:
   HexagonGDIEStub(ELFSection *O, ResolveInfo *R)
       : HexagonTLSStub(HexagonTLSStub::GDtoIE, O, R, 4,
@@ -91,6 +100,9 @@ public:
 };
 
 class HexagonLDLEStub : public HexagonTLSStub {
+public:
+  static std::string getTypeName() { return "HexagonLDLEStub"; }
+
 public:
   HexagonLDLEStub(ELFSection *O, ResolveInfo *R)
       : HexagonTLSStub(HexagonTLSStub::LDtoLE, O, R, 4,

--- a/lib/Target/RISCV/RISCVAttributeFragment.h
+++ b/lib/Target/RISCV/RISCVAttributeFragment.h
@@ -28,9 +28,14 @@ class LinkerConfig;
 
 class RISCVAttributeFragment : public TargetFragment {
 public:
+  static std::string getTypeName() { return "RISCVAttributeFragment"; }
+
+public:
   enum class AttributeType { Hidden, Numeric, Text, NumericAndText };
 
   struct AttributeItem {
+  public:
+    static std::string getTypeName() { return "AttributeItem"; }
     AttributeType Type;
     unsigned Tag;
     unsigned IntValue;

--- a/lib/Target/RISCV/RISCVELFDynamic.h
+++ b/lib/Target/RISCV/RISCVELFDynamic.h
@@ -13,6 +13,9 @@ namespace eld {
 
 class RISCVELFDynamic : public ELFDynamic {
 public:
+  static std::string getTypeName() { return "RISCVELFDynamic"; }
+
+public:
   RISCVELFDynamic(GNULDBackend &pParent, LinkerConfig &pConfig);
   ~RISCVELFDynamic();
 

--- a/lib/Target/RISCV/RISCVGOT.h
+++ b/lib/Target/RISCV/RISCVGOT.h
@@ -19,6 +19,9 @@ namespace eld {
 
 class RISCVGOT : public GOT {
 public:
+  static std::string getTypeName() { return "RISCVGOT"; }
+
+public:
   // Going to be used by GOTPLT0
   RISCVGOT(GOTType T, ELFSection *O, ResolveInfo *R, uint32_t Align,
            uint32_t Size)
@@ -72,6 +75,9 @@ public:
 template <typename T, uint32_t Align, uint32_t Size>
 class RISCVTGOT : public RISCVGOT {
 public:
+  static std::string getTypeName() { return "RISCVTGOT"; }
+
+public:
   // Going to be used by GOTPLT0
   RISCVTGOT(GOTType gotType, ELFSection *O, ResolveInfo *R)
       : RISCVGOT(gotType, O, R, Align, Size),
@@ -101,6 +107,9 @@ private:
 template <typename T, uint32_t Align, uint32_t Size>
 class RISCVGOTPLTN : public RISCVTGOT<T, Align, Size> {
 public:
+  static std::string getTypeName() { return "RISCVGOTPLTN"; }
+
+public:
   RISCVGOTPLTN(ELFSection *O, ResolveInfo *R)
       : RISCVTGOT<T, Align, Size>(GOT::GOTPLTN, O, R) {}
 
@@ -112,6 +121,9 @@ public:
 template <typename T>
 class RISCVGOTPLT0 : public RISCVTGOT<T, sizeof(T), sizeof(T) * 2> {
 public:
+  static std::string getTypeName() { return "RISCVGOTPLT0"; }
+
+public:
   RISCVGOTPLT0(ELFSection *O, ResolveInfo *R)
       : RISCVTGOT<T, sizeof(T), sizeof(T) * 2>(GOT::GOTPLT0, O, R) {}
 
@@ -122,6 +134,9 @@ public:
 
 template <typename T, uint32_t Align, uint32_t Size>
 class RISCVGDGOT : public RISCVTGOT<T, Align, Size> {
+public:
+  static std::string getTypeName() { return "RISCVGDGOT"; }
+
 public:
   RISCVGDGOT(ELFSection *O, ResolveInfo *R)
       : RISCVTGOT<T, Align, Size>(GOT::TLS_GD, O, R),
@@ -138,6 +153,9 @@ private:
 template <typename T, uint32_t Align, uint32_t Size>
 class RISCVLDGOT : public RISCVTGOT<T, Align, Size> {
 public:
+  static std::string getTypeName() { return "RISCVLDGOT"; }
+
+public:
   RISCVLDGOT(ELFSection *O, ResolveInfo *R)
       : RISCVTGOT<T, Align, Size>(GOT::TLS_LD, O, R),
         Other(make<RISCVTGOT<T, Align, Size>>(GOT::TLS_LD, O, R)) {}
@@ -152,6 +170,9 @@ private:
 
 template <typename T, uint32_t Align, uint32_t Size>
 class RISCVIEGOT : public RISCVTGOT<T, Align, Size> {
+public:
+  static std::string getTypeName() { return "RISCVIEGOT"; }
+
 public:
   RISCVIEGOT(ELFSection *O, ResolveInfo *R)
       : RISCVTGOT<T, Align, Size>(GOT::TLS_IE, O, R) {}

--- a/lib/Target/RISCV/RISCVInfo.h
+++ b/lib/Target/RISCV/RISCVInfo.h
@@ -15,6 +15,9 @@ namespace eld {
 
 class RISCVInfo : public TargetInfo {
 public:
+  static std::string getTypeName() { return "RISCVInfo"; }
+
+public:
   RISCVInfo(LinkerConfig &m_Config);
 
   uint32_t machine() const override { return llvm::ELF::EM_RISCV; }

--- a/lib/Target/RISCV/RISCVLDBackend.h
+++ b/lib/Target/RISCV/RISCVLDBackend.h
@@ -31,6 +31,9 @@ class RISCVRelaxationStats;
 ///
 class RISCVLDBackend : public GNULDBackend {
 public:
+  static std::string getTypeName() { return "RISCVLDBackend"; }
+
+public:
   RISCVLDBackend(Module &pModule, RISCVInfo *pInfo);
 
   ~RISCVLDBackend();

--- a/lib/Target/RISCV/RISCVPLT.h
+++ b/lib/Target/RISCV/RISCVPLT.h
@@ -17,6 +17,9 @@ class RISCVLDBackend;
 
 class RISCVPLT : public PLT {
 public:
+  static std::string getTypeName() { return "RISCVPLT"; }
+
+public:
   RISCVPLT(PLT::PLTType T, RISCVGOT *G, ELFSection *P, ResolveInfo *R,
            uint32_t Align, uint32_t Size)
       : PLT(T, G, P, R, Align, Size) {}
@@ -38,6 +41,9 @@ public:
 template <typename T, uint32_t Align, uint32_t Size>
 class RISCVTPLT : public RISCVPLT {
 public:
+  static std::string getTypeName() { return "RISCVTPLT"; }
+
+public:
   // Going to be used by GOTPLT0
   RISCVTPLT(PLT::PLTType pltType, RISCVGOT *G, ELFSection *O, ResolveInfo *R)
       : RISCVPLT(pltType, G, O, R, Align, Size) {}
@@ -47,6 +53,9 @@ public:
 
 template <typename T, uint32_t Align, uint32_t Size>
 class RISCVPLT0 : public RISCVTPLT<T, Align, Size> {
+public:
+  static std::string getTypeName() { return "RISCVPLT0"; }
+
 public:
   RISCVPLT0(RISCVGOT *G, RISCVLDBackend &Backend, ELFSection *P)
       : RISCVTPLT<T, Align, Size>(PLT::PLT0, G, P, nullptr),
@@ -62,6 +71,9 @@ private:
 
 template <typename T, uint32_t Align, uint32_t Size>
 class RISCVPLTN : public RISCVTPLT<T, Align, Size> {
+public:
+  static std::string getTypeName() { return "RISCVPLTN"; }
+
 public:
   RISCVPLTN(RISCVGOT *G, ELFSection *P, ResolveInfo *R)
       : RISCVTPLT<T, Align, Size>(PLT::PLTN, G, P, R) {}

--- a/lib/Target/RISCV/RISCVRelaxationStats.h
+++ b/lib/Target/RISCV/RISCVRelaxationStats.h
@@ -12,6 +12,9 @@
 namespace eld {
 class RISCVRelaxationStats : public LinkStats {
 public:
+  static std::string getTypeName() { return "RISCVRelaxationStats"; }
+
+public:
   RISCVRelaxationStats()
       : LinkStats("RelaxationStats", LinkStats::Kind::Relaxation) {}
 

--- a/lib/Target/RISCV/RISCVRelocator.cpp
+++ b/lib/Target/RISCV/RISCVRelocator.cpp
@@ -27,6 +27,8 @@ typedef Relocator::Result (*ApplyFunctionType)(
     RelocationDescription &pRelocDesc);
 
 struct RelocationDescription {
+public:
+  static std::string getTypeName() { return "RelocationDescription"; }
   // The application function for the relocation.
   const ApplyFunctionType func;
   // The Relocation type, this is just kept for convenience when writing new

--- a/lib/Target/RISCV/RISCVRelocator.h
+++ b/lib/Target/RISCV/RISCVRelocator.h
@@ -23,6 +23,9 @@ class LinkerConfig;
  */
 class RISCVRelocator : public Relocator {
 public:
+  static std::string getTypeName() { return "RISCVRelocator"; }
+
+public:
   RISCVRelocator(RISCVLDBackend &pParent, LinkerConfig &pConfig,
                  Module &pModule);
   ~RISCVRelocator();

--- a/lib/Target/RISCV/RISCVStandaloneInfo.h
+++ b/lib/Target/RISCV/RISCVStandaloneInfo.h
@@ -15,6 +15,9 @@ namespace eld {
 
 class RISCVStandaloneInfo : public RISCVInfo {
 public:
+  static std::string getTypeName() { return "RISCVStandaloneInfo"; }
+
+public:
   RISCVStandaloneInfo(LinkerConfig &pConfig) : RISCVInfo(pConfig) {}
 
   uint64_t startAddr(bool linkerScriptHasSectionsCmd, bool isDynExec,

--- a/lib/Target/TargetInfo.cpp
+++ b/lib/Target/TargetInfo.cpp
@@ -22,6 +22,8 @@ using namespace eld;
 namespace {
 
 struct NameMap {
+public:
+  static std::string getTypeName() { return "NameMap"; }
   const char *from; ///< the prefix of the input string. (match FROM*)
   const char *to;   ///< the output string.
   InputSectDesc::Policy policy; /// mark whether the input is kept in GC

--- a/lib/Target/Template/TemplateInfo.h
+++ b/lib/Target/Template/TemplateInfo.h
@@ -14,6 +14,9 @@ namespace eld {
 
 class TemplateInfo : public TargetInfo {
 public:
+  static std::string getTypeName() { return "TemplateInfo"; }
+
+public:
   TemplateInfo(LinkerConfig &m_Config);
 
   uint32_t machine() const override {

--- a/lib/Target/Template/TemplateLDBackend.h
+++ b/lib/Target/Template/TemplateLDBackend.h
@@ -24,6 +24,9 @@ class TemplateInfo;
 ///
 class TemplateLDBackend : public GNULDBackend {
 public:
+  static std::string getTypeName() { return "TemplateLDBackend"; }
+
+public:
   TemplateLDBackend(Module &pModule, TemplateInfo *pInfo);
 
   ~TemplateLDBackend();

--- a/lib/Target/Template/TemplateRelocationFunctions.h
+++ b/lib/Target/Template/TemplateRelocationFunctions.h
@@ -50,6 +50,8 @@ typedef Relocator::Result (*ApplyFunctionType)(
     RelocationDescription &pRelocDesc);
 
 struct RelocationDescription {
+public:
+  static std::string getTypeName() { return "RelocationDescription"; }
   // The application function for the relocation.
   const ApplyFunctionType func;
   // The Relocation type, this is just kept for convenience when writing new
@@ -63,10 +65,12 @@ struct RelocationDescription {
 };
 
 struct RelocationDescription RelocDesc[] = {
-    /* {  func =         &applyNone
-            ,  type =        llvm::ELF::
-            ,  forceVerify =  false
-    } */
+  public : static std::string getTypeName(){return "RelocationDescription";
+} // namespace eld
+/* {  func =         &applyNone
+        ,  type =        llvm::ELF::
+        ,  forceVerify =  false
+} */
 };
 
 } // namespace eld

--- a/lib/Target/Template/TemplateRelocator.h
+++ b/lib/Target/Template/TemplateRelocator.h
@@ -23,6 +23,9 @@ class LinkerConfig;
  */
 class TemplateRelocator : public Relocator {
 public:
+  static std::string getTypeName() { return "TemplateRelocator"; }
+
+public:
   TemplateRelocator(TemplateLDBackend &pParent, LinkerConfig &pConfig,
                     Module &pModule);
   ~TemplateRelocator();

--- a/lib/Target/Template/TemplateStandaloneInfo.h
+++ b/lib/Target/Template/TemplateStandaloneInfo.h
@@ -16,6 +16,9 @@ namespace eld {
 
 class TemplateStandaloneInfo : public TemplateInfo {
 public:
+  static std::string getTypeName() { return "TemplateStandaloneInfo"; }
+
+public:
   TemplateStandaloneInfo(LinkerConfig &pConfig) : TemplateInfo(pConfig) {}
 
   virtual uint64_t startAddr(bool linkerScriptHasSectionsCmd, bool isDynExec,

--- a/lib/Target/x86_64/x86_64ELFDynamic.h
+++ b/lib/Target/x86_64/x86_64ELFDynamic.h
@@ -13,6 +13,9 @@ namespace eld {
 
 class x86_64ELFDynamic : public ELFDynamic {
 public:
+  static std::string getTypeName() { return "x86_64ELFDynamic"; }
+
+public:
   x86_64ELFDynamic(GNULDBackend &pParent, LinkerConfig &pConfig);
 
 private:

--- a/lib/Target/x86_64/x86_64GOT.h
+++ b/lib/Target/x86_64/x86_64GOT.h
@@ -19,6 +19,9 @@ namespace eld {
 
 class x86_64GOT : public GOT {
 public:
+  static std::string getTypeName() { return "x86_64GOT"; }
+
+public:
   // Going to be used by GOTPLT0
   x86_64GOT(GOTType T, ELFSection *O, ResolveInfo *R, uint32_t Align,
             uint32_t Size)
@@ -71,6 +74,9 @@ private:
  */
 class x86_64GOTPLT0 : public x86_64GOT {
 public:
+  static std::string getTypeName() { return "x86_64GOTPLT0"; }
+
+public:
   x86_64GOTPLT0(ELFSection *O, Module *M)
       : x86_64GOT(GOT::GOTPLT0, O, nullptr, /*Align=*/8, /*Size=*/24), M(M) {}
 
@@ -107,6 +113,9 @@ private:
  */
 class x86_64GOTPLTN : public x86_64GOT {
 public:
+  static std::string getTypeName() { return "x86_64GOTPLTN"; }
+
+public:
   x86_64GOTPLTN(ELFSection *O, ResolveInfo *R)
       : x86_64GOT(GOT::GOTPLTN, O, R, /*Align=*/8, /*Size=*/8),
         m_PLTEntry(nullptr) {}
@@ -138,6 +147,9 @@ private:
 
 class x86_64GDGOT : public x86_64GOT {
 public:
+  static std::string getTypeName() { return "x86_64GDGOT"; }
+
+public:
   x86_64GDGOT(ELFSection *O, ResolveInfo *R)
       : x86_64GOT(GOT::TLS_GD, O, R),
         Other(make<x86_64GOT>(GOT::TLS_GD, O, R)) {}
@@ -155,6 +167,9 @@ private:
 };
 
 class x86_64LDGOT : public x86_64GOT {
+public:
+  static std::string getTypeName() { return "x86_64LDGOT"; }
+
 public:
   x86_64LDGOT(ELFSection *O, ResolveInfo *R)
       : x86_64GOT(GOT::TLS_LD, O, R),
@@ -174,7 +189,10 @@ private:
 
 class x86_64IEGOT : public x86_64GOT {
 public:
-  x86_64IEGOT(ELFSection *O, ResolveInfo *R) : x86_64GOT(GOT::TLS_IE, O, R) {}
+  static std::string getTypeName() { return "x86_64IEGOT"; }
+
+public:
+  x86_64IEGOT(ELFSection *O, ResolveInfo *R) : x86_64GOT(GOT::TLS_LE, O, R) {}
 
   x86_64GOT *getFirst() override { return this; }
 

--- a/lib/Target/x86_64/x86_64Info.h
+++ b/lib/Target/x86_64/x86_64Info.h
@@ -15,6 +15,9 @@ namespace eld {
 
 class x86_64Info : public TargetInfo {
 public:
+  static std::string getTypeName() { return "x86_64Info"; }
+
+public:
   x86_64Info(LinkerConfig &m_Config);
 
   uint32_t machine() const override { return llvm::ELF::EM_X86_64; }

--- a/lib/Target/x86_64/x86_64LDBackend.h
+++ b/lib/Target/x86_64/x86_64LDBackend.h
@@ -25,6 +25,9 @@ class x86_64Info;
 ///
 class x86_64LDBackend : public GNULDBackend {
 public:
+  static std::string getTypeName() { return "x86_64LDBackend"; }
+
+public:
   x86_64LDBackend(Module &pModule, x86_64Info *pInfo);
 
   ~x86_64LDBackend();

--- a/lib/Target/x86_64/x86_64PLT.h
+++ b/lib/Target/x86_64/x86_64PLT.h
@@ -33,6 +33,9 @@ class IRBuilder;
 
 class x86_64PLT : public PLT {
 public:
+  static std::string getTypeName() { return "x86_64PLT"; }
+
+public:
   x86_64PLT(PLT::PLTType T, eld::IRBuilder &I, x86_64GOT *G, ELFSection *P,
             ResolveInfo *R, uint32_t Align, uint32_t Size)
       : PLT(T, G, P, R, Align, Size) {}
@@ -43,6 +46,9 @@ public:
 };
 
 class x86_64PLT0 : public x86_64PLT {
+public:
+  static std::string getTypeName() { return "x86_64PLT0"; }
+
 public:
   x86_64PLT0(x86_64GOT *G, eld::IRBuilder &I, ELFSection *P, ResolveInfo *R,
              uint32_t Align, uint32_t Size)
@@ -69,6 +75,9 @@ public:
  *  linker which .rela.plt entry corresponds to this function.
  */
 class x86_64PLTN : public x86_64PLT {
+public:
+  static std::string getTypeName() { return "x86_64PLTN"; }
+
 public:
   x86_64PLTN(x86_64GOT *G, eld::IRBuilder &I, ELFSection *P, ResolveInfo *R,
              uint32_t Align, uint32_t Size)

--- a/lib/Target/x86_64/x86_64RelocationFunctions.h
+++ b/lib/Target/x86_64/x86_64RelocationFunctions.h
@@ -8,6 +8,7 @@
 
 #include "x86_64LLVMExtern.h"
 #include "x86_64Relocator.h"
+#include <string>
 
 namespace eld {
 
@@ -40,6 +41,8 @@ typedef Relocator::Result (*ApplyFunctionType)(
     RelocationDescription &pRelocDesc);
 
 struct RelocationDescription {
+public:
+  static std::string getTypeName() { return "RelocationDescription"; }
   // The application function for the relocation.
   const ApplyFunctionType func;
   // The Relocation type, this is just kept for convenience when writing new

--- a/lib/Target/x86_64/x86_64Relocator.h
+++ b/lib/Target/x86_64/x86_64Relocator.h
@@ -27,6 +27,9 @@ class LinkerConfig;
  */
 class x86_64Relocator : public Relocator {
 public:
+  static std::string getTypeName() { return "x86_64Relocator"; }
+
+public:
   x86_64Relocator(x86_64LDBackend &pParent, LinkerConfig &pConfig,
                   Module &pModule);
   ~x86_64Relocator();

--- a/lib/Target/x86_64/x86_64StandaloneInfo.h
+++ b/lib/Target/x86_64/x86_64StandaloneInfo.h
@@ -15,6 +15,9 @@ namespace eld {
 
 class x86_64StandaloneInfo : public x86_64Info {
 public:
+  static std::string getTypeName() { return "x86_64StandaloneInfo"; }
+
+public:
   x86_64StandaloneInfo(LinkerConfig &pConfig) : x86_64Info(pConfig) {}
 
   uint64_t startAddr(bool linkerScriptHasSectionsCmd, bool isDynExec,

--- a/test/Common/standalone/CommandLine/PrintMemoryReport/Inputs/1.c
+++ b/test/Common/standalone/CommandLine/PrintMemoryReport/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 0; }

--- a/test/Common/standalone/CommandLine/PrintMemoryReport/PrintMemoryReport.test
+++ b/test/Common/standalone/CommandLine/PrintMemoryReport/PrintMemoryReport.test
@@ -1,0 +1,11 @@
+#---PrintmemoryReport.test--------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# This checks if the linker supports --print-memory-report/--emit-memory-report option.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
+RUN: %link %linkopts %t1.1.o -o %t2.out --print-memory-report 2>&1 | %filecheck %s --allow-empty
+RUN: %link %linkopts %t1.1.o -o %t2.out.1 --emit-memory-report=%t1.out.mem 2>&1
+RUN: %filecheck %s < %t1.out.mem
+#CHECK: Arena allocation report by type
+#END_TEST

--- a/tools/LSParserVerifier/LSParserVerifier.cpp
+++ b/tools/LSParserVerifier/LSParserVerifier.cpp
@@ -30,6 +30,9 @@
 
 class CommonTargetInfo : public eld::TargetInfo {
 public:
+  static std::string getTypeName() { return "CommonTargetInfo"; }
+
+public:
   CommonTargetInfo(eld::LinkerConfig &config) : eld::TargetInfo(config) {}
 
   uint64_t flags() const override { return 0; }
@@ -45,6 +48,9 @@ public:
 };
 
 class CommonLDBackend : public eld::GNULDBackend {
+public:
+  static std::string getTypeName() { return "CommonLDBackend"; }
+
 public:
   CommonLDBackend(eld::Module &module, eld::TargetInfo *info)
       : GNULDBackend(module, info) {}
@@ -66,6 +72,8 @@ public:
 };
 
 class LinkerModel {
+public:
+  static std::string getTypeName() { return "LinkerModel"; }
   eld::DiagnosticEngine m_DiagEngine;
   eld::LinkerConfig *m_Config = nullptr;
   eld::LinkerScript *m_LinkerScript = nullptr;


### PR DESCRIPTION
This prints memory allocated by linker core data structures with a count of how many and total bytes used.

This will be followed up by improvements to report virtual memory / resident memory size.

Resolves #606