### PR TITLE
Support [--enable|--disable]linker-version

### DIFF
--- a/docs/userguide/documentation/options/options.rst
+++ b/docs/userguide/documentation/options/options.rst
@@ -115,3 +115,19 @@ The following ``-z`` keywords are supported by ELD:
 
 ``-z max-page-size=<value>``
   Set the maximum supported page size used for segment alignment.
+
+Linker version directive
+------------------------
+
+``--enable-linker-version``
+  Enable the GNU linker-script ``LINKER_VERSION`` directive. When this option
+  is active, every ``LINKER_VERSION`` statement encountered in a linker script
+  emits a NUL-terminated string containing the eld version at that position in
+  the output section. This matches the GNU ld directive and is useful for
+  embedding the linker version directly into a binary. The option applies to
+  the entire link once specified.
+
+``--disable-linker-version``
+  Disable the ``LINKER_VERSION`` directive. This is the default behaviour, so
+  the directive is parsed but emits no data unless the feature has been
+  explicitly enabled.

--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -610,6 +610,14 @@ public:
 
   bool mergeStrings() const { return BMergeStrings; }
 
+  void setLinkerVersionDirectiveEnabled(bool Enable = true) {
+    EnableLinkerVersionDirective = Enable;
+  }
+
+  bool isLinkerVersionDirectiveEnabled() const {
+    return EnableLinkerVersionDirective;
+  }
+
   void setEmitRelocs(bool EmitRelocs) {
     BEmitRelocs = EmitRelocs;
     ;
@@ -1280,8 +1288,9 @@ private:
   bool HasMappingFile = false;      // --Mapping-file
   bool DumpMappings = false;        // --Dump-Mapping-file
   bool DumpResponse = false;        // --Dump-Response-file
-  bool InsertTimingStats = false;   // -emit-timing-stats-in-output
-  bool FatalInternalErrors = false; // --fatal-internal-errors
+  bool InsertTimingStats = false;        // -emit-timing-stats-in-output
+  bool FatalInternalErrors = false;      // --fatal-internal-errors
+  bool EnableLinkerVersionDirective = false; // --enable/disable-linker-version
 
   RpathListType RpathList;
   ScriptListType ScriptList;

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -899,6 +899,12 @@ def disable_newdtags : Flag<["--"], "disable-new-dtags">,
 def enable_newdtags : Flag<["--"], "enable-new-dtags">,
                       HelpText<"Enable new dynamic tags">,
                       Group<grp_extendedopts>;
+def disable_linker_version : Flag<["--"], "disable-linker-version">,
+                             HelpText<"Disable the LINKER_VERSION linker script directive (default)">,
+                             Group<grp_extendedopts>;
+def enable_linker_version : Flag<["--"], "enable-linker-version">,
+                            HelpText<"Enable the LINKER_VERSION linker script directive">,
+                            Group<grp_extendedopts>;
 def rosegment
     : Flag<[ "-", "--" ], "rosegment">,
       HelpText<"Put read-only non-executable sections in their own segment">,

--- a/include/eld/Script/OutputSectData.h
+++ b/include/eld/Script/OutputSectData.h
@@ -93,5 +93,20 @@ private:
   Expression &ExpressionToEvaluate;
   ELFSection *ThisSectionion = nullptr;
 };
+
+class LinkerVersionOutputData : public InputSectDesc {
+public:
+  static LinkerVersionOutputData *create(uint32_t ID,
+                                         OutputSectDesc &OutSectDesc);
+
+  LinkerVersionOutputData(uint32_t ID, InputSectDesc::Policy Policy,
+                          const InputSectDesc::Spec Spec,
+                          OutputSectDesc &OutSectDesc);
+
+  eld::Expected<void> activate(Module &) override;
+
+private:
+  ELFSection *createSection(Module &Module);
+};
 } // namespace eld
 #endif

--- a/include/eld/Script/ScriptFile.h
+++ b/include/eld/Script/ScriptFile.h
@@ -293,6 +293,7 @@ public:
   /// BYTE, SHORT, LONG, QUAD, and SQUAD.
   ///
   void addOutputSectData(OutputSectData::OSDKind DataKind, Expression *Expr);
+  void addLinkerVersionData();
 
   // ------------------------ REGION_ALIAS ------------------------------------
   void addRegionAlias(const StrToken *Alias, const StrToken *Region);

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -596,6 +596,23 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
   if (Args.hasArg(T::disable_newdtags))
     Config.options().setNewDTags(false);
 
