### PR TITLE
Update YAMLMapParser.py shebang to an external-user-friendly path

### DIFF
--- a/utils/YAMLMapParser/YAMLMapParser.py
+++ b/utils/YAMLMapParser/YAMLMapParser.py
@@ -1,4 +1,4 @@
-#!/pkg/qct/software/python/3.4.0/bin/python
+#!/usr/bin/env python3
 
 import argparse
 import os


### PR DESCRIPTION
We probably shouldn't be exposing internal paths and this isn't meaningful for external users. Just use the python3 found in the env as that seems closest to what is done in other scripts.

I think this should be safe as it looks like most tests don't invoke the parser this way. If there are any issues exposed by using a non-3.4 version of Python, I'm also assuming those should be treated as bugs given 3.4 has been end of life for a number of years at this point.