### PR TITLE
Make `ThinArchiveMissingMember.test` LIT check case-insensitive

### DIFF
--- a/test/Common/standalone/ThinArchivesMissingMember/ThinArchiveMissingMember.test
+++ b/test/Common/standalone/ThinArchivesMissingMember/ThinArchiveMissingMember.test
@@ -8,7 +8,7 @@ RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
 RUN: %clang %clangopts -o %t1.main.o %p/Inputs/main.c -c -ffunction-sections
 RUN: %ar cr %aropts --thin %t1.lib1.a %t1.1.o
 RUN: %rm %t1.1.o
-RUN: %not %link %linkopts -o %t1.main.out %t1.main.o %t1.lib1.a 2>&1 | %filecheck %s --check-prefix=ERROR
+RUN: %not %link %linkopts -o %t1.main.out %t1.main.o %t1.lib1.a 2>&1 | %filecheck --ignore-case %s --check-prefix=ERROR
 #END_TEST
 
 ERROR: Fatal: LLVM: '{{.*}}1.o': No such file or directory


### PR DESCRIPTION
This patch makes the `ThinArchiveMissingMember.test` case-insensitive this enables the test check to be platform agnostic.
Fixes: #623 