### PR TITLE
Fix Hexagon linux tests marked unsupported on Windows locally

### DIFF
--- a/test/Hexagon/linux/lit.local.cfg
+++ b/test/Hexagon/linux/lit.local.cfg
@@ -1,4 +1,4 @@
 config.suffixes = ['.test']
 
-if 'hexagon-unknown-elf' in config.target_triple:
+if 'hexagon-unknown-linux' in config.target_triple:
   config.unsupported = True


### PR DESCRIPTION
This patch changes `lit.local.cfg` to check for `hexagon-unknown-linux` instead of `hexagon-unknown-elf` in the target triple condition. This fixes tests being incorrectly marked as unsupported on Windows local builds while maintaining compatibility with Linux and CI builders.