### PR TITLE
Read merge string sections in parallel

### DIFF
--- a/include/eld/Fragment/MergeStringFragment.h
+++ b/include/eld/Fragment/MergeStringFragment.h
@@ -16,6 +16,7 @@ class DiagnosticEngine;
 class MergeStringFragment;
 class Module;
 class OutputSectionEntry;
+class InputFile;
 
 /// A MergeableString is a null terminated string that is part of an input merge
 /// string section that may be merged with identical strings destined for the
@@ -91,6 +92,13 @@ private:
   /// called and set the output offset of every string owned by this fragment
   void assignOutputOffsets();
 };
+
+void addMergeStringSection(
+    ELFSection *sec, llvm::SmallVectorImpl<MergeStringFragment *> &fragments);
+
+Expected<void> readMergeStringSections(
+    LinkerConfig &cfg, Module &m, InputFile &file,
+    llvm::SmallVectorImpl<MergeStringFragment *> &fragments);
 
 } // namespace eld
 

--- a/include/eld/Readers/ELFRelocObjParser.h
+++ b/include/eld/Readers/ELFRelocObjParser.h
@@ -65,9 +65,6 @@ private:
   eld::Expected<bool> readLinkOnceSection(ELFReaderBase &ELFReader,
                                           ELFSection *S);
 
-  eld::Expected<bool> readMergeStrSection(ELFReaderBase &ELFReader,
-                                          ELFSection *S);
-
   eld::Expected<bool> readDebugSection(ELFReaderBase &ELFReader, ELFSection *S);
 
   eld::Expected<bool> readTimingSection(ELFReaderBase &ELFReader,

--- a/lib/Target/LDFileFormat.cpp
+++ b/lib/Target/LDFileFormat.cpp
@@ -36,6 +36,12 @@ LDFileFormat::Kind LDFileFormat::getELFSectionKind(
   bool IsSectionMergeStrings =
       ((Flags & (llvm::ELF::SHF_MERGE)) && (Flags & (llvm::ELF::SHF_STRINGS)));
 
+  if (Config.options().stripDebug()) {
+    if (Name.starts_with(".debug") || Name.starts_with(".zdebug") ||
+        Name.starts_with(".line") || Name.starts_with(".stab"))
+      return LDFileFormat::Ignore;
+  }
+
   if (IsSectionMergeStrings && AddrAlign == 1 && EntSize == 1 && !IsPartialLink)
     return LDFileFormat::MergeStr;
 
@@ -44,6 +50,10 @@ LDFileFormat::Kind LDFileFormat::getELFSectionKind(
       return LDFileFormat::MergeStr;
   }
 
+  if (Name.starts_with(".debug") || Name.starts_with(".zdebug") ||
+      Name.starts_with(".line") || Name.starts_with(".stab"))
+    return LDFileFormat::Debug;
+
   if (Name == ".note.gnu.property")
     return LDFileFormat::GNUProperty;
   if (Name == ".hexagon.attributes")
@@ -51,9 +61,6 @@ LDFileFormat::Kind LDFileFormat::getELFSectionKind(
 
   if (Name.starts_with(".note.qc.timing"))
     return LDFileFormat::Timing;
-  if (Name.starts_with(".debug") || Name.starts_with(".zdebug") ||
-      Name.starts_with(".line") || Name.starts_with(".stab"))
-    return LDFileFormat::Debug;
   if (Name.starts_with(".comment"))
     return LDFileFormat::MetaData;
   if (Name.starts_with(".interp") || Name.starts_with(".dynamic"))

--- a/test/Common/standalone/MergeStrings/CompressedStrings.test
+++ b/test/Common/standalone/MergeStrings/CompressedStrings.test
@@ -1,0 +1,12 @@
+# REQUIRES: zlib
+## Checks that compressed merge string sections can be read.
+
+RUN: split-file %s %t
+RUN: %clang %clangopts -c -g -gz %t/compressed.c -o %t.o
+RUN: %link %linkopts %t.o -o %t.out --verbose 2>&1 | %filecheck %s
+
+CHECK: Reading compressed section .debug_str
+CHECK: created mergeable string
+
+#--- compressed.c
+int foo() { return 0; }

--- a/test/Common/standalone/MergeStrings/StripZDebug.s
+++ b/test/Common/standalone/MergeStrings/StripZDebug.s
@@ -1,0 +1,15 @@
+## Checks reading of a bad merge string section with and without --strip-debug.
+## With the flag, the section should not be processed at all, and omitted
+## from the output. Without the flag, we should process and error as usual.
+
+# RUN: %clang -c %clangopts %s -o %t.o
+
+# RUN: %not %link %linkopts %t.o -o %t.bad.out 2>&1 | %filecheck %s --check-prefix=ERR
+# RUN: %link %linkopts --strip-debug %t.o -o %t.strip.out
+# RUN: %readelf -S %t.strip.out | %filecheck %s --check-prefix=STRIP
+
+# ERR: Error: {{.*}}.o:(.zdebug_str): string is not null terminated
+# STRIP-NOT: zdebug_str
+
+.section .zdebug_str, "MS", %progbits,1
+.ascii "unterminated"


### PR DESCRIPTION
Read merge string sections after section discovery and use
llvm::parallelFor to parse the strings concurrently when threads
are enabled. This reduces time spent in merge string parsing on
inputs with many SHF_MERGE|SHF_STRINGS sections.