### PR TITLE
[NFC] Fix release build warnings from compiled-out ASSERTs

### DIFF
--- a/lib/Fragment/FragmentRef.cpp
+++ b/lib/Fragment/FragmentRef.cpp
@@ -111,7 +111,7 @@ void FragmentRef::memcpy(void *PDest, size_t PNBytes, Offset POffset) const {
     return;
   }
   case Fragment::OutputSectDataFragType:
-    ASSERT(false, "OutputSectDataFragment cannot be copied!");
+    llvm_unreachable("OutputSectDataFragment cannot be copied!");
   case Fragment::Fillment:
   default:
     return;

--- a/lib/Input/ArchiveFile.cpp
+++ b/lib/Input/ArchiveFile.cpp
@@ -50,7 +50,7 @@ size_t ArchiveFile::numOfSymbols() const {
 void ArchiveFile::addSymbol(llvm::StringRef Name, uint32_t FileOffset,
                             uint8_t Type, uint8_t Status) {
   ASSERT(AFI, "AFI must not be null!");
-  const char *Base = getContents().data();
+  [[maybe_unused]] const char *Base = getContents().data();
   ASSERT(Name.data() >= Base &&
              (Name.data() + Name.size()) <= (Base + getContents().size()),
          "archive symbol name must reference archive contents");

--- a/lib/LinkerWrapper/CheckLinkState.h
+++ b/lib/LinkerWrapper/CheckLinkState.h
@@ -26,9 +26,9 @@ static inline bool
 isValidLinkState(const eld::plugin::LinkerWrapper &LW,
                  std::initializer_list<std::string_view> ValidLinkStates) {
   for (const auto &S : ValidLinkStates) {
-    bool b = S == "Initializing" || S == "BeforeLayout" ||
-             S == "CreatingSections" || S == "CreatingSegments" ||
-             S == "AfterLayout";
+    [[maybe_unused]] bool b = S == "Initializing" || S == "BeforeLayout" ||
+                              S == "CreatingSections" ||
+                              S == "CreatingSegments" || S == "AfterLayout";
     ASSERT(b, "Invalid link state: " + std::string(S));
     if (S == "Initializing" && LW.isLinkStateInitializing())
       return true;

--- a/lib/LinkerWrapper/DWARF.cpp
+++ b/lib/LinkerWrapper/DWARF.cpp
@@ -270,9 +270,13 @@ bool getSize(llvm::DWARFDie &Die, uint64_t &Size, uint32_t PointerSize) {
     Size = ArrayCount * BaseTypeSize;
     return true;
   }
-  default:
-    ASSERT(false, "found unknown type " + TagString(Die.getTag()).str() +
-                      " @Offset 0x" + llvm::utohexstr(Die.getOffset(), true));
+  default: {
+    std::string Msg =
+        (llvm::Twine("found unknown type ") + TagString(Die.getTag()) +
+         " @Offset 0x" + llvm::utohexstr(Die.getOffset(), true))
+            .str();
+    llvm_unreachable(Msg.c_str());
+  }
   }
 }
 

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -1800,7 +1800,7 @@ std::string GnuLdDriver::getDriverFlavorName() const {
   case DriverFlavor::Invalid:
     break;
   }
-  ASSERT(false, "Invalid DriverFlavor!");
+  llvm_unreachable("Invalid DriverFlavor!");
 }
 
 void GnuLdDriver::printRepositoryVersion() const {

--- a/lib/Readers/ELFReaderBase.cpp
+++ b/lib/Readers/ELFReaderBase.cpp
@@ -195,6 +195,7 @@ eld::Expected<bool> ELFReaderBase::readOneGroup(ELFSection *S) {
 eld::Expected<bool> ELFReaderBase::readRelocationSection(ELFSection *RS) {
   ASSERT(0, "readRelocationSection must only be called for relocatable "
             "object files.");
+  return false;
 }
 
 eld::Expected<ObjectFile::ELFKind>

--- a/lib/Script/Expression.cpp
+++ b/lib/Script/Expression.cpp
@@ -146,7 +146,7 @@ eld::Expected<uint64_t> Symbol::evalImpl() {
   if (ThisSymbol->hasFragRef() && !ThisSymbol->shouldIgnore()) {
     FragmentRef *FragRef = ThisSymbol->fragRef();
     ELFSection *Section = FragRef->getOutputELFSection();
-    bool IsAllocSection = Section ? Section->isAlloc() : false;
+    [[maybe_unused]] bool IsAllocSection = Section ? Section->isAlloc() : false;
 
     ASSERT(IsAllocSection,
            "using a symbol that points to a non allocatable section!");

--- a/lib/Script/OutputSectData.cpp
+++ b/lib/Script/OutputSectData.cpp
@@ -69,7 +69,10 @@ std::size_t OutputSectData::getDataSize() const {
   case Squad:
     return 8;
   default:
-    ASSERT(0, "Invalid output section data: " + getOSDKindAsStr().str());
+    llvm_unreachable(
+        (llvm::Twine("Invalid output section data: ") + getOSDKindAsStr())
+            .str()
+            .c_str());
   }
 }
 

--- a/lib/Target/Hexagon/HexagonInfo.cpp
+++ b/lib/Target/Hexagon/HexagonInfo.cpp
@@ -139,7 +139,7 @@ uint64_t HexagonInfo::translateFlag(uint64_t pFlag) const {
   case llvm::ELF::EF_HEXAGON_MACH_V91:
     return LINK_V91;
   default:
-    ASSERT(0, llvm::Twine("Unknown flag " + pflagStr).str().c_str());
+    llvm_unreachable(llvm::Twine("Unknown flag " + pflagStr).str().c_str());
   }
 }
 


### PR DESCRIPTION
`ASSERT`s are now no-ops in release builds, leading to new warnings such as unused variables for assert-only locals, or missing return paths from unreachable sections previously denoted by `ASSERT(0)`.