### PR TITLE
Fix address of `_GLOBAL_OFFSET_TABLE_`

### DIFF
--- a/lib/Target/AArch64/AArch64LDBackend.h
+++ b/lib/Target/AArch64/AArch64LDBackend.h
@@ -139,8 +139,6 @@ public:
     return DynRelocType::DEFAULT;
   }
 
-  bool finalizeScanRelocations() override;
-
   Stub *getBranchIslandStub(Relocation *pReloc,
                             int64_t targetValue) const override;
 
@@ -162,8 +160,6 @@ private:
   ELFSection *createGOTSection(InputFile &InputFile);
   ELFSection *createGOTPLTSection(InputFile &InputFile);
   ELFSection *createPLTSection(InputFile &InputFile);
-
-  void defineGOTSymbol(Fragment &F);
 
   /// maxBranchOffset
   /// FIXME:

--- a/lib/Target/AArch64/AArch64Relocator.cpp
+++ b/lib/Target/AArch64/AArch64Relocator.cpp
@@ -898,7 +898,8 @@ Relocator::Result ld64_gotpage_lo15(Relocation &pReloc, AArch64Relocator &pParen
   Relocator::Address GOT_S = pParent.getTarget()
                                  .findEntryInGOT(pReloc.symInfo())
                                  ->getAddr(pParent.config().getDiagEngine());
-  Relocator::Address GOT_ORG = pParent.getTarget().getGOT()->pAddr();
+  Relocator::Address GOT_ORG =
+      pParent.getTarget().getGOT()->getOutputSection()->getSection()->addr();
   Relocator::DWord X = GOT_S - helper_get_page_address(GOT_ORG);
 
   if ((X & 7) != 0 || X >= (1ULL << 15)) {

--- a/test/AArch64/standalone/Reloc_gotpage_lo15/R_AARCH64_LD64_GOTPAGE_LO15.test
+++ b/test/AArch64/standalone/Reloc_gotpage_lo15/R_AARCH64_LD64_GOTPAGE_LO15.test
@@ -10,6 +10,6 @@ RUN: %objdump -d --dynamic-reloc %t1.so | %filecheck %s
 #CHECK: 00000000000010f8 R_AARCH64_GLOB_DAT       second
 
 #CHECK: 1b8: b0000000      adrp    x0, 0x1000 <second+0x1000>
-#CHECK: 1bc: 91040000      add     x0, x0, #0x100
+#CHECK: 1bc: 9103c000      add     x0, x0, #0xf0
 #CHECK: 1c0: f9407801      ldr     x1, [x0, #0xf0]
 #CHECK: 1c4: f9407c02      ldr     x2, [x0, #0xf8]


### PR DESCRIPTION
On AArch64, it's supposed to be the address of the beginning of the GOT. The address itself doesn't actually matter that much; there isn't anything in particular located at the beginning of the GOT. But to make R_AARCH64_LD64_GOTPAGE_LO15 work correctly, it needs to be consistent with the address used by R_AARCH64_LD64_GOTPAGE_LO15, and it needs to be less than or equal to every GOT entry.