### PR TITLE
Fix crash when image refer to certain kind of symbols

### DIFF
--- a/lib/SymbolResolver/LDSymbol.cpp
+++ b/lib/SymbolResolver/LDSymbol.cpp
@@ -30,9 +30,9 @@ static LDSymbol GNullSymbol;
 // LDSymbol
 //===----------------------------------------------------------------------===//
 LDSymbol::LDSymbol(ResolveInfo *R, bool IsGc)
-    : ThisResolveInfo(R), ThisFragRef(nullptr), ThisShndx(0), ThisSymIdx(0),
-      ThisSymbolsIsScriptDefined(false), ThisSymbolHasScriptValue(false),
-      ThisSymbolGarbageCollected(IsGc) {}
+    : ThisResolveInfo(R), ThisFragRef(FragmentRef::null()), ThisShndx(0),
+      ThisSymIdx(0), ThisSymbolsIsScriptDefined(false),
+      ThisSymbolHasScriptValue(false), ThisSymbolGarbageCollected(IsGc) {}
 
 LDSymbol::~LDSymbol() {}
 

--- a/test/Hexagon/standalone/TrampolineUndefWrapLTO/Inputs/1.s
+++ b/test/Hexagon/standalone/TrampolineUndefWrapLTO/Inputs/1.s
@@ -1,0 +1,4 @@
+.section .text
+{
+  p0 = cmp.eq(r0,#0); if (p0.new) jump:nt #bar
+}

--- a/test/Hexagon/standalone/TrampolineUndefWrapLTO/Inputs/2.c
+++ b/test/Hexagon/standalone/TrampolineUndefWrapLTO/Inputs/2.c
@@ -1,0 +1,2 @@
+extern int bar();
+int baz() { return bar(); }

--- a/test/Hexagon/standalone/TrampolineUndefWrapLTO/Inputs/3.s
+++ b/test/Hexagon/standalone/TrampolineUndefWrapLTO/Inputs/3.s
@@ -1,0 +1,2 @@
+.section .text
+.space 0x1000

--- a/test/Hexagon/standalone/TrampolineUndefWrapLTO/TrampolineUndefWrapLTO.test
+++ b/test/Hexagon/standalone/TrampolineUndefWrapLTO/TrampolineUndefWrapLTO.test
@@ -1,0 +1,14 @@
+# --TrampolinesUndefWrapLTO.test--------------------- Shared Library-----------------------#
+# BEGIN_COMMENT
+# Linker needs to create PLT entries for calls to undefined symbols.
+# END_COMMENT
+# -----------------------------------------------------------------------------------------#
+# START_TEST
+RUN: %clang %clangopts -c -fPIC %p/Inputs/1.s -o %t1.1.o
+RUN: %clang %clangopts -c -fPIC %p/Inputs/3.s -o %t1.3.o
+RUN: %clang %clangopts -c -fPIC %p/Inputs/2.c -flto -o %t1.2.o
+RUN: %link %linkopts -shared %t1.3.o %t1.2.o %t1.1.o  \
+RUN: -o %t2.so --wrap bar --trace=trampolines 2>&1 | %filecheck %s
+
+#CHECK: trampoline_for___wrap_bar{{.*}}
+#END_TEST


### PR DESCRIPTION
The linker would crash when inserting a trampoline to a wrap symbol that would be read as part of LTO.

This would fail when building a shared object when allowing for undefined symbols.

The fix is to initialize the symbol to a sentinel fragment ref (NullFragRef) instead of a nullptr.

Resolves #727