### PR TITLE
[AArch64] Add support for R_AARCH64_LD64_GOTPAGE_LO15

### DIFF
--- a/lib/Target/AArch64/AArch64RelocationFunctions.h
+++ b/lib/Target/AArch64/AArch64RelocationFunctions.h
@@ -27,6 +27,7 @@
   DECL_AARCH64_APPLY_RELOC_FUNC(add_abs_lo12)                                  \
   DECL_AARCH64_APPLY_RELOC_FUNC(adr_got_page)                                  \
   DECL_AARCH64_APPLY_RELOC_FUNC(ld64_got_lo12)                                 \
+  DECL_AARCH64_APPLY_RELOC_FUNC(ld64_gotpage_lo15)                             \
   DECL_AARCH64_APPLY_RELOC_FUNC(ldst_abs_lo12)                                 \
   DECL_AARCH64_APPLY_RELOC_FUNC(movw_abs_g)                                    \
   DECL_AARCH64_APPLY_RELOC_FUNC(tls_gottprel_page)                             \
@@ -83,12 +84,81 @@
                                   "R_AARCH64_LDST32_ABS_LO12_NC", 32)),        \
       ValueType(0x11e, MappedType(&ldst_abs_lo12,                              \
                                   "R_AARCH64_LDST64_ABS_LO12_NC", 32)),        \
+      ValueType(0x11f,                                                         \
+                MappedType(&unsupport, "R_AARCH64_MOVW_PREL_G0", 32)),         \
+      ValueType(0x120,                                                         \
+                MappedType(&unsupport, "R_AARCH64_MOVW_PREL_G0_NC", 32)),      \
+      ValueType(0x121,                                                         \
+                MappedType(&unsupport, "R_AARCH64_MOVW_PREL_G1", 32)),         \
+      ValueType(0x122,                                                         \
+                MappedType(&unsupport, "R_AARCH64_MOVW_PREL_G1_NC", 32)),      \
+      ValueType(0x123,                                                         \
+                MappedType(&unsupport, "R_AARCH64_MOVW_PREL_G2", 32)),         \
+      ValueType(0x124,                                                         \
+                MappedType(&unsupport, "R_AARCH64_MOVW_PREL_G2_NC", 32)),      \
+      ValueType(0x125,                                                         \
+                MappedType(&unsupport, "R_AARCH64_MOVW_PREL_G3", 32)),         \
       ValueType(0x12b, MappedType(&ldst_abs_lo12,                              \
                                   "R_AARCH64_LDST128_ABS_LO12_NC", 32)),       \
+      ValueType(0x12c,                                                         \
+                MappedType(&unsupport, "R_AARCH64_MOVW_GOTOFF_G0", 32)),       \
+      ValueType(0x12d,                                                         \
+                MappedType(&unsupport, "R_AARCH64_MOVW_GOTOFF_G0_NC", 32)),    \
+      ValueType(0x12e,                                                         \
+                MappedType(&unsupport, "R_AARCH64_MOVW_GOTOFF_G1", 32)),       \
+      ValueType(0x12f,                                                         \
+                MappedType(&unsupport, "R_AARCH64_MOVW_GOTOFF_G1_NC", 32)),    \
+      ValueType(0x130,                                                         \
+                MappedType(&unsupport, "R_AARCH64_MOVW_GOTOFF_G2", 32)),       \
+      ValueType(0x131,                                                         \
+                MappedType(&unsupport, "R_AARCH64_MOVW_GOTOFF_G2_NC", 32)),    \
+      ValueType(0x132,                                                         \
+                MappedType(&unsupport, "R_AARCH64_MOVW_GOTOFF_G3", 32)),       \
+      ValueType(0x133,                                                         \
+                MappedType(&unsupport, "R_AARCH64_GOTREL64", 64)),             \
+      ValueType(0x134,                                                         \
+                MappedType(&unsupport, "R_AARCH64_GOTREL32", 32)),             \
+      ValueType(0x135,                                                         \
+                MappedType(&unsupport, "R_AARCH64_GOT_LD_PREL19", 32)),        \
+      ValueType(0x136,                                                         \
+                MappedType(&unsupport, "R_AARCH64_LD64_GOTOFF_LO15", 32)),     \
       ValueType(0x137,                                                         \
                 MappedType(&adr_got_page, "R_AARCH64_ADR_GOT_PAGE", 32)),      \
       ValueType(0x138,                                                         \
                 MappedType(&ld64_got_lo12, "R_AARCH64_LD64_GOT_LO12_NC", 32)), \
