### PR TITLE
Optimize rule-matching by reordering the OutSection-Rule-Sections loop

### DIFF
--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -732,6 +732,10 @@ public:
 
   bool setScriptOption(std::string ScriptOptions);
 
+  bool useOldRuleMatching() const { return BUseOldRuleMatching; }
+
+  void setUseOldRuleMatching(bool B) { BUseOldRuleMatching = B; }
+
   const SymbolRenameMap &renameMap() const { return SymbolRenames; }
   SymbolRenameMap &renameMap() { return SymbolRenames; }
 
@@ -1256,6 +1260,7 @@ private:
   bool BNoStdlib = false;                    // -nostdlib
   bool BPrintMap = false;                    // --print-map
   bool WarnMismatch = true;                  // --[no-]warn-mismatch
+  bool BUseOldRuleMatching = false;          // --use-old-rule-matching
   bool BGCSections = false;          // --gc-sections
   bool BPrintGCSections = false;     // --print-gc-sections
   bool BGenUnwindInfo = true;        // --ld-generated-unwind-info

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -1116,6 +1116,11 @@ defm no_emit_relocs
                        "relocations in the output file, applicable to "
                        "--emit-relocs-llvm option too">,
       Group<grp_extendedopts>;
+def use_old_rule_matching
+    : FF<"use-old-rule-matching">,
+      HelpText<"Use the original (pre-optimization) linker script "
+               "rule-matching algorithm">,
+      Group<grp_extendedopts>;
 defm script_options : mDashEq<"script-options", "script_options",
                               "Specify a match type, match-gnu/match-llvm">,
                       MetaVarName<"<matchtype>">,

--- a/include/eld/Object/ObjectBuilder.h
+++ b/include/eld/Object/ObjectBuilder.h
@@ -61,6 +61,8 @@ public:
 
   void assignInputFromOutput(eld::InputFile *Obj);
 
+  void assignInputFromOutputLegacy(eld::InputFile *Obj);
+
   void assignOutputSections(std::vector<InputFile *> Inputs, bool);
 
   /// Update section mappings for pending section overrides associated with the

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -1324,6 +1324,9 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
     Config.options().setArchiveMemberReportFile(A->getValue());
   }
 
+  if (Args.hasArg(T::use_old_rule_matching))
+    Config.options().setUseOldRuleMatching(true);
+
   Config.options().setUnknownOptions(Args.getAllArgValues(T::UNKNOWN));
   return true;
 }

