### PR TITLE
Update symbols with retain attribute

### DIFF
--- a/lib/GarbageCollection/GarbageCollection.cpp
+++ b/lib/GarbageCollection/GarbageCollection.cpp
@@ -574,8 +574,12 @@ bool GarbageCollection::getEntrySections(SectionSetTy &EntrySections) {
           continue;
       }
 
-      if (!treatSymbolAsEntry(Info))
+      if (!treatSymbolAsEntry(Info)) {
         continue;
+      }
+
+      if (Info->getOwningSection() && Info->getOwningSection()->isRetain())
+        Info->outSymbol()->setShouldIgnore(false);
 
       // only the target symbols defined in the concerned sections can be
       // entries
@@ -810,6 +814,10 @@ void GarbageCollection::stripSections(SectionSetTy &S,
 bool GarbageCollection::treatSymbolAsEntry(ResolveInfo *R) const {
   // Symbol resolved from shared object.
   if (R->isDyn())
+    return true;
+
+  // All retain sections are entry
+  if (R->getOwningSection() && R->getOwningSection()->isRetain())
     return true;
 
   if (!R->isDefine() || R->isLocal())

--- a/test/Hexagon/Plugin/CMakeLists.txt
+++ b/test/Hexagon/Plugin/CMakeLists.txt
@@ -7,6 +7,7 @@ endfunction()
 
 add_subdirectory(AllOutSectAddresses)
 add_subdirectory(ChangeSymbol)
+add_subdirectory(UpdateSymbol)
 add_subdirectory(ConfigFile)
 add_subdirectory(CreateChunk)
 add_subdirectory(DiscardSections)

--- a/test/Hexagon/Plugin/UpdateSymbol/CMakeLists.txt
+++ b/test/Hexagon/Plugin/UpdateSymbol/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(SOURCES UpdateSymbol.cpp)
+
+if(NOT CYGWIN AND LLVM_ENABLE_PIC)
+  set(SHARED_LIB_SOURCES ${SOURCES})
+
+  set(bsl ${BUILD_SHARED_LIBS})
+
+  set(BUILD_SHARED_LIBS ON)
+
+  add_llvm_library(updatesymbol ${SHARED_LIB_SOURCES} LINK_LIBS LW)
+
+  set(BUILD_SHARED_LIBS ${bsl})
+
+endif()
+
+add_plugin(changesymbol)

--- a/test/Hexagon/Plugin/UpdateSymbol/Inputs/1.c
+++ b/test/Hexagon/Plugin/UpdateSymbol/Inputs/1.c
@@ -1,0 +1,3 @@
+int bar();
+
+int foo() { return bar(); }

--- a/test/Hexagon/Plugin/UpdateSymbol/Inputs/2.c
+++ b/test/Hexagon/Plugin/UpdateSymbol/Inputs/2.c
@@ -1,0 +1,3 @@
+__attribute__((retain)) int baz() {
+  return 1;
+}

--- a/test/Hexagon/Plugin/UpdateSymbol/Inputs/script.t
+++ b/test/Hexagon/Plugin/UpdateSymbol/Inputs/script.t
@@ -1,0 +1,13 @@
+PLUGIN_ITER_SECTIONS("updatesymbol","UPDATESYMBOL");
+SECTIONS {
+.foo : {
+  *(.text.foo)
+}
+.bar : {
+  *(.text.bar)
+}
+
+.baz : {
+  *(.text.baz)
+}
+}

--- a/test/Hexagon/Plugin/UpdateSymbol/UpdateSymbol.cpp
+++ b/test/Hexagon/Plugin/UpdateSymbol/UpdateSymbol.cpp
@@ -1,0 +1,124 @@
+#include "Expected.h"
+#include "LinkerWrapper.h"
+#include "PluginVersion.h"
+#include "SectionIteratorPlugin.h"
+#include <algorithm>
+#include <cstring>
+#include <iostream>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+using namespace eld::plugin;
+
+class DLL_A_EXPORT UpdateSymbolPlugin : public SectionIteratorPlugin {
+
+public:
+  UpdateSymbolPlugin() : SectionIteratorPlugin("UPDATESYMBOL") {}
+
+  // Perform any initialization here
+  void Init(std::string Options) override {}
+
+  void processSection(Section S) override {}
+
+  // After the linker lays out the image, but before it creates the elf file,
+  // it will call this run function.
+  Status Run(bool Trace) override {
+    return eld::plugin::Plugin::Status::SUCCESS;
+  }
+
+  void Destroy() override {}
+
+  uint32_t GetLastError() override { return 0; }
+
+  std::string GetLastErrorAsString() override { return "SUCCESS"; }
+
+  std::string GetName() override { return "UPDATESYMBOL"; }
+};
+
+class DLL_A_EXPORT UpdateSymbolPluginConfig : public LinkerPluginConfig {
+public:
+  UpdateSymbolPluginConfig(UpdateSymbolPlugin *P)
+      : LinkerPluginConfig(P), P(P) {}
+
+  void Init() override {
+    std::string b22pcrel = "R_HEX_B22_PCREL";
+    eld::Expected<void> expRegReloc =
+        P->getLinker()->registerReloc(getRelocationType(b22pcrel));
+    ELDEXP_REPORT_AND_RETURN_VOID_IF_ERROR(P->getLinker(), expRegReloc);
+  }
+
+  void RelocCallBack(Use U) override {
+    if (P->getLinker()->isMultiThreaded()) {
+      std::lock_guard<std::mutex> M(Mutex);
+      printMessage(U);
+      return;
+    }
+    printMessage(U);
+  }
+
+private:
+  void printMessage(Use U) {
+    if (!P->getLinker()->isLinkStateBeforeLayout())
+      return;
+    std::cerr << "Got a callback for " << getRelocationName(U.getType())
+              << " Payload : " << U.getName() << "\n";
+    std::cerr << getPath(U.getTargetChunk().getInputFile()) << "\t"
+              << getPath(U.getSourceChunk().getInputFile()) << "\t"
+              << U.getOffsetInChunk() << "\n";
+    if (U.getName() == "bar")
+      changeSymbol(U);
+  }
+
+  uint32_t getRelocationType(std::string Name) {
+    uint32_t rType =
+        P->getLinker()->getRelocationHandler().getRelocationType(Name);
+    return rType;
+  }
+
+  std::string getRelocationName(uint32_t Type) {
+    return P->getLinker()->getRelocationHandler().getRelocationName(Type);
+  }
+
+  std::string getPath(InputFile I) const {
+    std::string FileName = std::string(I.getFileName());
+    if (I.isArchive())
+      return FileName + "(" + I.getMemberName() + ")";
+    return FileName;
+  }
+
+  void changeSymbol(eld::plugin::Use &U) {
+    eld::Expected<Symbol> S = P->getLinker()->getSymbol("baz");
+    U.resetSymbol(*S);
+  }
+
+private:
+  UpdateSymbolPlugin *P;
+  std::mutex Mutex;
+};
+
+std::unordered_map<std::string, Plugin *> Plugins;
+
+UpdateSymbolPlugin *ThisPlugin = nullptr;
+eld::plugin::LinkerPluginConfig *ThisPluginConfig = nullptr;
+
+extern "C" {
+bool DLL_A_EXPORT RegisterAll() {
+  ThisPlugin = new UpdateSymbolPlugin();
+  ThisPluginConfig = new UpdateSymbolPluginConfig(ThisPlugin);
+  return true;
+}
+
+PluginBase DLL_A_EXPORT *getPlugin(const char *T) { return ThisPlugin; }
+
+LinkerPluginConfig DLL_A_EXPORT *getPluginConfig(const char *T) {
+  return ThisPluginConfig;
+}
+
+void DLL_A_EXPORT Cleanup() {
+  if (ThisPlugin)
+    delete ThisPlugin;
+  if (ThisPluginConfig)
+    delete ThisPluginConfig;
+}
+}

--- a/test/Hexagon/Plugin/UpdateSymbol/UpdateSymbol.test
+++ b/test/Hexagon/Plugin/UpdateSymbol/UpdateSymbol.test
@@ -1,0 +1,11 @@
+#---UpdateSymbol.test----------------------- Executable,LS --------------------#
+#BEGIN_COMMENT
+#This tests that the plugin can replace the call to symbol bar with baz
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangg0opts -c %p/Inputs/1.c -o %t1.1.o  -ffunction-sections -fdata-sections
+RUN: %clang %clangg0opts -c %p/Inputs/2.c -o %t1.2.o  -ffunction-sections -fdata-sections
+RUN: %link %linkopts %t1.1.o %t1.2.o -T %p/Inputs/script.t --gc-sections --trace=plugin -o %t2.out -L %p/Inputs 2>&1
+RUN: %objdump -d %t2.out 2>&1 | %filecheck %s
+#END_TEST
+#CHECK: baz


### PR DESCRIPTION
Sections that are specified with a retain attribute are not garbage collected, and symbols are also not garbage collected too.

The book keeping of how relocations are applied needs the ShouldIgnore property for symbols that need to be retained.

This patch updates this and enables plugins to update symbols and relocations to symbols that are retained.

Fixes #498