### PR TITLE
Add initial support for creating executables that use symbol versioning

### DIFF
--- a/include/eld/Diagnostics/DiagSymbolVersioning.inc
+++ b/include/eld/Diagnostics/DiagSymbolVersioning.inc
@@ -22,3 +22,10 @@ DIAG(error_missing_version_node, DiagnosticEngine::Error,
      "%0: symbol %1 has undefined version %2")
 DIAG(trace_assign_output_version_ids, DiagnosticEngine::Trace,
      "Assigning version IDs to output symbols")
+DIAG(trace_adding_verneed_entry, DiagnosticEngine::Trace,
+     "Adding verneed entry: '%0' -> '%1'")
+DIAG(trace_reading_symbol_versioning_section, DiagnosticEngine::Trace,
+     "Reading %0[%1]")
+
+DIAG(trace_symbol_to_output_version_id, DiagnosticEngine::Trace,
+     "Symbol '%0' -> version id %1")

--- a/include/eld/Fragment/Fragment.h
+++ b/include/eld/Fragment/Fragment.h
@@ -54,6 +54,7 @@ public:
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
     GNUVerDef,
     GNUVerSym,
+    GNUVerNeed
 #endif
   };
 

--- a/include/eld/Fragment/GNUVerNeedFragment.h
+++ b/include/eld/Fragment/GNUVerNeedFragment.h
@@ -1,0 +1,72 @@
+//===- GNUVerNeedFragment.h----------------------------------------------------===//
+// Part of the eld Project, under the BSD License
+// See https://github.com/qualcomm/eld/LICENSE.txt for license information.
+// SPDX-License-Identifier: BSD-3-Clause
+//===--------------------------------------------------------------------------===//
+//
+//                     The MCLinker Project
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===--------------------------------------------------------------------------===//
+
+#ifndef ELD_FRAGMENT_GNUVERNEEDFRAGMENT_H
+#define ELD_FRAGMENT_GNUVERNEEDFRAGMENT_H
+
+#include "eld/Fragment/Fragment.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace eld {
+class DiagnosticEngine;
+class ELFSection;
+class InputFile;
+class ELFFileFormat;
+
+/** \class VerNeedFragment
+ *  \brief VerNeedFragment is a kind of Fragment containing input memory region
+ */
+// Region fragment expression
+class GNUVerNeedFragment : public Fragment {
+public:
+  GNUVerNeedFragment(ELFSection *S);
+
+  static bool classof(const Fragment *F) {
+    return F->getKind() == Fragment::Type::GNUVerNeed;
+  }
+
+  template <class ELFT>
+  eld::Expected<void>
+  computeVersionNeeds(const std::vector<InputFile *> &DynamicObjectFiles,
+                      ELFFileFormat *FileFormat, DiagnosticEngine &DE);
+
+  eld::Expected<void> emit(MemoryRegion &Mr, Module &M) override;
+
+  size_t size() const override;
+
+  size_t getNeedCount() { return VersionNeeds.size(); }
+
+private:
+  template <class ELFT> eld::Expected<void> emitImpl(uint8_t *Buf, Module &M);
+
+public:
+  struct VernAuxInfo {
+    uint32_t VersionNameOffset = 0;
+    uint32_t VersionID = 0;
+    uint32_t VersionNameHash = 0;
+  };
+
+  struct VerNeedInfo {
+    uint32_t SONameOffset = 0;
+    std::vector<VernAuxInfo> Vernauxs;
+  };
+
+protected:
+  std::vector<VerNeedInfo> VersionNeeds;
+  size_t VerNeedEntrySize = 0;
+  size_t VernAuxEntrySize = 0;
+};
+
+} // namespace eld
+
+#endif

--- a/include/eld/Input/ELFDynObjectFile.h
+++ b/include/eld/Input/ELFDynObjectFile.h
@@ -35,8 +35,130 @@ public:
 
   std::string getFallbackSOName() const;
 
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  void setVerDefSection(ELFSection *S) { VerDefSection = S; }
+
+  ELFSection *getVerDefSection() const { return VerDefSection; }
+
+  void setVerNeedSection(ELFSection *S) { VerNeedSection = S; }
+
+  ELFSection *getVerNeedSection() const { return VerNeedSection; }
+
+  void setVerSymSection(ELFSection *S) { VerSymSection = S; }
+
+  ELFSection *getVerSymSection() const { return VerSymSection; }
+
+  // Cache parsed Verdef entries indexed by vd_ndx.
+  void setVerDefs(std::vector<const void *> VDefs) { VerDefs = VDefs; }
+
+  // Verdef table indexed by version index (vd_ndx).
+  const std::vector<const void *> &getVerDefs() const { return VerDefs; }
+
+  // Cache parsed Vernaux name offsets for needed versions indexed by vna_other.
+  void setVerNeeds(std::vector<uint32_t> VNeeds) { VerNeeds = VNeeds; }
+
+  // Verneed name offsets indexed by version index (vna_other & VERSYM_VERSION).
+  const std::vector<uint32_t> &getVerNeeds() const { return VerNeeds; }
+
+  // Cache parsed versym entries (vs_index) from the input DSO.
+  void setVerSyms(std::vector<uint16_t> VSyms) { VerSyms = VSyms; }
+
+  // Raw versym entries (vs_index) indexed by dynsym index.
+  const std::vector<uint16_t> &getVerSyms() const { return VerSyms; }
+
+  // Record the input DSO's .dynstr section used by verdef/verneed names.
+  void setDynStrTabSection(ELFSection *S) { DynStrTabSection = S; }
+
+  // Returns the contents of the input DSO's .dynstr (empty if missing).
+  llvm::StringRef getDynStringTable() const;
+
+  template <class ELFT>
+  // Returns the version name associated with a dynsym entry.
+  // For VER_NDX_LOCAL/VER_NDX_GLOBAL this returns an empty StringRef.
+  llvm::StringRef getSymbolVersionName(uint32_t SymIdx,
+                                       ResolveInfo::Desc SymDesc) const {
+    uint16_t SymVerID = getSymbolVersionID(SymIdx);
+    llvm::StringRef VerName;
+    if (SymVerID == llvm::ELF::VER_NDX_LOCAL ||
+        SymVerID == llvm::ELF::VER_NDX_GLOBAL)
+      return VerName;
+    if (SymDesc == ResolveInfo::Desc::Undefined)
+      VerName = getDynStringTable().data() + VerNeeds[SymVerID];
+    else {
+      auto VerNameOffset =
+          reinterpret_cast<const typename ELFT::Verdef *>(VerDefs[SymVerID])
+              ->getAux()
+              ->vda_name;
+      VerName = getDynStringTable().data() + VerNameOffset;
+    }
+    return VerName;
+  }
+
+  // Returns the version index for a dynsym entry (clears VERSYM_HIDDEN).
+  uint16_t getSymbolVersionID(uint32_t SymIdx) const {
+    assert(SymIdx < VerSyms.size() && "Invalid SymIdx");
+    return VerSyms[SymIdx] & llvm::ELF::VERSYM_VERSION;
+  }
+
+  // Returns true if the versym entry is not hidden (default version).
+  bool isDefaultVersionedSymbol(uint32_t SymIdx) const {
+    assert(SymIdx < VerSyms.size() && "Invalid SymIdx");
+    return VerSyms[SymIdx] == getSymbolVersionID(SymIdx);
+  }
+
+  // Returns the output verneed index for an input version index.
+  // The value of 0 means unassigned index.
+  uint16_t getOutputVernAuxID(uint16_t InputVersionID) {
+    if (InputVersionID >= OutputVernAuxIDMap.size())
+      OutputVernAuxIDMap.resize(InputVersionID + 1, 0);
+    return OutputVernAuxIDMap[InputVersionID];
+  }
+
+  // Assign an output verneed index for an input version index.
+  void setOutputVernAuxID(uint16_t InputVersionID, uint16_t OutputVersionID) {
+    if (InputVersionID >= OutputVernAuxIDMap.size())
+      OutputVernAuxIDMap.resize(InputVersionID + 1, 0);
+    OutputVernAuxIDMap[InputVersionID] = OutputVersionID;
+  }
+
+  // Returns the entire input->output version-id map for this DSO.
+  const std::vector<uint16_t> &getOutputVernAuxIDMap() const {
+    return OutputVernAuxIDMap;
+  }
+
+  // Returns a pointer to the parsed Verdef entry for an input version index.
+  const void *getVerDef(uint16_t InputVersionID) const {
+    assert(InputVersionID < VerDefs.size() && "Invalid InputVersionID");
+    return VerDefs[InputVersionID];
+  }
+
+  bool hasSymbolVersioningInfo() const { return VerSymSection != nullptr; }
+
+  // Record non-canonical symbols. For example, foo for `foo@@V1`.
+  void addNonCanonicalSymbol(LDSymbol *Sym) {
+    NonCanonicalSymbols.push_back(Sym);
+  }
+
+  // Returns the set of recorded non-canonical alias symbols
+  const std::vector<LDSymbol *> &getNonCanonicalSymbols() const {
+    return NonCanonicalSymbols;
+  }
+#endif
+
 private:
   std::vector<ELFSection *> Sections;
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  ELFSection *VerDefSection = nullptr;
+  ELFSection *VerNeedSection = nullptr;
+  ELFSection *VerSymSection = nullptr;
+  ELFSection *DynStrTabSection = nullptr;
+  std::vector<const void *> VerDefs;
+  std::vector<uint32_t> VerNeeds;
+  std::vector<uint16_t> VerSyms;
+  /// It stores the output version ID for input version IDs.
+  std::vector<uint16_t> OutputVernAuxIDMap;
+  std::vector<LDSymbol *> NonCanonicalSymbols;
+#endif
 };
 
 } // namespace eld