--- a/lib/Object/ObjectBuilder.cpp
+++ b/lib/Object/ObjectBuilder.cpp
@@ -263,6 +263,114 @@ void ObjectBuilder::doPluginIterateSections(eld::InputFile *Obj,
 }
 
 void ObjectBuilder::assignInputFromOutput(eld::InputFile *Obj) {
+  if (ThisConfig.options().useOldRuleMatching()) {
+    assignInputFromOutputLegacy(Obj);
+    return;
+  }
+  bool IsPartialLink = (ThisConfig.codeGenType() == LinkerConfig::Object);
+  bool IsGnuCompatible =
+      (ThisConfig.options().getScriptOption() == GeneralOptions::MatchGNU);
+  bool LinkerScriptHasSectionsCommand =
+      ThisModule.getScript().linkerScriptHasSectionsCommand();
+  SectionMap &SectionMap = ThisModule.getScript().sectionMap();
+  ObjectFile *ObjFile = llvm::dyn_cast<ObjectFile>(Obj);
+  std::vector<Section *> Sections = getInputSectionsForRuleMatching(ObjFile);
+  // For each input section.
+  for (Section *Sect : Sections) {
+    ELFSection *ELFSect = llvm::dyn_cast<eld::ELFSection>(Sect);
+
+    bool IsRetrySect = false;
+
+    // Skip sections with merge strings and if there is no linker scripts
+    // provided.
+    if (IsPartialLink && (ELFSect && ELFSect->isMergeStr()) &&
+        !LinkerScriptHasSectionsCommand)
+      continue;
+    InputFile *Input = Obj;
+    bool IsCommonSection = false;
+    if (CommonELFSection *CommonSection =
+            llvm::dyn_cast<CommonELFSection>(Sect)) {
+      Input = CommonSection->getOrigin();
+      IsCommonSection = true;
+    }
+    if (Sect->getOldInputFile())
+      Input = Sect->getOldInputFile();
+    std::string const &PInputFile =
+        Input->getInput()->getResolvedPath().native();
+    std::string const &Name = Input->getInput()->getName();
+    bool IsArchive = Input->isArchive() ||
+                     llvm::dyn_cast<eld::ArchiveMemberInput>(Input->getInput());
+    // Hash of all the required things for Match.
+    uint64_t InputFileHash = Input->getInput()->getResolvedPathHash();
+    uint64_t NameHash = Input->getInput()->getArchiveMemberNameHash();
+    std::string SectName = Sect->name().str();
+    uint64_t InputSectionHash = Sect->sectionNameHash();
+    if (ELFSection *ELFSect = llvm::dyn_cast<ELFSection>(Sect)) {
+      if (auto OptRThisSectionName =
+              ObjFile->getRuleMatchingSectName(ELFSect->getIndex())) {
+        SectName = OptRThisSectionName.value();
+        InputSectionHash = llvm::hash_combine(SectName);
+      }
+    }
+    // For all output sections.
+    for (auto *Out : SectionMap) {
+      if (ELFSect) {
+        // If the rule needs to match on permissions, skip if the rule doesnot
+        // satisfy.
+        switch (Out->prolog().constraint()) {
+        case OutputSectDesc::NO_CONSTRAINT:
+          break;
+        case OutputSectDesc::ONLY_IF_RO:
+          if (ELFSect->isWritable())
+            continue;
+          break;
+        case OutputSectDesc::ONLY_IF_RW:
+          if (!ELFSect->isWritable())
+            continue;
+          break;
+        }
+      }
+      bool shouldSkipMatch = false;
+      // For each input rule.
+      for (auto *In : *Out) {
+        // If the section has an already assigned output section, skip.
+        // If the section needs to be retried, we may need to revisit the
+        // section to match the best rule.
+        if (Sect->getOutputSection() && !IsRetrySect) {
+          shouldSkipMatch = true;
+          break;
+        }
+        // auto Start = std::chrono::system_clock::now();
+        if (SectionMap.matched(*In, Input, PInputFile, SectName, IsArchive,
+                               Name, InputSectionHash, InputFileHash, NameHash,
+                               IsGnuCompatible, IsCommonSection)) {
+          In->incMatchCount();
+          Sect->setOutputSection(Out);
+          Sect->setMatchedLinkerScriptRule(In);
+          // FIXME: Shouldn't we set ELFSect to LDFileFormat::Discard?
+          if (ELFSect && Out->isDiscard()) {
+            ELFSect->setKind(LDFileFormat::Ignore);
+            if (ThisConfig.options().isSectionTracingRequested() &&
+                ThisConfig.options().traceSection(ELFSect->name().str()))
+              ThisConfig.raise(Diag::discarded_section_info)
+                  << ELFSect->getDecoratedName(ThisConfig.options())
+                  << ObjFile->getInput()->decoratedPath();
+          }
+          if (IsRetrySect && !In->isSpecial())
+            IsRetrySect = false;
+          // Retry the match until the closest match is found.
+          if (In->isSpecial())
+            IsRetrySect = true;
+        } // end match
+        // RuleMatchTimes[In] += std::chrono::system_clock::now() - Start;
+      } // end each rule
+      if (shouldSkipMatch)
+        break;
+    } // end each output section
+  } // end each input section
+}
+
+void ObjectBuilder::assignInputFromOutputLegacy(eld::InputFile *Obj) {
   std::unordered_map<Section *, bool> RetrySections;
   bool IsPartialLink = (ThisConfig.codeGenType() == LinkerConfig::Object);
   bool IsGnuCompatible =

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -99,6 +99,16 @@ add_custom_target(check-eld-summary
   USES_TERMINAL)
 set_target_properties(check-eld-summary PROPERTIES FOLDER "Linker Tests")
 
+# Extended test target: builds and runs everything check-eld does, plus a
+# per-arch lit suite with --use-old-rule-matching appended to %linkopts.
+set(EXTENDED_TARGET_NAME check-eld-extended)
+add_custom_target(${EXTENDED_TARGET_NAME})
+add_dependencies(${EXTENDED_TARGET_NAME} ${TARGET_NAME})
+
+process_options_and_generate_lit_test_suite(
+  "${EXTENDED_TARGET_NAME}" "${TEST_TARGETS}"
+  "--use-old-rule-matching" "old_rule_matching")
+
 add_subdirectory(UnitTests)
 add_subdirectory(Common)
 add_subdirectory(Hexagon)
@@ -106,6 +116,7 @@ add_subdirectory(Hexagon)
 # Setup a legacy alias for 'check-eld'. This will likely change to be an alias
 # for 'check-all' at some point in the future.
 set_target_properties(check-eld PROPERTIES FOLDER "Linker Tests")
+set_target_properties(check-eld-extended PROPERTIES FOLDER "Linker Tests")
 if(USE_LINKER_ALT_NAME)
   string(TOLOWER ${USE_LINKER_ALT_NAME} linker_alt_name_lower)
   if(linker_alt_name_lower MATCHES "ld.([a-z]+)*")

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -297,8 +297,6 @@ if config.test_target == 'Hexagon':
     linkdriverg0opts = linkdriveropts + ' -G0'
     link = 'ld.eld'
     linkopts = '--thread-count 4  --emit-relocs'
-    if hasattr(config,'eld_option') and config.eld_option != 'default':
-        linkopts = '--thread-count 4 ' + config.eld_option
     linkg0opts = '-G0'
     linkdriverdynopts = linkdriverdynopts + " -Wl,-Bdynamic,-E,--force-dynamic"
     ar = 'llvm-ar'
@@ -342,8 +340,6 @@ if config.test_target == 'X86':
     objdump = 'llvm-objdump'
     dwarfdump = 'llvm-dwarfdump'
     linkopts = '--thread-count 4  --emit-relocs'
-    if hasattr(config,'eld_option') and config.eld_option != 'default':
-        linkopts = '--thread-count 4 ' + config.eld_option
     config.available_features.add('x86')
 
 if config.test_target == 'ARM':
@@ -365,8 +361,6 @@ if config.test_target == 'ARM':
         config.available_features.add('arm')
     link = 'ld.eld'
     linkopts = '--thread-count 4  --threads'
-    if hasattr(config,'eld_option') and config.eld_option != 'default':
-        linkopts = '--thread-count 4 ' + config.eld_option
     linkg0opts = '--threads'
     clangopts = clangcommonopts + '-momit-leaf-frame-pointer'
     embedclangopts = clangcommonopts
@@ -403,8 +397,6 @@ if config.test_target == 'AArch64':
     clangxx = 'clang++ -target aarch64-unknown-none-elf'
     clangas = 'clang'
     linkopts = '--thread-count 4  --threads'
-    if hasattr(config,'eld_option') and config.eld_option != 'default':
-        linkopts = '--thread-count 4 ' + config.eld_option
     linkg0opts = '--threads'
     clangopts = clangcommonopts +'-fno-asynchronous-unwind-tables -mllvm -fast-isel=true'
     embedclangopts = clangcommonopts +'-fno-asynchronous-unwind-tables'
@@ -440,8 +432,6 @@ if config.test_target == 'RISCV64':
     linkdriveropts = clangcommonopts + clangcommonxxopts
     linkdriverg0opts = linkdriveropts + ' -G0'
     linkopts = '--thread-count 4  --emit-relocs --image-base 0'
-    if hasattr(config,'eld_option') and config.eld_option != 'default':
-        linkopts = '--thread-count 4 ' + config.eld_option
     llvmmc = f'{llvmmc} -triple=riscv64'
     readelf = 'llvm-readelf'
     ar = 'llvm-ar'
@@ -470,8 +460,6 @@ if config.test_target == 'RISCV':
     linkdriveropts = clangcommonopts + clangcommonxxopts
     linkdriverg0opts = linkdriveropts + ' -G0'
     linkopts = '--thread-count 4  --emit-relocs --image-base 0'
-    if hasattr(config,'eld_option') and config.eld_option != 'default':
-        linkopts = '-mtriple riscv32-unknown-elf --thread-count 4 ' + config.eld_option
     llvmmc = f'{llvmmc} -triple=riscv32 --defsym ELF32=1'
     readelf = 'llvm-readelf'
     ar = 'llvm-ar'
@@ -479,6 +467,12 @@ if config.test_target == 'RISCV':
     objdump = 'llvm-objdump'
     dwarfdump = 'llvm-dwarfdump'
     linuxtarget = 'riscv32-linux-gnu'
+
+# Append the option supplied via ELD_TESTS_TO_RUN (or check-eld-extended) to
+# the per-target linkopts. For the default option, eld_option == 'default'
+# nothing is appended, leaving the per-target linkopts untouched.
+if hasattr(config, 'eld_option') and config.eld_option != 'default':
+    linkopts = linkopts + ' ' + config.eld_option
 
 cnot = which(cnot)
 clangxx = which(clangxx)


### PR DESCRIPTION
This commit improves the performance of linker script rule-matching by reordering the nested OutputSection-LinkerScriptRule-InputSections loop.

Currently, the nested loop is as follows:

```
for (auto O : OutSections) {
  for (auto R : O.rules()) {
    for (auto S : InputSections) {
      // ...
    }
  }
}
```

This patch changes the nested loop to:

```
for (auto S : InputSections) {
  for (auto O : OutSections) {
    for (auto R : O.rules()) {
      // ...
    }
  }
}
```

The new loop structure has the following benefits:

- Once an input section is matched to a rule, we waste no iterations over it. On the contrary, in the old design, all the input sections are always iterated over for EACH rule.
- We do a lot of computation for a section. In the old design, all the computations are repeated for EACH rule, whereas in the new design all the computations happen once-per-section in the outermost loop.

On a contrived test case that make good use of linker script rule-matching, this patch results in ~15% performance improvement for the rule-matching phase.