### PR TITLE
[ELFSection] Move DependentSections to side table

### DIFF
--- a/include/eld/Input/ObjectFile.h
+++ b/include/eld/Input/ObjectFile.h
@@ -8,7 +8,9 @@
 #define ELD_INPUT_OBJECTFILE_H
 
 #include "eld/Input/InputFile.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/SmallVector.h"
 #include <optional>
 #include <unordered_map>
 #include <vector>
@@ -178,6 +180,10 @@ public:
     return ((Kind == ELF64LEKind) || (Kind == ELF64BEKind));
   }
 
+  void addDependentSection(const ELFSection *A, ELFSection *B);
+  const llvm::SmallVectorImpl<ELFSection *> &
+  getDependentSections(const ELFSection *S) const;
+
 protected:
   std::vector<Section *> MSectionTable;
   std::vector<LDSymbol *> SymTab;
@@ -202,6 +208,8 @@ private:
   std::vector<std::string> Features;
   std::unordered_map<std::pair<uint64_t, uint64_t>, LDSymbol *, HashPair>
       LocalSymbolInfoMap;
+  llvm::DenseMap<const ELFSection *, llvm::SmallVector<ELFSection *, 2>>
+      DependentSectionsMap;
 };
 
 } // namespace eld

--- a/include/eld/Readers/ELFSection.h
+++ b/include/eld/Readers/ELFSection.h
@@ -276,12 +276,6 @@ public:
   // Linker Script support for sorting sections.
   int getPriority() const;
 
-  void addDependentSection(ELFSection *S) { DependentSections.push_back(S); }
-
-  const llvm::SmallVectorImpl<ELFSection *> &getDependentSections() const {
-    return DependentSections;
-  }
-
   Fragment *getFirstFragmentInRule() const;
 
   std::string getDecoratedName(const GeneralOptions &options) const override;
@@ -328,11 +322,10 @@ protected:
 
   /// FIXME: These vectors can be moved out of this class?
   llvm::SmallVector<const ELFSection *, 0> GroupSections;
-  llvm::SmallVector<ELFSection *, 0> DependentSections;
 };
 
 #ifndef _WIN32
-static_assert(sizeof(ELFSection) <= 248, "ELFSection grew too large!");
+static_assert(sizeof(ELFSection) <= 232, "ELFSection grew too large!");
 #endif
 
 } // namespace eld

--- a/lib/Input/ObjectFile.cpp
+++ b/lib/Input/ObjectFile.cpp
@@ -75,3 +75,15 @@ const ResolveInfo *ObjectFile::getMatchingLocalSymbol(uint64_t SectionIndex,
     return nullptr;
   return Sym->resolveInfo();
 }
+
+void ObjectFile::addDependentSection(const ELFSection *A, ELFSection *B) {
+  DependentSectionsMap[A].push_back(B);
+}
+
+const llvm::SmallVectorImpl<ELFSection *> &
+ObjectFile::getDependentSections(const ELFSection *S) const {
+  if (DependentSectionsMap.contains(S))
+    return DependentSectionsMap.at(S);
+  static auto Empty = llvm::SmallVector<ELFSection *, 0>();
+  return Empty;
+}

--- a/lib/LinkerWrapper/PluginADT.cpp
+++ b/lib/LinkerWrapper/PluginADT.cpp
@@ -589,7 +589,10 @@ std::vector<plugin::Section> plugin::Section::getDependentSections() const {
   ELFSection *S = llvm::dyn_cast<ELFSection>(m_Section);
   if (!S)
     return DependentSections;
-  const llvm::SmallVectorImpl<ELFSection *> &D = S->getDependentSections();
+  auto *Obj = llvm::dyn_cast<ObjectFile>(S->getInputFile());
+  if (!Obj)
+    return DependentSections;
+  const llvm::SmallVectorImpl<ELFSection *> &D = Obj->getDependentSections(S);
   if (!D.size())
     return DependentSections;
   for (auto &Sec : D)

--- a/lib/Readers/ELFReader.cpp
+++ b/lib/Readers/ELFReader.cpp
@@ -151,7 +151,8 @@ template <class ELFT> bool ELFReader<ELFT>::setLinkInfoAttributes() {
       else
         S->setLink(EFileBase->getELFSection(rawSectHdr.sh_link));
       if (S->isLinkOrder())
-        EFileBase->getELFSection(rawSectHdr.sh_link)->addDependentSection(S);
+        EFileBase->addDependentSection(
+            EFileBase->getELFSection(rawSectHdr.sh_link), S);
     }
   }
   return true;


### PR DESCRIPTION
DependentSections was a per-section vector only
used via the pluginAPI. Move it to a ObjectFile 
owned Map so sections with no dependencies pay nothing.

Saves 16 bytes per section.