### PR TITLE
Default to Linux Emulation on RISC-V

### DIFF
--- a/lib/Target/RISCV/RISCVStandaloneInfo.h
+++ b/lib/Target/RISCV/RISCVStandaloneInfo.h
@@ -27,15 +27,13 @@ public:
     if (m_Config.codeGenType() == LinkerConfig::DynObj)
       return 0;
 
-    if (m_Config.targets().triple().isOSLinux()) {
-      // 64-bit dynamic executables also needs starting address
-      // as non zero
-      if (m_Config.targets().is64Bits())
-        return 0x400000;
-      // 32-bit
-      if (!isDynExec)
-        return 0x8048000;
-    }
+    // 64-bit dynamic executables also needs starting address
+    // as non zero
+    if (m_Config.targets().is64Bits())
+      return 0x400000;
+    // 32-bit
+    if (!isDynExec)
+      return 0x8048000;
 
     return 0x0;
   }

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -409,7 +409,7 @@ if config.test_target == 'RISCV64':
     embedclangxxopts = clangcommonopts
     linkdriveropts = clangcommonopts + clangcommonxxopts
     linkdriverg0opts = linkdriveropts + ' -G0'
-    linkopts = '--thread-count 4  --emit-relocs'
+    linkopts = '--thread-count 4  --emit-relocs --image-base 0'
     if hasattr(config,'eld_option') and config.eld_option != 'default':
         linkopts = '--thread-count 4 ' + config.eld_option
     llvmmc = 'llvm-mc'
@@ -438,7 +438,7 @@ if config.test_target == 'RISCV':
     embedclangxxopts = clangcommonopts
     linkdriveropts = clangcommonopts + clangcommonxxopts
     linkdriverg0opts = linkdriveropts + ' -G0'
-    linkopts = '--thread-count 4 -mtriple riscv32-unknown-elf  --emit-relocs'
+    linkopts = '--thread-count 4  --emit-relocs --image-base 0'
     if hasattr(config,'eld_option') and config.eld_option != 'default':
         linkopts = '-mtriple riscv32-unknown-elf --thread-count 4 ' + config.eld_option
     llvmmc = 'llvm-mc'


### PR DESCRIPTION
We want to default to linux emulation for RISC-V.

Use linker script to override defaults.

Linux emulation includes

- A specific start address for 32bit/64bit Linux binaries
- Loading of program headers (default)
- Minimum page size is set to 0x1000

Resolves #766