### PR TITLE
Add linker script source in map-file for outside SECTIONS assignment

### DIFF
--- a/include/eld/LayoutMap/TextLayoutPrinter.h
+++ b/include/eld/LayoutMap/TextLayoutPrinter.h
@@ -22,6 +22,7 @@
 namespace eld {
 
 class LinkerConfig;
+class Assignment;
 
 class TextLayoutPrinter {
 public:
@@ -86,7 +87,9 @@ public:
 
   void flush();
 
-private:
+ private:
+  void printAssignment(const Assignment &A, Module &M, bool UseColor);
+
   void printChangeOutputSectionInfo(const ELFSection *S) const;
 
   void printChunkOps(eld::Module &M, Fragment *F) const;

--- a/test/Common/standalone/Map/OutsideSectionsAssignmentsContext/Inputs/1.c
+++ b/test/Common/standalone/Map/OutsideSectionsAssignmentsContext/Inputs/1.c
@@ -1,0 +1,1 @@
+int main() { return 0; }

--- a/test/Common/standalone/Map/OutsideSectionsAssignmentsContext/Inputs/script.t
+++ b/test/Common/standalone/Map/OutsideSectionsAssignmentsContext/Inputs/script.t
@@ -1,0 +1,5 @@
+var_u = 0x1;
+SECTIONS {
+  var_v = 0x3;
+}
+var_w = 0x5;

--- a/test/Common/standalone/Map/OutsideSectionsAssignmentsContext/OutsideSectionsAssignmentsContext.test
+++ b/test/Common/standalone/Map/OutsideSectionsAssignmentsContext/OutsideSectionsAssignmentsContext.test
@@ -1,0 +1,14 @@
+#---OutsideSectionsAssignmentsContext.test-------- Executable -----------------#
+#BEGIN_COMMENT
+# Verifies that linker script assignments outside SECTIONS include their
+# originating script context in the text map file.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
+RUN: %link -MapStyle txt %linkopts %t1.1.o -Map %t2.map -o %t2.out -T %p/Inputs/script.t
+RUN: %filecheck %s < %t2.map
+#END_TEST
+
+CHECK: var_u(0x1) = 0x1; # var_u = 0x1; {{.*}}script.t
+CHECK: var_w(0x5) = 0x5; # var_w = 0x5; {{.*}}script.t
+CHECK: var_v(0x3) = 0x3; # var_v = 0x3; {{.*}}script.t


### PR DESCRIPTION
We are missing the linker script source information in the map-file for the assignments that are present outside the SECTIONS command. This commit fixes the assignment printing behavior to be the same for both the assignments inside and outside the SECTIONS command.

Resolves #758