### PR TITLE
Use llvm-project@main instead of BASE_BRANCH_NAME

### DIFF
--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: llvm/llvm-project
-          ref: ${{ env.BASE_BRANCH_NAME }}
+          ref: main # Update on release branches
           path: nightly/llvm-project
 
       - name: Checkout ELD main branch


### PR DESCRIPTION
Stops failures caused by BASE_BRANCH_NAME pointing to ELD-only branches during manual workflow_dispatch runs. ELD continues to use BASE_BRANCH_NAME normally.