### PR TITLE
Add basic LLVM_DISTRIBUTION_COMPONENTS compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,13 @@ install(
   PATTERN "*.template"
   PATTERN ".git" EXCLUDE
   PATTERN ".svn" EXCLUDE)
+if (NOT LLVM_ENABLE_IDE)
+  # LLVM_DISTRIBUTION_COMPONENTS requires that each component have both a
+  # component and an install-component target, so add appropriate dummy targets.
+  add_custom_target(linker-script)
+  add_llvm_install_targets(install-linker-script
+                           COMPONENT linker-script)
+endif()
 
 set(ELD_INSTALL_YAML_MAP_PARSER
     ON
@@ -224,5 +231,13 @@ if(ELD_INSTALL_YAML_MAP_PARSER)
     set(ELD_YAML_MAP_PARSER_DEST_DIR "bin")
   endif()
   install(PROGRAMS utils/YAMLMapParser/YAMLMapParser.py
-          DESTINATION ${ELD_YAML_MAP_PARSER_DEST_DIR})
+          DESTINATION ${ELD_YAML_MAP_PARSER_DEST_DIR}
+          COMPONENT YAMLMapParser)
+  if (NOT LLVM_ENABLE_IDE)
+    # LLVM_DISTRIBUTION_COMPONENTS requires that each component have both a
+    # component and an install-component target, so add appropriate dummy targets.
+    add_custom_target(YAMLMapParser)
+    add_llvm_install_targets(install-YAMLMapParser
+                             COMPONENT YAMLMapParser)
+  endif()
 endif()

--- a/include/eld/CMakeLists.txt
+++ b/include/eld/CMakeLists.txt
@@ -21,4 +21,12 @@ if(ENABLE_ELD_PLUGIN_SUPPORT)
       DESTINATION include/ELD/PluginAPI/
       COMPONENT PluginAPIHeaders)
   endif()
+
+  if (NOT LLVM_ENABLE_IDE)
+    # LLVM_DISTRIBUTION_COMPONENTS requires that each component have both a
+    # component and an install-component target, so add appropriate dummy targets.
+    add_custom_target(PluginAPIHeaders)
+    add_llvm_install_targets(install-PluginAPIHeaders
+                             COMPONENT PluginAPIHeaders)
+  endif()
 endif()

--- a/tools/eld/CMakeLists.txt
+++ b/tools/eld/CMakeLists.txt
@@ -28,7 +28,15 @@ configure_file(eld_install.cmake.in
 # from top level llvm build directory
 configure_file(eld_install.cmake.in ${CMAKE_BINARY_DIR}/eld_install.cmake)
 
-install(TARGETS ld.eld RUNTIME DESTINATION bin)
+install(TARGETS ld.eld RUNTIME DESTINATION bin COMPONENT ld.eld)
+if (NOT LLVM_ENABLE_IDE)
+  add_llvm_install_targets(install-ld.eld
+                           DEPENDS ld.eld
+                           COMPONENT ld.eld)
+  add_dependencies(install-ld.eld install-${LINKER_WRAPPER_LIB})
+  add_dependencies(install-ld.eld-stripped
+                   install-${LINKER_WRAPPER_LIB}-stripped)
+endif()
 
 # FIXME: We need to switch to ELD_TARGETS_TO_BUILD after the buildbot upgrade
 if("${LLVM_TARGETS_TO_BUILD}" MATCHES "Hexagon" AND "${TARGET_TRIPLE}" MATCHES
@@ -79,4 +87,5 @@ if(DEFINED USE_LINKER_ALT_NAME)
 endif()
 
 # Create the symlink at installation time.
-install(SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/ld_eld_symlink.cmake)
+install(SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/ld_eld_symlink.cmake
+        COMPONENT ld.eld)


### PR DESCRIPTION
LLVM_DISTRIBUTION_COMPONENTS seems to require that each component have
a) install-* and install-*-stripped targets and b) a component associated with
the things to install.

So, there's a few separate changes made to add this support into eld:
- For each of the components we want to support, `add_llvm_install_targets`
  is used to create the install* and install-*-stripped targets. I think this
  is the easiest (and a recommended) way to do this.
- I think eld has five components we need to handle: ld.eld, LW,
  PluginAPIHeaders, linker-script (templates), and YAMLMapParser. Each
  of these had the appropriate install targets and components added, as
  needed. Hopefully I'm not missing any additional components we need to
  consider for distributions.

  It might make sense to more aggressively couple some of these, but I
  think the granularity here matches pretty well with available CMake
  options (to ex: disable the YAMLMapParser) and current toolchains with
  eld included (where the PluginAPIHeaders, templates, etc. may be stripped
  out). So, I left this as-is.
- A dependency was added between the ld.eld and LW install targets--without
  these ld.eld would always fail at runtime about the missing LW library, if
  only ex: `ninja install-ld.eld` was run. Which, doesn't seem that helpful.
  So, make ld.eld's install depend on LW's.

Expected usage looks something like:

`-DLLVM_DISTRIBUTION_COMPONENTS='...;ld.eld;LW;PluginAPIHeaders;linker-script;YAMLMapParser'`

and these items can generally be added/removed based on what people want in
the distribution (modulo ld.eld's dependency on LW).

And, as per the install-* target requirement mentioned above, each of
these components can now be individually installed with ex: install-ld.eld.

Fixes https://github.com/qualcomm/eld/issues/693