+      ValueType(0x139,                                                         \
+                MappedType(&ld64_gotpage_lo15,                                 \
+			   "R_AARCH64_LD64_GOTPAGE_LO15", 32)),                \
+      ValueType(0x13a,                                                         \
+                MappedType(&unsupport, "R_AARCH64_PLT32", 32)),                \
+      ValueType(0x13b,                                                         \
+                MappedType(&unsupport, "R_AARCH64_GOTPCREL32", 32)),           \
+      ValueType(0x13c,                                                         \
+                MappedType(&unsupport, "R_AARCH64_PATCHINST", 32)),            \
+      ValueType(0x13d,                                                         \
+                MappedType(&unsupport, "R_AARCH64_FUNCINIT64", 64)),           \
+      ValueType(0x200,                                                         \
+                MappedType(&unsupport, "R_AARCH64_TLSGD_ADR_PREL21", 32)),     \
+      ValueType(0x201,                                                         \
+                MappedType(&unsupport, "R_AARCH64_TLSGD_ADR_PAGE21", 32)),     \
+      ValueType(0x202,                                                         \
+                MappedType(&unsupport, "R_AARCH64_TLSGD_ADD_LO12_NC", 32)),    \
+      ValueType(0x203,                                                         \
+                MappedType(&unsupport, "R_AARCH64_TLSGD_MOVW_G0_NC", 32)),     \
+      ValueType(0x204,                                                         \
+                MappedType(&unsupport, "R_AARCH64_TLSGD_MOVW_G1", 32)),        \
+      ValueType(0x205,                                                         \
+                MappedType(&unsupport, "R_AARCH64_TLSLD_ADR_PREL21")),         \
+      ValueType(0x206,                                                         \
+                MappedType(&unsupport, "R_AARCH64_TLSLD_ADR_PAGE21")),         \
+      ValueType(0x207,                                                         \
+                MappedType(&unsupport, "R_AARCH64_TLSLD_ADD_LO12_NC")),        \
+      ValueType(0x208,                                                         \
+                MappedType(&unsupport, "R_AARCH64_TLSLD_MOVW_G1")),            \
+      ValueType(0x209,                                                         \
+                MappedType(&unsupport, "R_AARCH64_TLSLD_MOVW_G0_NC")),         \
+      ValueType(0x20a,                                                         \
+                MappedType(&unsupport, "R_AARCH64_TLSLD_LD_PREL19")),          \
       ValueType(0x20b,                                                         \
                 MappedType(&unsupport, "R_AARCH64_TLSLD_MOVW_DTPREL_G2")),     \
       ValueType(0x20c,                                                         \
@@ -164,13 +234,35 @@
                 MappedType(&unsupport, "R_AARCH64_TLSLE_LDST64_TPREL_LO12")),  \
       ValueType(0x22f, MappedType(&unsupport,                                  \
                                   "R_AARCH64_TLSLE_LDST64_TPREL_LO12_NC")),    \
+      ValueType(0x230, MappedType(&unsupport,                                  \
+                                  "R_AARCH64_TLSDESC_LD_PREL19", 32)),         \
+      ValueType(0x231, MappedType(&unsupport,                                  \
+                                  "R_AARCH64_TLSDESC_ADR_PREL21", 32)),        \
       ValueType(0x232, MappedType(&tls_tlsdesc_page,                           \
                                   "R_AARCH64_TLSDESC_ADR_PAGE21", 32)),        \
       ValueType(0x233, MappedType(&tls_tlsdesc_lo,                             \
                                   "R_AARCH64_TLSDESC_LD64_LO12", 32)),         \
       ValueType(0x234, MappedType(&tls_tlsdesc_add,                            \
                                   "R_AARCH64_TLSDESC_ADD_LO12", 32)),          \
