### PR TITLE
Fix build failure error undeclared CHERIOT1VendorRelocationOffset

### DIFF
--- a/lib/Target/RISCV/RISCVRelocationInternal.h
+++ b/lib/Target/RISCV/RISCVRelocationInternal.h
@@ -74,8 +74,9 @@ enum : uint32_t {
   QUALCOMMVendorRelocationOffset =
       FirstQUALCOMMVendorRelocation - FirstNonstandardRelocation,
 
-  /* We don't support ANDES vendor relocations */
+  /* We don't support ANDES and CHERIOT1 vendor relocations */
   ANDESVendorRelocationOffset = 0,
+  CHERIOT1VendorRelocationOffset = 0,
 
 #define ELF_RISCV_NONSTANDARD_RELOC(vendor_symbol, name, value)                \
   name = value + vendor_symbol##VendorRelocationOffset,


### PR DESCRIPTION
This commit defines a 0-initialized CHERIOT1VendorRelocationOffset enum value to fix the build failure with the error `use of undeclared identifier 'CHERIOT1VendorRelocationOffset`. This value is automatically referenced when ELF_RISCV_NONSTANDARD_RELOC macro is expanded in the file llvm/BinaryFormat/ELFRelocs/RISCV_nonstandard.def.

Resolves #676