### PR TITLE
Correct sysroot-prepend conditions for script inputs

### DIFF
--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -136,7 +136,7 @@ defm output_file : smDashTwoWithOpt<"o", "output", "output_file",
                    MetaVarName<"<outputfile>">,
                    Group<grp_general>;
 defm sysroot : smDash<"sysroot", "sysroot", "Set the system root">,
-              MetaVarName<"<sysroot-path>">,
+               MetaVarName<"<sysroot-path>">,
                Group<grp_general>;
 def version : Flag<["--"], "version">,
               HelpText<"Print the Linker version">,

--- a/include/eld/Input/Input.h
+++ b/include/eld/Input/Input.h
@@ -76,6 +76,12 @@ public:
 
   void setMemberNameHash(uint64_t Hash) { MemberNameHash = Hash; }
 
+  /// Set the parent script file for inputs from INPUT/GROUP commands.
+  void setParentScriptFile(InputFile *File) { ParentScriptFile = File; }
+
+  /// Get the parent script file.
+  InputFile *getParentScriptFile() const { return ParentScriptFile; }
+
   uint32_t getInputOrdinal() { return InputOrdinal; }
 
   Attribute &getAttribute() { return Attr; }
@@ -163,6 +169,12 @@ private:
   // Check if a path is valid and emit any errors
   bool isPathValid(const std::string &Path) const;
 
+  // Return true if sysroot should be prepended for a Script-typed input whose
+  // filename starts with '/'. This is used for INPUT/GROUP entries coming from
+  // a linker script: sysroot is applied only when the parent script is within
+  // the sysroot directory.
+  bool shouldPrependSysrootToScriptInput(const LinkerConfig &Config) const;
+
 protected:
   InputFile *IF = nullptr;
   MemoryArea *MemArea = nullptr;
@@ -178,6 +190,7 @@ protected:
   InputType Type = Default; // The type of input file.
   bool TraceMe = false;
   DiagnosticEngine *DiagEngine = nullptr;
+  InputFile *ParentScriptFile = nullptr; // Parent script for INPUT/GROUP inputs.
 
   /// Keeps track of already created MemoryAreas.
   ///

--- a/test/Common/standalone/linkerscript/SysrootInputGroup/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/SysrootInputGroup/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/Common/standalone/linkerscript/SysrootInputGroup/Inputs/2.c
+++ b/test/Common/standalone/linkerscript/SysrootInputGroup/Inputs/2.c
@@ -1,0 +1,1 @@
+int bar() { return 2; }

--- a/test/Common/standalone/linkerscript/SysrootInputGroup/Inputs/main.c
+++ b/test/Common/standalone/linkerscript/SysrootInputGroup/Inputs/main.c
@@ -1,0 +1,1 @@
+int main() { return 0; }

--- a/test/Common/standalone/linkerscript/SysrootInputGroup/Inputs/script1.t
+++ b/test/Common/standalone/linkerscript/SysrootInputGroup/Inputs/script1.t
@@ -1,0 +1,1 @@
+GROUP(/lib64/lib1.so)

--- a/test/Common/standalone/linkerscript/SysrootInputGroup/Inputs/script2.t
+++ b/test/Common/standalone/linkerscript/SysrootInputGroup/Inputs/script2.t
@@ -1,0 +1,1 @@
+INPUT(/lib64/lib2.so)

--- a/test/Common/standalone/linkerscript/SysrootInputGroup/SysrootInputGroup.test
+++ b/test/Common/standalone/linkerscript/SysrootInputGroup/SysrootInputGroup.test
@@ -1,0 +1,32 @@
+#---SysrootInputGroup.test---------------- Linker Script ----------------#
+#BEGIN_COMMENT
+# Validate sysroot handling for INPUT/GROUP script commands (issue #808).
+# Sysroot is prepended for "/..." only when the linker script itself is within
+# the sysroot directory.
+#END_COMMENT
+#START_TEST
+
+RUN: rm -rf %t.dir && mkdir -p %t.dir/lib64 %t.dir/scripts
+RUN: %clang %clangopts -o %t.1.o %p/Inputs/1.c -c -fPIC
+RUN: %clang %clangopts -o %t.2.o %p/Inputs/2.c -c -fPIC
+RUN: %clang %clangopts -o %t.main.o %p/Inputs/main.c -c
+RUN: %link %linkopts -o %t.dir/lib64/lib1.so -shared %t.1.o
+RUN: %link %linkopts -o %t.dir/lib64/lib2.so -shared %t.2.o
+
+# Script outside sysroot: do not prepend sysroot for "/...".
+RUN: %not %link %linkopts -o %t.out1 --sysroot=%t.dir -T %p/Inputs/script1.t %t.main.o 2>&1 | %filecheck %s --check-prefix=ERR1
+RUN: %not %link %linkopts -o %t.out2 --sysroot=%t.dir -T %p/Inputs/script2.t %t.main.o 2>&1 | %filecheck %s --check-prefix=ERR2
+
+# Script in sysroot: prepend sysroot for "/...".
+RUN: %cp %p/Inputs/script1.t %t.dir/scripts/script1.t
+RUN: %cp %p/Inputs/script2.t %t.dir/scripts/script2.t
+RUN: %link %linkopts -o %t.out3 --sysroot=%t.dir -T %t.dir/scripts/script1.t %t.main.o --verbose 2>&1 | %filecheck %s --check-prefix=SYSROOT1
+RUN: %link %linkopts -o %t.out4 --sysroot=%t.dir -T %t.dir/scripts/script2.t %t.main.o --verbose 2>&1 | %filecheck %s --check-prefix=SYSROOT2
+#END_TEST
+
+ERR1: Fatal: cannot read file /lib64/lib1.so
+ERR2: Fatal: cannot read file /lib64/lib2.so
+
+SYSROOT1: Verbose: Mapping input file '{{.*}}dir/lib64/lib1.so' into memory
+SYSROOT2: Verbose: Mapping input file '{{.*}}dir/lib64/lib2.so' into memory
+