--- a/include/eld/Input/ELFFileBase.h
+++ b/include/eld/Input/ELFFileBase.h
@@ -46,6 +46,10 @@ public:
 
   ELFSection *getStringTable() const { return StringTable; }
 
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  llvm::StringRef getStringTableData() const;
+#endif
+
   /// ------------ Extended Symbol Table ---------------------------------------
   void setExtendedSymbolTable(ELFSection *SymTab) {
     ExtendedSymbolTable = SymTab;

--- a/include/eld/Readers/DynamicELFReader.h
+++ b/include/eld/Readers/DynamicELFReader.h
@@ -53,9 +53,23 @@ public:
   eld::Expected<ELFSection *>
   createSection(typename ELFReader<ELFT>::Elf_Shdr rawSectHdr) override;
 
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  void
+  setSectionInInputFile(ELFSection *S,
+                        typename ELFReader<ELFT>::Elf_Shdr rawSectHdr) override;
+
+  eld::Expected<void> readSections() override;
+#endif
+
 protected:
   explicit DynamicELFReader(Module &module, InputFile &inputFile,
                             plugin::DiagnosticEntry &diagEntry);
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+private:
+  eld::Expected<void> readVerDefSection();
+  eld::Expected<void> readVerSymSection();
+  eld::Expected<void> readVerNeedSection();
+#endif
 };
 } // namespace eld
 #endif

--- a/include/eld/Readers/ELFReader.h
+++ b/include/eld/Readers/ELFReader.h
@@ -147,7 +147,7 @@ protected:
   /// - SHT_SYMTAB
   /// - SHT_SYMTAB_SHNDX
   /// - SHT_STRTAB
-  void setSectionInInputFile(ELFSection *S, Elf_Shdr rawSectHdr);
+  virtual void setSectionInInputFile(ELFSection *S, Elf_Shdr rawSectHdr);
 
   /// Set link and info attributes to the sections.
   bool setLinkInfoAttributes();

--- a/include/eld/Readers/ELFReaderBase.h
+++ b/include/eld/Readers/ELFReaderBase.h
@@ -109,6 +109,10 @@ public:
 
   virtual eld::Expected<bool> readRelocationSection(ELFSection *RS);
 
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  virtual eld::Expected<void> readSections();
+#endif
+
   /// Returns the symbol type.
   static ResolveInfo::Type getSymbolType(uint8_t info, uint32_t shndx);
 

--- a/include/eld/SymbolResolver/IRBuilder.h
+++ b/include/eld/SymbolResolver/IRBuilder.h
@@ -96,6 +96,16 @@ public:
                                Relocation::Type Type, LDSymbol &PSym,
                                uint32_t POffset, Relocation::Address CurAddend);
 
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  /// Normalize versioned symbol aliases.
+  ///
+  /// When both a canonical (version-suffixed) and a non-canonical (bare-name)
+  /// alias resolve to output symbols, prefer the canonical one, merge relevant
+  /// attributes (e.g. exportToDyn), and rewrite references to use the canonical
+  /// ResolveInfo.
+  void normalizeSymbols();
+#endif
+
 private:
   LDSymbol *
   addSymbolFromObject(InputFile &Input, const std::string &SymbolName,
@@ -111,7 +121,8 @@ private:
                                 ResolveInfo::SizeType Size,
                                 LDSymbol::ValueType Value,
                                 ResolveInfo::Visibility Visibility,
-                                uint32_t Shndx, bool IsPostLtoPhase);
+                                uint32_t Shndx, bool IsPostLtoPhase,
+                                uint32_t SymIdx);
 
 public:
   void addToCref(InputFile &Input, Resolver::Result PResult);
@@ -126,6 +137,12 @@ private:
   LinkerConfig &ThisConfig;
   bool IsGarbageCollected;
   InputBuilder ThisInputBuilder;
+
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  // 0th element -> Canonical version symbol, 1st element -> Non-canonical
+  // version symbol.
+  std::vector<std::pair<LDSymbol *, LDSymbol *>> VersionedSymbols;
+#endif
 };
 
 template <>

--- a/include/eld/SymbolResolver/ResolveInfo.h
+++ b/include/eld/SymbolResolver/ResolveInfo.h
@@ -254,6 +254,10 @@ public:
 
   llvm::StringRef getName() const { return SymbolName; }
 
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  void setName(llvm::StringRef SymName) { SymbolName = SymName; }
+#endif
+
   unsigned int nameSize() const { return SymbolName.size(); }
 
   uint32_t info() const { return (ThisBitField & InfoMask); }

--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -56,6 +56,7 @@ class ELFObjectFileFormat;
 class ELFSegmentFactory;
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
 class GNUVerDefFragment;
+class GNUVerNeedFragment;
 #endif
 class TargetInfo;
 class Layout;
@@ -868,6 +869,8 @@ public:
   ELFSection *getGNUVerSymSection() const { return GNUVerSymSection; }
   ELFSection *getGNUVerDefSection() const { return GNUVerDefSection; }
   GNUVerDefFragment *getGNUVerDefFragment() const { return GNUVerDefFrag; }
+  ELFSection *getGNUVerNeedSection() const { return GNUVerNeedSection; }
+  GNUVerNeedFragment *getGNUVerNeedFragment() const { return GNUVerNeedFrag; }
   void setShouldEmitVersioningSections(bool Should) {
     ShouldEmitVersioningSections = Should;
   }
@@ -1206,6 +1209,8 @@ protected:
   ELFSection *GNUVerSymSection = nullptr;
   ELFSection *GNUVerDefSection = nullptr;
   GNUVerDefFragment *GNUVerDefFrag = nullptr;
+  ELFSection *GNUVerNeedSection = nullptr;
+  GNUVerNeedFragment *GNUVerNeedFrag = nullptr;
   std::unordered_map<const ResolveInfo *, uint16_t> OutputVersionIDs;
 #endif
 };

--- a/lib/Core/Linker.cpp
+++ b/lib/Core/Linker.cpp
@@ -425,6 +425,9 @@ bool Linker::normalize() {
     if (!ObjLinker->normalize())
       return false;
   }
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  IR->normalizeSymbols();
+#endif
   return true;
 }
 

--- a/lib/Fragment/CMakeLists.txt
+++ b/lib/Fragment/CMakeLists.txt
@@ -25,7 +25,8 @@ llvm_add_library(
   PARTIAL_SOURCES_INTENDED)
 
 if (ELD_ENABLE_SYMBOL_VERSIONING)
-  target_sources(ELDFragment PRIVATE GNUVerDefFragment.cpp GNUVerSymFragment.cpp)
+  target_sources(ELDFragment PRIVATE GNUVerDefFragment.cpp GNUVerNeedFragment.cpp
+                  GNUVerSymFragment.cpp)
 endif()
 
 target_link_libraries(ELDFragment PRIVATE ELDSymbolResolver)

