### PR TITLE
[NFC] Store MergeableStrings by value

### DIFF
--- a/lib/Fragment/FragmentRef.cpp
+++ b/lib/Fragment/FragmentRef.cpp
@@ -140,14 +140,14 @@ FragmentRef::Offset FragmentRef::getOutputOffset(Module &M) const {
   if (ThisFragment->isMergeStr()) {
     auto *MSF = llvm::cast<MergeStringFragment>(ThisFragment);
     OutputSectionEntry *O = getOutputSection();
-    MergeableString *S = MSF->findString(ThisOffset);
+    const MergeableString *S = MSF->findString(ThisOffset);
     assert(S);
     /// The target string could be a suffix
     uint32_t OffsetInString = ThisOffset - S->InputOffset;
     bool GlobalMerge = M.getConfig().options().shouldGlobalStringMerge();
-    if (const MergeableString *Merged = (!S->isAlloc() && GlobalMerge)
-                                            ? M.getMergedNonAllocString(S)
-                                            : O->getMergedString(S)) {
+    if (const MergeableString *Merged =
+            (!S->isAlloc() && GlobalMerge) ? M.getMergedNonAllocString(S)
+                                           : O->getMergedString(S)) {
       assert(S->Exclude);
       assert(!Merged->Exclude);
       assert(Merged->hasOutputOffset());

--- a/lib/LayoutMap/LayoutInfo.cpp
+++ b/lib/LayoutMap/LayoutInfo.cpp
@@ -55,9 +55,9 @@ void LayoutInfo::recordFragment(InputFile *Input,
 
   if (auto *Strings = llvm::dyn_cast<MergeStringFragment>(Frag)) {
     llvm::StringRef CommandLinePrefix = "Command:";
-    for (const MergeableString *String : Strings->getStrings())
-      if (String->String.starts_with(CommandLinePrefix))
-        recordCommentFragment(String->String.data());
+    for (const MergeableString &String : Strings->getStrings())
+      if (String.String.starts_with(CommandLinePrefix))
+        recordCommentFragment(String.String.data());
   }
 
   LayoutFragmentInfo *FragmentInfo;

--- a/lib/LayoutMap/TextLayoutPrinter.cpp
+++ b/lib/LayoutMap/TextLayoutPrinter.cpp
@@ -680,18 +680,18 @@ void TextLayoutPrinter::printFragInfo(Fragment *Frag, LayoutFragmentInfo *Info,
       (M.isLinkStateCreatingSegments() || M.isLinkStateAfterLayout());
   if (llvm::isa<MergeStringFragment>(Frag) && !M.isLinkStateBeforeLayout()) {
     auto *Strings = llvm::cast<MergeStringFragment>(Frag);
-    for (MergeableString *S : Strings->getStrings()) {
-      if (S->Exclude)
+    for (MergeableString &S : Strings->getStrings()) {
+      if (S.Exclude)
         continue;
       if (!GC && HasFragInfo)
         AddressOrOffset =
-            S->OutputOffset +
+            S.OutputOffset +
             (Section->isAlloc() ? Section->addr() : Section->offset());
-      PrintOneFragOrString(S->size(), AddressOrOffset);
+      PrintOneFragOrString(S.size(), AddressOrOffset);
       /// if showStrings there is still extra content to be printed on this line
       if (!ThisLayoutInfo->showStrings())
         outputStream() << "\n";
-      printMergeString(S, M);
+      printMergeString(&S, M);
     }
   } else {
     if (!GC && HasFragInfo)

--- a/lib/LinkerWrapper/PluginADT.cpp
+++ b/lib/LinkerWrapper/PluginADT.cpp
@@ -233,9 +233,9 @@ std::vector<plugin::Section> Chunk::getDependentSections() const {
 std::vector<plugin::MergeableString>
 plugin::MergeStringChunk::getStrings() const {
   std::vector<plugin::MergeableString> Strings;
-  for (eld::MergeableString *S :
+  for (const eld::MergeableString &S :
        llvm::cast<MergeStringFragment>(getFragment())->getStrings())
-    Strings.push_back(plugin::MergeableString(S));
+    Strings.emplace_back(&S);
   return Strings;
 }
 

--- a/lib/Object/ObjectBuilder.cpp
+++ b/lib/Object/ObjectBuilder.cpp
@@ -186,14 +186,14 @@ void ObjectBuilder::traceMergeStrings(const MergeableString *From,
 
 void ObjectBuilder::mergeStrings(MergeStringFragment *F,
                                  OutputSectionEntry *O) {
-  for (MergeableString *S : F->getStrings()) {
-    MergeableString *MergedString =
-        MergeStringFragment::mergeStrings(S, O, module());
-    if (!MergedString)
+  for (MergeableString &S : F->getStrings()) {
+    MergeableString &MergedString =
+        MergeStringFragment::mergeStrings(&S, O, module());
+    if (&MergedString == &S)
       continue;
     if (config().getPrinter()->traceMergeStrings() ||
         config().getPrinter()->isVerbose())
-      traceMergeStrings(S, MergedString);
+      traceMergeStrings(&S, &MergedString);
   }
 }
 

--- a/lib/Target/Relocator.cpp
+++ b/lib/Target/Relocator.cpp
@@ -96,15 +96,15 @@ Relocator::findFragmentForMergeStr(const ELFSection *RelocationSection,
                                    const Relocation *R,
                                    MergeStringFragment *F) const {
   uint32_t Addend = getAddend(R);
-  MergeableString *String = F->findString(Addend);
-  uint32_t OffsetInString = Addend - String->InputOffset;
-
+  const MergeableString *String = F->findString(Addend);
   if (!String)
     return {nullptr, 0};
 
+  uint32_t OffsetInString = Addend - String->InputOffset;
+
   OutputSectionEntry *OutputSection = F->getOwningSection()->getOutputSection();
   bool GlobalMerge = m_Config.options().shouldGlobalStringMerge();
-  if (MergeableString *DeDuped =
+  if (const MergeableString *DeDuped =
           (!F->getOwningSection()->isAlloc() && GlobalMerge)
               ? m_Module.getMergedNonAllocString(String)
               : OutputSection->getMergedString(String)) {


### PR DESCRIPTION
Avoids making N heap allocations for N strings and provides better cache locality using values instead of pointers.

`make<T>` is also not thread safe, so eliminating those calls will allow mergeable string sections to be read and split in parallel. 