### PR TITLE
Add `REQUIRES:yaml` to `eld/test/ARM/standalone/Strings/Strings.test`

### DIFF
--- a/test/ARM/standalone/Strings/Strings.test
+++ b/test/ARM/standalone/Strings/Strings.test
@@ -1,3 +1,4 @@
+REQUIRES: yaml
 #---Strings.test------------------------------------ Executable --------------------#
 #BEGIN_COMMENT
 # Check that the rodata is split properly in the Map file


### PR DESCRIPTION
This patch adds the `REQUIRES:yaml` directive to `eld/test/ARM/standalone/Strings/Strings.test`