### PR TITLE
Enable target-independent tests that use LLVM assembly

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -194,6 +194,7 @@ cp = 'cp'
 tail = 'tail'
 xlen = 4
 dirname = 'dirname'
+datalayout = ''
 
 # Control RISC-V Compression extension option, on by default
 clangnorvcopts = ''
@@ -252,10 +253,13 @@ config.test_target = config.eld_targets_to_build.split('_', 1)[0]
 
 if config.test_target == 'Hexagon':
     clang = 'clang -target hexagon'
+    if not config.target_triple:
+        config.target_triple = "hexagon-unknown-none-elf"
     config.arch = 'v75'
     config.emulation = '-m' + config.arch
     config.march = '-march=hexagon'
     config.mcpu = '-mcpu=hexagon' + config.arch
+    datalayout = 'e-m:e-p:32:32:32-a:0-n16:32-i64:64:64-i32:32:32-i16:16:16-i1:8:8-f32:32:32-f64:64:64-v32:32:32-v64:64:64-v512:512:512-v1024:1024:1024-v2048:2048:2048'
     embedclangopts = clangcommonopts + config.emulation
     embedclangxxopts = clangcommonopts + clangcommonxxopts + config.emulation
     clangopts = clangcommonopts + ' ' + config.emulation
@@ -298,7 +302,10 @@ if config.test_target == 'Hexagon':
         config.available_features.add('hexagon')
 
 if config.test_target == 'X86':
+    if not config.target_triple:
+        config.target_triple = "x86_64-unknown-linux-gnu"
     config.march = ''
+    datalayout = 'e-m:e-i64:64-f80:128-n8:16:32:64-S128'
     clang = 'clang -target x86_64-linux-gnu'
     clangxx = 'clang++'
     llvmmc = 'llvm-mc'
@@ -312,7 +319,10 @@ if config.test_target == 'X86':
     config.available_features.add('x86')
 
 if config.test_target == 'ARM':
+    if not config.target_triple:
+        config.target_triple = "arm-unknown-none-eabi"
     config.march = '-march=arm'
+    datalayout = 'e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64'
     clang ='clang -target arm'
     clangxx ='clang++ -target arm'
     clangas = 'clang -target arm'
@@ -344,7 +354,10 @@ if config.test_target == 'ARM':
             config.available_features.add("ndk-build")
 
 if config.test_target == 'AArch64':
+    if not config.target_triple:
+        config.target_triple = "aarch64-unknown-none-elf"
     config.march = '-march=aarch64'
+    datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
     # Features for buildbot to XFAIL tests while they are being fixed.
     if platform.system() == 'Windows':
         config.available_features.add('aarch64-windows')
@@ -377,7 +390,10 @@ if config.test_target == 'AArch64':
             config.available_features.add("ndk-build")
 
 if config.test_target == 'RISCV64':
+    if not config.target_triple:
+        config.target_triple = "riscv64-unknown-none-elf"
     config.march = '-march=riscv64'
+    datalayout = 'e-m:e-p:64:64-i64:64-i128:128-n32:64-S128'
     config.available_features.add('riscv64')
     xlen = 8
     clang = 'clang -target riscv64'
@@ -404,7 +420,10 @@ if config.test_target == 'RISCV64':
     dwarfdump = 'llvm-dwarfdump'
 
 if config.test_target == 'RISCV':
+    if not config.target_triple:
+        config.target_triple = "riscv32-unknown-none-elf"
     config.march = '-march=riscv32'
+    datalayout = 'e-m:e-p:32:32-i64:64-n32-S128'
     config.available_features.add('riscv32')
     clang = 'clang -target riscv32'
     clangxx = 'clang++ -target riscv32'
@@ -532,6 +551,8 @@ else:
 
 # Add substitutions.
 config.substitutions.append( ("%xlen", str(xlen)))
+config.substitutions.append( ("%triple","".join(config.target_triple)) )
+config.substitutions.append( ("%datalayout", datalayout))
 config.substitutions.append( ("%aropts", ar_opts))
 config.substitutions.append( ("%clangxxopts","".join(clangxxopts)) )
 config.substitutions.append( ("%embedclangxxopts","".join(embedclangxxopts)) )

--- a/test/lld/ELF/new-pass-manager.ll
+++ b/test/lld/ELF/new-pass-manager.ll
@@ -1,14 +1,10 @@
-; REQUIRES: x86
-; RUN: %llvm-as %s -o %t.o
+; RUN: %opt --mtriple=%triple --data-layout=%datalayout %s -o %t.o
 
 ; Test debug-pass-manager option
 ; RUN: %link %linkopts --plugin-opt=debug-pass-manager -o /dev/null %t.o 2>&1 | FileCheck %s
 ; RUN: %link %linkopts --lto-debug-pass-manager -o /dev/null %t.o 2>&1 | FileCheck %s
 
 ; CHECK: Running pass: GlobalOptPass
-
-target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-unknown-linux-gnu"
 
 define void @foo() {
   ret void

--- a/test/lld/ELF/opt-level.ll
+++ b/test/lld/ELF/opt-level.ll
@@ -1,5 +1,5 @@
-; REQUIRES: x86
-; RUN: %llvm-as -o %t.o %s
+; RUN: %opt --mtriple=%triple --data-layout=%datalayout -o %t.o %s
+
 ; RUN: %link %linkopts -o %t0 -e main --lto-O0 %t.o
 ; RUN: llvm-nm %t0 | FileCheck --check-prefix=CHECK-O0 %s
 ; RUN: %link %linkopts -o %t0 -e main --plugin-opt=O0 %t.o
@@ -28,16 +28,15 @@
 ; RUN:   FileCheck --check-prefix=INVALIDNEGATIVE2 %s
 ; INVALIDNEGATIVE2: Error: Invalid value for --lto-O: -1
 
-target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-unknown-linux-gnu"
-
 ; CHECK-O0: foo
 ; CHECK-O2-NOT: foo
-define internal void @foo() {
+define internal void @foo() #0 {
   ret void
 }
 
-define void @main() {
+define void @main() #0 {
   call void @foo()
   ret void
 }
+
+attributes #0 = { nounwind }


### PR DESCRIPTION
Some lld tests are written in LLVM assembly (`.ll`) and need target triple and data layout. These tests are usually compiled with `llvm-as` and run only on x86 because they have the x86 triple and data layout hard coded inside. `llvm-as` can override data layout but unfortunately not the target triple.

`.ll` tests can be made target independent if `opt` is used instead of `llvm-as` as `opt` can override both target triple and data layout, which we need to provide in the command line. Note that `opt` does code optimization in addition to just parsing so this may not works for some tests or need additional adjustments.

With this changes we remove `REQUIRES: x86` from the two `.ll` tests sourced from lld.

Another options is to write tests in C, which is often easier but the may take longer to run.