### PR TITLE
Reiterate layout step until section addresses converge

### DIFF
--- a/include/eld/Diagnostics/DiagLayouts.inc
+++ b/include/eld/Diagnostics/DiagLayouts.inc
@@ -61,5 +61,6 @@ DIAG(warning_zero_sized_fragment_for_non_zero_symbol, DiagnosticEngine::Warning,
      "Zero sized fragment %0 for non zero sized symbol %1 from input file %2")
 DIAG(error_offset_not_assigned_for_output_section, DiagnosticEngine::Error,
      "Requested offset for output section %0 has not yet been assigned")
-DIAG(warn_empty_segment, DiagnosticEngine::Warning,
-     "Empty segment: '%0'")
+DIAG(warn_empty_segment, DiagnosticEngine::Warning, "Empty segment: '%0'")
+DIAG(note_section_address_not_converging, DiagnosticEngine::Note,
+     "Section '%0' address did not converge after %1 layout passes")

--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -72,6 +72,7 @@ class ScriptMemoryRegion;
 class StubFactory;
 class SymDefReader;
 class TimingFragment;
+class OutputSectionEntry;
 
 /** \class GNULDBackend
  *  \brief GNULDBackend provides a common interface for all GNU Unix-OS
@@ -762,6 +763,21 @@ public:
 
   // -------------------- Finalize Layout callback ----------------
   virtual bool finalizeLayout() { return true; }
+
+  struct SectionAddrs {
+    uint64_t vma = 0;
+    uint64_t lma = 0;
+  };
+
+  struct LayoutSnapshot {
+    llvm::DenseMap<const OutputSectionEntry *, SectionAddrs> outSections;
+  };
+
+  // Capture current layout snapshot keyed by OutputSectionEntry*.
+  LayoutSnapshot captureLayoutSnapshot() const;
+
+  const OutputSectionEntry *findDivergence(const LayoutSnapshot &Prev,
+                                           const LayoutSnapshot &cur) const;
 
   // --- Exclude symbol support
   void markSymbolForRemoval(const ResolveInfo *S);

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -3280,6 +3280,39 @@ bool GNULDBackend::layout() {
   return config().getDiagEngine()->diagnose();
 }
 
+GNULDBackend::LayoutSnapshot GNULDBackend::captureLayoutSnapshot() const {
+  LayoutSnapshot S;
+  const SectionMap &SM = m_Module.getScript().sectionMap();
+  for (auto It = SM.begin(), End = SM.end(); It != End; ++It) {
+    const OutputSectionEntry *O = *It;
+    const ELFSection *Sec = O->getSection();
+    ASSERT(Sec, "Must not be null!");
+    SectionAddrs A;
+    A.vma = Sec->addr();
+    A.lma = Sec->pAddr();
+    S.outSections.insert({O, A});
+  }
+  return S;
+}
+
+const OutputSectionEntry *
+GNULDBackend::findDivergence(const LayoutSnapshot &Prev,
+                             const LayoutSnapshot &cur) const {
+  const SectionMap &SM = m_Module.getScript().sectionMap();
+  for (auto It = SM.begin(), End = SM.end(); It != End; ++It) {
+    const OutputSectionEntry *O = *It;
+    auto PrevIt = Prev.outSections.find(O);
+    auto CurIt = cur.outSections.find(O);
+    if (PrevIt == Prev.outSections.end() || CurIt == cur.outSections.end())
+      return O;
+    const SectionAddrs &A = PrevIt->second;
+    const SectionAddrs &B = CurIt->second;
+    if (A.vma != B.vma || A.lma != B.lma)
+      return O;
+  }
+  return nullptr;
+}
+
 // Create or return an already created relocation output section for partial
 // linking.
 ELFSection *GNULDBackend::getOutputRelocationSection(ELFSection *S,
@@ -4074,15 +4107,33 @@ bool GNULDBackend::relax() {
   while (!finished) {
     auto start = std::chrono::steady_clock::now();
     {
-      eld::RegisterTimer T("Assign Address", "Establish Layout",
-                           m_Module.getConfig().options().printTimingStats());
-      bool hasError = createProgramHdrs();
-      if (hasError)
-        m_Module.setFailure(true);
-      if (updateTargetSections()) {
+      // Bounded convergence loop over address assignment.
+      LayoutSnapshot prevSnap, curSnap;
+      prevSnap = captureLayoutSnapshot();
+      constexpr int maxIterations = 4;
+      const OutputSectionEntry *changed = nullptr;
+      for (int i = 0; i < maxIterations; ++i) {
+        eld::RegisterTimer T("Assign Address", "Establish Layout",
+                             m_Module.getConfig().options().printTimingStats());
         bool hasError = createProgramHdrs();
         if (hasError)
           m_Module.setFailure(true);
+        if (updateTargetSections()) {
+          bool hasError = createProgramHdrs();
+          if (hasError)
+            m_Module.setFailure(true);
+        }
+        curSnap = captureLayoutSnapshot();
+        changed = findDivergence(prevSnap, curSnap);
+        if (!changed)
+          break;
+        prevSnap = std::move(curSnap);
+      }
+      if (changed) {
+        // Emit a note for the first observed changed section.
+        if (const ELFSection *S = changed->getSection())
+          config().raise(Diag::note_section_address_not_converging)
+              << S->name() << maxIterations;
       }
       if (LinkerConfig::Object != config().codeGenType()) {
         if (!setupProgramHdrs()) {

--- a/test/Common/standalone/DotForwReference/DotForwReference.test
+++ b/test/Common/standalone/DotForwReference/DotForwReference.test
@@ -1,0 +1,35 @@
+#---DotForwReference.test--------------------- Executable,LS ------------------#
+#BEGIN_COMMENT
+# Validates that a forward reference to a symbol in dot assignments within
+# SECTIONS is handled correctly.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.1.t
+RUN: %readelf -S %t1.1.out | %filecheck %s
+RUN: %link %linkopts -o %t1.1.phdr.out %t1.1.o -T %p/Inputs/script.1.phdr.t
+RUN: %readelf -S %t1.1.phdr.out | %filecheck %s
+RUN: %link %linkopts -o %t1.2.out %t1.1.o -T %p/Inputs/script.2.t 2>&1 \
+RUN:   --trace=assignments | %filecheck %s --allow-empty --check-prefix TRACE
+RUN: %readelf -S %t1.2.out | %filecheck %s --check-prefix CHECK2
+RUN: %link %linkopts -o %t1.2.phdr.out %t1.1.o -T %p/Inputs/script.2.phdr.t 2>&1 \
+RUN:   --trace=assignments | %filecheck %s --allow-empty --check-prefix TRACE
+RUN: %readelf -S %t1.2.phdr.out | %filecheck %s --check-prefix CHECK2
+RUN: %link %linkopts -o %t1.1.3.out %t1.1.o -T %p/Inputs/script.3.t 2>&1 \
+RUN:   | %filecheck %s --check-prefix=NON_CONVERGENCE_NOTE
+RUN: %link %linkopts -o %t1.1.3.out %t1.1.o -T %p/Inputs/script.3.phdr.t 2>&1 \
+RUN:   | %filecheck %s --check-prefix=NON_CONVERGENCE_NOTE
+#END_TEST
+
+CHECK: .text PROGBITS {{0+}}3000
+
+TRACE: Trace: OUTPUT_SECTION(EVALUATE) >> .text VMA : 0x0 LMA : 0x0
+TRACE: Trace: OUTPUT_SECTION(EVALUATE) >> .text VMA : 0x4000 LMA : 0x4000
+TRACE: Trace: OUTPUT_SECTION(EVALUATE) >> .text VMA : 0x5000 LMA : 0x5000
+TRACE: Trace: OUTPUT_SECTION(EVALUATE) >> .text VMA : 0x5000 LMA : 0x5000
+TRACE-NOT: address did not converge
+
+CHECK2: .text PROGBITS {{0+}}5000
+
+NON_CONVERGENCE_NOTE: Note: Section '.text' address did not converge after 4 layout passes
+

--- a/test/Common/standalone/DotForwReference/Inputs/1.c
+++ b/test/Common/standalone/DotForwReference/Inputs/1.c
@@ -1,0 +1,3 @@
+int foo() { return 1; }
+
+int val = 3;

--- a/test/Common/standalone/DotForwReference/Inputs/script.1.phdr.t
+++ b/test/Common/standalone/DotForwReference/Inputs/script.1.phdr.t
@@ -1,0 +1,12 @@
+PHDRS {
+  TEXT PT_LOAD;
+  DATA PT_LOAD;
+  COMMENT PT_NOTE;
+}
+SECTIONS {
+  . = u;
+  .text : { *(.text*) } :TEXT
+  .data : { *(.data*) } :DATA
+  .comment : { *(.comment*) } :COMMENT
+  u = 0x3000;
+}

--- a/test/Common/standalone/DotForwReference/Inputs/script.1.t
+++ b/test/Common/standalone/DotForwReference/Inputs/script.1.t
@@ -1,0 +1,7 @@
+SECTIONS {
+  . = u;
+  .text : { *(.text*) }
+  .data : { *(.data*) }
+  .comment : { *(.comment*) }
+  u = 0x3000;
+}

--- a/test/Common/standalone/DotForwReference/Inputs/script.2.phdr.t
+++ b/test/Common/standalone/DotForwReference/Inputs/script.2.phdr.t
@@ -1,0 +1,15 @@
+PHDRS {
+  TEXT PT_LOAD;
+  DATA PT_LOAD;
+  COMMENT PT_NOTE;
+}
+SECTIONS {
+  TEXT_START = u;
+  . = TEXT_START;
+  .text : { *(.text*) } :TEXT
+  .data : { *(.data*) } :DATA
+  .comment : { *(.comment*) } :COMMENT
+  u = 0x4000 + v;
+  w = MIN(0x1000, w + 0xf00);
+  v = ALIGN(w, 0x1000);
+}

--- a/test/Common/standalone/DotForwReference/Inputs/script.2.t
+++ b/test/Common/standalone/DotForwReference/Inputs/script.2.t
@@ -1,0 +1,10 @@
+SECTIONS {
+  TEXT_START = u;
+  . = TEXT_START;
+  .text : { *(.text*) }
+  .data : { *(.data*) }
+  .comment : { *(.comment*) }
+  u = 0x4000 + v;
+  w = MIN(0x1000, w + 0xf00);
+  v = ALIGN(w, 0x1000);
+}

--- a/test/Common/standalone/DotForwReference/Inputs/script.3.phdr.t
+++ b/test/Common/standalone/DotForwReference/Inputs/script.3.phdr.t
@@ -1,0 +1,15 @@
+PHDRS {
+  TEXT PT_LOAD;
+  DATA PT_LOAD;
+  COMMENT PT_NOTE;
+}
+SECTIONS {
+  TEXT_START = u;
+  . = TEXT_START;
+  .text : { *(.text*) } :TEXT
+  .data : { *(.data*) } :DATA
+  .comment : { *(.comment*) } :COMMENT
+  u = 0x4000 + v;
+  w = MIN(0x3000, w + 0xf00);
+  v = ALIGN(w, 0x1000);
+}

--- a/test/Common/standalone/DotForwReference/Inputs/script.3.t
+++ b/test/Common/standalone/DotForwReference/Inputs/script.3.t
@@ -1,0 +1,10 @@
+SECTIONS {
+  TEXT_START = u;
+  . = TEXT_START;
+  .text : { *(.text*) }
+  .data : { *(.data*) }
+  .comment : { *(.comment*) }
+  u = 0x4000 + v;
+  w = MIN(0x3000, w + 0xf00);
+  v = ALIGN(w, 0x1000);
+}


### PR DESCRIPTION
This commit modifies the layout step to reiterate until the section addresses converge. The reiteration has an upper limit of 4. On reaching this limit, a warning is emitted and the layout reiteration is stopped.

Please note that this reiteration limit is for layout iterations before relaxations take place. After a layout relaxation pass, the reiteration count is reset to 0.

Resolves #687