### PR TITLE
Relax static assert in `ELFSection.h`

### DIFF
--- a/include/eld/Readers/ELFSection.h
+++ b/include/eld/Readers/ELFSection.h
@@ -338,7 +338,9 @@ protected:
   llvm::SmallVector<ELFSection *, 0> DependentSections;
 };
 
-static_assert(sizeof(ELFSection) <= 240, "ELFSection grew too large!");
+#ifndef _WIN32
+static_assert(sizeof(ELFSection) <= 248, "ELFSection grew too large!");
+#endif
 
 } // namespace eld
 


### PR DESCRIPTION
This patch disables the static assert in `include/eld/Readers/ELFSection.h` on windows.