### PR TITLE
Fix crash when AArch64 objects contain unsupported relocations.

### DIFF
--- a/lib/Readers/Relocation.cpp
+++ b/lib/Readers/Relocation.cpp
@@ -39,8 +39,10 @@ Relocation *Relocation::Create() { return make<Relocation>(0, nullptr, 0, 0); }
 Relocation *Relocation::Create(Type pType, Size pSize, FragmentRef *pFragRef,
                                Address pAddend) {
   DWord targetData = 0;
+  pSize /= 8;
+  ASSERT(pSize <= sizeof(targetData), "unexpected relocation size.");
   if (pSize != 0)
-    pFragRef->memcpy(&targetData, pSize / 8);
+    pFragRef->memcpy(&targetData, pSize);
   return make<Relocation>(pType, pFragRef, pAddend, targetData);
 }
 
@@ -64,7 +66,9 @@ Relocation::Relocation(const Relocator *pRelocator, Relocation::Type pType,
                        FragmentRef *pTargetRef, Relocation::Address pAddend)
     : m_pSymInfo(nullptr), m_TargetAddress(pTargetRef), m_Addend(pAddend),
       m_TargetData(0), m_Type(pType) {
-  Size relocSize = pRelocator->getSize(pType);
+  // Size is returned in bits
+  Size relocSize = pRelocator->getSize(pType) / 8;
+  ASSERT(relocSize <= sizeof(m_TargetData), "unexpected relocation size.");
   if (relocSize != 0)
     pTargetRef->memcpy(&m_TargetData, relocSize);
 }

--- a/lib/Target/AArch64/AArch64Relocator.h
+++ b/lib/Target/AArch64/AArch64Relocator.h
@@ -82,7 +82,9 @@ public:
   }
 
 private:
-  bool isInvalidReloc(Relocation &pType) const;
+  bool isInvalidReloc(Relocation &pReloc) const;
+  bool isRelocSupported(Relocation &pReloc) const;
+
   void scanLocalReloc(InputFile &pInput, Relocation &pReloc,
                       const ELFSection &pSection);
 

--- a/test/AArch64/standalone/Relocations/UnsupportedReloc.test
+++ b/test/AArch64/standalone/Relocations/UnsupportedReloc.test
@@ -1,0 +1,94 @@
+#---UnsupportedReloc.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+# Test that linker handles unsupported relocation types.
+#END_COMMENT
+#START_TEST
+# Test dynamic executable with unsupported relocation
+# RUN: %yaml2obj --docnum=1 %s -o %t.o
+# RUN: %not %link %linkopts %t.o -o %t_dynamic.out 2>&1 | %filecheck %s -check-prefix=DYNAMIC
+# DYNAMIC: Found unsupported reloc type 65535 in section .rela.text
+
+# Test static executable with unsupported relocation
+# RUN: %not %link %linkopts -static %t.o -o %t.out 2>&1 | %filecheck %s -check-prefix=STATIC
+# STATIC: Found unsupported reloc type 65535 in section .rela.text
+
+# Test shared library with unsupported relocation
+# RUN: %not %link %linkopts -shared %t.o -o %t.so 2>&1 | %filecheck %s -check-prefix=SHARED
+# SHARED: Found unsupported reloc type 65535 in section .rela.text
+
+# Test partial linking with unsupported relocation (should not error, just copy through)
+# RUN: %link %linkopts -r %t.o -o %t_partial.o
+
+# Test unsupported relocation in discarded section (should not error)
+# RUN: %yaml2obj --docnum=2 %s -o %t_gc.o
+# RUN: %link %linkopts --gc-sections %t_gc.o -o %t_gc.out
+#END_TEST
+
+# Document 1: Unsupported relocation type in live section
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_AARCH64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Content: "00000000"
+  - Name:  .rela.text
+    Type:  SHT_RELA
+    Link:  .symtab
+    Info:  .text
+    Relocations:
+      - Offset: 0x0
+        Symbol: foo
+        Type:   0xFFFF  # Invalid/unsupported relocation type
+        Addend: 0
+Symbols:
+  - Name:    foo
+    Type:    STT_FUNC
+    Section: .text
+    Value:   0x0
+    Size:    4
+
+# Document 2: Unsupported relocation in section that will be discarded
+--- !ELF
+FileHeader:
+  Class:   ELFCLASS64
+  Data:    ELFDATA2LSB
+  Type:    ET_REL
+  Machine: EM_AARCH64
+Sections:
+  - Name:  .text
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Content: "c0035fd6"  # ret
+  - Name:  .text.unused
+    Type:  SHT_PROGBITS
+    Flags: [ SHF_ALLOC, SHF_EXECINSTR ]
+    Content: "00000094"  # bl instruction
+  - Name:  .rela.text.unused
+    Type:  SHT_RELA
+    Link:  .symtab
+    Info:  .text.unused
+    Relocations:
+      - Offset: 0x0
+        Symbol: some_func
+        Type:   0xFFFF  # Unsupported relocation in unused section
+        Addend: 0
+Symbols:
+  - Name:    _start
+    Type:    STT_FUNC
+    Section: .text
+    Binding: STB_GLOBAL
+    Value:   0x0
+    Size:    4
+  - Name:    unused_func
+    Type:    STT_FUNC
+    Section: .text.unused
+    Value:   0x0
+    Size:    4
+  - Name:    some_func
+    Type:    STT_FUNC
+    Binding: STB_GLOBAL


### PR DESCRIPTION
Due to a missing assert, eld crashes when trying to link AArch64 objects including unsupported relocations.

This commit add the missing assert, as well as two additional checks on the size (that triggered when the size was pointing to invalid data in memory).

A unit test is making sure eld is asserting on invalid/unsupported relocations.