+  // --enable-linker-version / --disable-linker-version
+  if (Args.hasArg(T::enable_linker_version) &&
+      Args.hasArg(T::disable_linker_version)) {
+    errs() << "Cannot specify enable and disable LINKER_VERSION at same time!\n";
+    return false;
+  }
+
+  if (Args.hasArg(T::enable_linker_version)) {
+    Config.options().setLinkerVersionDirectiveEnabled(true);
+    Config.addCommandLine(Table->getOptionName(T::enable_linker_version), true);
+  }
+
+  if (Args.hasArg(T::disable_linker_version)) {
+    Config.options().setLinkerVersionDirectiveEnabled(false);
+    Config.addCommandLine(Table->getOptionName(T::disable_linker_version), true);
+  }
+
   // --emit-relocs
   if (Args.hasArg(T::emit_relocs)) {
     Config.options().setEmitGNUCompatRelocs(true);

--- a/lib/Script/ScriptFile.cpp
+++ b/lib/Script/ScriptFile.cpp
@@ -675,6 +675,24 @@ void ScriptFile::addOutputSectData(OutputSectData::OSDKind DataKind,
   OutputSectionDescription->pushBack(OSD);
 }
 
+void ScriptFile::addLinkerVersionData() {
+  assert(ScriptStateInSectionsCommmand);
+
+  if (!ThisModule.getConfig().options().isLinkerVersionDirectiveEnabled())
+    return;
+
+  LayoutInfo *layoutInfo = ThisModule.getLayoutInfo();
+  if (layoutInfo)
+    layoutInfo->recordLinkerScriptRule();
+
+  auto *OSD = LinkerVersionOutputData::create(
+      ThisModule.getScript().getIncrementedRuleCount(),
+      *OutputSectionDescription);
+  OSD->setInputFileInContext(getContext());
+  OSD->setParent(getParent());
+  OutputSectionDescription->pushBack(OSD);
+}
+
 void ScriptFile::addRegionAlias(const StrToken *Alias, const StrToken *Region) {
   RegionAlias *R = eld::make<RegionAlias>(Alias, Region);
   R->setInputFileInContext(getContext());

--- a/lib/ScriptParser/ScriptParser.cpp
+++ b/lib/ScriptParser/ScriptParser.cpp
@@ -1052,6 +1052,11 @@ void ScriptParser::readRegionAlias() {
 }
 
 bool ScriptParser::readOutputSectionData(llvm::StringRef Tok) {
+  if (Tok == "LINKER_VERSION") {
+    ThisScriptFile.addLinkerVersionData();
+    return true;
+  }
+
   std::optional<OutputSectData::OSDKind> OptDataKind =
       llvm::StringSwitch<std::optional<OutputSectData::OSDKind>>(Tok)
           .Case("BYTE", OutputSectData::OSDKind::Byte)

--- a/test/Common/standalone/linkerscript/LinkerVersionDirective/Inputs/linkerversion.script
+++ b/test/Common/standalone/linkerscript/LinkerVersionDirective/Inputs/linkerversion.script
@@ -1,0 +1,5 @@
+SECTIONS
+{
+  .myver 0 : { LINKER_VERSION }
+  .text : { *(.text) }
+}

--- a/test/Common/standalone/linkerscript/LinkerVersionDirective/Inputs/main.c
+++ b/test/Common/standalone/linkerscript/LinkerVersionDirective/Inputs/main.c
@@ -1,0 +1,1 @@
+int foo(void) { return 42; }

--- a/test/Common/standalone/linkerscript/LinkerVersionDirective/LinkerVersionDirective.test
+++ b/test/Common/standalone/linkerscript/LinkerVersionDirective/LinkerVersionDirective.test
@@ -1,0 +1,21 @@
+#---LinkerVersionDirective.test---------------------------#
+#BEGIN_COMMENT
+# Verify LINKER_VERSION directive honouring enable/disable options.
+#END_COMMENT
+RUN: %clang %clangopts -c %p/Inputs/main.c -o %t.o
+
+# Directive is parsed but emits nothing by default.
+RUN: %link %linkopts %t.o -T %p/Inputs/linkerversion.script -o %t.disabled
+RUN: %readelf -S -W %t.disabled | %filecheck %s --check-prefix=DISABLED
+
+# Enabling the feature injects the eld version string into the section.
+RUN: %link %linkopts --enable-linker-version %t.o -T %p/Inputs/linkerversion.script -o %t.enabled
+RUN: %readelf -S -W %t.enabled | %filecheck %s --check-prefix=ENABLED
+RUN: %readelf -p .myver %t.enabled | %filecheck %s --check-prefix=STRING
+
+#DISABLED-NOT: .myver
+
+#ENABLED: .myver {{.*}} {{[0-9a-f]+}} {{.*}}
+
+#STRING: String dump of section '.myver':
+#STRING-NEXT: {{eld}} {{.*}}(GNU Compatible linker)


### PR DESCRIPTION
Add support for GNU linker command line option --enable-linker-version and --disable-linker-version.

This is modeled in the same way as how BYTE command is handled.