--- a/lib/Fragment/GNUVerNeedFragment.cpp
+++ b/lib/Fragment/GNUVerNeedFragment.cpp
@@ -1,0 +1,116 @@
+//===- GNUVerNeedFragment.cpp---------------------------------------------------===//
+// Part of the eld Project, under the BSD License
+// See https://github.com/qualcomm/eld/LICENSE.txt for license information.
+// SPDX-License-Identifier: BSD-3-Clause
+//===---------------------------------------------------------------------------===//
+//
+//                     The MCLinker Project
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===---------------------------------------------------------------------------===//
+#include "eld/Fragment/GNUVerNeedFragment.h"
+#include "eld/Core/Module.h"
+#include "eld/Diagnostics/DiagnosticEngine.h"
+#include "eld/Input/ELFDynObjectFile.h"
+#include "eld/Input/InputFile.h"
+#include "eld/Target/ELFFileFormat.h"
+#include "llvm/Object/ELF.h"
+#include <cstdint>
+
+using namespace eld;
+
+GNUVerNeedFragment::GNUVerNeedFragment(ELFSection *S)
+    : Fragment(Fragment::Type::GNUVerNeed, S) {}
+
+template <class ELFT>
+eld::Expected<void> GNUVerNeedFragment::computeVersionNeeds(
+    const std::vector<InputFile *> &DynamicObjectFiles,
+    ELFFileFormat *FileFormat, DiagnosticEngine &DE) {
+  VerNeedEntrySize = sizeof(typename ELFT::Verneed);
+  VernAuxEntrySize = sizeof(typename ELFT::Vernaux);
+  bool traceSV = DE.getPrinter()->traceSymbolVersioning();
+  for (auto *IF : DynamicObjectFiles) {
+    auto *DynObjFile = llvm::cast<ELFDynObjectFile>(IF);
+    const auto &VernAuxIDMap = DynObjFile->getOutputVernAuxIDMap();
+    VerNeedInfo VNI;
+    VNI.SONameOffset =
+        FileFormat->addStringToDynStrTab(DynObjFile->getSOName());
+    for (std::size_t i = 0; i < VernAuxIDMap.size(); ++i) {
+      if (VernAuxIDMap[i] == 0)
+        continue;
+      auto *verdef = reinterpret_cast<const typename ELFT::Verdef *>(
+          DynObjFile->getVerDef(i));
+      llvm::StringRef VerName = DynObjFile->getDynStringTable().data() +
+                                static_cast<size_t>(verdef->getAux()->vda_name);
+      VernAuxInfo AuxInfo = {
+          static_cast<uint32_t>(
+              FileFormat->addStringToDynStrTab(VerName.str())),
+          VernAuxIDMap[i], verdef->vd_hash};
+      if (traceSV)
+        DE.raise(Diag::trace_adding_verneed_entry)
+            << VernAuxIDMap[i] << VerName.str();
+      VNI.Vernauxs.push_back(AuxInfo);
+    }
+    if (!VNI.Vernauxs.empty())
+      VersionNeeds.push_back(VNI);
+  }
+  return {};
+}
+
+size_t GNUVerNeedFragment::size() const {
+  size_t VerNeedSize = VersionNeeds.size() * VerNeedEntrySize;
+  size_t VernAuxSize = 0;
+  for (const auto &VNI : VersionNeeds) {
+    VernAuxSize += VNI.Vernauxs.size() * VernAuxEntrySize;
+  }
+  return VerNeedSize + VernAuxSize;
+}
+
+eld::Expected<void> GNUVerNeedFragment::emit(MemoryRegion &Mr, Module &M) {
+  uint8_t *Buf = Mr.begin() + getOffset(M.getConfig().getDiagEngine());
+  bool Is32Bits = M.getConfig().targets().is32Bits();
+  if (Is32Bits) {
+    return emitImpl<llvm::object::ELF32LE>(Buf, M);
+  } else {
+    return emitImpl<llvm::object::ELF64LE>(Buf, M);
+  }
+  return {};
+}
+
+template <class ELFT>
+eld::Expected<void> GNUVerNeedFragment::emitImpl(uint8_t *Buf, Module &M) {
+  auto *VerNeedBuf = reinterpret_cast<typename ELFT::Verneed *>(Buf);
+  auto *VernAuxBuf = reinterpret_cast<typename ELFT::Vernaux *>(
+      VerNeedBuf + VersionNeeds.size());
+  for (const auto &VN : VersionNeeds) {
+    VerNeedBuf->vn_version = 1;
+    VerNeedBuf->vn_cnt = VN.Vernauxs.size();
+    VerNeedBuf->vn_file = VN.SONameOffset;
+    VerNeedBuf->vn_aux = reinterpret_cast<const char *>(VernAuxBuf) -
+                         reinterpret_cast<const char *>(VerNeedBuf);
+    VerNeedBuf->vn_next = sizeof(typename ELFT::Verneed);
+    ++VerNeedBuf;
+    for (const auto &VA : VN.Vernauxs) {
+      VernAuxBuf->vna_hash = VA.VersionNameHash;
+      VernAuxBuf->vna_flags = 0;
+      VernAuxBuf->vna_other = VA.VersionID;
+      VernAuxBuf->vna_name = VA.VersionNameOffset;
+      VernAuxBuf->vna_next = sizeof(typename ELFT::Vernaux);
+      ++VernAuxBuf;
+    }
+    VernAuxBuf[-1].vna_next = 0;
+  }
+  VerNeedBuf[-1].vn_next = 0;
+  return {};
+}
+
+template eld::Expected<void>
+GNUVerNeedFragment::computeVersionNeeds<llvm::object::ELF32LE>(
+    const std::vector<InputFile *> &DynamicObjectFiles,
+    ELFFileFormat *FileFormat, DiagnosticEngine &DE);
+template eld::Expected<void>
+GNUVerNeedFragment::computeVersionNeeds<llvm::object::ELF64LE>(
+    const std::vector<InputFile *> &DynamicObjectFiles,
+    ELFFileFormat *FileFormat, DiagnosticEngine &DE);

--- a/lib/Input/ELFDynObjectFile.cpp
+++ b/lib/Input/ELFDynObjectFile.cpp
@@ -6,6 +6,9 @@
 
 #include "eld/Input/ELFDynObjectFile.h"
 #include "eld/Support/Memory.h"
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+#include "eld/Readers/ELFSection.h"
+#endif
 
 using namespace eld;
 
@@ -30,3 +33,11 @@ std::string ELFDynObjectFile::getFallbackSOName() const {
     return filename.substr(1);
   return I->getResolvedPath().filename().native();
 }
+
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+llvm::StringRef ELFDynObjectFile::getDynStringTable() const {
+  if (DynStrTabSection)
+    return DynStrTabSection->getContents();
+  return llvm::StringRef();
+}
+#endif

--- a/lib/Input/ELFFileBase.cpp
+++ b/lib/Input/ELFFileBase.cpp
@@ -22,3 +22,11 @@ void ELFFileBase::addSection(ELFSection *S) {
   S->setIndex(MSectionTable.size());
   ObjectFile::addSection(S);
 }
+
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+llvm::StringRef ELFFileBase::getStringTableData() const {
+  if (StringTable)
+    return StringTable->getContents();
+  return llvm::StringRef();
+}
+#endif

--- a/lib/Input/Input.cpp
+++ b/lib/Input/Input.cpp
@@ -100,7 +100,6 @@ bool Input::resolvePath(const LinkerConfig &PConfig) {
     ResolvedPath = eld::sys::fs::Path(FileName);
     return true;
   }
