### PR TITLE
Fix ELDExpected test windows failure

### DIFF
--- a/test/Common/standalone/PluginAPI/ELDExpected.test
+++ b/test/Common/standalone/PluginAPI/ELDExpected.test
@@ -3,7 +3,7 @@
 # This test checks the functioning of eld::Expected.
 #END_COMMENT
 #START_TEST
-RUN: %llvmobjroot/bin/tests/ELDExpectedUsage%var | %filecheck %s
+RUN: %llvmobjroot/bin/tests%config/ELDExpectedUsage%var | %filecheck %s
 #END_TEST
 #CHECK: e1.has_value(): 1
 #CHECK: e1.value(): 11

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -550,6 +550,26 @@ else:
     lit_config.note('musl-clang not found - tests with REQUIRES: musl will be skipped')
 
 # Add substitutions.
+
+# For multi-config generators (Visual Studio, Xcode), binaries are in config subdirectories
+# We need to detect this at runtime by checking which path exists
+def find_config_dir(base_path):
+    """Find the configuration directory for multi-config generators."""
+    import os
+    # Try common configuration names
+    for config_name in ['Release', 'Debug', 'RelWithDebInfo', 'MinSizeRel']:
+        if os.path.exists(os.path.join(base_path, config_name)):
+            return "/" + config_name
+    # No config subdirectory found (single-config generator)
+    return ""
+
+# Determine config directory by checking if Release/Debug subdirectories exist
+config_dir = ""
+if config.llvm_obj_root:
+    test_path = os.path.join(config.llvm_obj_root, "bin", "tests")
+    config_dir = find_config_dir(test_path)
+
+config.substitutions.append( ("%config", config_dir))
 config.substitutions.append( ("%xlen", str(xlen)))
 config.substitutions.append( ("%triple","".join(config.target_triple)) )
 config.substitutions.append( ("%datalayout", datalayout))


### PR DESCRIPTION
This test fixes the eldexpected test windows failure occuring due to presence of the binary in the config subdirectory in case of multi-config setups.