### PR TITLE
multiple tls segments support - picolibc

### DIFF
--- a/test/Hexagon/standalone/linkerscript/MultipleTLSSegments/Inputs/script.t
+++ b/test/Hexagon/standalone/linkerscript/MultipleTLSSegments/Inputs/script.t
@@ -1,0 +1,18 @@
+PHDRS {
+  flash PT_LOAD;
+  ram_init PT_LOAD;
+  ram PT_LOAD;
+  tls_init PT_TLS;
+  tls PT_TLS;
+}
+
+MEMORY {
+  flash (rx!w) : ORIGIN = 0x40000000, LENGTH = 0x100
+  ram (w!rx)   : ORIGIN = 0x40000200, LENGTH = 0x100
+}
+
+SECTIONS {
+  .text : { *(.text*) } >flash AT>flash :flash
+  .tdata : { *(.tdata*) } >ram AT>flash :tls_init :ram_init
+  .tbss (NOLOAD) : { *(.tbss*) } >ram AT>ram :tls :ram
+}

--- a/test/Hexagon/standalone/linkerscript/MultipleTLSSegments/Inputs/tls.c
+++ b/test/Hexagon/standalone/linkerscript/MultipleTLSSegments/Inputs/tls.c
@@ -1,0 +1,4 @@
+__thread int a = 1;
+__thread int b = 0;
+
+int main(int argc, char *argv[]) { return a + b; }

--- a/test/Hexagon/standalone/linkerscript/MultipleTLSSegments/MultipleTLSSegments.test
+++ b/test/Hexagon/standalone/linkerscript/MultipleTLSSegments/MultipleTLSSegments.test
@@ -1,0 +1,14 @@
+#---MultipleTLSSegments.test--------------------- Executable,LS------------------#
+#BEGIN_COMMENT
+# This tests that the linker can handle multiple TLS segments.
+#END_COMMENT
+RUN: %clang %clangopts -c %p/Inputs/tls.c  -o %t1.1.o -ffunction-sections -fdata-sections -O2
+RUN: %link -MapStyle txt %linkopts %t1.1.o -T %p/Inputs/script.t -o %t2.out -Map %t2.map.out
+RUN: %filecheck %s < %t2.map.out
+RUN: %readelf -l -W %t2.out | %filecheck %s -check-prefix=SEGMENT
+RUN: %objdump -d %t2.out | %filecheck %s -check-prefix=TPOFF
+
+#CHECK: .tbss [[ADDR:[xa-f0-9]+]]
+#SEGMENT-COUNT-2: TLS
+#TPOFF: ##-0x8)
+#TPOFF: ##-0x4)


### PR DESCRIPTION
The TLS template size for computing TLS offsets will need to be adjusted if there are multiple PT_TLS segments. This support is exercised by picolibc for TLS support.

Resolves #689