### PR TITLE
Fix pathspec error when recording builds for dashboard.

### DIFF
--- a/.github/workflows/BuildStatusDataRecorder/action.yaml
+++ b/.github/workflows/BuildStatusDataRecorder/action.yaml
@@ -87,7 +87,7 @@ runs:
         cp build-status.db ${DASH_DIR}/
         rm -f record_builds.py
         echo "Removing ${{ inputs.workflow-name }} ${{ inputs.arch-name }} data lock."
-        git rm -f data.lock
+        rm -f data.lock
         git add .
         git commit -m "Add ${{ inputs.workflow-name }} ${{ inputs.arch-name }} build status data in DB"
         # Keep trying until lock/conflicts are resolved and build data is pushed successfully.
@@ -97,7 +97,7 @@ runs:
           git fetch --all
           git reset --hard origin/dashboard
           cp -f ${DASH_DIR}/build-status.db .
-          git rm -f data.lock
+          rm -f data.lock
           git add .
           git commit -m "Add ${{ inputs.workflow-name }} ${{ matrix.arch.name }} build status data in DB"
         done


### PR DESCRIPTION
Use "rm" in place of "git rm" to resolve the pathspec error, which happens when remote branch has lock file removed.