### PR TITLE
[NFC] Remove pattern map that stores match results

### DIFF
--- a/include/eld/Input/Input.h
+++ b/include/eld/Input/Input.h
@@ -18,9 +18,7 @@
 #include "eld/Script/WildcardPattern.h"
 #include "eld/Support/MemoryArea.h"
 #include "eld/Support/Path.h"
-#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Hashing.h"
-#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
 #include <unordered_map>
@@ -144,31 +142,6 @@ public:
 
   void setName(std::string N) { Name = N; }
 
-  /// --------------------- WildcardPattern ------------------------
-  void addFileMatchedPattern(const WildcardPattern *W, bool R) {
-    FilePatternMap[W] = R;
-  }
-
-  bool findFileMatchedPattern(const WildcardPattern *W, bool &Result) {
-    auto F = FilePatternMap.find(W);
-    if (F == FilePatternMap.end())
-      return false;
-    Result = F->second;
-    return true;
-  }
-
-  void addMemberMatchedPattern(const WildcardPattern *W, bool R);
-
-  bool findMemberMatchedPattern(const WildcardPattern *W, bool &Result);
-
-  uint64_t getWildcardPatternSize();
-
-  void resize(uint32_t N);
-
-  void clear();
-
-  bool isPatternMapInitialized() const { return PatternMapInitialized; }
-
   static llvm::hash_code computeFilePathHash(llvm::StringRef FilePath);
 
   /// If MemoryArea is previously allocated for filepath, then return it;
@@ -197,9 +170,6 @@ protected:
   uint64_t MemberNameHash = 0;
   InputType Type = Default; // The type of input file.
   bool TraceMe = false;
-  llvm::DenseMap<const WildcardPattern *, bool> FilePatternMap;
-  llvm::DenseMap<const WildcardPattern *, bool> MemberPatternMap;
-  bool PatternMapInitialized = false;
   DiagnosticEngine *DiagEngine = nullptr;
 
   /// Keeps track of already created MemoryAreas.

--- a/include/eld/Object/ObjectBuilder.h
+++ b/include/eld/Object/ObjectBuilder.h
@@ -83,8 +83,6 @@ public:
 
   void mayChangeSectionTypeOrKind(ELFSection *, ELFSection *) const;
 
-  void storePatternsForInputFile(InputFile *, eld::SectionMap &);
-
   void mergeStrings(MergeStringFragment *F, OutputSectionEntry *O);
 
 private:

--- a/include/eld/Object/SectionMap.h
+++ b/include/eld/Object/SectionMap.h
@@ -135,7 +135,7 @@ public:
                std::string const &CurInputSection, bool IsArchive,
                std::string const &Name, uint64_t CurInputSectionHash,
                uint64_t FileNameHash, uint64_t NameHash, bool GNUCompatible,
-               bool IsCommonSection, bool StorePatterns = true) const;
+               bool IsCommonSection) const;
 
   bool matched(const WildcardPattern &PPattern, llvm::StringRef PName,
                uint64_t Hash) const;
@@ -155,13 +155,12 @@ public:
                                 bool DoNotUseRmName) const;
 
 private:
-  bool matchedSections(InputFile *I, const WildcardPattern &InputFilePattern,
-                       const WildcardPattern &PPattern,
+  bool matchedSections(const WildcardPattern &PPattern,
                        std::string const &PName, std::string const &Filename,
                        std::string const &CurInputSection, bool IsArchive,
                        uint64_t CurInputSectionHash, uint64_t FileNameHash,
                        uint64_t NameHash, bool IsCommonSection,
-                       const ExcludeFiles &EF, bool StorePatterns = true) const;
+                       const ExcludeFiles &EF) const;
 
   /// If 'pattern' is COMMON or one of the .scommon.x, then return the pattern
   /// COMMON.* or .scommon.x.* repectively. Otherwise, return 'pattern' as

--- a/include/eld/SymbolResolver/SymbolResolutionInfo.h
+++ b/include/eld/SymbolResolver/SymbolResolutionInfo.h
@@ -8,6 +8,7 @@
 #define ELD_SYMBOLRESOLVER_SYMBOLRESOLUTIONINFO_H
 #include "eld/SymbolResolver/SymbolInfo.h"
 #include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include <optional>
 

--- a/lib/Input/Input.cpp
+++ b/lib/Input/Input.cpp
@@ -164,35 +164,6 @@ llvm::StringRef Input::getFileContents() const {
 
 Input::~Input() { IF = nullptr; }
 
-void Input::addMemberMatchedPattern(const WildcardPattern *W, bool R) {
-  MemberPatternMap[W] = R;
-}
-
-bool Input::findMemberMatchedPattern(const WildcardPattern *W, bool &Result) {
-  auto F = MemberPatternMap.find(W);
-  if (F == MemberPatternMap.end())
-    return false;
-  Result = F->second;
-  return true;
-}
-
-uint64_t Input::getWildcardPatternSize() {
-  return (sizeof(FilePatternMap) * FilePatternMap.size()) +
-         (sizeof(MemberPatternMap) * MemberPatternMap.size());
-}
-
-void Input::resize(uint32_t N) {
-  FilePatternMap.reserve(N);
-  MemberPatternMap.reserve(N);
-  PatternMapInitialized = true;
-}
-
-void Input::clear() {
-  PatternMapInitialized = false;
-  FilePatternMap.clear();
-  MemberPatternMap.clear();
-}
-
 std::string Input::getDecoratedRelativePath(const std::string &Basepath) const {
   if (isInternal())
     return decoratedPath(/*showAbsolute=*/false);


### PR DESCRIPTION
This map can grow and is per input file and when there are large amount of input files, and when the linker runs with a large linker script memory consumption goes up significantly.

This should not have effect on performance as the code is already multithreaded.