+      ValueType(0x235, MappedType(&unsupport,                                  \
+                                  "R_AARCH64_TLSDESC_OFF_G1", 32)),            \
+      ValueType(0x236, MappedType(&unsupport,                                  \
+                                  "R_AARCH64_TLSDESC_OFF_G0_NC", 32)),         \
+      ValueType(0x237, MappedType(&unsupport,                                  \
+                                  "R_AARCH64_TLSDESC_LDR", 32)),               \
+      ValueType(0x238, MappedType(&unsupport,                                  \
+                                  "R_AARCH64_TLSDESC_ADD", 32)),               \
       ValueType(0x239, MappedType(&tls_call, "R_AARCH64_TLSDESC_CALL", 32)),   \
+      ValueType(0x23a, MappedType(&unsupport,                                  \
+                                  "R_AARCH64_TLSLE_LDST128_TPREL_LO12", 32)),  \
+      ValueType(0x23b,                                                         \
+                MappedType(&unsupport,                                         \
+                           "R_AARCH64_TLSLE_LDST128_TPREL_LO12_NC", 32)),      \
+      ValueType(0x23c, MappedType(&unsupport,                                  \
+                                  "R_AARCH64_TLSLE_LDST128_DTPREL_LO12", 32)), \
+      ValueType(0x23d,                                                         \
+                MappedType(&unsupport,                                         \
+                           "R_AARCH64_TLSLE_LDST128_DTPREL_LO12_NC", 32)),     \
       ValueType(1024, MappedType(&unsupport, "R_AARCH64_COPY")),               \
       ValueType(1025, MappedType(&unsupport, "R_AARCH64_GLOB_DAT")),           \
       ValueType(1026, MappedType(&unsupport, "R_AARCH64_JUMP_SLOT")),          \

--- a/test/AArch64/standalone/Reloc_gotpage_lo15/Inputs/a.s
+++ b/test/AArch64/standalone/Reloc_gotpage_lo15/Inputs/a.s
@@ -1,0 +1,7 @@
+.type main,@function
+.global main
+main:
+adrp x0, _GLOBAL_OFFSET_TABLE_
+add x0, x0, #:lo12:_GLOBAL_OFFSET_TABLE_
+ldr x1, [x0, #:gotpage_lo15:first]
+ldr x2, [x0, #:gotpage_lo15:second]

--- a/test/AArch64/standalone/Reloc_gotpage_lo15/R_AARCH64_LD64_GOTPAGE_LO15.test
+++ b/test/AArch64/standalone/Reloc_gotpage_lo15/R_AARCH64_LD64_GOTPAGE_LO15.test
@@ -1,0 +1,15 @@
+#---R_AARCH64_LD64_GOTPAGE_LO15.test--------------------- SharedLibrary------------------#
+#BEGIN_COMMENT
+# This tests that R_AARCH64_LD64_GOTPAGE_LO15 can be used to load from the GOT
+#END_COMMENT
+RUN: %clang %clangopts -c %p/Inputs/a.s -fPIC -o %t1.1.o  -target aarch64
+RUN: %link %linkopts %t1.1.o -shared -o %t1.so -march aarch64
+RUN: %objdump -d --dynamic-reloc %t1.so | %filecheck %s
+
+#CHECK: 00000000000010f0 R_AARCH64_GLOB_DAT       first
+#CHECK: 00000000000010f8 R_AARCH64_GLOB_DAT       second
+
+#CHECK: 1b8: b0000000      adrp    x0, 0x1000 <second+0x1000>
+#CHECK: 1bc: 91040000      add     x0, x0, #0x100
+#CHECK: 1c0: f9407801      ldr     x1, [x0, #0xf0]
+#CHECK: 1c4: f9407c02      ldr     x2, [x0, #0xf8]


### PR DESCRIPTION
The formula is pretty simple: just the GOT entry address minus the GOT base.  gcc uses this with "-fpie"; the typical sequence is something like the following:

```
f():
        adrp    x0, _GLOBAL_OFFSET_TABLE_
        ldr     x0, [x0, #:gotpage_lo15:x]
        ret
```

While I was here, I added stubs for all the other missing relocations, so it's easier to understand future bug reports.

There's a related problem here: I think `_GLOBAL_OFFSET_TABLE_` is not resolving to the correct address. AArch64GNUInfoLDBackend::finalizeScanRelocations is computing the address of the PLT instead of the GOT. But the obvious fix doesn't work.