### PR TITLE
Add --record-command-line extended linker option

### DIFF
--- a/docs/userguide/documentation/options/options.rst
+++ b/docs/userguide/documentation/options/options.rst
@@ -131,3 +131,13 @@ Linker version directive
   Disable the ``LINKER_VERSION`` directive. This is the default behaviour, so
   the directive is parsed but emits no data unless the feature has been
   explicitly enabled.
+
+Record command line
+-------------------
+
+``--record-command-line``
+  Record the linker command line in the ``.comment`` section. This is disabled
+  by default.
+
+``--no-record-command-line``
+  Do not record the linker command line in the ``.comment`` section.

--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -618,6 +618,10 @@ public:
     return EnableLinkerVersionDirective;
   }
 
+  void setRecordCommandLine(bool Enable = true) { RecordCommandLine = Enable; }
+
+  bool recordCommandLine() const { return RecordCommandLine; }
+
   void setEmitRelocs(bool EmitRelocs) {
     BEmitRelocs = EmitRelocs;
     ;
@@ -1291,6 +1295,7 @@ private:
   bool InsertTimingStats = false;        // -emit-timing-stats-in-output
   bool FatalInternalErrors = false;      // --fatal-internal-errors
   bool EnableLinkerVersionDirective = false; // --enable/disable-linker-version
+  bool RecordCommandLine = false;            // --{no-,}record-command-line
 
   RpathListType RpathList;
   ScriptListType ScriptList;

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -905,6 +905,12 @@ def disable_linker_version : Flag<["--"], "disable-linker-version">,
 def enable_linker_version : Flag<["--"], "enable-linker-version">,
                             HelpText<"Enable the LINKER_VERSION linker script directive">,
                             Group<grp_extendedopts>;
+def record_command_line : Flag<["--"], "record-command-line">,
+                           HelpText<"Record the linker command line in the comment section">,
+                           Group<grp_extendedopts>;
+def no_record_command_line : Flag<["--"], "no-record-command-line">,
+                              HelpText<"Do not record the linker command line in the comment section">,
+                              Group<grp_extendedopts>;
 def rosegment
     : Flag<[ "-", "--" ], "rosegment">,
       HelpText<"Put read-only non-executable sections in their own segment">,

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -613,6 +613,10 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
     Config.addCommandLine(Table->getOptionName(T::disable_linker_version), true);
   }
 
+  bool recordCommandLine = Args.hasFlag(
+      T::record_command_line, T::no_record_command_line, /*default=*/false);
+  Config.options().setRecordCommandLine(recordCommandLine);
+
   // --emit-relocs
   if (Args.hasArg(T::emit_relocs)) {
     Config.options().setEmitGNUCompatRelocs(true);

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -4796,9 +4796,7 @@ void GNULDBackend::makeVersionString() {
           LLVMRevisionF->getOwningSection()->getInputFile(),
           LLVMRevisionF->getOwningSection(), LLVMRevisionF);
   }
-  if ((LinkerConfig::Object != config().codeGenType()) &&
-      (LinkerConfig::DynObj != config().codeGenType()) &&
-      !config().options().isPIE())
+  if (!config().options().recordCommandLine())
     return;
   // Add the command line information to the link
   std::string CommandLine = "Command:";

--- a/test/Common/standalone/Map/Comment/Comment.test
+++ b/test/Common/standalone/Map/Comment/Comment.test
@@ -11,4 +11,4 @@ RUN: %filecheck %s < %t2.map
 #END_TEST
 
 #CHECK: .comment{{.*}}1.o
-#CMDLINE: Command:
+#CMDLINE-NOT: Command:


### PR DESCRIPTION
Previously eld used to record command line info by default, record it only when using the flag.