### PR TITLE
Add basic LLVM_DISTRIBUTION_COMPONENTS compatibility with a unified component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,7 @@ if(ELD_INSTALL_LINKER_SCRIPT_TEMPLATES)
   install(
     DIRECTORY templates/
     DESTINATION templates
-    COMPONENT linker-script
+    COMPONENT ld.eld
     FILES_MATCHING
     PATTERN "*.template"
     PATTERN ".git" EXCLUDE
@@ -223,5 +223,6 @@ if(ELD_INSTALL_YAML_MAP_PARSER)
     set(ELD_YAML_MAP_PARSER_DEST_DIR "bin")
   endif()
   install(PROGRAMS utils/YAMLMapParser/YAMLMapParser.py
-          DESTINATION ${ELD_YAML_MAP_PARSER_DEST_DIR})
+          DESTINATION ${ELD_YAML_MAP_PARSER_DEST_DIR}
+          COMPONENT ld.eld)
 endif()

--- a/include/eld/CMakeLists.txt
+++ b/include/eld/CMakeLists.txt
@@ -7,7 +7,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/PluginAPI/PluginBase.h.inc
 install(
   DIRECTORY PluginAPI/
   DESTINATION include/ELD/PluginAPI/
-  COMPONENT PluginAPIHeaders
+  COMPONENT ld.eld
   FILES_MATCHING
   PATTERN "*.h"
   PATTERN "PluginConfig.h" EXCLUDE
@@ -17,4 +17,4 @@ install(
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/PluginAPI/PluginBase.h
   DESTINATION include/ELD/PluginAPI/
-  COMPONENT PluginAPIHeaders)
+  COMPONENT ld.eld)

--- a/lib/LinkerWrapper/CMakeLists.txt
+++ b/lib/LinkerWrapper/CMakeLists.txt
@@ -110,9 +110,12 @@ endforeach()
 if(ELD_ON_MSVC)
   install(TARGETS LW
     RUNTIME DESTINATION "${ELD_TOOLS_INSTALL_DIR}"
-    ARCHIVE DESTINATION lib)
+    ARCHIVE DESTINATION lib
+    COMPONENT ld.eld)
 else()
-  install(TARGETS LW LIBRARY DESTINATION lib)
+  install(TARGETS LW
+    LIBRARY DESTINATION lib
+    COMPONENT ld.eld)
 endif()
 
 set(BUILD_SHARED_LIBS ${bsl})

--- a/tools/eld/CMakeLists.txt
+++ b/tools/eld/CMakeLists.txt
@@ -16,7 +16,14 @@ add_dependencies(ld.eld update-eld-verinfo)
 set(LINKER_WRAPPER_LIB "LW")
 target_link_libraries(ld.eld PRIVATE ${LINKER_WRAPPER_LIB})
 
-install(TARGETS ld.eld RUNTIME DESTINATION "${ELD_TOOLS_INSTALL_DIR}")
+install(TARGETS ld.eld
+        RUNTIME DESTINATION "${ELD_TOOLS_INSTALL_DIR}"
+        COMPONENT ld.eld)
+if (NOT LLVM_ENABLE_IDE)
+  add_llvm_install_targets(install-ld.eld
+                           DEPENDS ld.eld
+                           COMPONENT ld.eld)
+endif()
 
 # FIXME: We need to switch to ELD_TARGETS_TO_BUILD after the buildbot upgrade
 if("${LLVM_TARGETS_TO_BUILD}" MATCHES "Hexagon" AND "${TARGET_TRIPLE}" MATCHES


### PR DESCRIPTION
This is an alternate implementation of https://github.com/qualcomm/eld/pull/694 with everything unified under one component.

Note that there are additional commits doing the cleanup mentioned in https://github.com/qualcomm/eld/pull/694 (making it possible to not install the 'templates/' dir, always enabling the PluginHeaders). These are included here as I think it is worth deciding on what can/can't be omitted from the install/distribution (whether that be via individual components, or CMake options). But, they can be separate PRs--this is just for convenience.