### PR TITLE
Fix parsing of `"archive:mem"` input section description pattern

### DIFF
--- a/include/eld/Script/StrToken.h
+++ b/include/eld/Script/StrToken.h
@@ -44,10 +44,18 @@ public:
 
   std::string getDecoratedName() const;
 
+  void setLeftQuoted() { LeftQuoted = true; }
+  bool isLeftQuoted() const { return LeftQuoted; }
+
+  void setRightQuoted() { RightQuoted = true; }
+  bool isRightQuoted() const { return RightQuoted; }
+
 protected:
   std::string Name;
   bool Quoted = false;
   Kind ScriptFileKind;
+  bool LeftQuoted = false;
+  bool RightQuoted = false;
 };
 
 } // namespace eld

--- a/lib/Script/ScriptFile.cpp
+++ b/lib/Script/ScriptFile.cpp
@@ -537,14 +537,23 @@ StrToken *ScriptFile::createParserStr(const char *PText, size_t PLength) {
 }
 
 StrToken *ScriptFile::createParserStr(llvm::StringRef S) {
-  bool IsQuoted = false;
+  bool isLeftQuoted = false;
+  bool isRightQuoted = false;
   if (S.starts_with("\"")) {
-    S = S.substr(1, S.size() - 2);
-    IsQuoted = true;
+    S = S.substr(1);
+    isLeftQuoted = true;
+  }
+  if (S.ends_with("\"")) {
+    S = S.drop_back(1);
+    isRightQuoted = true;
   }
   StrToken *Tok = make<eld::StrToken>(S.str());
-  if (IsQuoted)
+  if (isLeftQuoted && isRightQuoted)
     Tok->setQuoted();
+  if (isLeftQuoted)
+    Tok->setLeftQuoted();
+  if (isRightQuoted)
+    Tok->setRightQuoted();
   return Tok;
 }
 

--- a/lib/Script/StrToken.cpp
+++ b/lib/Script/StrToken.cpp
@@ -22,10 +22,10 @@ StrToken::StrToken(const std::string &PString, StrToken::Kind K)
 
 std::string StrToken::getDecoratedName() const {
   std::string R = "";
-  if (isQuoted())
+  if (isQuoted() || LeftQuoted)
     R = "\"";
   R += Name;
-  if (isQuoted())
+  if (isQuoted() || RightQuoted)
     R += "\"";
   return R;
 }

--- a/lib/Script/WildcardPattern.cpp
+++ b/lib/Script/WildcardPattern.cpp
@@ -35,6 +35,10 @@ WildcardPattern::WildcardPattern(StrToken *PPattern, SortPolicy PPolicy,
       MBPatternIsPrefix(false), MBPatternIsSuffix(false), CurID(0) {
   if (PPattern->isQuoted())
     setQuoted();
+  if (PPattern->isLeftQuoted())
+    setLeftQuoted();
+  if (PPattern->isRightQuoted())
+    setRightQuoted();
   createGlobPattern(llvm::StringRef(PPattern->name()));
 }
 

--- a/test/Common/standalone/linkerscript/QuotedArchiveMemberPattern/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/QuotedArchiveMemberPattern/Inputs/1.c
@@ -1,0 +1,2 @@
+int foo() { return 1; }
+

--- a/test/Common/standalone/linkerscript/QuotedArchiveMemberPattern/Inputs/main.c
+++ b/test/Common/standalone/linkerscript/QuotedArchiveMemberPattern/Inputs/main.c
@@ -1,0 +1,3 @@
+int foo();
+int main() { return foo(); }
+

--- a/test/Common/standalone/linkerscript/QuotedArchiveMemberPattern/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/QuotedArchiveMemberPattern/Inputs/script.t
@@ -1,0 +1,4 @@
+SECTIONS {
+  .foo : { "*lib1.a:*1.o"(.text*) }
+  .text : { *(.text*) }
+}

--- a/test/Common/standalone/linkerscript/QuotedArchiveMemberPattern/QuotedArchiveMemberPattern.test
+++ b/test/Common/standalone/linkerscript/QuotedArchiveMemberPattern/QuotedArchiveMemberPattern.test
@@ -1,0 +1,19 @@
+#---QuotedArchiveMemberPattern.test--------------------- Executable ------------------#
+#BEGIN_COMMENT
+# Validates that a quoted archive:member file pattern in an input section
+# description is interpreted correctly.
+#END_COMMENT
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
+RUN: %clang %clangopts -o %t1.main.o %p/Inputs/main.c -c -ffunction-sections
+RUN: %ar cr %t1.lib1.a %t1.1.o
+RUN: %link %linkopts -o %t1.main.out %t1.main.o %t1.lib1.a -MapStyle txt -T %p/Inputs/script.t -Map %t1.main.map.txt
+RUN: %filecheck %s --check-prefix MAP < %t1.main.map.txt
+RUN: %readelf -S %t1.main.out | %filecheck %s --check-prefix SECT
+
+MAP: .foo {{.*}} # Offset
+MAP: "*lib1.a:*1.o"
+MAP: .text.foo
+MAP: foo
+MAP: .text {{.*}} # Offset
+
+SECT: .foo PROGBITS


### PR DESCRIPTION
This commit fixes the parsing / interpretation of `"archive:mem"` file pattern. Previously, it was getting incorrectly stored because we were not properly handling quotes when a single quoted token in the linker script (`"archive:member"`) is stored as two separate patterns in the linker implementation.

Resolves #680