### PR TITLE
Remove the redundant return values

### DIFF
--- a/include/eld/Readers/Relocation.h
+++ b/include/eld/Readers/Relocation.h
@@ -145,10 +145,10 @@ public:
 
   bool isMergeKind() const;
 
-  bool issueSignedOverflow(Relocator &R, int64_t Value, int64_t Min,
+  void issueSignedOverflow(Relocator &R, int64_t Value, int64_t Min,
                            int64_t Max) const;
 
-  bool issueUnsignedOverflow(Relocator &R, uint64_t Value, uint64_t Min,
+  void issueUnsignedOverflow(Relocator &R, uint64_t Value, uint64_t Min,
                              uint64_t Max) const;
 
   bool issueUnencodableImmediate(Relocator &R, int64_t Imm) const;

--- a/lib/Readers/Relocation.cpp
+++ b/lib/Readers/Relocation.cpp
@@ -215,24 +215,22 @@ static std::string getLocation(FragmentRef *Ref, Relocator &R) {
   return "";
 }
 
-bool Relocation::issueSignedOverflow(Relocator &R, int64_t Value, int64_t Min,
+void Relocation::issueSignedOverflow(Relocator &R, int64_t Value, int64_t Min,
                                      int64_t Max) const {
   std::string Location = getLocation(targetRef(), R);
   R.config().getDiagEngine()->raise(Diag::result_overflow_moreinfo)
       << Location << R.getName(type()) << Value << Min << Max
       << getSymbolName(symInfo(), R.doDeMangle());
   ASSERT(!Location.empty(), "expected a section location.");
-  return false;
 }
 
-bool Relocation::issueUnsignedOverflow(Relocator &R, uint64_t Value,
+void Relocation::issueUnsignedOverflow(Relocator &R, uint64_t Value,
                                        uint64_t Min, uint64_t Max) const {
   std::string Location = getLocation(targetRef(), R);
   R.config().getDiagEngine()->raise(Diag::result_overflow_moreinfo)
       << Location << R.getName(type()) << Value << Min << Max
       << getSymbolName(symInfo(), R.doDeMangle());
   ASSERT(!Location.empty(), "expected a section location.");
-  return false;
 }
 
 bool Relocation::issueUnencodableImmediate(Relocator &R, int64_t Imm) const {


### PR DESCRIPTION
Change the return type of `Relocation::issueSignedOverflow` and `Relocation::issueUnsignedOverflow` to void

It looks like `Relocation::issueUnencodableImmediate` also falls under the same category. Should I include it too?

closes #611