### PR TITLE
[NFC] Create FDE and CIE as a piece of EhFrameFragment

### DIFF
--- a/include/eld/Fragment/EhFrameHdrFragment.h
+++ b/include/eld/Fragment/EhFrameHdrFragment.h
@@ -17,10 +17,10 @@
 namespace eld {
 
 class DiagnosticEngine;
+class EhFrameFragment;
 class EhFrameHdrSection;
 class LinkerConfig;
-class CIEFragment;
-class FDEFragment;
+class FDEPiece;
 class Relocation;
 
 class EhFrameHdrFragment : public Fragment {
@@ -56,7 +56,7 @@ private:
 
   uint64_t readFdeAddr(uint8_t *Buf, int Size, DiagnosticEngine *DiagEngine);
 
-  uint64_t getFdePc(uint8_t *, FDEFragment *, uint8_t Enc,
+  uint64_t getFdePc(uint8_t *, const EhFrameFragment &, FDEPiece *, uint8_t Enc,
                     DiagnosticEngine *DiagEngine);
 
   bool Is64Bit = false;

--- a/include/eld/Readers/EhFrameHdrSection.h
+++ b/include/eld/Readers/EhFrameHdrSection.h
@@ -15,7 +15,7 @@ namespace eld {
 
 class DiagnosticEngine;
 class ELFSection;
-class CIEFragment;
+class EhFrameFragment;
 class EhFrameHdrFragment;
 
 class EhFrameHdrSection : public ELFSection {
@@ -27,7 +27,7 @@ public:
     return S->getSectionKind() == Section::Kind::EhFrameHdr;
   }
 
-  void addCIE(std::vector<CIEFragment *> &C);
+  void addEhFrame(EhFrameFragment &F);
 
   size_t getNumCIE() const { return NumCIE; }
 
@@ -35,10 +35,10 @@ public:
 
   size_t sizeOfHeader() const { return 12; }
 
-  std::vector<CIEFragment *> &getCIEs() { return m_CIEs; }
+  const std::vector<EhFrameFragment *> &getEhFrames() const { return EhFrames; }
 
 private:
-  std::vector<CIEFragment *> m_CIEs;
+  std::vector<EhFrameFragment *> EhFrames;
   size_t NumCIE = 0;
   size_t NumFDE = 0;
 };

--- a/include/eld/Readers/EhFrameSection.h
+++ b/include/eld/Readers/EhFrameSection.h
@@ -18,10 +18,10 @@ class DiagnosticPrinter;
 class ELFSection;
 class Module;
 class Relocation;
-class RegionFragment;
 class EhFrameSection;
-class CIEFragment;
+class EhFrameCIE;
 class EhFramePiece;
+class EhFrameFragment;
 
 class EhFrameSection : public ELFSection {
 public:
@@ -36,19 +36,15 @@ public:
 
   Relocation *getReloc(size_t Off, size_t Size);
 
-  RegionFragment *getEhFrameFragment() const { return m_EhFrame; }
+  EhFrameFragment *getEhFrameFragment() const { return m_EhFrame; }
 
-  llvm::ArrayRef<uint8_t> getData() const { return Data; }
+  llvm::ArrayRef<uint8_t> getData() const;
 
   bool createCIEAndFDEFragments();
 
-  CIEFragment *addCie(EhFramePiece &P);
+  EhFrameCIE *addCie(EhFramePiece &P);
 
   bool isFdeLive(EhFramePiece &P);
-
-  std::vector<EhFramePiece> &getPieces() { return m_EhFramePieces; }
-
-  std::vector<CIEFragment *> &getCIEs() { return m_CIEFragments; }
 
   void finishAddingFragments(Module &M);
 
@@ -57,13 +53,7 @@ private:
   DiagnosticPrinter *getDiagPrinter();
 
 private:
-  RegionFragment *m_EhFrame = nullptr;
-  llvm::ArrayRef<uint8_t> Data;
-  std::vector<EhFramePiece> m_EhFramePieces;
-  llvm::DenseMap<size_t, CIEFragment *> m_OffsetToCie;
-  std::vector<CIEFragment *> m_CIEFragments;
-  size_t NumCie = 0;
-  size_t NumFDE = 0;
+  EhFrameFragment *m_EhFrame = nullptr;
   DiagnosticEngine *m_DiagEngine = nullptr;
 };
 } // namespace eld

--- a/lib/Fragment/FragmentRef.cpp
+++ b/lib/Fragment/FragmentRef.cpp
@@ -123,7 +123,7 @@ FragmentRef::Offset FragmentRef::getOutputOffset(Module &M) const {
     // Find the proper piece
     EhFrameSection *S =
         llvm::dyn_cast<eld::EhFrameSection>(ThisFragment->getOwningSection());
-    std::vector<EhFramePiece> &Pieces = S->getPieces();
+    std::vector<EhFramePiece> &Pieces = S->getEhFrameFragment()->getPieces();
     size_t I = 0;
     while (I != Pieces.size() &&
            Pieces[I].getOffset() + Pieces[I].getSize() <= ThisOffset)

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -836,8 +836,8 @@ bool ObjectLinker::mergeInputSections(ObjectBuilder &Builder,
             *ThisModule);
         if (getTargetBackend().getEhFrameHdr() &&
             Sect->getKind() == LDFileFormat::EhFrame) {
-          getTargetBackend().getEhFrameHdr()->addCIE(
-              llvm::dyn_cast<eld::EhFrameSection>(Sect)->getCIEs());
+          getTargetBackend().getEhFrameHdr()->addEhFrame(
+              *llvm::dyn_cast<eld::EhFrameSection>(Sect)->getEhFrameFragment());
           // Since we found an EhFrame section, lets go ahead and start creating
           // the fragments necessary to create the .eh_frame_hdr section and
           // the filler eh_frame section.

--- a/lib/Readers/EhFrameHdrSection.cpp
+++ b/lib/Readers/EhFrameHdrSection.cpp
@@ -23,9 +23,9 @@ EhFrameHdrSection::EhFrameHdrSection(std::string Name, uint32_t pType,
                  pFlag, entSize, /*AddrAlign=*/0, pType, /*Info=*/0,
                  /*Link=*/nullptr, pSize, /*PAddr=*/0) {}
 
-void EhFrameHdrSection::addCIE(std::vector<CIEFragment *> &C) {
-  for (auto &CIE : C) {
-    m_CIEs.push_back(CIE);
+void EhFrameHdrSection::addEhFrame(EhFrameFragment &F) {
+  EhFrames.push_back(&F);
+  for (auto *CIE : F.getCIEs()) {
     ++NumCIE;
     NumFDE += CIE->getNumFDE();
   }

--- a/test/Common/standalone/Map/EhFrameDump/EhFrameDump.test
+++ b/test/Common/standalone/Map/EhFrameDump/EhFrameDump.test
@@ -1,0 +1,12 @@
+#UNSUPPORTED: arm
+#---EhFrameDump.test--------------------------- Executable -----------------#
+# This test verifies that .eh_frame and .eh_frame_hdr fragments dump into the
+# text map output.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/eh-frame-map.s -o %t.o
+RUN: %link %linkopts --eh-frame-hdr %t.o -o %t.out -MapStyle txt -Map %t.map
+RUN: %filecheck %s < %t.map
+
+#CHECK: # CIE out=0x
+#CHECK: # FDE out=0x
+#CHECK: # Hdr out=0x

--- a/test/Common/standalone/Map/EhFrameDump/EhFrameDumpGcFDE.test
+++ b/test/Common/standalone/Map/EhFrameDump/EhFrameDumpGcFDE.test
@@ -1,0 +1,10 @@
+#UNSUPPORTED: arm, aarch64, riscv32, riscv64
+#---EhFrameDumpGcFDE.test---------------------- Executable -----------------#
+# This test checks that GC'd functions do not contribute FDEs to the image.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/eh-frame-gc.s -o %t.o
+RUN: %link %linkopts --gc-sections --eh-frame-hdr %t.o -o %t.out -MapStyle txt -Map %t.map
+RUN: %filecheck %s --input-file=%t.map
+
+#CHECK: sym={{.*}}foo
+#CHECK-NOT: sym=bar

--- a/test/Common/standalone/Map/EhFrameDump/EhFrameDumpMergeCIE.test
+++ b/test/Common/standalone/Map/EhFrameDump/EhFrameDumpMergeCIE.test
@@ -1,0 +1,12 @@
+#UNSUPPORTED: arm
+#---EhFrameDumpMergeCIE.test------------------- Executable -----------------#
+# This test verifies that identical CIEs from multiple inputs are merged.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/eh-frame-merge-1.s -o %t1.o
+RUN: %clang %clangopts -c %p/Inputs/eh-frame-merge-2.s -o %t2.o
+RUN: %link %linkopts --eh-frame-hdr %t1.o %t2.o -o %t.out -MapStyle txt -Map %t.map
+RUN: %filecheck %s --input-file=%t.map
+
+#CHECK-COUNT-1: # CIE out=0x{{[0-9A-Fa-f]+}}
+#CHECK-COUNT-2: # FDE out=0x{{[0-9A-Fa-f]+}}
+#CHECK: # Hdr out=0x{{[0-9A-Fa-f]+}}

--- a/test/Common/standalone/Map/EhFrameDump/EhFrameDumpMulti.test
+++ b/test/Common/standalone/Map/EhFrameDump/EhFrameDumpMulti.test
@@ -1,0 +1,12 @@
+#UNSUPPORTED: arm
+#---EhFrameDumpMulti.test---------------------- Executable -----------------#
+# This test verifies map dumps for multiple .eh_frame records.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/eh-frame-map-multi.s -o %t.o
+RUN: %link %linkopts --eh-frame-hdr %t.o -o %t.out -MapStyle txt -Map %t.map
+RUN: %filecheck %s --input-file=%t.map
+
+#CHECK: # CIE out=0x
+#CHECK-DAG: # FDE out=0x
+#CHECK-DAG: # FDE out=0x
+#CHECK: # Hdr out=0x

--- a/test/Common/standalone/Map/EhFrameDump/Inputs/eh-frame-gc.s
+++ b/test/Common/standalone/Map/EhFrameDump/Inputs/eh-frame-gc.s
@@ -1,0 +1,27 @@
+	.section .text.main,"ax",@progbits
+	.globl	main
+	.type	main, @function
+main:
+	.cfi_startproc
+	call	foo
+	nop
+	.cfi_endproc
+	.size	main, .-main
+
+	.section .text.foo,"ax",@progbits
+	.globl	foo
+	.type	foo, @function
+foo:
+	.cfi_startproc
+	nop
+	.cfi_endproc
+	.size	foo, .-foo
+
+	.section .text.bar,"ax",@progbits
+	.globl	bar
+	.type	bar, @function
+bar:
+	.cfi_startproc
+	nop
+	.cfi_endproc
+	.size	bar, .-bar

--- a/test/Common/standalone/Map/EhFrameDump/Inputs/eh-frame-map-multi.s
+++ b/test/Common/standalone/Map/EhFrameDump/Inputs/eh-frame-map-multi.s
@@ -1,0 +1,16 @@
+	.text
+	.globl	foo
+	.type	foo, @function
+foo:
+	.cfi_startproc
+	nop
+	.cfi_endproc
+	.size	foo, .-foo
+
+	.globl	bar
+	.type	bar, @function
+bar:
+	.cfi_startproc
+	nop
+	.cfi_endproc
+	.size	bar, .-bar

--- a/test/Common/standalone/Map/EhFrameDump/Inputs/eh-frame-map.s
+++ b/test/Common/standalone/Map/EhFrameDump/Inputs/eh-frame-map.s
@@ -1,0 +1,8 @@
+	.text
+	.globl	foo
+	.type	foo, @function
+foo:
+	.cfi_startproc
+	nop
+	.cfi_endproc
+	.size	foo, .-foo

--- a/test/Common/standalone/Map/EhFrameDump/Inputs/eh-frame-merge-1.s
+++ b/test/Common/standalone/Map/EhFrameDump/Inputs/eh-frame-merge-1.s
@@ -1,0 +1,8 @@
+	.text
+	.globl	foo
+	.type	foo, @function
+foo:
+	.cfi_startproc
+	nop
+	.cfi_endproc
+	.size	foo, .-foo

--- a/test/Common/standalone/Map/EhFrameDump/Inputs/eh-frame-merge-2.s
+++ b/test/Common/standalone/Map/EhFrameDump/Inputs/eh-frame-merge-2.s
@@ -1,0 +1,8 @@
+	.text
+	.globl	bar
+	.type	bar, @function
+bar:
+	.cfi_startproc
+	nop
+	.cfi_endproc
+	.size	bar, .-bar


### PR DESCRIPTION
We used to create CIE fragments and FDE fragments, which might interfere with how dependent chunks are handled. The atomic unit that the linker should treat are chunks that cannot be further divided up.

Fix these cases and cleanup to form a better design.

Also add support for dumping EhFrame and EhFrame Header chunks for debug support, making the linker map files further useful to debug eh_frame handling.