### PR TITLE
Disable "new-pass-manager.ll" test on windows

### DIFF
--- a/test/lld/ELF/new-pass-manager.ll
+++ b/test/lld/ELF/new-pass-manager.ll
@@ -1,3 +1,4 @@
+#UNSUPPORTED: windows
 ; RUN: %opt --mtriple=%triple --data-layout=%datalayout %s -o %t.o
 
 ; Test debug-pass-manager option


### PR DESCRIPTION
This patch aims to temporarily disable "new-pass-manager.ll" test on windows.