### PR TITLE
Revert "[ELFSection] Remove unnecessary Annotations member."

### DIFF
--- a/include/eld/LayoutMap/TextLayoutPrinter.h
+++ b/include/eld/LayoutMap/TextLayoutPrinter.h
@@ -132,9 +132,6 @@ public:
 
   void printStat(llvm::StringRef S, const std::string &Stat) const;
 
-  std::optional<std::string>
-  getPluginSectionAnnotations(const ELFSection *S) const;
-
   std::string showDecoratedSymbolName(eld::Module &CurModule,
                                       const ResolveInfo *R) const;
 

--- a/include/eld/Readers/ELFSection.h
+++ b/include/eld/Readers/ELFSection.h
@@ -147,6 +147,12 @@ public:
 
   static std::string getELFPermissionsStr(uint32_t Permissions);
 
+  std::string getSectionAnnotations() const;
+
+  bool hasAnnotations() const;
+
+  void addSectionAnnotation(const std::string &Annotation);
+
   bool hasOffset() const;
 
   /// FIXME: We change the offset for input sections so this will not return the
@@ -318,16 +324,14 @@ protected:
   /// the section properties instead of storing this?
   bool ShouldExcludeFromGC = false;
 
+  llvm::SmallVector<std::string> Annotations;
+
   llvm::SmallVector<Fragment *, 0> Fragments;
   llvm::SmallVector<Relocation *, 0> Relocations;
 
   /// FIXME: These vectors can be moved out of this class?
   llvm::SmallVector<const ELFSection *, 0> GroupSections;
 };
-
-#ifndef _WIN32
-static_assert(sizeof(ELFSection) <= 224, "ELFSection grew too large!");
-#endif
 
 } // namespace eld
 

--- a/lib/Core/LinkerScript.cpp
+++ b/lib/Core/LinkerScript.cpp
@@ -338,6 +338,7 @@ void LinkerScript::updateRuleOp(plugin::LinkerWrapper *W, eld::Module *M,
                                 RuleContainer *R, ELFSection *S,
                                 const std::string &Annotation) {
   UpdateRulePluginOp *Op = eld::make<UpdateRulePluginOp>(W, R, S, Annotation);
+  S->addSectionAnnotation(Annotation);
   S->setOutputSection(R->getSection()->getOutputSection());
   S->setMatchedLinkerScriptRule(R);
   R->incMatchCount();

--- a/lib/Readers/ELFSection.cpp
+++ b/lib/Readers/ELFSection.cpp
@@ -108,6 +108,21 @@ std::string ELFSection::getELFPermissionsStr(uint32_t permissions) {
   return elfPermStr;
 }
 
+std::string ELFSection::getSectionAnnotations() const {
+  std::ostringstream oss;
+  for (size_t i = 0; i < Annotations.size(); ++i) {
+    oss << Annotations[i];
+    if (i != Annotations.size() - 1)
+      oss << ", ";
+  }
+  return oss.str();
+}
+
+bool ELFSection::hasAnnotations() const { return !Annotations.empty(); }
+
+void ELFSection::addSectionAnnotation(const std::string &Annotation) {
+  Annotations.push_back(Annotation);
+}
 // If an input section is in the form of "foo.N" where N is a number,
 // return N. Otherwise, returns 65536, which is one greater than the
 // lowest priority.


### PR DESCRIPTION
This reverts commit 8f235b406e3019928d9e926da001c15d063de177. This commit is getting reverted because it caused a performance regression while computing section annotations when there are large number of plugin operations.