### PR TITLE
Disable x86 LIT tests for windows that require virtualization

### DIFF
--- a/test/x86_64/linux/TlsGDnonpreemptible/TlsGDnonpreemptible.test
+++ b/test/x86_64/linux/TlsGDnonpreemptible/TlsGDnonpreemptible.test
@@ -1,4 +1,5 @@
 #------TlsGDnonpreemptible.test-------Executable------#
+#UNSUPPORTED: windows
 #BEGIN_COMMENT
 # Verifies TLS General Dynamic (GD) model with non-preemptible symbols.
 # When TLS variables are defined and used in the same shared library

--- a/test/x86_64/linux/TlsGDpreemptible/TlsGDpreemptible.test
+++ b/test/x86_64/linux/TlsGDpreemptible/TlsGDpreemptible.test
@@ -1,4 +1,5 @@
 #------TlsGDpreemptible.test-------Executable------#
+#UNSUPPORTED: windows
 #BEGIN_COMMENT
 # Verifies TLS General Dynamic (GD) model when a TLS variable is defined in one
 # shared library (lib3.so) and accessed from another shared library (lib2.so).

--- a/test/x86_64/linux/TlsIEModel/TlsIEModel.test
+++ b/test/x86_64/linux/TlsIEModel/TlsIEModel.test
@@ -1,4 +1,5 @@
 #------TlsIEModel.test-------Executable------#
+#UNSUPPORTED: windows
 #BEGIN_COMMENT
 # Verifies TLS Initial Exec (IE) model when a TLS variable is referenced in the
 # main executable and defined in a shared library. The linker should emit an


### PR DESCRIPTION
This patch temporarily disables some X86 tests on windows that require emulation support.