### PR TITLE
Add eld tablegen targets to LLVM_COMMON_DEPENDS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,14 @@ set(ENABLE_ELD_PLUGIN_SUPPORT
     CACHE BOOL ON FORCE)
 
 add_subdirectory(include)
+
+# After the driver option TableGen targets are created in include/eld/Driver,
+# append them to LLVM_COMMON_DEPENDS so all subsequent compilation targets
+# added via add_llvm_library/llvm_add_library/add_llvm_executable depend on
+# these TableGen outputs.
+get_property(_eld_driver_tg GLOBAL PROPERTY ELD_DRIVER_TABLEGEN_TARGETS)
+set(LLVM_COMMON_DEPENDS ${LLVM_COMMON_DEPENDS} ${_eld_driver_tg})
+
 add_subdirectory(lib)
 add_subdirectory(tools)
 add_subdirectory(docs)

--- a/include/eld/Driver/CMakeLists.txt
+++ b/include/eld/Driver/CMakeLists.txt
@@ -17,3 +17,14 @@ add_public_tablegen_target(RISCVDriverOptions)
 set(LLVM_TARGET_DEFINITIONS x86_64LinkerOptions.td)
 tablegen(LLVM x86_64LinkerOptions.inc -gen-opt-parser-defs)
 add_public_tablegen_target(x86_64DriverOptions)
+
+# Collect the driver TableGen targets in a global property so other
+# directories (e.g., the top-level CMakeLists) can make use of them.
+set(ELD_DRIVER_TABLEGEN_TARGETS
+    GnuDriverOptions
+    HexagonDriverOptions
+    ARMDriverOptions
+    RISCVDriverOptions
+    x86_64DriverOptions)
+set_property(GLOBAL PROPERTY ELD_DRIVER_TABLEGEN_TARGETS
+             "${ELD_DRIVER_TABLEGEN_TARGETS}")


### PR DESCRIPTION
This commit adds eld tablegen targets to LLVM_COMMON_DEPENDS. Adding them to LLVM_COMMON_DEPENDS make these targets a dependency of all the targets created using add_llvm_library / add_llvm_executable / ... functions. This change is required because the tablegen targets needs to be a dependency of all the compilation targets, otherwise we may see errors for missing <Target>LinkerOptions.h include files during compilation. These file are generated by tablegen.