### PR TITLE
Install LLVM utilities in nightly-test workflow

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 7 * * *'  # Runs daily at 1:00 AM CST
   workflow_dispatch:     # Allows manual triggering
+  pull_request:
+    paths:
+      - ".github/workflows/nightly-test.yml"
 
 jobs:
   build-and-runtest-nightly:
@@ -69,6 +72,7 @@ jobs:
             -DLLVM_CCACHE_DIR:STRING=$PWD/ccache/ \
             -DELD_TARGETS_TO_BUILD='ARM;AArch64;RISCV;Hexagon;x86_64' \
             -DLLVM_ENABLE_SPHINX=OFF \
+            -DLLVM_INSTALL_UTILS=On \
             ../llvm-project/llvm
 
       - name: Build and install toolchain


### PR DESCRIPTION
This commit modifies nightly-test workflow to install LLVM utilities. We need LLVM utilities (FileCheck) if we want to use the (nightly) toolchain generated by this workflow in other workflows.