### PR TITLE
Add release artifact builder

### DIFF
--- a/.github/workflows/release-artifact-builder.yaml
+++ b/.github/workflows/release-artifact-builder.yaml
@@ -1,0 +1,45 @@
+name: Release builder
+on:
+  workflow_dispatch:     # Allows manual triggering
+  # pull_request hook must be removed once the PR looks good.
+  pull_request:
+    paths:
+      - ".github/workflows/release-artifact-builder.yaml"
+  push:
+    branches:
+      - main
+
+
+jobs:
+  release-toolchain:
+    runs-on: ubuntu-latest
+    env:
+      ELD_SOURCE_DIR: llvm-project/llvm/tools/eld
+    steps:
+      - name: Checkout eld
+        uses: actions/checkout@v4
+        with:
+          path: llvm-project/llvm/tools/eld
+
+      - uses: ./llvm-project/llvm/tools/eld/.github/workflows/FetchNightlyToolset
+
+      - name: Create tarball
+        run: |
+          BIN_DIR=$(dirname $(which ld.eld))
+          INSTALL_DIR=$(realpath ${BIN_DIR}/..)
+          VER="nightly"
+          branch=${{ github.base_ref || github.ref_name }}
+          if [[ ${branch} != release/* ]]; then
+            VER="${branch/\//-}"
+          fi
+          echo "VER=${VER}" >> $GITHUB_ENV
+          FILTERED_INSTALL_DIR=inst-filtered
+          llvm-project/llvm/tools/eld/.github/workflows/scripts/FilterELDInstall.sh ${INSTALL_DIR} ${FILTERED_INSTALL_DIR}
+          tar -cvf eld-${VER}-linux-x86_64.tar ${FILTERED_INSTALL_DIR}
+
+      - uses: ncipollo/release-action@v1
+        with:
+          artifacts: eld-*-linux-x86_64.tar
+          allowUpdates: true
+          tag: ${{ github.base_ref || github.ref_name }}
+          name: eld ${{ github.base_ref == 'main' && 'Nightly' || github.base_ref || github.ref_name }} Release

--- a/.github/workflows/scripts/FilterELDInstall.sh
+++ b/.github/workflows/scripts/FilterELDInstall.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+INSTALL_DIR="$1"
+FILTERED_INSTALL_DIR="$2"
+
+mkdir -p ${FILTERED_INSTALL_DIR}
+cd ${FILTERED_INSTALL_DIR}
+rm -rf *
+mkdir -p bin include lib tools/bin
+BIN_DIR=${INSTALL_DIR}/bin
+cp ${BIN_DIR}/ld.eld ${BIN_DIR}/hexagon-link ${BIN_DIR}/arm-link \
+  ${BIN_DIR}/aarch64-link ${BIN_DIR}/riscv-link ${BIN_DIR}/x86-link \
+  ${BIN_DIR}/hexagon-link bin
+cp ${INSTALL_DIR}/lib/libLW* lib
+cp -r ${INSTALL_DIR}/templates .
+cp -r ${INSTALL_DIR}/include/ELD .
+cp ${INSTALL_DIR}/tools/bin/YAMLMapParser.py tools/bin


### PR DESCRIPTION
This commit adds a release artifact builder. The builder trigger events are push to main, with manual dispatch, and any changes to the `.github/workflows/release-artifact-builder.yaml` in a PR. The last event must be removed once this PR is good to merge, and later on we should extend the builder trigger event to include release branches as well.

The release artifact tarball only contains the eld-relevant files. This is done by adding a bash script that creates a filtered toolchain.