### PR TITLE
Add source assignment in symbol nodes

### DIFF
--- a/include/eld/Script/Expression.h
+++ b/include/eld/Script/Expression.h
@@ -337,6 +337,7 @@ private:
   Expression *getRightExpression() const override { return nullptr; }
 
   mutable LDSymbol *ThisSymbol = nullptr;
+  const Assignment *SourceAssignment = nullptr;
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -23,6 +23,7 @@
 #include "eld/Readers/ELFSection.h"
 #include "eld/Readers/SymDefReader.h"
 #include "eld/Script/Assignment.h"
+#include "eld/Script/Expression.h"
 #include "eld/Script/VersionScript.h"
 #include "eld/SymbolResolver/ResolveInfo.h"
 #include "eld/Target/ELFSegment.h"
@@ -902,6 +903,17 @@ public:
   }
 #endif
 
+  const Assignment *getLatestAssignment(llvm::StringRef SymName) {
+    auto it = SymbolNameToLatestAssignment.find(SymName);
+    if (it != SymbolNameToLatestAssignment.end())
+      return it->getValue();
+    return nullptr;
+  }
+
+  void updateLatestAssignment(llvm::StringRef SymName, const Assignment *A) {
+    SymbolNameToLatestAssignment[SymName] = A;
+  }
+
 protected:
   virtual int numReservedSegments() const { return m_NumReservedSegments; }
 
@@ -1230,6 +1242,8 @@ protected:
   GNUVerNeedFragment *GNUVerNeedFrag = nullptr;
   std::unordered_map<const ResolveInfo *, uint16_t> OutputVersionIDs;
 #endif
+
+  llvm::StringMap<const Assignment *> SymbolNameToLatestAssignment;
 };
 
 } // namespace eld

--- a/lib/Script/Assignment.cpp
+++ b/lib/Script/Assignment.cpp
@@ -224,6 +224,9 @@ bool Assignment::assign(Module &CurModule, const ELFSection *Section) {
     ThisSymbol->setScriptValueDefined();
   }
 
+  auto &Backend = CurModule.getBackend();
+  Backend.updateLatestAssignment(Name, this);
+
   if (CurModule.getPrinter()->traceAssignments())
     trace(llvm::outs());
   return true;

--- a/lib/Script/Expression.cpp
+++ b/lib/Script/Expression.cpp
@@ -9,6 +9,7 @@
 #include "eld/Core/LinkerScript.h"
 #include "eld/Core/Module.h"
 #include "eld/Readers/ELFSection.h"
+#include "eld/Script/Assignment.h"
 #include "eld/Script/ScriptFile.h"
 #include "eld/Support/MsgHandling.h"
 #include "eld/Support/Utils.h"
