### PR TITLE
Fix re-evaluation of DEFINED expression

### DIFF
--- a/lib/Script/Expression.cpp
+++ b/lib/Script/Expression.cpp
@@ -1450,6 +1450,8 @@ void Defined::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   Outs << "DEFINED(" << Name << ")";
 }
 eld::Expected<uint64_t> Defined::evalImpl() {
+  if (MResult)
+    return MResult.value();
   const LDSymbol *Symbol = ThisModule.getNamePool().findSymbol(Name);
   if (Symbol == nullptr)
     return 0;

--- a/test/Common/standalone/linkerscript/DefinedExpr/DefinedExpr.test
+++ b/test/Common/standalone/linkerscript/DefinedExpr/DefinedExpr.test
@@ -1,0 +1,16 @@
+#---DefinedExpr.test------------------------- LinkerScript -----------------------#
+#BEGIN_COMMENT
+# This test verifies that the DEFINED expression is evaluated only once. The
+# original result is simply reused on re-evaluations.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.o %p/Inputs/1.c -c -ffunction-sections -fno-common
+RUN: %link %linkopts -o %t1.out %t1.o -T %p/Inputs/script.t -Map %t1.map.txt
+RUN: %filecheck %s --check-prefix=MAP < %t1.map.txt
+RUN: %readelf -S %t1.out | %filecheck %s
+#END_TEST
+MAP: .text 0x3000 {{.*}} # Offset
+MAP: .data 0x4000 {{.*}} # Offset
+CHECK: .text {{.*}} {{0+}}3000
+CHECK: .data {{.*}} {{0+}}4000
+

--- a/test/Common/standalone/linkerscript/DefinedExpr/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/DefinedExpr/Inputs/1.c
@@ -1,0 +1,5 @@
+int bar() { return 3; }
+int foo() { return bar(); }
+
+int u = 1;
+

--- a/test/Common/standalone/linkerscript/DefinedExpr/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/DefinedExpr/Inputs/script.t
@@ -1,0 +1,14 @@
+SECTIONS {
+  . = u;
+  .text : {
+    *(.text*)
+  }
+  .exidx : { *(*exidx*) }
+  u = 0x3000;
+  DATA_START = DEFINED(DATA_START) ? DATA_START : .;
+  . = ALIGN(DATA_START, 0x1000);
+  .data : {
+    *(.data)
+  }
+}
+


### PR DESCRIPTION
This commit fixes the re-evaluation of DEFINED(...) linker script expression. Previously, DEFINED(...) expression used to get re-evaluted in each layout pass. This lead to incorrect evaluated.

This commit fixes this my evaluating DEFINED(...) linker script node only once, and reusing the result for further evaluations.

Resolves #671