### PR TITLE
Fix windows nightly failures

### DIFF
--- a/test/Hexagon/Plugin/ConfigFile/DefaultINIConfigFilePathTest/DefaultINIConfigFilePathTest.test
+++ b/test/Hexagon/Plugin/ConfigFile/DefaultINIConfigFilePathTest/DefaultINIConfigFilePathTest.test
@@ -1,3 +1,4 @@
+#UNSUPPORTED: windows
 #---DefaultINIConfigFilePathTest.test----------------------- Executable,LS --------------------#
 #BEGIN_COMMENT
 # Tests that plugins are able to load .config from search dirs and .ini files from default path

--- a/test/lld/ELF/new-pass-manager.ll
+++ b/test/lld/ELF/new-pass-manager.ll
@@ -1,8 +1,8 @@
 ; RUN: %opt --mtriple=%triple --data-layout=%datalayout %s -o %t.o
 
 ; Test debug-pass-manager option
-; RUN: %link %linkopts --plugin-opt=debug-pass-manager -o /dev/null %t.o 2>&1 | FileCheck %s
-; RUN: %link %linkopts --lto-debug-pass-manager -o /dev/null %t.o 2>&1 | FileCheck %s
+; RUN: %link %linkopts --plugin-opt=debug-pass-manager -o %t.temp %t.o 2>&1 | FileCheck %s
+; RUN: %link %linkopts --lto-debug-pass-manager -o %t.temp %t.o 2>&1 | FileCheck %s
 
 ; CHECK: Running pass: GlobalOptPass
 


### PR DESCRIPTION
This patch fixes windows nightly failures related to `/dev/null` path issue and multiconfig build related path issue.