### PR TITLE
[AArch64] Add support for pointer authentication relocations

### DIFF
--- a/include/eld/Diagnostics/DiagRelocations.inc
+++ b/include/eld/Diagnostics/DiagRelocations.inc
@@ -20,6 +20,8 @@ DIAG(undefined_reference_text, DiagnosticEngine::Error,
 DIAG(non_pic_relocation, DiagnosticEngine::Fatal,
      "Current link configuration does not support relocation type `%0' for "
      "symbol `%1' referred from %2 , recompile with -fPIC")
+DIAG(reloc_nonalloc_section, DiagnosticEngine::Fatal,
+     "relocation type `%0' for symbol `%1' cannot be used when referred from non-allocated section `%2'")
 DIAG(base_relocation, DiagnosticEngine::Fatal,
      "relocation type `%0' is not supported for symbol `%1'")
 DIAG(dynamic_relocation, DiagnosticEngine::Fatal,

--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -661,7 +661,7 @@ public:
   virtual LDSymbol *getGOTSymbol() const { return m_pGOTSymbol; }
 
   void recordRelativeReloc(Relocation *R, const Relocation *N) {
-    m_RelativeRelocMap[R] = N;
+    m_RelativeRelocMap[N] = R;
   }
 
   // Patching sections.
@@ -1171,7 +1171,7 @@ protected:
   // Dynamic linking
   ELFObjectFile *m_DynamicSectionHeadersInputFile = nullptr;
   LDSymbol *m_pGOTSymbol = nullptr;
-  llvm::DenseMap<Relocation *, const Relocation *> m_RelativeRelocMap;
+  llvm::DenseMap<const Relocation *, Relocation *> m_RelativeRelocMap;
 
   // Patching.
   llvm::DenseMap<ResolveInfo *, const ResolveInfo *> m_AbsolutePLTMap;

--- a/lib/Target/AArch64/AArch64ELFDynamic.cpp
+++ b/lib/Target/AArch64/AArch64ELFDynamic.cpp
@@ -31,7 +31,8 @@ void AArch64ELFDynamic::reserveTargetEntries() {
 void AArch64ELFDynamic::applyTargetEntries() {
   uint32_t relaCount = 0;
   for (auto &R : m_Backend.getRelaDyn()->getRelocations()) {
-    if (R->type() == llvm::ELF::R_AARCH64_RELATIVE)
+    if (R->type() == llvm::ELF::R_AARCH64_RELATIVE ||
+        R->type() == llvm::ELF::R_AARCH64_AUTH_RELATIVE)
       relaCount++;
   }
   applyOne(llvm::ELF::DT_RELACOUNT, relaCount);

--- a/lib/Target/AArch64/AArch64LDBackend.cpp
+++ b/lib/Target/AArch64/AArch64LDBackend.cpp
@@ -773,8 +773,12 @@ void AArch64LDBackend::recordPLT(ResolveInfo *I, AArch64PLT *P) {
   m_PLTMap[I] = P;
 }
 
+Relocation *AArch64LDBackend::findRelativeReloc(const Relocation *pReloc) const {
+  return m_RelativeRelocMap.lookup(pReloc);
+}
+
 Stub *AArch64LDBackend::getBranchIslandStub(Relocation *pReloc,
-                                                   int64_t targetValue) const {
+                                            int64_t targetValue) const {
   (void)pReloc;
   (void)targetValue;
   return *getStubFactory()->getAllStubs().cbegin();

--- a/lib/Target/AArch64/AArch64LDBackend.h
+++ b/lib/Target/AArch64/AArch64LDBackend.h
@@ -110,6 +110,8 @@ public:
       return false;
     if (X->type() == llvm::ELF::R_AARCH64_RELATIVE)
       return false;
+    if (X->type() == llvm::ELF::R_AARCH64_AUTH_RELATIVE)
+      return false;
     if (X->symInfo() && X->symInfo()->binding() == ResolveInfo::Local)
       return false;
     return true;
@@ -123,6 +125,8 @@ public:
     if (X->type() == llvm::ELF::R_AARCH64_ABS64)
       return DynRelocType::WORD_DEPOSIT;
     if (X->type() == llvm::ELF::R_AARCH64_RELATIVE)
+      return DynRelocType::RELATIVE;
+    if (X->type() == llvm::ELF::R_AARCH64_AUTH_RELATIVE)
       return DynRelocType::RELATIVE;
     if (X->type() == llvm::ELF::R_AARCH64_IRELATIVE)
       return DynRelocType::RELATIVE;
@@ -138,6 +142,8 @@ public:
     }
     return DynRelocType::DEFAULT;
   }
+
+  Relocation *findRelativeReloc(const Relocation *pReloc) const;
 
   Stub *getBranchIslandStub(Relocation *pReloc,
                             int64_t targetValue) const override;

--- a/lib/Target/AArch64/AArch64RelocationFunctions.h
+++ b/lib/Target/AArch64/AArch64RelocationFunctions.h
@@ -128,7 +128,7 @@
                 MappedType(&ld64_got_lo12, "R_AARCH64_LD64_GOT_LO12_NC", 32)), \
       ValueType(0x139,                                                         \
                 MappedType(&ld64_gotpage_lo15,                                 \
-			   "R_AARCH64_LD64_GOTPAGE_LO15", 32)),                \
+                           "R_AARCH64_LD64_GOTPAGE_LO15", 32)),                \
       ValueType(0x13a,                                                         \
                 MappedType(&unsupport, "R_AARCH64_PLT32", 32)),                \
       ValueType(0x13b,                                                         \
@@ -272,6 +272,59 @@
       ValueType(1030, MappedType(&unsupport, "R_AARCH64_TLS_TPREL64")),        \
       ValueType(1031, MappedType(&unsupport, "R_AARCH64_TLSDESC")),            \
       ValueType(1032, MappedType(&unsupport, "R_AARCH64_IRELATIVE")),          \
+      ValueType(0x244, MappedType(&abs, "R_AARCH64_AUTH_ABS64", 64)),          \
+      ValueType(0x245,                                                         \
+                MappedType(&unsupport, "R_AARCH64_AUTH_MOVW_GOTOFF_G0", 32)),  \
+      ValueType(0x246,                                                         \
+                MappedType(&unsupport,                                         \
+                           "R_AARCH64_AUTH_MOVW_GOTOFF_G0_NC", 32)),           \
+      ValueType(0x247,                                                         \
+                MappedType(&unsupport, "R_AARCH64_AUTH_MOVW_GOTOFF_G1", 32)),  \
+      ValueType(0x248,                                                         \
+                MappedType(&unsupport,                                         \
+                           "R_AARCH64_AUTH_MOVW_GOTOFF_G1_NC", 32)),           \
+      ValueType(0x249,                                                         \
+                MappedType(&unsupport, "R_AARCH64_AUTH_MOVW_GOTOFF_G2", 32)),  \
+      ValueType(0x24a,                                                         \
+                MappedType(&unsupport,                                         \
+                           "R_AARCH64_AUTH_MOVW_GOTOFF_G2_NC", 32)),           \
+      ValueType(0x24b,                                                         \
+                MappedType(&unsupport, "R_AARCH64_AUTH_MOVW_GOTOFF_G3", 32)),  \
+      ValueType(0x24c,                                                         \
+                MappedType(&unsupport, "R_AARCH64_AUTH_GOT_LD_PREL19", 32)),   \
+      ValueType(0x24d,                                                         \
+                MappedType(&unsupport,                                         \
+                           "R_AARCH64_AUTH_LD64_GOTOFF_LO15", 32)),            \
+      ValueType(0x24e,                                                         \
+                MappedType(&unsupport, "R_AARCH64_AUTH_ADR_GOT_PAGE", 32)),    \
+      ValueType(0x24f,                                                         \
+                MappedType(&unsupport,                                         \
+                           "R_AARCH64_AUTH_LD64_GOT_LO12_NC", 32)),            \
+      ValueType(0x250,                                                         \
+                MappedType(&unsupport,                                         \
+                           "R_AARCH64_AUTH_LD64_GOTPAGE_LO15", 32)),           \
+      ValueType(0x251,                                                         \
+                MappedType(&unsupport, "R_AARCH64_AUTH_GOT_ADD_LO12_NC", 32)), \
+      ValueType(0x252,                                                         \
+                MappedType(&unsupport,                                         \
+                           "R_AARCH64_AUTH_GOT_ADR_PREL_LO21", 32)),           \
+      ValueType(0x253,                                                         \
+                MappedType(&unsupport,                                         \
+                           "R_AARCH64_AUTH_TLSDESC_ADR_PAGE21", 32)),          \
+      ValueType(0x254,                                                         \
+                MappedType(&unsupport,                                         \
+                           "R_AARCH64_AUTH_TLSDESC_LD64_LO12", 32)),           \
+      ValueType(0x255,                                                         \
+                MappedType(&unsupport,                                         \
+                           "R_AARCH64_AUTH_TLSDESC_ADD_LO12", 32)),            \
+      ValueType(0x411,                                                         \
+                MappedType(&unsupport, "R_AARCH64_AUTH_RELATIVE")),            \
+      ValueType(0x412,                                                         \
+                MappedType(&unsupport, "R_AARCH64_AUTH_GLOB_DAT")),            \
+      ValueType(0x413,                                                         \
+                MappedType(&unsupport, "R_AARCH64_AUTH_TLSDESC")),             \
+      ValueType(0x414,                                                         \
+                MappedType(&unsupport, "R_AARCH64_AUTH_IRELATIVE")),           \
       ValueType(1033, MappedType(&copyInstruction, "R_AARCH64_COPY_INSN", 32))
 
 #define AARCH64_MAXRELOCS (R_AARCH64_COPY_INSN + 1)

--- a/lib/Target/AArch64/AArch64Relocator.h
+++ b/lib/Target/AArch64/AArch64Relocator.h
@@ -84,6 +84,7 @@ public:
 private:
   bool isInvalidReloc(Relocation &pReloc) const;
   bool isRelocSupported(Relocation &pReloc) const;
+  bool relocNeedsDynRel(Relocation &pReloc) const;
 
   void scanLocalReloc(InputFile &pInput, Relocation &pReloc,
                       const ELFSection &pSection);

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -4674,8 +4674,8 @@ void GNULDBackend::doPostLayout() {
     eld::RegisterTimer T("Update Relative Relocations", "Do Post Layout",
                          m_Module.getConfig().options().printTimingStats());
     for (auto &r : m_RelativeRelocMap) {
-      Relocation *R = r.first;
-      const Relocation *N = r.second;
+      const Relocation *N = r.first;
+      Relocation *R = r.second;
       R->modifyRelocationFragmentRef(N->targetFragRef());
       R->setAddend(N->addend());
     }

--- a/test/AArch64/standalone/Relocations/PAuthReloc.s
+++ b/test/AArch64/standalone/Relocations/PAuthReloc.s
@@ -1,0 +1,191 @@
+#---PAuthReloc.s--------------------- Executable------------------#
+#BEGIN_COMMENT
+# Test that linker handles signed relocations (pauth).
+#END_COMMENT
+#START_TEST
+# RUN: rm -rf %t && split-file %s %t && cd %t
+
+# RUN: %llvm-mc -filetype=obj -triple=aarch64 a.s -o a.o
+# RUN: %link %linkopts -shared a.o -o a.so
+# RUN: %llvm-mc -filetype=obj -triple=aarch64 main.s -o main.o
+
+# Test PAuth relocations with PIE
+# RUN: %link %linkopts main.o -pie a.so -o main
+# RUN: %readelf --elf-output-style LLVM -r main 2>&1 | %filecheck %s --check-prefix=UNPACKED
+
+# UNPACKED:          Section ({{.+}}) .rela.dyn {
+# UNPACKED-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# UNPACKED-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# UNPACKED-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# UNPACKED-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# UNPACKED-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0xFFFFFFFFFFFFF{{[0-9A-F]+}}
+# UNPACKED-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0x12345{{[0-9A-F]+}}
+# UNPACKED-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0x34567{{[0-9A-F]+}}
+# UNPACKED-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0xFFFFFFFFCBA98{{[0-9A-F]+}}
+# UNPACKED-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# UNPACKED-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# UNPACKED-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# UNPACKED-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_ABS64 bar 0x64
+# UNPACKED-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_ABS64 bar 0x0
+# UNPACKED-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_ABS64 foo 0x1111
+# UNPACKED-NEXT:     }
+
+# Validate relocation place (and signing schema) in section data
+# RUN: %readelf -x .test main | %filecheck %s --check-prefix=HEX
+
+# HEX: Hex dump of section '.test':
+# HEX-NEXT: {{0x[0-9a-f]+}} 00000000 2a000020 00000000 2b000000
+##                          ^^^^^^^^ No implicit val (rela reloc)
+##                                   ^^^^ Discr = 42
+##                                         ^^ Key = DA
+##                                            ^^^^^^^^ No implicit val (rela reloc)
+##                                                     ^^^^ Discr = 43
+##                                                           ^^ Key = IA
+# HEX-NEXT: {{0x[0-9a-f]+}} 00000000 2c000080 00000000 2d000020
+##                          ^^^^^^^^ No implicit val (rela reloc)
+##                                   ^^^^ Discr = 44
+##                                         ^^ Key = IA, Addr
+##                                            ^^^^^^^^ No implicit val (rela reloc)
+##                                                     ^^^^ Discr = 45
+##                                                           ^^ Key = DA
+# HEX-NEXT: {{0x[0-9a-f]+}} 00000000 2e000020 00000000 2f000020
+##                          ^^^^^^^^ No implicit val (rela reloc)
+##                                   ^^^^ Discr = 46
+##                                         ^^ Key = DA
+##                                            ^^^^^^^^ No implicit val (rela reloc)
+##                                                     ^^^^ Discr = 47
+##                                                           ^^ Key = DA
+# HEX-NEXT: {{0x[0-9a-f]+}} 00000000 30000020 00000000 31000020
+##                          ^^^^^^^^ No implicit val (rela reloc)
+##                                   ^^^^ Discr = 48
+##                                         ^^ Key = DA
+##                                            ^^^^^^^^ No implicit val (preemptible abs reloc)
+##                                                     ^^^^ Discr = 49
+##                                                           ^^ Key = DA
+# HEX-NEXT: {{0x[0-9a-f]+}} 00000000 32000000 77000000 00330000
+##                          ^^^^^^^^ No implicit val (preemptible abs reloc)
+##                                   ^^^^ Discr = 50
+##                                         ^^ Key = IA
+##                                            ^^ padding byte
+##                                              ^^^^^^ ^^ No implicit val (rela reloc)
+##                                                       ^^^^ Discr = 51
+# HEX-NEXT: {{0x[0-9a-f]+}} 20770000 00003400 0020
+##                          ^^ Key = DA
+##                            ^^ padding byte
+##                              ^^^^ ^^^^ No implicit val (rela reloc)
+##                                       ^^^^ Discr = 52
+##                                              ^^ Key = DA
+
+# Test PAuth relocations in read-only section
+# RUN: %readelf -x .rodata main | %filecheck %s --check-prefix=RODATA
+
+# RODATA: Hex dump of section '.rodata':
+# RODATA-NEXT: {{0x[0-9a-f]+}} 00000000 35000020 00000000 36000000
+##                             ^^^^^^^^ No implicit val (rela reloc)
+##                                      ^^^^ Discr = 53
+##                                            ^^ Key = DA
+##                                               ^^^^^^^^ No implicit val (rela reloc)
+##                                                        ^^^^ Discr = 54
+##                                                              ^^ Key = IA
+# RODATA-NEXT: {{0x[0-9a-f]+}} 00000000 37000020
+##                             ^^^^^^^^ No implicit val (rela reloc)
+##                                      ^^^^ Discr = 55
+##                                            ^^ Key = DA
+# Test PAuth relocations without PIE
+# RUN: %link %linkopts main.o -no-pie a.so -o main.nopie
+# RUN: %readelf --elf-output-style LLVM -r main.nopie 2>&1 | %filecheck %s --check-prefix=NOPIE
+
+# NOPIE:      Section ({{.+}}) .rela.dyn {
+# NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0xFFFFFFFFFFFFF{{[0-9A-F]+}}
+# NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0x12345{{[0-9A-F]+}}
+# NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0x34567{{[0-9A-F]+}}
+# NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0xFFFFFFFFCBA98{{[0-9A-F]+}}
+# NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_ABS64 bar 0x64
+# NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_ABS64 bar 0x0
+# NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_ABS64 foo 0x1111
+# NOPIE-NEXT: }
+
+# Test PAuth relocations with static executable (PIE)
+# RUN: %link %linkopts -static main.o -pie a.o -o main.static
+# RUN: %readelf --elf-output-style LLVM -r main.static 2>&1 | %filecheck %s --check-prefix=STATIC
+
+# STATIC:      Section ({{.+}}) .rela.dyn {
+# STATIC-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0xFFFFFFFFFFFFF{{[0-9A-F]+}}
+# STATIC-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0x12345{{[0-9A-F]+}}
+# STATIC-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0x34567{{[0-9A-F]+}}
+# STATIC-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0xFFFFFFFFCBA98{{[0-9A-F]+}}
+# STATIC-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC-NEXT: }
+
+# Test PAuth relocations with static executable (without PIE)
+# RUN: %link %linkopts -static main.o -no-pie a.o -o main.static.nopie
+# RUN: %readelf --elf-output-style LLVM -r main.static.nopie 2>&1 | %filecheck %s --check-prefix=STATIC_NOPIE
+
+# STATIC_NOPIE:      Section ({{.+}}) .rela.dyn {
+# STATIC_NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC_NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC_NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC_NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC_NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC_NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC_NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC_NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC_NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC_NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC_NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC_NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC_NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC_NOPIE-NEXT:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# STATIC_NOPIE-NEXT: }
+
+#END_TEST
+
+#--- a.s
+.global bar
+.type bar, @function
+bar:
+
+.global foo
+foo:
+
+#--- main.s
+.section .test, "aw"
+.p2align 3
+.quad (__etext + 1)@AUTH(da,42)
+.quad (.test + 2)@AUTH(ia,43)
+.quad (__etext - 1000)@AUTH(ia,44,addr)
+.quad (__etext + 0x12345678)@AUTH(da,45)
+## Addend wider than 32 bits, not enough room for storing implicitly, would go to rela
+.quad (__etext + 0x123456789A)@AUTH(da,46)
+## Negative addend wider than 32 bits, not enough room for storing implicitly, would go to rela
+.quad (__etext - 0x123456789A)@AUTH(da,47)
+## INT32_MAX plus non-zero .test is wider than 32 bits, not enough room for storing implicitly, would go to rela
+.quad (.test + 0x7FFFFFFF)@AUTH(da,48)
+.quad (foo + 0x1111)@AUTH(da,49)
+.quad bar@AUTH(ia,50)
+.byte 0x77
+.quad (__etext + 4)@AUTH(da,51)
+.byte 0x77
+.quad (.test + 5)@AUTH(da,52)
+
+.section .rodata, "a"
+.p2align 3
+.quad (__etext + 10)@AUTH(da,53)
+.quad (.rodata + 8)@AUTH(ia,54)
+.quad (bar + 100)@AUTH(da,55)

--- a/test/AArch64/standalone/Relocations/PAuthRelocCopy.s
+++ b/test/AArch64/standalone/Relocations/PAuthRelocCopy.s
@@ -1,0 +1,48 @@
+#---PAuthRelocCopy.s------------ Executable------------------#
+#BEGIN_COMMENT
+# Test that linker rejects AUTH relocations that would require COPY relocations.
+#END_COMMENT
+#START_TEST
+# RUN: rm -rf %t && split-file %s %t && cd %t
+
+# RUN: %llvm-mc -filetype=obj -triple=aarch64 a.s -o a.o
+# RUN: %link %linkopts -shared a.o -soname=a.so -o a.so
+# RUN: %llvm-mc -filetype=obj -triple=aarch64 main.s -o main.o
+
+# Test non-PIE executable - this is where COPY relocations would be needed
+# RUN: %not %link %linkopts main.o -no-pie a.so -o main 2>&1
+
+# CHECK: {{.*}}relocation{{.*}}R_AARCH64_AUTH_ABS64{{.*}}cannot be used{{.*}}foo
+# CHECK: {{.*}}relocation{{.*}}R_AARCH64_AUTH_ABS64{{.*}}cannot be used{{.*}}bar
+
+# PIE executable should work (uses dynamic relocations, not COPY)
+# RUN: %link %linkopts main.o -pie a.so -o main.pie
+# RUN: %readelf --elf-output-style LLVM -r main.pie | %filecheck %s --check-prefix=PIE
+
+# PIE: {{0x[0-9A-F]+}} R_AARCH64_AUTH_ABS64 bar 0x0
+# PIE: {{0x[0-9A-F]+}} R_AARCH64_AUTH_ABS64 foo 0x0
+
+#END_TEST
+
+#--- a.s
+.global bar
+.type bar, @object
+.size bar, 8
+bar:
+  .quad 0x1234
+
+.global foo
+.type foo, @object
+.size foo, 4
+foo:
+  .word 42
+
+#--- main.s
+.global _start
+_start:
+  ret
+
+.section .data
+.p2align 3
+.quad foo@AUTH(da,42)
+.quad bar@AUTH(ia,43)

--- a/test/AArch64/standalone/Relocations/PAuthRelocDebug.s
+++ b/test/AArch64/standalone/Relocations/PAuthRelocDebug.s
@@ -1,0 +1,100 @@
+#---PAuthRelocDebug.s------------ Executable------------------#
+#BEGIN_COMMENT
+# Test that linker rejects AUTH relocations when referred from non-allocated sections.
+# AUTH relocations require runtime signing by the dynamic linker, which only
+# processes allocated sections. Non-allocated sections like .debug_* cannot
+# have AUTH relocations.
+#END_COMMENT
+#START_TEST
+# RUN: rm -rf %t && split-file %s %t && cd %t
+
+# RUN: %llvm-mc -filetype=obj -triple=aarch64 a.s -o a.o
+# RUN: %link %linkopts -shared a.o -o a.so
+# RUN: %llvm-mc -filetype=obj -triple=aarch64 main.s -o main.o
+
+# Test PIE executable with AUTH relocations in debug section (should fail)
+# RUN: %not %link %linkopts main.o -pie a.so -o main 2>&1 | %filecheck %s --check-prefix=PIE
+
+# PIE: Fatal: relocation type `R_AARCH64_AUTH_ABS64' for symbol `foo' cannot be used when referred from non-allocated section `.rela.debug_info'
+# PIE: Fatal: relocation type `R_AARCH64_AUTH_ABS64' for symbol `bar' cannot be used when referred from non-allocated section `.rela.debug_info'
+# PIE: Fatal: relocation type `R_AARCH64_AUTH_ABS64' for symbol `.text' cannot be used when referred from non-allocated section `.rela.debug_info'
+
+# Test non-PIE executable with AUTH relocations in debug section (should also fail)
+# RUN: %not %link %linkopts main.o -no-pie a.so -o main.nopie 2>&1 | %filecheck %s --check-prefix=NOPIE
+
+# NOPIE: Fatal: relocation type `R_AARCH64_AUTH_ABS64' for symbol `foo' cannot be used when referred from non-allocated section `.rela.debug_info'
+# NOPIE: Fatal: relocation type `R_AARCH64_AUTH_ABS64' for symbol `bar' cannot be used when referred from non-allocated section `.rela.debug_info'
+# NOPIE: Fatal: relocation type `R_AARCH64_AUTH_ABS64' for symbol `.text' cannot be used when referred from non-allocated section `.rela.debug_info'
+
+# Test static executable with AUTH relocations in debug section (should also fail)
+# RUN: %not %link %linkopts -static main.o a.o -o main.static 2>&1 | %filecheck %s --check-prefix=STATIC
+
+# STATIC: Fatal: relocation type `R_AARCH64_AUTH_ABS64' for symbol `foo' cannot be used when referred from non-allocated section `.rela.debug_info'
+# STATIC: Fatal: relocation type `R_AARCH64_AUTH_ABS64' for symbol `bar' cannot be used when referred from non-allocated section `.rela.debug_info'
+# STATIC: Fatal: relocation type `R_AARCH64_AUTH_ABS64' for symbol `.text' cannot be used when referred from non-allocated section `.rela.debug_info'
+
+# Verify that regular (non-AUTH) relocations in debug sections still work
+# RUN: %llvm-mc -filetype=obj -triple=aarch64 main_regular.s -o main_regular.o
+# RUN: %link %linkopts main_regular.o -pie a.so -o main.regular
+# RUN: %readelf -r main.regular | %filecheck %s --check-prefix=REGULAR --allow-empty
+
+# Debug relocations are resolved statically, so no dynamic relocations should appear
+# REGULAR-NOT: .debug_info
+
+#END_TEST
+
+#--- a.s
+.global bar
+.type bar, @function
+bar:
+  ret
+
+.global foo
+.data
+foo:
+  .word 42
+
+#--- main.s
+.global _start
+.type _start, @function
+_start:
+  ret
+
+baz:
+  nop
+
+# AUTH relocations in non-allocated debug section (should be rejected)
+.section .debug_info, "", @progbits
+.p2align 3
+.quad foo@AUTH(da,42)
+.quad bar@AUTH(ia,43)
+.quad baz@AUTH(da,44)
+
+# AUTH relocations in allocated sections should work fine
+.section .data
+.p2align 3
+.quad foo@AUTH(da,45)
+.quad bar@AUTH(ia,46)
+.quad baz@AUTH(da,47)
+
+#--- main_regular.s
+.global _start
+.type _start, @function
+_start:
+  ret
+
+baz:
+  nop
+
+# Regular (non-AUTH) relocations in debug sections are fine
+.section .debug_info, "", @progbits
+.p2align 3
+.quad foo
+.quad bar
+.quad baz
+
+.section .data
+.p2align 3
+.quad foo
+.quad bar
+.quad baz

--- a/test/AArch64/standalone/Relocations/PAuthRelocWeak.s
+++ b/test/AArch64/standalone/Relocations/PAuthRelocWeak.s
@@ -1,0 +1,108 @@
+#---PAuthRelocWeak.s------------ Executable------------------#
+#BEGIN_COMMENT
+# Test that linker handles weak undefined symbols with AUTH relocations.
+# Per spec section 8.1.1: "if the target symbol is an undefined weak reference,
+# the result of the relocation is 0 (nullptr) regardless of the signing schema"
+#END_COMMENT
+#START_TEST
+# RUN: rm -rf %t && split-file %s %t && cd %t
+
+# RUN: %llvm-mc -filetype=obj -triple=aarch64 main.s -o main.o
+
+# Test PIE executable with weak undefined symbols
+# RUN: %link %linkopts main.o -pie -o main.pie
+# RUN: %readelf --elf-output-style LLVM -r main.pie 2>&1 | %filecheck %s --check-prefix=PIE-RELOCS --allow-empty
+# RUN: %readelf -x .data main.pie | %filecheck %s --check-prefix=PIE-DATA
+
+# No dynamic relocations should be emitted for weak undefined symbols
+# PIE-RELOCS-NOT: weak_undef
+
+# All weak undefined AUTH relocations should resolve to 0
+# PIE-DATA:      Hex dump of section '.data':
+# PIE-DATA-NEXT: {{0x[0-9a-f]+}} 00000000 00000000 00000000 00000000
+##                               ^^^^^^^^ ^^^^^^^^ weak_undef_func@AUTH(da,42) = 0
+##                                                 ^^^^^^^^ ^^^^^^^^ weak_undef_data@AUTH(ia,43) = 0
+# PIE-DATA-NEXT: {{0x[0-9a-f]+}} 00000000 00000000
+##                               ^^^^^^^^ ^^^^^^^^ (weak_undef_func + 0x1234)@AUTH(da,44) = 0
+
+# Test non-PIE executable
+# RUN: %link %linkopts main.o -no-pie -o main.nopie
+# RUN: %readelf --elf-output-style LLVM -r main.nopie 2>&1 | %filecheck %s --check-prefix=NOPIE-RELOCS --allow-empty
+# RUN: %readelf -x .data main.nopie | %filecheck %s --check-prefix=NOPIE-DATA
+
+# NOPIE-RELOCS-NOT: weak_undef
+
+# NOPIE-DATA:      Hex dump of section '.data':
+# NOPIE-DATA-NEXT: {{0x[0-9a-f]+}} 00000000 00000000 00000000 00000000
+# NOPIE-DATA-NEXT: {{0x[0-9a-f]+}} 00000000 00000000
+
+# Test static executable
+# RUN: %link %linkopts -static main.o -pie -o main.static
+# RUN: %readelf --elf-output-style LLVM -r main.static 2>&1 | %filecheck %s --check-prefix=STATIC-RELOCS --allow-empty
+# RUN: %readelf -x .data main.static | %filecheck %s --check-prefix=STATIC-DATA
+
+# STATIC-RELOCS-NOT: weak_undef
+
+# STATIC-DATA:      Hex dump of section '.data':
+# STATIC-DATA-NEXT: {{0x[0-9a-f]+}} 00000000 00000000 00000000 00000000
+# STATIC-DATA-NEXT: {{0x[0-9a-f]+}} 00000000 00000000
+
+# Test that weak DEFINED symbols work normally (not resolved to 0)
+# RUN: %llvm-mc -filetype=obj -triple=aarch64 weak_def.s -o weak_def.o
+# RUN: %link %linkopts weak_def.o -pie -o weak_def
+# RUN: %readelf --elf-output-style LLVM -r weak_def 2>&1 | %filecheck %s --check-prefix=WEAK-DEF-RELOCS
+# RUN: %readelf -x .data weak_def | %filecheck %s --check-prefix=WEAK-DEF-DATA
+
+# Weak defined symbols should generate AUTH_RELATIVE relocations
+# WEAK-DEF-RELOCS:      Section ({{.+}}) .rela.dyn {
+# WEAK-DEF-RELOCS:      {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
+# WEAK-DEF-RELOCS:      }
+
+# Weak defined symbols should have signing schema encoded
+# WEAK-DEF-DATA:      Hex dump of section '.data':
+# WEAK-DEF-DATA-NEXT: {{0x[0-9a-f]+}} 00000000 2a000020
+##                                    ^^^^^^^^ No implicit val (rela reloc)
+##                                             ^^^^ Discr = 42
+##                                                   ^^ Key = DA
+
+#END_TEST
+
+#--- main.s
+.global _start
+.type _start, @function
+_start:
+  ret
+
+# Declare weak undefined symbols
+.weak weak_undef_func
+.weak weak_undef_data
+
+.section .data
+.p2align 3
+
+# Test weak undefined with AUTH relocations
+# Should resolve to 0 regardless of signing schema
+.quad weak_undef_func@AUTH(da,42)
+.quad weak_undef_data@AUTH(ia,43)
+
+# Test with non-zero addend - should still resolve to 0
+.quad (weak_undef_func + 0x1234)@AUTH(da,44)
+
+#--- weak_def.s
+.global _start
+.type _start, @function
+_start:
+  ret
+
+# Declare weak DEFINED symbol (not undefined)
+# This should NOT resolve to 0
+.weak weak_def_func
+.type weak_def_func, @function
+weak_def_func:
+  ret
+
+.section .data
+.p2align 3
+
+# Should generate AUTH_RELATIVE relocation, not resolve to 0
+.quad weak_def_func@AUTH(da,42)


### PR DESCRIPTION
Implements basic PAuth support for AArch64 following the PAuth ABI Extension specification (2025Q1):
https://github.com/ARM-software/abi-aa/blob/main/pauthabielf64/pauthabielf64.rst

**Adds:**
- R_AARCH64_AUTH_ABS64 (0x244): authenticated absolute relocations
- R_AARCH64_AUTH_RELATIVE (0x411): authenticated relative relocations

**Testing:**
Covers PIE/non-PIE/static executables, as well as various corner cases from the spec like undefined weak references, COPY relocations and non-allocating sections.

**Not included:**
GOT/PLT signing, additional AUTH relocation types (future work).

**Notes:**
I changed the way *GNULDBackend::recordRelativeReloc* store relative relocations. The original map is only iterated once (in a linear way), but reversing the key / values allows to implement an efficient *GNULDBackend::findRelativeReloc*.

No changes to existing non-AUTH relocation behavior.