-
   if (Type == Input::Script) {
     if (shouldPrependSysrootToScriptInput(PConfig)) {
       ResolvedPath = PSearchDirs.sysroot();

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -1605,6 +1605,10 @@ bool ObjectLinker::addSymbolToOutput(const ResolveInfo &PInfo) const {
       ThisModule->hasWrapReference(PInfo.name()) && ResolvedOrigin->isBitcode())
     return false;
 
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  if (PInfo.isDyn() && PInfo.outSymbol() && PInfo.outSymbol()->shouldIgnore())
+    return false;
+#endif
   // Let the backend choose to add the symbol to the output.
   if (!getTargetBackend().addSymbolToOutput(const_cast<ResolveInfo *>(&PInfo)))
     return false;
@@ -3395,6 +3399,7 @@ bool ObjectLinker::insertPostLTOELF() {
       if (!BitcodeObject) {
         BitcodeObject = (*Obj);
         BitcodeObj = Obj;
+        // FIXME: break can be added here!
       }
     }
   }
@@ -3761,6 +3766,11 @@ bool ObjectLinker::readAndProcessInput(Input *Input, bool IsPostLto) {
         ThisConfig.raiseDiagEntry(std::move(ExpRead.error()));
       return false;
     }
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+    ELFDynObjectFile *DynObjFile = llvm::cast<ELFDynObjectFile>(CurInput);
+    if (DynObjFile->hasSymbolVersioningInfo())
+      getTargetBackend().setShouldEmitVersioningSections(true);
+#endif
     ThisModule->getDynLibraryList().push_back(CurInput);
   } else if (CurInput->getKind() == InputFile::GNUArchiveFileKind) {
     eld::RegisterTimer T("Read Archive Files", "Read all Input files",

--- a/lib/Readers/ELFDynObjParser.cpp
+++ b/lib/Readers/ELFDynObjParser.cpp
@@ -50,6 +50,12 @@ eld::Expected<bool> ELFDynObjParser::parseFile(InputFile &inputFile) {
   eld::Expected<bool> expReadHeaders = readSectionHeaders(*ELFReader);
   if (!expReadHeaders.has_value() || !expReadHeaders.value())
     return expReadHeaders;
+
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  eld::Expected<void> expReadSections = ELFReader->readSections();
+  ELDEXP_RETURN_DIAGENTRY_IF_ERROR(expReadSections);
+#endif
+
   eld::Expected<bool> expReadSymbols = readSymbols(*ELFReader);
   if (!expReadSymbols || !expReadSymbols.value())
     return expReadSymbols;

--- a/lib/Readers/ELFReaderBase.cpp
+++ b/lib/Readers/ELFReaderBase.cpp
@@ -232,3 +232,10 @@ ELFReaderBase::inspectELFKind(const InputFile &I) {
   return (endian == llvm::ELF::ELFDATA2LSB) ? ObjectFile::ELFKind::ELF64LEKind
                                             : ObjectFile::ELFKind::ELF64BEKind;
 }
+
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+// FIXME: Move ELFRelocObjParser::readSections to RelocELFReader::readSections
+eld::Expected<void> ELFReaderBase::readSections() {
+  ASSERT(0, "readSections must only be called for shared object files.");
+}
+#endif

--- a/lib/SymbolResolver/IRBuilder.cpp
+++ b/lib/SymbolResolver/IRBuilder.cpp
@@ -22,6 +22,7 @@
 #include "eld/Input/ELFDynObjectFile.h"
 #include "eld/Input/ELFFileBase.h"
 #include "eld/Input/ELFObjectFile.h"
+#include "eld/Input/ObjectFile.h"
 #include "eld/Object/ObjectBuilder.h"
 #include "eld/Support/Memory.h"
 #include "eld/Support/MemoryArea.h"
@@ -29,12 +30,15 @@
 #include "eld/Support/RegisterTimer.h"
 #include "eld/SymbolResolver/LDSymbol.h"
 #include "eld/SymbolResolver/NamePool.h"
+#include "eld/SymbolResolver/ResolveInfo.h"
 #include "eld/SymbolResolver/SymbolInfo.h"
 #include "eld/SymbolResolver/SymbolResolutionInfo.h"
 #include "eld/Target/Relocator.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Object/ELF.h"
+#include "llvm/Support/StringSaver.h"
 #include <unordered_map>
 
 using namespace eld;
@@ -214,7 +218,7 @@ LDSymbol *IRBuilder::addSymbol(InputFile &Input, const std::string &SymbolName,
 
       LDSymbol *InputSym =
           addSymbolFromDynObj(Input, Name, Type, Desc, Binding, Size, Value,
-                              Vis, Shndx, IsPostLtoPhase);
+                              Vis, Shndx, IsPostLtoPhase, Idx);
       if (InputSym)
         llvm::cast<ELFDynObjectFile>(&Input)->addSymbol(InputSym);
       return InputSym;
@@ -310,7 +314,8 @@ LDSymbol *IRBuilder::addSymbolFromDynObj(
     InputFile &Input, const std::string &SymbolName, ResolveInfo::Type Type,
     ResolveInfo::Desc Desc, ResolveInfo::Binding Binding,
     ResolveInfo::SizeType Size, LDSymbol::ValueType Value,
-    ResolveInfo::Visibility Visibility, uint32_t Shndx, bool IsPostLtoPhase) {
+    ResolveInfo::Visibility Visibility, uint32_t Shndx, bool IsPostLtoPhase,
+    uint32_t SymIdx) {
   // We don't need sections of dynamic objects. So we ignore section symbols.
   if (Type == ResolveInfo::Section)
     return nullptr;
@@ -323,19 +328,6 @@ LDSymbol *IRBuilder::addSymbolFromDynObj(
 
   eld::RegisterTimer T("Create && Resolve dynamic symbols", "Symbol Resolution",
                        ThisConfig.options().printTimingStats());
-  // create an input LDSymbol.
-  LDSymbol *InputSym = makeLDSymbol(nullptr);
-  InputSym->setFragmentRef(FragmentRef::null());
-  InputSym->setSectionIndex(Shndx);
-
-  SymbolInfo SymInfo(&Input, Size, Binding, Type, Visibility, Desc,
-                     /*isBitcode=*/false);
-
-  if (ThisModule.getLayoutInfo() &&
-      ThisModule.getLayoutInfo()->showSymbolResolution())
-    ThisModule.getNamePool().getSRI().recordSymbolInfo(InputSym, SymInfo);
-  // insert symbol and resolve it immediately
-  Resolver::Result ResolvedResult = {nullptr, false, false};
   NamePool &NP = ThisModule.getNamePool();
 
   // Get the old symbol before resolution to check if it's from an object file
@@ -348,53 +340,110 @@ LDSymbol *IRBuilder::addSymbolFromDynObj(
       SymbolName, Input, /*isDyn=*/true, Type, Desc, Binding, Size, Visibility,
       Value, /*isPatchable=*/false);
 
-  auto &PM = ThisModule.getPluginManager();
-  DiagnosticPrinter *DP = ThisConfig.getPrinter();
-  auto OldErrorCount = DP->getNumErrors() + DP->getNumFatalErrors();
-  PM.callVisitSymbolHook(InputSym, InputSymbolResolveInfo.getName(), SymInfo);
-  auto NewErrorCount = DP->getNumErrors() + DP->getNumFatalErrors();
-  if (NewErrorCount != OldErrorCount)
-    return nullptr;
-  // Resolve symbol
-  bool S = NP.insertNonLocalSymbol(InputSymbolResolveInfo, *InputSym,
-                                   IsPostLtoPhase, ResolvedResult);
-  if (!S)
-    return nullptr;
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  ELFDynObjectFile *DynObjFile = llvm::cast<ELFDynObjectFile>(&Input);
+  bool IsDefaultVersionedSymbol = false;
+  std::optional<std::string> OptVersionedName;
+  if (DynObjFile->hasSymbolVersioningInfo()) {
+    llvm::StringRef VerName =
+        (ThisConfig.targets().is32Bits()
+             ? DynObjFile->getSymbolVersionName<llvm::object::ELF32LE>(SymIdx,
+                                                                       Desc)
+             : DynObjFile->getSymbolVersionName<llvm::object::ELF64LE>(SymIdx,
+                                                                       Desc));
+    // Version name is empty for the VER_NDX_GLOBAL and VER_NDX_LOCAL versions.
+    if (!VerName.empty())
+      OptVersionedName = SymbolName + "@" + VerName.str();
 
-  // the return ResolveInfo should not nullptr
-  assert(nullptr != ResolvedResult.Info);
-  if (ThisConfig.options().cref() || ThisConfig.options().buildCRef())
-    addToCref(Input, ResolvedResult);
+    IsDefaultVersionedSymbol = DynObjFile->isDefaultVersionedSymbol(SymIdx);
+  }
+#endif
+  SymbolInfo SymInfo(&Input, Size, Binding, Type, Visibility, Desc,
+                     /*isBitcode=*/false);
+  auto AddSymbol = [&Input, IsPostLtoPhase, &NP, Shndx, SymIdx, SymInfo, this,
+                    Value, oldOrigin](ResolveInfo RI) -> LDSymbol * {
+    // insert symbol and resolve it immediately
+    // create an input LDSymbol.
+    LDSymbol *InputSym = makeLDSymbol(nullptr);
+    InputSym->setFragmentRef(FragmentRef::null());
+    InputSym->setSectionIndex(Shndx);
+    InputSym->setSymbolIndex(SymIdx);
 
-  InputSym->setResolveInfo(*(ResolvedResult.Info));
+    if (ThisModule.getLayoutInfo() &&
+        ThisModule.getLayoutInfo()->showSymbolResolution())
+      ThisModule.getNamePool().getSRI().recordSymbolInfo(InputSym, SymInfo);
 
-  if (ResolvedResult.Overriden || !ResolvedResult.Existent) {
-    ResolvedResult.Info->setValue(Value, false);
-    Input.setNeeded();
-    // Mark this library as needed if the symbol resolver selected the current
-    // symbol and the old symbol is not from a shared library or from a needed
-    // shared library
-    if (ResolvedResult.Overriden && oldOrigin) {
-      ELFFileBase *oldOriginELFBase = llvm::dyn_cast<ELFFileBase>(oldOrigin);
-      if (!oldOrigin->isDynamicLibrary() ||
-          (oldOriginELFBase && oldOriginELFBase->isELFNeeded()))
-        Input.setUsed(true);
+    Resolver::Result ResolvedResult = {nullptr, false, false};
+    auto &PM = ThisModule.getPluginManager();
+    DiagnosticPrinter *DP = ThisConfig.getPrinter();
+    auto OldErrorCount = DP->getNumErrors() + DP->getNumFatalErrors();
+    PM.callVisitSymbolHook(InputSym, RI.getName(), SymInfo);
+    auto NewErrorCount = DP->getNumErrors() + DP->getNumFatalErrors();
+    if (NewErrorCount != OldErrorCount)
+      return nullptr;
+    bool S =
+        NP.insertNonLocalSymbol(RI, *InputSym, IsPostLtoPhase, ResolvedResult);
+    // Resolve symbol
+    if (!S)
+      return nullptr;
+    // the return ResolveInfo should not nullptr
+    assert(nullptr != ResolvedResult.Info);
+    if (ThisConfig.options().cref() || ThisConfig.options().buildCRef())
+      addToCref(Input, ResolvedResult);
+
+    InputSym->setResolveInfo(*(ResolvedResult.Info));
+    if (ResolvedResult.Overriden || !ResolvedResult.Existent) {
+      ResolvedResult.Info->setValue(Value, false);
+      Input.setNeeded();
+      // Mark this library as needed if the symbol resolver selected the current
+      // symbol and the old symbol is not from a shared library or from a needed
+      // shared library
+      if (ResolvedResult.Overriden && oldOrigin) {
+        ELFFileBase *oldOriginELFBase = llvm::dyn_cast<ELFFileBase>(oldOrigin);
+        if (!oldOrigin->isDynamicLibrary() ||
+            (oldOriginELFBase && oldOriginELFBase->isELFNeeded()))
+          Input.setUsed(true);
+      }
+      NP.addSharedLibSymbol(InputSym);
     }
-    NP.addSharedLibSymbol(InputSym);
+    if (ResolvedResult.Overriden && ResolvedResult.Info->outSymbol()) {
+      ResolvedResult.Info->setOutSymbol(InputSym);
+    }
+    // If the symbol is from dynamic library and we are not making a dynamic
+    // library, we either need to export the symbol by dynamic list or sometimes
+    // we export it since the dynamic library may be referring it defined in
+    // executable, either case it must be in .dynsym
+    ResolveInfo *InputSymRI = InputSym->resolveInfo();
+    LDSymbol *OutSym = InputSymRI->outSymbol();
+    if (ThisConfig.codeGenType() != LinkerConfig::DynObj &&
+        ((OutSym && OutSym->hasFragRef()) || InputSymRI->isCommon()))
+      InputSymRI->setExportToDyn();
+    return InputSym;
+  };
+
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  // foo
+  LDSymbol *SymbolWithoutVerName = nullptr;
+  // foo@VerName
+  LDSymbol *CanonicalSymbol = nullptr;
+  if (IsDefaultVersionedSymbol) {
+    SymbolWithoutVerName = AddSymbol(InputSymbolResolveInfo);
+    if (!SymbolWithoutVerName)
+      return nullptr;
+    DynObjFile->addNonCanonicalSymbol(SymbolWithoutVerName);
   }
-  if (ResolvedResult.Overriden && ResolvedResult.Info->outSymbol()) {
-    ResolvedResult.Info->setOutSymbol(InputSym);
-  }
-  // If the symbol is from dynamic library and we are not making a dynamic
-  // library, we either need to export the symbol by dynamic list or sometimes
-  // we export it since the dynamic library may be referring it defined in
-  // executable, either case it must be in .dynsym
-  LDSymbol *OutSym = InputSym->resolveInfo()->outSymbol();
-  ResolveInfo *RI = InputSym->resolveInfo();
-  if (ThisConfig.codeGenType() != LinkerConfig::DynObj &&
-      ((OutSym && OutSym->hasFragRef()) || RI->isCommon()))
-    RI->setExportToDyn();
-  return InputSym;
+  if (OptVersionedName)
+    InputSymbolResolveInfo.setName(Saver.save(OptVersionedName.value()));
+  CanonicalSymbol = AddSymbol(InputSymbolResolveInfo);
+  if (!CanonicalSymbol)
+    return nullptr;
+  if (SymbolWithoutVerName && CanonicalSymbol)
+    VersionedSymbols.push_back({CanonicalSymbol, SymbolWithoutVerName});
+  return CanonicalSymbol;
+#else
+  LDSymbol *Sym = AddSymbol(InputSymbolResolveInfo);
+  return Sym;
+#endif
 }
 
 void IRBuilder::addToCref(InputFile &Input, Resolver::Result PResult) {
@@ -667,3 +716,66 @@ LDSymbol *IRBuilder::addSymbol<IRBuilder::AsReferred, IRBuilder::Resolve>(
                                    Value, CurFragmentRef, Visibility,
                                    IsPostLtoPhase, IsBitCode, IsPatchable);
 }
+
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+void IRBuilder::normalizeSymbols() {
+  std::unordered_map<ResolveInfo *, ResolveInfo *> RIReplacementMap;
+  for (const auto &P : VersionedSymbols) {
+    // P.first is the canonical version symbol, P.second is the non-canonical
+    // version symbol.
+    LDSymbol *CanonicalSym = P.first;
+    LDSymbol *NonCanonicalSym = P.second;
+    assert(CanonicalSym && NonCanonicalSym && "must not be null!");
+
+    if (CanonicalSym->resolveInfo()->outSymbol() == CanonicalSym &&
+        NonCanonicalSym->resolveInfo()->outSymbol() == NonCanonicalSym) {
+      ResolveInfo *CanonicalRI = P.first->resolveInfo();
+      ResolveInfo *NonCanonicalRI = P.second->resolveInfo();
+      if (NonCanonicalRI->exportToDyn())
+        CanonicalRI->setExportToDyn();
+
+      // NonCanonicalSym should not be used anymore when both the canonical
+      // and the non-canonical versioned symbols are selected by the symbol
+      // resolver.
+      NonCanonicalSym->setShouldIgnore();
+      RIReplacementMap[NonCanonicalRI] = CanonicalRI;
+    }
+  }
+
+  const auto &ObjectFiles = ThisModule.getObjectList();
+  const auto &DynObjectFiles = ThisModule.getDynLibraryList();
+
+  std::vector<InputFile *> AllInputs;
+  AllInputs.insert(AllInputs.end(), ObjectFiles.begin(), ObjectFiles.end());
+  AllInputs.insert(AllInputs.end(), DynObjectFiles.begin(),
+                   DynObjectFiles.end());
+
+  for (InputFile *Input : AllInputs) {
+    ObjectFile *ObjFile = llvm::dyn_cast<ObjectFile>(Input);
+    if (ObjFile) {
+      for (LDSymbol *Sym : ObjFile->getSymbols()) {
+        ResolveInfo *RI = Sym->resolveInfo();
+        auto it = RIReplacementMap.find(RI);
+
+        if (it != RIReplacementMap.end()) {
+          Sym->setResolveInfo(*(it->second));
+        }
+      }
+    }
+
+    ELFDynObjectFile *DynObjFile = llvm::dyn_cast<ELFDynObjectFile>(Input);
+    if (!DynObjFile)
+      continue;
+
+    const auto &NonCanonicalSymbols = DynObjFile->getNonCanonicalSymbols();
+    for (LDSymbol *NonCanonicalSym : NonCanonicalSymbols) {
+      ResolveInfo *NonCanonicalRI = NonCanonicalSym->resolveInfo();
+      auto it = RIReplacementMap.find(NonCanonicalRI);
+
+      if (it != RIReplacementMap.end()) {
+        NonCanonicalSym->setResolveInfo(*(it->second));
+      }
+    }
+  }
+}
+#endif

--- a/lib/Target/ELFDynamic.cpp
+++ b/lib/Target/ELFDynamic.cpp
@@ -21,6 +21,9 @@
 #include "eld/Target/GNULDBackend.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/Support/ErrorHandling.h"
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+#include "eld/Fragment/GNUVerNeedFragment.h"
+#endif
 
 using namespace eld;
 using namespace elf_dynamic;
@@ -248,6 +251,13 @@ void ELFDynamic::reserveEntries(ELFFileFormat &pFormat, Module &pModule) {
       reserveOne(llvm::ELF::DT_VERDEFNUM);
     }
   }
+
+  if (auto verNeed = m_Backend.getGNUVerNeedSection()) {
+    if (verNeed->size()) {
+      reserveOne(llvm::ELF::DT_VERNEED);
+      reserveOne(llvm::ELF::DT_VERNEEDNUM);
+    }
+  }
 #endif
 
   reserveOne(llvm::ELF::DT_DEBUG); // for Debugging
@@ -427,6 +437,15 @@ void ELFDynamic::applyEntries(const ELFFileFormat &pFormat,
       applyOne(llvm::ELF::DT_VERDEF, S->addr());
       // Def count equals section sh_info
       applyOne(llvm::ELF::DT_VERDEFNUM, S->getInfo());
+    }
+  }
+
+  if (ELFSection *S = m_Backend.getGNUVerNeedSection()) {
+    if (S->size()) {
+      applyOne(llvm::ELF::DT_VERNEED, S->addr());
+      GNUVerNeedFragment *F = m_Backend.getGNUVerNeedFragment();
+      ASSERT(F, "Must not be null!");
+      applyOne(llvm::ELF::DT_VERNEEDNUM, F->getNeedCount());
     }
   }
 #endif

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -26,6 +26,7 @@
 #include "eld/Fragment/GNUHashFragment.h"
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
 #include "eld/Fragment/GNUVerDefFragment.h"
+#include "eld/Fragment/GNUVerNeedFragment.h"
 #include "eld/Fragment/GNUVerSymFragment.h"
 #endif
 #include "eld/Fragment/RegionFragment.h"
@@ -781,7 +782,12 @@ bool GNULDBackend::SetSymbolsToBeExported() {
           m_Module.getNamePool().findInfo(R->getNonVersionedName().str());
       if (nonVerSym) {
         auto nonVerSymScope = SymbolScopes.find(nonVerSym);
-        if (nonVerSymScope == SymbolScopes.end())
+        // Only clear export for the non-versioned alias when the
+        // version script explicitly marks it local. If there is no
+        // scope information, keep the export to satisfy relocations
+        // against the unversioned name (e.g., foo).
+        if (nonVerSymScope != SymbolScopes.end() &&
+            nonVerSymScope->second->isLocal())
           nonVerSym->clearExportToDyn();
       }
     }
@@ -849,6 +855,9 @@ void GNULDBackend::sizeDynNamePools() {
 
   // Versioning assignment and fragment creation only when enabled.
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  if (!shouldEmitVersioningSections())
+    return;
+
   assignOutputVersionIDs();
   if (!config().getDiagEngine()->diagnose())
     return;
@@ -880,6 +889,23 @@ void GNULDBackend::sizeDynNamePools() {
     GNUVerDefSection->addFragmentAndUpdateSize(F);
     GNUVerDefFrag = F;
     GNUVerDefSection->setInfo(F->defCount());
+  }
+
+  if (GNUVerNeedSection) {
+    if (DP->traceSymbolVersioning())
+      config().raise(Diag::trace_creating_symbol_versioning_fragment) <<
+          GNUVerNeedSection->name();
+    GNUVerNeedFragment *F = make<GNUVerNeedFragment>(GNUVerNeedSection);
+    bool is32Bits = config().targets().is32Bits();
+    if (is32Bits)
+      F->computeVersionNeeds<llvm::object::ELF32LE>(
+          m_Module.getDynLibraryList(), getOutputFormat(), *DE);
+    else
+      F->computeVersionNeeds<llvm::object::ELF64LE>(
+          m_Module.getDynLibraryList(), getOutputFormat(), *DE);
+    GNUVerNeedSection->addFragmentAndUpdateSize(F);
+    GNUVerNeedFrag = F;
+    GNUVerNeedSection->setInfo(F->getNeedCount());
   }
 #endif
 }
@@ -1031,7 +1057,7 @@ void GNULDBackend::sizeSymTab() {
         m_SymbolsToRemove.count(Sym)) {
       continue;
     }
-    std::string symName = Sym->name();
+    std::string symName = Sym->outSymbol()->name();
     strtab += symName.size() + 1;
     ++NumSymbols;
   }
@@ -1137,7 +1163,7 @@ void GNULDBackend::emitSymbol64(llvm::ELF::Elf64_Sym &pSym, LDSymbol *pSymbol,
       pSym.st_name = optSymNameOffset.value();
     } else {
       pSym.st_name = pStrtabsize;
-      strcpy((pStrtab + pStrtabsize), pSymbol->name());
+      strcpy((pStrtab + pStrtabsize), std::string(pSymbol->name()).data());
     }
   }
   if ((pSymbol->resolveInfo()->isUndef()) || (pSymbol->isDyn()))
@@ -5374,6 +5400,16 @@ void GNULDBackend::initSymbolVersioningSections() {
       llvm::ELF::SHT_GNU_verdef, llvm::ELF::SHF_ALLOC,
       /*Align=*/sizeof(uint32_t));
   GNUVerDefSection->setLink(getOutputFormat()->getDynStrTab());
+
+  if (DP->traceSymbolVersioning())
+    config().raise(Diag::trace_creating_symbol_versioning_section)
+        << ".gnu.version_r";
+  GNUVerNeedSection = m_Module.createInternalSection(
+      Module::InternalInputType::SymbolVersioning,
+      LDFileFormat::Kind::SymbolVersion, ".gnu.version_r",
+      llvm::ELF::SHT_GNU_verneed, llvm::ELF::SHF_ALLOC,
+      /*Align=*/sizeof(uint32_t));
+  GNUVerNeedSection->setLink(getOutputFormat()->getDynStrTab());
 }
 #endif
 
@@ -5401,11 +5437,18 @@ void GNULDBackend::assignOutputVersionIDs() {
   uint16_t defaultVersionID = llvm::ELF::VER_NDX_GLOBAL;
 
   setSymbolVersionID(DynamicSymbols[0], llvm::ELF::VER_NDX_LOCAL);
+  if (shouldTraceSymbolVersioning)
+    config().raise(Diag::trace_symbol_to_output_version_id)
+        << DynamicSymbols[0]->name() << llvm::ELF::VER_NDX_LOCAL;
   // First, assign default version to any symbol without an explicit one.
   for (std::size_t i = 1, e = DynamicSymbols.size(); i < e; ++i) {
     ResolveInfo *R = DynamicSymbols[i];
-    if (!getSymbolVersionID(R))
+    if (!getSymbolVersionID(R)) {
       setSymbolVersionID(R, defaultVersionID);
+      if (shouldTraceSymbolVersioning)
+        config().raise(Diag::trace_symbol_to_output_version_id)
+            << R->name() << defaultVersionID;
+    }
   }
 
   // For output-defined symbols with explicit version suffix foo@VER or
@@ -5443,6 +5486,36 @@ void GNULDBackend::assignOutputVersionIDs() {
     if (!isDefaultVersionSymbol)
       VernID |= llvm::ELF::VERSYM_HIDDEN;
     setSymbolVersionID(R, VernID);
+    if (shouldTraceSymbolVersioning)
+      config().raise(Diag::trace_symbol_to_output_version_id)
+          << R->name() << (VernID & ~llvm::ELF::VERSYM_HIDDEN);
+  }
+
+  for (std::size_t i = 1, e = DynamicSymbols.size(); i < e; ++i) {
+    ResolveInfo *R = DynamicSymbols[i];
+    ELFDynObjectFile *DynObjFile =
+        llvm::dyn_cast<ELFDynObjectFile>(R->resolvedOrigin());
+    if (!DynObjFile)
+      continue;
+    LDSymbol *sym = R->outSymbol();
+    ASSERT(sym, "Must not be null!");
+    if (R->isUndef())
+      continue;
+    if (!DynObjFile->hasSymbolVersioningInfo())
+      continue;
+    uint16_t InputVersionID = DynObjFile->getSymbolVersionID(sym->getSymbolIndex());
+    if (InputVersionID == llvm::ELF::VER_NDX_LOCAL ||
+        InputVersionID == llvm::ELF::VER_NDX_GLOBAL)
+      continue;
+    auto VernAuxID = DynObjFile->getOutputVernAuxID(InputVersionID);
+    if (VernAuxID == 0) {
+      VernAuxID = NextVerID++;
+      DynObjFile->setOutputVernAuxID(InputVersionID, VernAuxID);
+    }
+    setSymbolVersionID(R, VernAuxID);
+    if (shouldTraceSymbolVersioning)
+      config().raise(Diag::trace_symbol_to_output_version_id)
+          << R->name() << VernAuxID;
   }
 }
 #endif

--- a/lib/Writers/ELFObjectWriter.cpp
+++ b/lib/Writers/ELFObjectWriter.cpp
@@ -18,6 +18,7 @@
 #include "eld/Fragment/FillFragment.h"
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
 #include "eld/Fragment/GNUVerDefFragment.h"
+#include "eld/Fragment/GNUVerNeedFragment.h"
 #endif
 #include "eld/Fragment/RegionFragment.h"
 #include "eld/Fragment/StringFragment.h"
@@ -706,6 +707,8 @@ uint64_t ELFObjectWriter::getSectEntrySize(ELFSection *CurSection) const {
     return CurSection->getEntSize();
   if (CurSection->getType() == llvm::ELF::SHT_GNU_verdef)
     return CurSection->getEntSize();
+  if (CurSection->getType() == llvm::ELF::SHT_GNU_verneed)
+    return CurSection->getEntSize();
 #endif
   return 0x0;
 }
@@ -730,6 +733,8 @@ uint64_t ELFObjectWriter::getSectLink(const ELFSection *S) const {
   if (llvm::ELF::SHT_GNU_versym == S->getType())
     Link = ThisModule.getBackend().getOutputFormat()->getDynSymTab();
   if (llvm::ELF::SHT_GNU_verdef == S->getType())
+    Link = ThisModule.getBackend().getOutputFormat()->getDynStrTab();
+  if (llvm::ELF::SHT_GNU_verneed == S->getType())
     Link = ThisModule.getBackend().getOutputFormat()->getDynStrTab();
 #endif
   if (ThisModule.getConfig().isLinkPartial() &&
@@ -763,6 +768,8 @@ uint64_t ELFObjectWriter::getSectInfo(ELFSection *CurSection) const {
   if (llvm::ELF::SHT_GNU_verdef == CurSection->getType()) {
     return ThisModule.getBackend().getGNUVerDefFragment()->defCount();
   }
+  if (llvm::ELF::SHT_GNU_verneed == CurSection->getType())
+    return ThisModule.getBackend().getGNUVerNeedFragment()->getNeedCount();
 #endif
 
   if (CurSection->isRelocationSection()) {

--- a/test/Common/standalone/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/BuildingExecutablesWithSymbolVersioning.test
+++ b/test/Common/standalone/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/BuildingExecutablesWithSymbolVersioning.test
@@ -1,0 +1,18 @@
+REQUIRES: symbol_versioning
+#---BuildingExecutablesWithSymbolVersioning.test---------------------------------------#
+#BEGIN_COMMENT
+# This test verifies that linker properly creates executables that use
+# shared libraries with symbol versioning information.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -fPIC
+RUN: %clang %clangopts -o %t1.2.o %p/Inputs/2.c -c -fPIC
+RUN: %link %linkopts -o %t1.lib1.so %t1.1.o -shared --version-script %p/Inputs/vs.1.t
+RUN: %link %linkopts -o %t1.lib2.so %t1.2.o -shared --version-script %p/Inputs/vs.1.t
+RUN: %clang %clangopts -o %t1.main.1.o %p/Inputs/main.1.c -c
+RUN: %link %linkopts -o %t1.main.1.out %t1.main.1.o %t1.lib1.so %t1.lib2.so
+RUN: %readelf --dyn-syms %t1.main.1.out | %filecheck %s --check-prefix CHECK1
+#END_TEST
+
+CHECK1: UND foo@V1
+CHECK1-NOT foo@V1

--- a/test/Common/standalone/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/Inputs/1.c
+++ b/test/Common/standalone/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/Inputs/1.c
@@ -1,0 +1,5 @@
+__asm__(".symver foo1, foo@@V1");
+int foo1() { return 1; }
+
+__asm__(".symver foo2, foo@V2");
+int foo2() { return 3; }

--- a/test/Common/standalone/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/Inputs/2.c
+++ b/test/Common/standalone/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/Inputs/2.c
@@ -1,0 +1,5 @@
+__asm__(".symver foo1, foo@@V2");
+int foo1() { return 1; }
+
+__asm__(".symver foo2, foo@V1");
+int foo2() { return 3; }

--- a/test/Common/standalone/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/Inputs/main.1.c
+++ b/test/Common/standalone/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/Inputs/main.1.c
@@ -1,0 +1,8 @@
+int foo();
+
+__asm__(".symver bar, foo@V1");
+int bar();
+
+int main() {
+  return foo() + bar();
+}

--- a/test/Common/standalone/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/Inputs/main.2.c
+++ b/test/Common/standalone/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/Inputs/main.2.c
@@ -1,0 +1,7 @@
+int foo() {
+  return 1;
+}
+
+int main() {
+  return foo();
+}

--- a/test/Common/standalone/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/Inputs/vs.1.t
+++ b/test/Common/standalone/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/Inputs/vs.1.t
@@ -1,0 +1,9 @@
+V1 {
+  global:
+    foo;
+};
+
+V2 {
+  global:
+    foo;
+};

--- a/test/Common/standalone/SymbolVersioning/BuildingSharedLibsWithSymbolVersioning/BuildingSharedLibsWithSymbolVersioningErrors.test
+++ b/test/Common/standalone/SymbolVersioning/BuildingSharedLibsWithSymbolVersioning/BuildingSharedLibsWithSymbolVersioningErrors.test
@@ -6,7 +6,7 @@ REQUIRES: symbol_versioning
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -o %t1.2.o %p/Inputs/2.c -c -fPIC
-RUN: %not %link %linkopts -o %t1.lib1.so %t1.2.o -shared 2>&1 | %filecheck %s --check-prefix=ERRORS1
+RUN: %not %link %linkopts -o %t1.lib1.so %t1.2.o -shared --version-script %p/Inputs/vs.5.t 2>&1 | %filecheck %s --check-prefix=ERRORS1
 #END_TEST
 
 ERRORS1: Error: {{.*}}2.o: symbol foo@V1 has undefined version V1

--- a/test/Common/standalone/SymbolVersioning/BuildingSharedLibsWithSymbolVersioning/Inputs/vs.5.t
+++ b/test/Common/standalone/SymbolVersioning/BuildingSharedLibsWithSymbolVersioning/Inputs/vs.5.t
@@ -1,0 +1,4 @@
+V0 {
+  global:
+    foo;
+};

--- a/test/x86_64/linux/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/BuildingExecutablesWithSymbolVersioning.test
+++ b/test/x86_64/linux/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/BuildingExecutablesWithSymbolVersioning.test
@@ -1,0 +1,40 @@
+REQUIRES: symbol_versioning
+#---BuildingExecutablesWithSymbolVersioning.test---------------------------------------#
+#BEGIN_COMMENT
+# This test verifies that linker properly creates executables that use
+# symbol versioning.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -fPIC
+RUN: %link %linkopts -o %t1.lib1.so %t1.1.o -shared --version-script %p/Inputs/vs.1.t
+RUN: %clang %clangopts -o %t1.2.o %p/Inputs/2.c -c -fPIC
+RUN: %link %linkopts -o %t1.lib2.so %t1.2.o -shared --version-script %p/Inputs/vs.1.t
+RUN: %clang %clangopts -o %t1.main.1.o %p/Inputs/main.1.c -c
+RUN: %clang %clangopts -fuse-ld=%link -o %t1.a.1.out %t1.main.1.o \
+RUN:   %t1.lib1.so %t1.lib2.so -Wl,-rpath=$(dirname %t1.lib1.so)
+RUN: %t1.a.1.out | %filecheck %s --check-prefix CHECK1
+RUN: %clang %clangopts -fuse-ld=%link -o %t1.a.2.out %t1.main.1.o \
+RUN:   %t1.lib2.so %t1.lib1.so -Wl,-rpath=$(dirname %t1.lib1.so)
+RUN: %t1.a.2.out | %filecheck %s --check-prefix CHECK2
+RUN: %clang %clangopts -o %t1.main.2.o %p/Inputs/main.2.c -c
+RUN: %clang %clangopts -fuse-ld=%link -o %t1.a.3.out %t1.main.2.o \
+RUN:   %t1.lib1.so %t1.lib2.so -Wl,-rpath=$(dirname %t1.lib1.so)
+RUN: %t1.a.3.out | %filecheck %s --check-prefix CHECK3
+RUN: %clang %clangopts -fuse-ld=%link -o %t1.a.4.out %t1.main.2.o \
+RUN:   %t1.lib2.so %t1.lib1.so -Wl,-rpath=$(dirname %t1.lib1.so)
+RUN: %t1.a.4.out | %filecheck %s --check-prefix CHECK4
+RUN: %clang %clangopts -o %t1.main.3.o %p/Inputs/main.3.c -c
+RUN: %clang %clangopts -fuse-ld=bfd -o %t1.a.5.out %t1.main.3.o \
+RUN:   %t1.lib1.so -Wl,-rpath=$(dirname %t1.lib1.so)
+RUN: %t1.a.5.out | %filecheck %s --check-prefix CHECK5
+#END_TEST
+
+CHECK1: foo(): 1
+
+CHECK2: foo(): 7
+
+CHECK3: foo() + bar(): 2
+
+CHECK4: foo() + bar(): 12
+
+CHECK5: foo() + foo1(): 22

--- a/test/x86_64/linux/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/Inputs/1.c
+++ b/test/x86_64/linux/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/Inputs/1.c
@@ -1,0 +1,5 @@
+__asm__(".symver foo1, foo@@V1");
+int foo1() { return 1; }
+
+__asm__(".symver foo2, foo@V2");
+int foo2() { return 3; }

--- a/test/x86_64/linux/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/Inputs/2.c
+++ b/test/x86_64/linux/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/Inputs/2.c
@@ -1,0 +1,8 @@
+__asm__(".symver foo1, foo@V1");
+int foo1() { return 5; }
+
+__asm__(".symver foo2, foo@@V2");
+int foo2() { return 7; }
+
+__asm__(".symver bar1, bar@@V1");
+int bar1() { return 9; }

--- a/test/x86_64/linux/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/Inputs/main.1.c
+++ b/test/x86_64/linux/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/Inputs/main.1.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#define show(x) printf(#x ": %d\n", x);
+
+int foo();
+
+int main() {
+  show(foo());
+  return 0;
+}

--- a/test/x86_64/linux/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/Inputs/main.2.c
+++ b/test/x86_64/linux/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/Inputs/main.2.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#define show(x) printf(#x ": %d\n", x);
+
+int foo();
+__asm__(".symver bar, foo@V1");
+int bar();
+
+int main() {
+  show(foo() + bar());
+  return 0;
+}

--- a/test/x86_64/linux/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/Inputs/main.3.c
+++ b/test/x86_64/linux/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/Inputs/main.3.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+#define show(x) printf(#x ": %d\n", x);
+
+int foo() {
+  return 11;
+}
+
+__asm__(".symver foo1, foo@V1");
+int foo1();
+
+int main() {
+  show(foo() + foo1());
+  return 0;
+}

--- a/test/x86_64/linux/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/Inputs/vs.1.t
+++ b/test/x86_64/linux/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/Inputs/vs.1.t
@@ -1,0 +1,8 @@
+V1 {
+  global:
+    foo;
+};
+V2 {
+  global:
+    foo;
+};

--- a/test/x86_64/linux/SymbolVersioning/BuildingSharedLibsWithSymbolVersioning/BuildingSharedLibsWithSymbolVersioning.test
+++ b/test/x86_64/linux/SymbolVersioning/BuildingSharedLibsWithSymbolVersioning/BuildingSharedLibsWithSymbolVersioning.test
@@ -9,21 +9,21 @@ REQUIRES: symbol_versioning
 RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -fPIC
 RUN: %link %linkopts -o %t1.lib1.so %t1.1.o -shared --version-script %p/Inputs/vs.1.t
 RUN: %clang %clangopts -o %t1.main.1.o %p/Inputs/main.1.c -c
-RUN: %clang %clangopts -o %t1.main.1.out %t1.main.1.o %t1.lib1.so -Wl,-rpath=$(dirname %t1.lib1.so)
+RUN: %clang %clangopts -fuse-ld=%link -o %t1.main.1.out %t1.main.1.o %t1.lib1.so -Wl,-rpath=$(dirname %t1.lib1.so)
 RUN: %t1.main.1.out | %filecheck %s --check-prefix=CHECK1
 RUN: %clang %clangopts -o %t1.main.2.o %p/Inputs/main.2.c -c
-RUN: %clang %clangopts -o %t1.main.2.out %t1.main.2.o %t1.lib1.so -Wl,-rpath=$(dirname %t1.lib1.so)
+RUN: %clang %clangopts -fuse-ld=%link -o %t1.main.2.out %t1.main.2.o %t1.lib1.so -Wl,-rpath=$(dirname %t1.lib1.so)
 RUN: %t1.main.2.out | %filecheck %s --check-prefix=CHECK2
 RUN: %clang %clangopts -o %t1.main.3.o %p/Inputs/main.3.c -c
-RUN: %clang %clangopts -o %t1.main.3.out %t1.main.3.o %t1.lib1.so -Wl,-rpath=$(dirname %t1.lib1.so)
+RUN: %clang %clangopts -fuse-ld=%link -o %t1.main.3.out %t1.main.3.o %t1.lib1.so -Wl,-rpath=$(dirname %t1.lib1.so)
 RUN: %t1.main.3.out | %filecheck %s --check-prefix=CHECK3
 RUN: %clang %clangopts -o %t1.2.o %p/Inputs/2.c -c -fPIC
 RUN: %link %linkopts -o %t1.lib2.so %t1.1.o -shared --version-script %p/Inputs/vs.1.t
-RUN: %clang %clangopts -o %t1.main.1.2.out %t1.main.1.o %t1.lib2.so -Wl,-rpath=$(dirname %t1.lib2.so)
+RUN: %clang %clangopts -fuse-ld=%link -o %t1.main.1.2.out %t1.main.1.o %t1.lib2.so -Wl,-rpath=$(dirname %t1.lib2.so)
 RUN: %t1.main.1.2.out | %filecheck %s --check-prefix=CHECK1
-RUN: %clang %clangopts -o %t1.main.2.2.out %t1.main.2.o %t1.lib2.so -Wl,-rpath=$(dirname %t1.lib2.so)
+RUN: %clang %clangopts -fuse-ld=%link -o %t1.main.2.2.out %t1.main.2.o %t1.lib2.so -Wl,-rpath=$(dirname %t1.lib2.so)
 RUN: %t1.main.2.2.out | %filecheck %s --check-prefix=CHECK2
-RUN: %clang %clangopts -o %t1.main.3.2.out %t1.main.3.o %t1.lib2.so -Wl,-rpath=$(dirname %t1.lib2.so)
+RUN: %clang %clangopts -fuse-ld=%link -o %t1.main.3.2.out %t1.main.3.o %t1.lib2.so -Wl,-rpath=$(dirname %t1.lib2.so)
 RUN: %t1.main.3.2.out | %filecheck %s --check-prefix=CHECK3
 #END_TEST
 


### PR DESCRIPTION
This commit adds primitive support for creating executables that use
shared libraries with symbol versioning information.
