### PR TITLE
Handle NOLOAD/TBSS/PROGBITS sections

### DIFF
--- a/lib/Target/CreateProgramHeaders.hpp
+++ b/lib/Target/CreateProgramHeaders.hpp
@@ -666,7 +666,8 @@ bool GNULDBackend::createProgramHdrs() {
             pt_gnu_relro->setAlign(pt_gnu_relro->getMaxSectionAlign());
           }
         }
-        prev = cur;
+        if (!cur->isTBSS())
+          prev = cur;
         if (isNoLoad)
           noLoadSections.push_back(cur);
         prevOut = (*out);

--- a/test/Common/standalone/linkerscript/TLS/DontMixTBSS/DontMixTBSS.test
+++ b/test/Common/standalone/linkerscript/TLS/DontMixTBSS/DontMixTBSS.test
@@ -1,0 +1,11 @@
+#---DontMixTBSS.test--------------------- Executable,LS------------------#
+#BEGIN_COMMENT
+# This tests that TBSS sections dont get mixed up with other sections
+# when the linker needs to create new segments
+#END_COMMENT
+RUN: %clang %clangg0opts -c %p/Inputs/tls.c  -o %t1.1.o -ffunction-sections -fdata-sections -fno-common
+RUN: %link -MapStyle txt %linkopts %t1.1.o -T %p/Inputs/script.t -o %t2.out.1 -Map %t2.map.out.1
+RUN: %readelf -l -W %t2.out.1 | %filecheck %s -check-prefix=SEGMENTS
+
+#SEGMENTS: LOAD 0x{{[0]+}}{{[12]}}000 0x{{[0]+}}2000 0x{{[0]+}}2000 0x{{[0]+}} 0x{{[0]+}}1000 RW
+#SEGMENTS: LOAD 0x{{[0]+}}{{[12]}}000 0x{{[0]+}}3000 0x{{[0]+}}3000 0x{{[0]+}}4 0x{{[0]+}}8 RW

--- a/test/Common/standalone/linkerscript/TLS/DontMixTBSS/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/TLS/DontMixTBSS/Inputs/script.t
@@ -1,0 +1,22 @@
+MEMORY {
+  RAM (rwx) : ORIGIN = 0x1000, LENGTH = 0x4000
+}
+
+SECTIONS {
+  .text : { *(.text*) } >RAM
+  .bss (NOLOAD) : ALIGN(0x1000) { *(.bss.empty_var2) *(.sbss.empty_var1) } >RAM
+  .v (NOLOAD) : {
+    *(.data.v)
+    *(.sdata.v*)
+    *(.sdata.4.v*)
+    . = ALIGN(0x1000);
+  } >RAM
+  .tbssa : { *(.tbss.a) } >RAM
+  .tbssb : { *(.tbss.b) } >RAM
+  .tbssc : { *(.tbss.c) } >RAM
+  .tbssd : { *(.tbss.d) } >RAM
+  .tbsse : { *(.tbss.e) } >RAM
+  .tbssf : { *(.tbss.f) } >RAM
+  .w : { *(.data.w) *(.sdata.w*) *(.sdata.4.w*) } >RAM
+  .empty_var2 (NOLOAD) : { *(.bss.empty_var1) *(.sbss.empty_var2) } >RAM
+}

--- a/test/Common/standalone/linkerscript/TLS/DontMixTBSS/Inputs/tls.c
+++ b/test/Common/standalone/linkerscript/TLS/DontMixTBSS/Inputs/tls.c
@@ -1,0 +1,11 @@
+int foo() { return 1;}
+
+int empty_var1;
+int empty_var2;
+__thread int a;
+__thread int b;
+__thread int c;
+__thread int d;
+__thread int e;
+__attribute__((section(".sdata.v"))) int v = 11;
+__attribute__((section(".sdata.w"))) int w = 13;


### PR DESCRIPTION
Linker used to mix NOLOAD(which gets turned to NOBITS) and PROGBITS sections, and create a invalid image when there is a TBSS sections that lands in between NOLOAD and PROGBITS sections. Make the linker treat TBSS sections specially n the layout when assigning virtual addresses to create new segments.

Resolves #711