### PR TITLE
Show the evaluated value of DEFINED and ALIGNOF in the text map-file

### DIFF
--- a/lib/Script/Expression.cpp
+++ b/lib/Script/Expression.cpp
@@ -726,6 +726,11 @@ bool AlignExpr::hasDot() const {
 void AlignOf::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   // format output for operator
   Outs << "ALIGNOF(" << Name << ")";
+  if (WithValues) {
+    Outs << "(0x";
+    Outs.write_hex(resultOrZero());
+    Outs << ")";
+  }
 }
 void AlignOf::getSymbols(std::vector<ResolveInfo *> &Symbols) {}
 
@@ -1448,6 +1453,11 @@ bool BitwiseAnd::hasDot() const {
 void Defined::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   // format output for operator
   Outs << "DEFINED(" << Name << ")";
+  if (WithValues) {
+    Outs << "(0x";
+    Outs.write_hex(resultOrZero());
+    Outs << ")";
+  }
 }
 eld::Expected<uint64_t> Defined::evalImpl() {
   if (MResult)

--- a/test/Common/standalone/Map/FunctionEvalValues/FunctionEvalValues.test
+++ b/test/Common/standalone/Map/FunctionEvalValues/FunctionEvalValues.test
@@ -1,0 +1,12 @@
+#---FunctionEvalValues.test------------------- Executable,LS -----------------#
+#BEGIN_COMMENT
+# Validate that builtin functions DEFINED and ALIGNOF show evaluated values
+# in the text map file.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o -c %p/Inputs/empty.c
+RUN: %link -MapStyle txt %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t -Map %t1.1.map.txt
+RUN: %filecheck %s < %t1.1.map.txt
+#END_TEST
+CHECK: var_u(0x1) = 0x1;
+CHECK: var_v(0x40) = (DEFINED(var_u)(0x1) ? ALIGNOF(.foo)(0x40) : 0x11);

--- a/test/Common/standalone/Map/FunctionEvalValues/Inputs/empty.c
+++ b/test/Common/standalone/Map/FunctionEvalValues/Inputs/empty.c
@@ -1,0 +1,2 @@
+int main(void) { return 0; }
+

--- a/test/Common/standalone/Map/FunctionEvalValues/Inputs/script.t
+++ b/test/Common/standalone/Map/FunctionEvalValues/Inputs/script.t
@@ -1,0 +1,6 @@
+var_u = 0x1;
+SECTIONS {
+  .foo : ALIGN(0x40) {}
+  var_v = (DEFINED(var_u) ? ALIGNOF(.foo) : 0x11);
+}
+


### PR DESCRIPTION
This commit improves the text map-file by improving the display of DEFINED and ALIGNOF linker script expressions in the text map-file such that these functions now display the evaluated value.

Resolves #759
Resolves #760