### PR TITLE
Fix incorrect NEEDED entry due to unneeded shared lib reference

### DIFF
--- a/test/Common/standalone/AsNeeded/UnneededSharedLibReference/Inputs/1.c
+++ b/test/Common/standalone/AsNeeded/UnneededSharedLibReference/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/Common/standalone/AsNeeded/UnneededSharedLibReference/Inputs/2.c
+++ b/test/Common/standalone/AsNeeded/UnneededSharedLibReference/Inputs/2.c
@@ -1,0 +1,3 @@
+int foo();
+int bar() { return 3; }
+int baz() { return foo(); }

--- a/test/Common/standalone/AsNeeded/UnneededSharedLibReference/Inputs/main.c
+++ b/test/Common/standalone/AsNeeded/UnneededSharedLibReference/Inputs/main.c
@@ -1,0 +1,1 @@
+int main() { return 0; }

--- a/test/Common/standalone/AsNeeded/UnneededSharedLibReference/UnneededSharedLibDependency.test
+++ b/test/Common/standalone/AsNeeded/UnneededSharedLibReference/UnneededSharedLibDependency.test
@@ -1,0 +1,26 @@
+#---UnneededSharedLibReference.test-------------------- Executable-------#
+#BEGIN_COMMENT
+# Validates that with --as-needed we do not add DT_NEEDED entries for libraries
+# that are referenced only by an unneeded shared library.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
+RUN: %clang %clangopts -o %t1.2.o %p/Inputs/2.c -c -ffunction-sections
+RUN: %clang %clangopts -o %t1.main.o %p/Inputs/main.c -c -ffunction-sections
+RUN: %link %linkopts -o %t1.lib1.so -shared %t1.1.o
+RUN: %link %linkopts -o %t1.lib2.so -shared %t1.2.o
+RUN: %link %linkopts -o %t1.out %t1.main.o --as-needed %t1.lib2.so %t1.lib1.so
+RUN: %readelf --dynamic %t1.out 2>&1 | %filecheck %s --check-prefix=CHECK1
+RUN: %link %linkopts -o %t1.out %t1.main.o %t1.lib2.so --as-needed %t1.lib1.so
+RUN: %readelf --dynamic %t1.out 2>&1 | %filecheck %s --check-prefix=CHECK2
+RUN: %link %linkopts -o %t1.out %t1.main.o --as-needed %t1.lib1.so --no-as-needed %t1.lib2.so
+RUN: %readelf --dynamic %t1.out 2>&1 | %filecheck %s --check-prefix=CHECK3
+#END_TEST
+CHECK1-NOT: lib2.so
+CHECK1-NOT: lib1.so
+
+CHECK2: lib2.so
+CHECK2: lib1.so
+
+CHECK3-NOT: lib1.so
+CHECK3: lib2.so


### PR DESCRIPTION
This commit fixes the incorrect NEEDED entry when --as-needed is used and a shared library symbol is referenced by an another unneeded shared library.

The root cause of the issue was the logic that was used to determine whether a shared library symbol ResolveInfo should have an outSymbol or not.

Resolves #668