### PR TITLE
Respect --thread-count by setting parallel strategy

### DIFF
--- a/include/eld/Config/LinkerConfig.h
+++ b/include/eld/Config/LinkerConfig.h
@@ -199,6 +199,10 @@ public:
     GlobalThreadingEnabled = true;
   }
 
+  bool useThreads() const {
+    return GenOptions.threadsEnabled() && GenOptions.numThreads() > 1;
+  }
+
   void addCommandLine(llvm::StringRef Option, bool Flag);
 
   void addCommandLine(llvm::StringRef Option, const char *);

--- a/include/eld/Core/Module.h
+++ b/include/eld/Core/Module.h
@@ -662,6 +662,8 @@ public:
   bool isBackendInitialized() const;
 
 private:
+  void initThreading();
+
   /// Verifies invariants of 'CreatingSections' linker state.
   /// Invariants here means the conditions and rules that 'CreatingSections'
   /// state expects to be true.
@@ -731,6 +733,7 @@ private:
   std::mutex Mutex;
   // ----------------- Central thread pool for Linker ---------------
   llvm::ThreadPoolInterface *LinkerThreadPool = nullptr;
+  llvm::ThreadPoolStrategy ThreadingStrategy;
 
   llvm::StringMap<MergeableString *> UniqueNonAllocStrings;
   llvm::SmallVector<MergeableString *> AllNonAllocStrings;

--- a/lib/LinkerWrapper/LinkerWrapper.cpp
+++ b/lib/LinkerWrapper/LinkerWrapper.cpp
@@ -590,12 +590,7 @@ size_t LinkerWrapper::getPluginThreadCount() const {
 
 bool LinkerWrapper::isMultiThreaded() const {
   const eld::LinkerConfig &Config = m_Module.getConfig();
-  if (Config.options().threadsEnabled()) {
-    uint32_t NumThreads = Config.options().numThreads();
-    if (NumThreads > 1)
-      return true;
-  }
-  return false;
+  return Config.useThreads();
 }
 
 plugin::LinkerScript LinkerWrapper::getLinkerScript() {

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -623,7 +623,7 @@ void ObjectLinker::mergeIdenticalStrings() const {
   /// between them wrt string merging. When global string merging is enabled,
   /// strings would need to be placed in one Module, so threads should
   /// not be used.
-  bool UseThreads = ThisConfig.options().numThreads() > 1;
+  bool UseThreads = ThisConfig.useThreads();
   bool GlobalMerge = ThisConfig.options().shouldGlobalStringMerge();
   llvm::ThreadPoolInterface *Pool = ThisModule->getThreadPool();
   auto MergeStrings = [&](OutputSectionEntry *O) {

--- a/lib/Readers/ArchiveParser.cpp
+++ b/lib/Readers/ArchiveParser.cpp
@@ -600,7 +600,7 @@ void ArchiveParser::warnRepeatedMembers(const ArchiveFile &archiveFile) const {
   std::unordered_map<uint64_t, size_t> memDataHashToMemIdxMap;
   const std::vector<Input *> &archiveMembers = archiveFile.getAllMembers();
   std::vector<uint64_t> archiveMemberHashes(archiveMembers.size(), 0);
-  size_t useThreads = config.options().numThreads() > 1;
+  size_t useThreads = config.useThreads();
   llvm::ThreadPoolInterface *Pool = m_Module.getThreadPool();
   auto computeAndSetHash = [&](size_t i) {
     archiveMemberHashes[i] =


### PR DESCRIPTION
ELD's --thread-count option wasn't affecting `llvm::parallelFor()` because `llvm::parallel::strategy` was never set, so LLVM always defaulted to hardware concurrency. Set the strategy from --thread-count so `parallelFor()` uses the requested thread limit.