### PR TITLE
Record build workflow data for dashboard.

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -26,6 +26,19 @@ jobs:
           path: llvm-project/llvm/tools/eld
           ref: main
 
+      - name: Record pre-build entry
+        if: github.event_name == 'schedule'
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "pre-"
+          workflow-name: "documentation"
+          record-mode: "record"
+          status: "fail"
+          run-id: ${{github.run_id}}
+          arch-name: "all"
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -66,3 +79,16 @@ jobs:
           git add .
           git commit -m "Update documentation"
           git push -f origin HEAD:refs/heads/documentation
+
+      - name: Update build entry
+        if: github.event_name == 'schedule'
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "post-"
+          workflow-name: "documentation"
+          record-mode: "update"
+          status: "pass"
+          run-id: ${{github.run_id}}
+          arch-name: "all"

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -54,6 +54,19 @@ jobs:
           path: llvm-project/llvm/tools/eld
           ref: main
 
+      - name: Record pre-build entry
+        if: github.event_name == 'schedule'
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "pre-"
+          workflow-name: "nightly"
+          record-mode: "record"
+          status: "fail"
+          run-id: ${{github.run_id}}
+          arch-name: "all"
+
       - name: Run CMake
         run: |
           mkdir obj
@@ -92,3 +105,16 @@ jobs:
         run: |
           cd obj
           ninja -j8 check-eld
+
+      - name: Update build entry
+        if: github.event_name == 'schedule'
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "post-"
+          workflow-name: "nightly"
+          record-mode: "update"
+          status: "pass"
+          run-id: ${{github.run_id}}
+          arch-name: "all"

--- a/.github/workflows/release-artifact-builder.yaml
+++ b/.github/workflows/release-artifact-builder.yaml
@@ -21,6 +21,19 @@ jobs:
         with:
           path: llvm-project/llvm/tools/eld
 
+      - name: Record pre-build entry
+        if: github.event_name == 'schedule'
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "pre-"
+          workflow-name: "release"
+          record-mode: "record"
+          status: "fail"
+          run-id: ${{github.run_id}}
+          arch-name: "all"
+
       - uses: ./llvm-project/llvm/tools/eld/.github/workflows/FetchNightlyToolset
 
       - name: Create tarball
@@ -43,3 +56,16 @@ jobs:
           allowUpdates: true
           tag: ${{ github.base_ref || github.ref_name }}
           name: eld ${{ github.base_ref == 'main' && 'Nightly' || github.base_ref || github.ref_name }} Release
+
+      - name: Update build entry
+        if: github.event_name == 'schedule'
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "post-"
+          workflow-name: "release"
+          record-mode: "update"
+          status: "pass"
+          run-id: ${{github.run_id}}
+          arch-name: "all"

--- a/.github/workflows/reviter.yml
+++ b/.github/workflows/reviter.yml
@@ -54,6 +54,19 @@ jobs:
           path: llvm-project/llvm/tools/eld
           ref: main
 
+      - name: Record pre-build entry
+        if: github.event_name == 'schedule'
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "pre-"
+          workflow-name: "reverse_iterator"
+          record-mode: "record"
+          status: "fail"
+          run-id: ${{github.run_id}}
+          arch-name: "all"
+
       - name: Run CMake
         run: |
           mkdir obj
@@ -80,3 +93,16 @@ jobs:
         run: |
           cd obj
           ninja -j8 check-eld
+
+      - name: Update build entry
+        if: github.event_name == 'schedule'
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "post-"
+          workflow-name: "reverse_iterator"
+          record-mode: "update"
+          status: "pass"
+          run-id: ${{github.run_id}}
+          arch-name: "all"

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -54,6 +54,19 @@ jobs:
           path: llvm-project/llvm/tools/eld
           ref: main
 
+      - name: Record pre-build entry
+        if: github.event_name == 'schedule'
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "pre-"
+          workflow-name: "sanitizer"
+          record-mode: "record"
+          status: "fail"
+          run-id: ${{github.run_id}}
+          arch-name: "all"
+
       - name: Run CMake
         run: |
           mkdir obj
@@ -81,3 +94,16 @@ jobs:
         run: |
           cd obj
           ninja -j8 check-eld
+
+      - name: Update build entry
+        if: github.event_name == 'schedule'
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "post-"
+          workflow-name: "sanitizer"
+          record-mode: "update"
+          status: "pass"
+          run-id: ${{github.run_id}}
+          arch-name: "all"

--- a/.github/workflows/scripts/record_builds.py
+++ b/.github/workflows/scripts/record_builds.py
@@ -28,6 +28,14 @@ except Exception as e:
 # Global
 _build_status_db = "build-status.db"
 _build_status_db_connection = None
+SUPPORTED_WORKFLOWS = ["picolibc",
+        "musl",
+        "sanitizer",
+        "reverse_iterator",
+        "nightly",
+        "release",
+        "documentation",
+        ]
 
 
 def close_connection():
@@ -176,9 +184,7 @@ def emitJSData(args):
         )
         all_data = cursor.fetchall()
     except Exception as e:
-        print(
-            "Error fetching build status data from table " + workflow + ": " + str(e)
-        )
+        print("Error fetching build status data from table " + workflow + ": " + str(e))
 
     for data in all_data:
         new_state = {
@@ -197,7 +203,7 @@ def emitJSData(args):
 
 def validateArgs(args):
     # Validate workflow
-    if args.workflow_build.lower() not in ["picolibc", "musl"]:
+    if args.workflow_build.lower() not in SUPPORTED_WORKFLOWS:
         sys.exit("Unsupported Workflow!")
 
     # Record/update mode must have a run_id.
@@ -217,7 +223,7 @@ def handleArguments():
         "-w",
         dest="workflow_build",
         required=True,
-        help="The workflow build name. Supported workflows: picolibc and musl",
+        help="The workflow build name. Supported workflows: " + str(SUPPORTED_WORKFLOWS),
     )
     parser.add_argument(
         "--arch",


### PR DESCRIPTION
This commit updates build workflows to record build status data for nightly, win-nightly, nightly-reverse-iterator, sanitizer and release-artifact workflows.
Closes #741