### PR TITLE
Deprecate functions working on the global context

### DIFF
--- a/lib/Readers/ArchiveParser.cpp
+++ b/lib/Readers/ArchiveParser.cpp
@@ -511,7 +511,7 @@ ArchiveParser::createMemberReader(
     const ArchiveFile &archiveFile, const llvm::object::Archive &archiveReader,
     const llvm::object::Archive::Child &member) const {
   LinkerConfig &config = m_Module.getConfig();
-  llvm::LLVMContext &context = *llvm::unwrap(LLVMGetGlobalContext());
+  llvm::LLVMContext &context = *llvm::unwrap(llvm::getGlobalContextForCAPI());
   Input *archiveMemInput =
       archiveFile.getLazyLoadMember(member.getChildOffset());
   ASSERT(archiveMemInput,


### PR DESCRIPTION
LLVM upstream landed https://github.com/llvm/llvm-project/pull/163979 (commit: ec1ea0a4ca02451731036ce04915e30aad0c81dd) and ELD also needs the corresponding change.