--- a/test/Common/standalone/sysRoot/VersionAndDynamicScripts/Inputs/1.c
+++ b/test/Common/standalone/sysRoot/VersionAndDynamicScripts/Inputs/1.c
@@ -1,0 +1,4 @@
+// Simple library with exported functions
+int exported_func_v1() { return 1; }
+int exported_func_v2() { return 2; }
+int hidden_func() { return 3; }

--- a/test/Common/standalone/sysRoot/VersionAndDynamicScripts/Inputs/dynamic.list
+++ b/test/Common/standalone/sysRoot/VersionAndDynamicScripts/Inputs/dynamic.list
@@ -1,0 +1,4 @@
+{
+  exported_func_v1;
+  exported_func_v2;
+};

--- a/test/Common/standalone/sysRoot/VersionAndDynamicScripts/Inputs/version.script
+++ b/test/Common/standalone/sysRoot/VersionAndDynamicScripts/Inputs/version.script
@@ -1,0 +1,6 @@
+{
+  global:
+    exported_func_v1;
+  local:
+    *;
+};

--- a/test/Common/standalone/sysRoot/VersionAndDynamicScripts/VersionAndDynamicScriptAbsolutePath.test
+++ b/test/Common/standalone/sysRoot/VersionAndDynamicScripts/VersionAndDynamicScriptAbsolutePath.test
@@ -1,0 +1,44 @@
+#---VersionAndDynamicScripts.test---- sysRoot ----------------#
+
+#BEGIN_COMMENT
+# Test that the version scripts and dynamic lists paths are properly handled
+# when sysroot is used.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c
+RUN: %rm -rf %t1.sysroot %t1.dir
+RUN: %mkdir %t.sysroot
+RUN: %link %linkopts -o %t1.lib1.so %t1.1.o -shared --sysroot=%t.sysroot -L=/ \
+RUN:   --version-script=%p/Inputs/version.script --verbose 2>&1 \
+RUN:   | %filecheck %s --check-prefix VersionScriptAbs
+RUN: %link %linkopts -o %t1.lib2.so %t1.1.o -shared --sysroot=%t.sysroot -L=/ \
+RUN:   --dynamic-list=%p/Inputs/dynamic.list --verbose 2>&1 \
+RUN:   | %filecheck %s --check-prefix DynScriptAbs
+RUN: %mkdir %t1.dir
+RUN: cd %t1.dir
+RUN: %link %linkopts -o %t1.lib1.so %t1.1.o -shared --sysroot=%p/Inputs -L=/ \
+RUN:   --version-script=version.script --verbose 2>&1 \
+RUN:   | %filecheck %s --check-prefix VersionScriptSysRoot
+RUN: %link %linkopts -o %t1.lib2.so %t1.1.o -shared --sysroot=%p/Inputs -L=/ \
+RUN:   --dynamic-list=dynamic.list --verbose 2>&1 \
+RUN:   | %filecheck %s --check-prefix DynScriptSysRoot
+RUN: %cp %p/Inputs/version.script version.script
+RUN: %cp %p/Inputs/dynamic.list dynamic.list
+RUN: %link %linkopts -o %t1.lib1.so %t1.1.o -shared --sysroot=%p/Inputs -L=/ \
+RUN:   --version-script=version.script --verbose 2>&1 \
+RUN:   | %filecheck %s --check-prefix VersionScriptRel
+RUN: %link %linkopts -o %t1.lib2.so %t1.1.o -shared --sysroot=%p/Inputs -L=/ \
+RUN:   --dynamic-list=dynamic.list --verbose 2>&1 \
+RUN:   | %filecheck %s --check-prefix DynScriptSysRel
+#END_TEST
+
+VersionScriptAbs: Verbose: Parsing version script
+
+DynScriptAbs: Verbose: Dynamic List[{{.*}}] : exported_func_v1
+DynScriptAbs: Verbose: Dynamic List[{{.*}}] : exported_func_v2
+
+VersionScriptSysRoot: Verbose: Trying to open input `{{.*}}/Inputs//version.script' of type `linker script' for namespec `version.script': found
+DynScriptSysRoot: Verbose: Trying to open input `{{.*}}/Inputs//dynamic.list' of type `linker script' for namespec `dynamic.list': found
+
+VersionScriptRel: Verbose: Mapping input file 'version.script' into memory
+DynScriptSysRel: Verbose: Mapping input file 'dynamic.list' into memory


### PR DESCRIPTION
This commit fixes the logic that determines when the script input path should be prepended with sysroot. The summary of the new behavior:

- sysroot is only prepended to the script inputs when all the below constraints are true:
  - the input is specified in INPUT/GROUP linker script command.
  - The input path begins with '/'.
  - The linker script that contains this INPUT/GROUP command is within the sysroot directory.
- In all other cases, sysroot is not prepended to the script inputs.

Resolves #786
Resolves #808