### PR TITLE
Fix which function to handle spaces in executable paths on Windows

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -32,6 +32,7 @@ def which(cmdline):
   if (ret is None):
     return "Not Found {}".format(tool)
   ret = ret.replace("\\", "/")
+  ret = '"' + ret + '"'
   return ' '.join([ret] + cmdline[1:])
 
 # name: The name of this test suite.


### PR DESCRIPTION
Certain LIT tests rely on the `which` function to retrieve the path of an executable from the environment without quotes. This works on Debian-based systems, but on Windows, directory names can contain spaces (e.g., `Program Files`). As a result, the path is truncated to the first word (e.g., `C:\Program`), causing tests to fail because the executable cannot be found.

This patch resolves the issue by returning the output of the `which` function wrapped in double quotes (""), ensuring paths with spaces are handled correctly.