### PR TITLE
Add `-debug-pass-manager` option for LTO

### DIFF
--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -1104,6 +1104,15 @@ defm plugin_opt_sample_profile
                         "Alias for -lto-sample-profile=">,
       Group<grp_ltooptions>;
 
+def lto_debug_pass_manager : FF<"lto-debug-pass-manager">,
+                             HelpText<"Debug new pass manager">,
+                             Group<grp_ltooptions>;
+
+def : F<"plugin-opt=debug-pass-manager">,
+      Alias<lto_debug_pass_manager>,
+      HelpText<"Alias for --lto-debug-pass-manager">,
+      Group<grp_ltooptions>;
+
 //===----------------------------------------------------------------------===//
 /// Linker speedup and control
 //===----------------------------------------------------------------------===//

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -1559,6 +1559,9 @@ bool GnuLdDriver::processLTOOptions(llvm::lto::Config &Conf,
   if (const auto *Arg = Args.getLastArg(OptTable::lto_sample_profile))
     Conf.SampleProfile = Arg->getValue();
 
+  if (Args.hasArg(OptTable::lto_debug_pass_manager))
+    Conf.DebugPassManager = true;
+
   if (const auto *Arg = Args.getLastArg(OptTable::lto_O)) {
     llvm::StringRef S = Arg->getValue();
     uint64_t Value;

--- a/test/lld/ELF/new-pass-manager.ll
+++ b/test/lld/ELF/new-pass-manager.ll
@@ -1,0 +1,15 @@
+; REQUIRES: x86
+; RUN: %llvm-as %s -o %t.o
+
+; Test debug-pass-manager option
+; RUN: %link %linkopts --plugin-opt=debug-pass-manager -o /dev/null %t.o 2>&1 | FileCheck %s
+; RUN: %link %linkopts --lto-debug-pass-manager -o /dev/null %t.o 2>&1 | FileCheck %s
+
+; CHECK: Running pass: GlobalOptPass
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @foo() {
+  ret void
+}


### PR DESCRIPTION
New options added:

--plugin-opt=debug-pass-manager and --lto-debug-pass-manager.

Fixes #661.