### PR TITLE
Fix __tbss_offset calculation

### DIFF
--- a/templates/staticExecutable/static-executable-h2-picolibc.lcs.template
+++ b/templates/staticExecutable/static-executable-h2-picolibc.lcs.template
@@ -105,7 +105,7 @@ SECTIONS
   TLS_END = _TLS_END_;
   __tbss_end = _TLS_END_;
   __tbss_size = __tbss_end - __tbss_start;
-  __tbss_offset = __tbss_end - __tdata_start;
+  __tbss_offset = __tbss_start - __tdata_start;
 
   . = ALIGN(4K);
 


### PR DESCRIPTION
__tbss_offset is `tbss_start - tdata_start` not `tbss_end - tdata_start`