@@ -135,7 +136,6 @@ bool Symbol::hasDot() const {
 }
 
 eld::Expected<uint64_t> Symbol::evalImpl() {
-
   if (!ThisSymbol)
     ThisSymbol = ThisModule.getNamePool().findSymbol(Name);
 
@@ -144,6 +144,15 @@ eld::Expected<uint64_t> Symbol::evalImpl() {
     return std::make_unique<plugin::DiagnosticEntry>(
         Diag::undefined_symbol_in_linker_script,
         std::vector<std::string>{Name});
+
+  if (!SourceAssignment &&
+      ThisSymbol->resolveInfo()->outSymbol()->scriptDefined()) {
+    auto &Backend = ThisModule.getBackend();
+    const auto *A = Backend.getLatestAssignment(Name);
+    if (!A)
+      A = ThisModule.getAssignmentForSymbol(Name);
+    SourceAssignment = A;
+  }
 
   if (ThisSymbol->hasFragRef() && !ThisSymbol->shouldIgnore()) {
     FragmentRef *FragRef = ThisSymbol->fragRef();
@@ -154,6 +163,10 @@ eld::Expected<uint64_t> Symbol::evalImpl() {
            "using a symbol that points to a non allocatable section!");
     return Section->addr() + FragRef->getOutputOffset(ThisModule);
   }
+  if (hasDot())
+    return ThisSymbol->value();
+  if (SourceAssignment)
+    return SourceAssignment->value();
   return ThisSymbol->value();
 }
 

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -3272,6 +3272,7 @@ bool GNULDBackend::layout() {
     return false;
   }
 
+  // FIXME: Adding more symbols this late can cause layout issues.
   {
     eld::RegisterTimer T("Define Magic Symbols", "Establish Layout",
                          m_Module.getConfig().options().printTimingStats());

--- a/test/Common/standalone/SymbolForwReference/Inputs/script.4.t
+++ b/test/Common/standalone/SymbolForwReference/Inputs/script.4.t
@@ -1,0 +1,10 @@
+SECTIONS {
+  a = b;
+  b = 0x100;
+  .text : { *(.text*) }
+  .data : { *(.data*) }
+  .comment : { *(.comment) }
+  .eh_frame : { *(.eh_frame) }
+  .note.GNU-stack : { *(.note.GNU-stack) }
+  b = 0x300;
+}

--- a/test/Common/standalone/SymbolForwReference/Inputs/script.5.t
+++ b/test/Common/standalone/SymbolForwReference/Inputs/script.5.t
@@ -1,0 +1,9 @@
+SECTIONS {
+  a = b;
+  .text : { *(.text*) }
+  .data : { *(.data*) }
+  .comment : { *(.comment) }
+  .eh_frame : { *(.eh_frame) }
+  .note.GNU-stack : { *(.note.GNU-stack) }
+  PROVIDE(b = 0x300);
+}

--- a/test/Common/standalone/SymbolForwReference/Inputs/script.6.t
+++ b/test/Common/standalone/SymbolForwReference/Inputs/script.6.t
@@ -1,0 +1,9 @@
+SECTIONS {
+  a = b;
+  .text : { *(.text*) }
+  .data : { *(.data*) }
+  .comment : { *(.comment) }
+  .eh_frame : { *(.eh_frame) }
+  .note.GNU-stack : { *(.note.GNU-stack) }
+  PROVIDE(b = non_existing_symbol);
+}

--- a/test/Common/standalone/SymbolForwReference/Inputs/script.7.t
+++ b/test/Common/standalone/SymbolForwReference/Inputs/script.7.t
@@ -1,0 +1,17 @@
+SECTIONS {
+  a = b;
+  f = 0x5 + g;
+  .text : { *(.text*) }
+  PROVIDE(b = d) ;
+  .data : { *(.data*) }
+  PROVIDE(b = c);
+  .comment : { *(.comment) }
+  PROVIDE(c = 0x11);
+  g = 0x7;
+  .eh_frame : { *(.eh_frame) }
+  PROVIDE(d = e);
+  .note.GNU-stack : { *(.note.GNU-stack) }
+  PROVIDE(e = 0x13);
+  PROVIDE(g = 0x9);
+  g = 0x15;
+}

--- a/test/Common/standalone/SymbolForwReference/SymbolForwReferenceWithInBetweenLayoutReset.test
+++ b/test/Common/standalone/SymbolForwReference/SymbolForwReferenceWithInBetweenLayoutReset.test
@@ -1,0 +1,35 @@
+#---SymbolForwReferenceWithInBetweenLayoutReset.test-------- LinkerScript ----------#
+#BEGIN_COMMENT
+# Verify symbol assignments with forward references are correctly evaluated
+# when layout resets and restarts during layout computation.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -fPIC
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.4.t
+RUN: %readelf -s %t1.1.out | %filecheck %s
+RUN: %link %linkopts -o %t1.2.out %t1.1.o -T %p/Inputs/script.5.t \
+RUN:   --trace=assignments 2>&1 | %filecheck %s --check-prefix=TRACE_ASSIGNMENTS
+RUN: %readelf -s %t1.2.out | %filecheck %s
+RUN: %not %link %linkopts -o %t1.3.out %t1.1.o -T %p/Inputs/script.6.t 2>&1 | \
+RUN:   %filecheck %s --check-prefix=UNDEFINED_SYMBOL_IN_PROVIDE
+RUN: %link %linkopts -o %t1.4.out %t1.1.o -T %p/Inputs/script.7.t
+RUN: %readelf -s %t1.4.out | %filecheck %s --check-prefix CHECK4
+#END_TEST
+
+CHECK-DAG: {{0*300}}     0 NOTYPE  GLOBAL DEFAULT   ABS a
+CHECK-DAG: {{0*300}}     0 NOTYPE  GLOBAL DEFAULT   ABS b
+
+TRACE_ASSIGNMENTS: OUTPUT_SECTION(EPILOGUE) >> a({{.*}}) = b(0x0);
+TRACE_ASSIGNMENTS: OUTPUT_SECTION(EPILOGUE) >> b({{.*}}) = 0x300;
+TRACE_ASSIGNMENTS: OUTPUT_SECTION(EPILOGUE) >> a({{.*}}) = b(0x300);
+TRACE_ASSIGNMENTS-NOT: OUTPUT_SECTION(EPILOGUE) >> a({{.*}}) = b(0x0);
+
+UNDEFINED_SYMBOL_IN_PROVIDE: Error: undefined symbol 'non_existing_symbol' referenced in expression
+
+CHECK4-DAG: {{0+}}13 {{.*}}ABS a
+CHECK4-DAG: {{0+}}13 {{.*}}ABS b
+CHECK4-DAG: {{0+}}13 {{.*}}ABS d
+CHECK4-DAG: {{0+}}13 {{.*}}ABS e
+CHECK4-DAG: {{0+}}1a {{.*}}ABS f
+CHECK4-DAG: {{0+}}15 {{.*}}ABS g
+CHECK4-NOT: ABS c


### PR DESCRIPTION
This commit changes how symbol expression nodes gets evaluated for
the absolute symbols. The key goal is to improve the layout convergence
when forward references is involved.
direction to improve the layout convergence.

When the linker script contains forward references, then we may need to
re-evaluate the linker script and the layout multiple times to reach
convergence. For example:

```
SECTIONS {
  u = v; // A1
  .foo (u) : { *(.text.foo) }
  v = 0x100; // A2
  .bar (v) : { *(.text.bar) }
  v = 0x300; // A3
}
```

The above linker script contains 3 assignments: A1, A2, and A3. The link
needs more than one pass of layout computation for reaching
convergence, because in the 1st pass, the assignment A1 is evaluted incorrectly
because `v` has not been assigned a value yet. To properly assign
layout here, the linker will recompute the layout iteratively. Let's
call this kind of layout pass as **FullLayoutPass**.

We also need to stop the layout pass in between and recompute the layout
from the beginning whenever some initial assumption changes such as a
new segment needs to be inserted. Let's call this kind of layout pass as
**InBetweenLayoutPass**.

There is an important difference between these two types of layout
recomputation. In the first type, that is, layout recomputation to
achieve layout convergence, we must use the symbol values from the
previous pass. However, in the second type, that is, layout recomputation
due to an initial assumption change such as a new segment needs to be inserted,
we must reset the symbol values before recomputing the layout, otherwise
we risk using stale/incorrect symbol values. Let's see why:

```
SECTIONS {
  u = v; // A1
  .foo : { *(.text.foo) }
  v = 0x100; // A2
  .data : { *(.text.data) }}
  v = 0x300; // A3
}
```

In the first evaluation of A1, u is assigned the value `0`.
On encountering '.data' output section, the layout is recomputed, and
this time when A1 is recomputed, u is assigned the value `0x100`
because A2 was evaluated in the last pass. The value `0x100` is
incorrect for `u` because the value of `v` that is to be used in A1 must
come from the last evaluation of `v`, that is, A3. Hence, reusing symbol values
from the last pass in this case leads to incorrect layout.

**We cannot add logic for when to reuse symbol values and when to
reset them because the two types of layout passes
(FullLayoutPass and InBetweenLayoutPass) have contradicting
requirements -- one requires preserving symbol values, and the other
requires resetting them, and InBetweenLayoutPass is invoked in-between
the FullLayoutPass.**

Adding a source assignment node with the symbol expression node makes
the recomputation simpler by obviating the need to reset the symbol
values in both the cases. **The key idea is that the value of a
symbol node of a script symbol is not the value of the corresponding
symbol, but instead is the result of the last assignment node for that
symbol.**

Adding the source assignment with a symbol node has additional benefits
as well:

1) It makes it easier to determine the culprit / closest assignment to
   use in diagnostics when a symbol value is not converging.

2) It makes it easier to add heuristics such as constant expression
   evaluation to speed up the layout convergence. For example:

```
u = v;
.foo (u) : { *(.text.foo) }
v = 0x2000;
```

  In this case, if the symbol v encodes the source assignment, then we
  can easily add heuristic to determine if `v` source assignment can be
  evaluated early.

3) Selectively recompute only those assignment nodes which needs to be recomputed.
   If we reset symbol values, then all the assignment nodes always needs
   to be recomputed in each layout pass.

Resolves #1037