### PR TITLE
[NFC] Rename createEhFrame...Section -> createEhFrame...Fragment

### DIFF
--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -711,7 +711,7 @@ public:
   // ------------------- EhFrame Hdr -------------------------------
   EhFrameHdrSection *getEhFrameHdr() const { return m_pEhFrameHdrSection; }
 
-  void createEhFrameFillerAndHdrSection();
+  void createEhFrameFillerAndHdrFragment();
 
   // ------------------------- EhFrame Hdr support ----------------
   bool hasEhFrameHdr() const { return m_pEhFrameHdrFragment != nullptr; }

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -802,7 +802,7 @@ bool ObjectLinker::mergeInputSections(ObjectBuilder &Builder,
           // Since we found an EhFrame section, lets go ahead and start creating
           // the fragments necessary to create the .eh_frame_hdr section and
           // the filler eh_frame section.
-          getTargetBackend().createEhFrameFillerAndHdrSection();
+          getTargetBackend().createEhFrameFillerAndHdrFragment();
         }
       }
     }

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -868,7 +868,7 @@ void GNULDBackend::sizeDynNamePools() {
 #endif
 }
 
-void GNULDBackend::createEhFrameFillerAndHdrSection() {
+void GNULDBackend::createEhFrameFillerAndHdrFragment() {
   eld::RegisterTimer T("Create EhFrame Hdr Output Section", "Perform Layout",
                        m_Module.getConfig().options().printTimingStats());
 


### PR DESCRIPTION
This commit renames GNULDBackend::createEhFrameFillerAndHdrSection to GNULDBackend::createEhFrameFillerAndHdrFragment. This change is helpful because this function is creating EhFrame fragments instead of sections.