### PR TITLE
Add space between `(` and the binary in LIT tests

### DIFF
--- a/test/Common/LTO/LTOTempObjNotWritable/LTOTempObjNotWritable.test
+++ b/test/Common/LTO/LTOTempObjNotWritable/LTOTempObjNotWritable.test
@@ -11,15 +11,11 @@ RUN: mkdir -p %t1.out.llvm-lto.1.o
 RUN: mkdir -p %t2.out.llvm-lto.0.o
 RUN: mkdir -p %t2.out.llvm-lto.1.o
 
-### TODO: remove ( .. || true) around linker invocation when it no longer
-### aborts on these errors. There is no consistent way to handle the crash
-### because it crashes only in some code paths when doing LTO.
-
 RUN: %clang %clangopts -c %p/Inputs/1.c -O2 -ffunction-sections -flto -o %t1.o
-RUN: (%not %link %linkopts --save-temps %t1.o -o %t1.out 2>&1 || true) | %filecheck %s
+RUN: %not %link %linkopts --save-temps %t1.o -o %t1.out 2>&1 | %filecheck %s
 
 RUN: %clang %clangopts -c %p/Inputs/1.c -O2 -ffunction-sections -flto=thin -o %t2.o
-RUN: (%not %link %linkopts --save-temps %t2.o -o %t2.out 2>&1 || true) | %filecheck %s
+RUN: %not %link %linkopts --save-temps %t2.o -o %t2.out 2>&1 | %filecheck %s
 
 CHECK: cannot compile code generator object
 CHECK: .out.llvm-lto.{{[0-9]+}}.o: {{Is a directory|is a directory}}

--- a/test/Common/standalone/Patching/Patch/Patch.test
+++ b/test/Common/standalone/Patching/Patch/Patch.test
@@ -69,7 +69,7 @@ PATCH-DAG: Symbol `__llvm_patchable_xxx_g' from Input file `{{.+}}.base' with in
 PATCH-DAG: Trace: Symbol xxx_f, application site: 0x[[#%x,PGOT]]
 PATCH-DAG: Trace: Symbol xxx_g, application site: 0x[[#%x,PGOT+XLEN]]
 
-RUN: (%readelf -s %t.base; %readelf -s %t.patch) | %filecheck %s --check-prefix=SYM --match-full-lines -D#%x,FP=0x8000
+RUN: ( %readelf -s %t.base; %readelf -s %t.patch) | %filecheck %s --check-prefix=SYM --match-full-lines -D#%x,FP=0x8000
 
 ## Read value values from base image.
 SYM: Symbol table '.symtab' contains [[#]] entries:
@@ -90,7 +90,7 @@ SYM-DAG:   [[#]]: {{0*}}[[#H]]         [[#]] FUNC    GLOBAL DEFAULT       ABS xx
 SYM-DAG:   [[#]]: {{0*}}[[#K]]         [[#]] FUNC    GLOBAL DEFAULT       ABS xxx_k
 
 ## The new .pgot will have the first pointer replaced, and the other one kept as is.
-RUN: (%readelf -s %t.base; %elfcopy -O binary -j .pgot %t.patch - | od -v -Ax -t x%xlen -w%xlen) | %filecheck %s --check-prefix=PGOT --match-full-lines -D#%x,FP=0x8000 -D#XLEN=%xlen
+RUN: ( %readelf -s %t.base; %elfcopy -O binary -j .pgot %t.patch - | od -v -Ax -t x%xlen -w%xlen) | %filecheck %s --check-prefix=PGOT --match-full-lines -D#%x,FP=0x8000 -D#XLEN=%xlen
 PGOT:      [[#]]: [[#%x,G:]]           [[#]] FUNC    GLOBAL DEFAULT     [[#]] xxx_g
 PGOT:      {{0*}}0                   {{0*}}[[#FP]]
 PGOT-NEXT: {{0*}}[[#%x,mul(XLEN,1)]] {{0*}}[[#%x,G]]

--- a/test/Common/standalone/Patching/PatchPatchPLT/PatchPatchPLT_FuncPtrCode.test
+++ b/test/Common/standalone/Patching/PatchPatchPLT/PatchPatchPLT_FuncPtrCode.test
@@ -12,7 +12,7 @@ RUN: %link %linkopts --no-emit-relocs --patch-enable --section-start=.plt=0x1000
 RUN: %clang %clangopts -mno-relax -O3 -fno-pic %p/Inputs/f.c -o %t.f.o -c
 RUN: %clang %clangopts -mno-relax -O3 -fno-pic %p/Inputs/2.riscv.s -o %t.2.o -c
 RUN: %link %linkopts --patch-base=%t.base --section-start=.text=0x8000 --section-start=.pgot=0x9000 %t.f.o %t.2.o -o %t.2
-RUN: (%readelf -s %t.2; %objdump -d -s %t.2) | %filecheck %s --match-full-lines
+RUN: ( %readelf -s %t.2; %objdump -d -s %t.2) | %filecheck %s --match-full-lines
 
 ## Check that symbol values are expected.
 CHECK-DAG: [[#]]: {{0*}}1000     [[#]] NOTYPE  GLOBAL DEFAULT   ABS __llvm_patchable_xxx_f

--- a/test/Common/standalone/Patching/PatchPatchPLT/PatchPatchPLT_FuncPtrData.test
+++ b/test/Common/standalone/Patching/PatchPatchPLT/PatchPatchPLT_FuncPtrData.test
@@ -12,7 +12,7 @@ RUN: %link %linkopts --no-emit-relocs --patch-enable --section-start=.plt=0x1000
 RUN: %clang %clangopts -mno-relax -O3 -fno-pic %p/Inputs/f.c -o %t.f.o -c
 RUN: %clang %clangopts -mno-relax -O3 -fno-pic %p/Inputs/3.riscv%xlen.s -o %t.3.o -c
 RUN: %link %linkopts --patch-base=%t.base --section-start=.text=0x8000 --section-start=.data=0xa000 --section-start=.pgot=0x9000 %t.f.o %t.3.o -o %t.3
-RUN: (%readelf -s %t.3; %elfcopy -O binary -j .data %t.3 - | od -v -Ax -t x%xlen -w%xlen) | %filecheck %s --match-full-lines -D#XLEN=%xlen
+RUN: ( %readelf -s %t.3; %elfcopy -O binary -j .data %t.3 - | od -v -Ax -t x%xlen -w%xlen) | %filecheck %s --match-full-lines -D#XLEN=%xlen
 
 ## Read symbol values.
 CHECK-DAG: [[#]]: [[#%x,F:]]     [[#]] NOTYPE  GLOBAL DEFAULT   ABS __llvm_patchable_xxx_f


### PR DESCRIPTION
This patch adds space between the `(` and the binary in some commands in LIT tests. These have been causing failures in specific windows environments.

The error occuring is 

 '(i:/bld/llvm/bin/not.exe': command not found