### PR TITLE
Temporarily disable `EmptyArchiveFile` test on windows.

### DIFF
--- a/test/Common/standalone/YAMLMapFile/EmptyArchiveFile/EmptyArchiveFile.test
+++ b/test/Common/standalone/YAMLMapFile/EmptyArchiveFile/EmptyArchiveFile.test
@@ -1,3 +1,4 @@
+#UNSUPPORTED: windows
 #---EmptyArchiveFile.test--------- Executable --------------------#
 #BEGIN_COMMENT
 # This test checks that the YAML map-file is correctly emitted when the link


### PR DESCRIPTION
This patch disables the `EmptyArchiveFile` test which fails on windows currently due to a bug in `llvm-ar`