### PR TITLE
[x86-64] Implement IRELATIVE relocations for ifunc support

### DIFF
--- a/test/x86_64/linux/relocIRELATIVE/Inputs/1.c
+++ b/test/x86_64/linux/relocIRELATIVE/Inputs/1.c
@@ -1,0 +1,1 @@
+int main() { return 11; }

--- a/test/x86_64/linux/relocIRELATIVE/relocIRELATIVE.test
+++ b/test/x86_64/linux/relocIRELATIVE/relocIRELATIVE.test
@@ -1,0 +1,20 @@
+#UNSUPPORTED: windows
+#------IRelativeStatic.test-------IRELATIVE Relocations in Static Executables------#
+#BEGIN_COMMENT
+# Verifies IRELATIVE relocations (R_X86_64_IRELATIVE) are generated when
+# statically linking with glibc. Static glibc contains ifunc implementations
+# for performance-critical functions like memcpy, memset, strcpy, etc.
+# The linker should generate  IRELATIVE relocations and define
+# the special symbols __rela_iplt_start and __rela_iplt_end for static ifunc resolution.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.1.o
+RUN: %clang %clangopts -fuse-ld=%link -static -o %t.out %t.1.o
+RUN: %t.out; echo $? | %filecheck %s --check-prefix=EXITCODE
+RUN: %readelf -r %t.out | %filecheck %s --check-prefix=COUNT-IRELATIVE
+RUN: %readelf -s %t.out | %filecheck %s --check-prefix=CHECK-IPLT-SYMBOLS
+COUNT-IRELATIVE-COUNT-22: R_X86_64_IRELATIV
+COUNT-IRELATIVE-NOT: R_X86_64_IRELATIV
+CHECK-IPLT-SYMBOLS-DAG: __rela_iplt_start
+CHECK-IPLT-SYMBOLS-DAG: __rela_iplt_end
+EXITCODE: 11


### PR DESCRIPTION
This PR implements R_X86_64_IRELATIVE relocations to enable ifunc symbol support in static executables, allowing ELD to successfully link with glibc.
ELD could not statically link with glibc because glibc uses ifunc symbols for performance-critical functions. These require special IRELATIVE relocations that were not implemented.

### Implementation

**1. IRELATIVE Relocation Generation**
- Detect STT_GNU_IFUNC symbols in static linking mode
- Generate R_X86_64_IRELATIVE instead of R_X86_64_JUMP_SLOT
- Handle ifunc PLT entries with eager binding

**2. glibc Compatibility**
- Create `__rela_iplt_start` and `__rela_iplt_end` symbols
- Properly bound .rela.plt section for ifunc resolution
- Match GNU ld behavior for static ifunc handling

**3. GOTPLT Handling**
- Add `NoInit` flag to prevent pre-initialization of ifunc GOTPLT entries
- Let runtime resolver fill the actual function addresses

Fixed #642 
Progress on #534 