### PR TITLE
[ELFSection] Remove unnecessary Annotations member.

### DIFF
--- a/include/eld/LayoutMap/TextLayoutPrinter.h
+++ b/include/eld/LayoutMap/TextLayoutPrinter.h
@@ -129,6 +129,9 @@ private:
 
   void printStat(llvm::StringRef S, const std::string &Stat) const;
 
+  std::optional<std::string>
+  getPluginSectionAnnotations(const ELFSection *S) const;
+
   std::string showDecoratedSymbolName(eld::Module &CurModule,
                                       const ResolveInfo *R) const;
 

--- a/include/eld/Readers/ELFSection.h
+++ b/include/eld/Readers/ELFSection.h
@@ -149,12 +149,6 @@ public:
 
   static std::string getELFPermissionsStr(uint32_t Permissions);
 
-  std::string getSectionAnnotations() const;
-
-  bool hasAnnotations() const;
-
-  void addSectionAnnotation(const std::string &Annotation);
-
   bool hasOffset() const;
 
   /// FIXME: We change the offset for input sections so this will not return the
@@ -336,8 +330,6 @@ protected:
   /// the section properties instead of storing this?
   bool ShouldExcludeFromGC = false;
 
-  llvm::SmallVector<std::string> Annotations;
-
   llvm::SmallVector<Fragment *, 0> Fragments;
   llvm::SmallVector<Relocation *, 0> Relocations;
 
@@ -345,6 +337,8 @@ protected:
   llvm::SmallVector<const ELFSection *, 0> GroupSections;
   llvm::SmallVector<ELFSection *, 0> DependentSections;
 };
+
+static_assert(sizeof(ELFSection) <= 240, "ELFSection grew too large!");
 
 } // namespace eld
 

--- a/lib/Core/LinkerScript.cpp
+++ b/lib/Core/LinkerScript.cpp
@@ -338,7 +338,6 @@ void LinkerScript::updateRuleOp(plugin::LinkerWrapper *W, eld::Module *M,
                                 RuleContainer *R, ELFSection *S,
                                 const std::string &Annotation) {
   UpdateRulePluginOp *Op = eld::make<UpdateRulePluginOp>(W, R, S, Annotation);
-  S->addSectionAnnotation(Annotation);
   S->setOutputSection(R->getSection()->getOutputSection());
   S->setMatchedLinkerScriptRule(R);
   R->incMatchCount();

--- a/lib/LayoutMap/TextLayoutPrinter.cpp
+++ b/lib/LayoutMap/TextLayoutPrinter.cpp
@@ -237,6 +237,24 @@ void TextLayoutPrinter::printMemoryRegions(GNULDBackend const &Backend,
   outputStream() << "]";
 }
 
+std::optional<std::string>
+TextLayoutPrinter::getPluginSectionAnnotations(const ELFSection *S) const {
+  if (!S || !ThisLayoutInfo)
+    return {};
+  llvm::SmallVector<std::string, 4> Annotations;
+  for (auto &[_, Ops] : ThisLayoutInfo->getPluginOps()) {
+    for (auto *Op : Ops) {
+      auto *UR = llvm::dyn_cast_or_null<UpdateRulePluginOp>(Op);
+      if (!UR || UR->getSection() != S)
+        continue;
+      Annotations.push_back(Op->getAnnotation());
+    }
+  }
+  if (Annotations.empty())
+    return {};
+  return llvm::join(Annotations, ", ");
+}
+
 // Print section information like name, address, offset, size, alignment,
 // etc. based on the section type.
 void TextLayoutPrinter::printSection(GNULDBackend const &Backend,
@@ -642,6 +660,7 @@ void TextLayoutPrinter::printFragInfo(Fragment *Frag, LayoutFragmentInfo *Info,
   bool GC = Frag->getOwningSection()->isIgnore();
   uint32_t Alignment = Frag->alignment();
   const GeneralOptions &Options = ThisLayoutInfo->getConfig().options();
+  const auto SectionAnnotations = getPluginSectionAnnotations(Info->section());
   auto PrintOneFragOrString =
       [&, this](uint32_t Size, std::optional<uint64_t> AddressOrOffset) {
         if (GC && !Onlylayout)
@@ -664,10 +683,8 @@ void TextLayoutPrinter::printFragInfo(Fragment *Frag, LayoutFragmentInfo *Info,
         outputStream() << Type << "," << Permissions << "," << Alignment;
         if (Info->section()->hasOldInputFile())
           outputStream() << "," << Info->getResolvedPath();
-        if (Info->section()->hasAnnotations()) {
-          outputStream() << ", Annotations: "
-                         << Info->section()->getSectionAnnotations();
-        }
+        if (SectionAnnotations && !SectionAnnotations->empty())
+          outputStream() << ", Annotations: " << *SectionAnnotations;
         if (!Onlylayout) {
           printChangeOutputSectionInfo(Info->section());
           printChunkOps(M, Frag);

--- a/lib/Readers/ELFSection.cpp
+++ b/lib/Readers/ELFSection.cpp
@@ -107,21 +107,6 @@ std::string ELFSection::getELFPermissionsStr(uint32_t permissions) {
   return elfPermStr;
 }
 
-std::string ELFSection::getSectionAnnotations() const {
-  std::ostringstream oss;
-  for (size_t i = 0; i < Annotations.size(); ++i) {
-    oss << Annotations[i];
-    if (i != Annotations.size() - 1)
-      oss << ", ";
-  }
-  return oss.str();
-}
-
-bool ELFSection::hasAnnotations() const { return !Annotations.empty(); }
-
-void ELFSection::addSectionAnnotation(const std::string &Annotation) {
-  Annotations.push_back(Annotation);
-}
 // If an input section is in the form of "foo.N" where N is a number,
 // return N. Otherwise, returns 65536, which is one greater than the
 // lowest priority.


### PR DESCRIPTION
The addition of this member caused ELFSection size to grow by 64 bytes from 240 to 304 Bytes. Also
adds a static_assert on ELFSection size at 240.