### PR TITLE
Mark MapStyleAll.test and SearchPathErrorMessage.test unsupported for windows

### DIFF
--- a/test/Common/standalone/Map/MapStyleAll/MapStyleAll.test
+++ b/test/Common/standalone/Map/MapStyleAll/MapStyleAll.test
@@ -2,6 +2,7 @@
 #BEGIN_COMMENT
 # Teach linker to emit multiple map files
 #END_COMMENT
+REQUIRES: yaml
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
 RUN: %link -MapStyle all %linkopts %t1.1.o -Map %t1.map -o %t2.out 2>&1

--- a/test/Common/standalone/SearchPathTest/SearchPathErrorMessage.test
+++ b/test/Common/standalone/SearchPathTest/SearchPathErrorMessage.test
@@ -2,6 +2,7 @@
 #BEGIN_COMMENT
 # This test check the error message when a search path can not be loaded.
 #END_COMMENT
+UNSUPPORTED: windows
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.o
 RUN: %link %linkopts %t.o -L /a/b -o %t.test.out 2>&1 | %filecheck %s --check-prefix=MSG


### PR DESCRIPTION
MapStyleAll.test is dependent on yaml module to be available on windows
builders otherwise it will fail. Therefore mark it unsupported for the
time being.
 
SearchPathErrorMessage.test checks for the non-existent library path
however, during path normalization in windowss`/a/b` path gets
normalized to `A:\b` which doesnt match the regex therefore mark it
unsupported as well for windows.