### PR TITLE
Add support for NEXT_SECTION

### DIFF
--- a/docs/userguide/documentation/linker_script.rst
+++ b/docs/userguide/documentation/linker_script.rst
@@ -302,6 +302,9 @@ Expressions
      | ALIGN (expression1, expression2)     | Return value when the value of expression1 is aligned to the next expression2 boundary.  |
      +--------------------------------------+------------------------------------------------------------------------------------------+
      | ALIGNOF (string)                     | Return the align information of the symbol or section.                                   |
+     |                                      | If string is NEXT_SECTION, return the alignment of the next allocated output section     |
+     |                                      | specified in the linker script, or zero if there is no such section.                     |
+     |                                      | NEXT_SECTION is only supported with ALIGNOF/SIZEOF; other uses are rejected.             |
      +--------------------------------------+------------------------------------------------------------------------------------------+
      | ASSERT (expression, string)          |  Throw an assertion if the expression result is zero.                                    |
      +--------------------------------------+------------------------------------------------------------------------------------------+
@@ -329,6 +332,9 @@ Expressions
      |                                      |   that segment. If nothing is found, return the value of the expression.                 |
      +--------------------------------------+------------------------------------------------------------------------------------------+
      | SIZEOF (string)                      |   Return the size of the symbol, section, or segment.                                    |
+     |                                      | If string is NEXT_SECTION, return the size of the next allocated output section          |
+     |                                      | specified in the linker script, or zero if there is no such section.                     |
+     |                                      | NEXT_SECTION is only supported with ALIGNOF/SIZEOF; other uses are rejected.             |
      +--------------------------------------+------------------------------------------------------------------------------------------+
      | SIZEOF_HEADERS                       | Return the section start file offset.                                                    |
      +--------------------------------------+------------------------------------------------------------------------------------------+

--- a/include/eld/Core/LinkerScript.h
+++ b/include/eld/Core/LinkerScript.h
@@ -139,6 +139,23 @@ public:
 
   bool linkerScriptHasRules() const { return RuleCount > 0; };
 
+  // ------------------- Linker script evaluation context -------------------
+  //
+  // Some builtins (e.g. ALIGNOF(NEXT_SECTION)) need to know which output
+  // section is currently being evaluated.
+  void setCurrentOutputSectionForScriptEval(ELFSection *S) {
+    CurrentOutputSectionForScriptEval = S;
+  }
+
+  ELFSection *getCurrentOutputSectionForScriptEval() const {
+    return CurrentOutputSectionForScriptEval;
+  }
+
+  // Returns the next allocated (SHF_ALLOC) output section after the current
+  // output section being evaluated, or nullptr if there is no such section (or
+  // if no current output section is set).
+  ELFSection *getNextAllocatedOutputSectionForScriptEval() const;
+
   void setHasSectionsCmd() { HasSectionsCmd = true; }
 
   void setHasExternCmd() { HasExternCmd = true; }
@@ -377,6 +394,7 @@ private:
                      std::unordered_set<const RuleContainer *>>
       MPendingRuleInsertions;
   std::unordered_map<std::string, Plugin *> MPluginInfo;
+  ELFSection *CurrentOutputSectionForScriptEval = nullptr;
 };
 
 } // namespace eld

--- a/include/eld/Script/ScopedScriptEvalContext.h
+++ b/include/eld/Script/ScopedScriptEvalContext.h
@@ -1,0 +1,37 @@
+//===- ScopedScriptEvalContext.h-------------------------------------------===//
+// Part of the eld Project, under the BSD License
+// See https://github.com/qualcomm/eld/LICENSE.txt for license information.
+// SPDX-License-Identifier: BSD-3-Clause
+//===----------------------------------------------------------------------===//
+
+#ifndef ELD_SCRIPT_SCOPEDSCRIPTEVALCONTEXT_H
+#define ELD_SCRIPT_SCOPEDSCRIPTEVALCONTEXT_H
+
+#include "eld/Core/LinkerScript.h"
+
+namespace eld {
+
+class ELFSection;
+
+class ScopedScriptEvalOutputSection {
+public:
+  ScopedScriptEvalOutputSection(LinkerScript &Script, ELFSection *Section)
+      : Script(Script) {
+    Script.setCurrentOutputSectionForScriptEval(Section);
+  }
+
+  ~ScopedScriptEvalOutputSection() {
+    Script.setCurrentOutputSectionForScriptEval(nullptr);
+  }
+
+  ScopedScriptEvalOutputSection(const ScopedScriptEvalOutputSection &) = delete;
+  ScopedScriptEvalOutputSection &
+  operator=(const ScopedScriptEvalOutputSection &) = delete;
+
+private:
+  LinkerScript &Script;
+};
+
+} // namespace eld
+
+#endif

--- a/lib/Fragment/OutputSectDataFragment.cpp
+++ b/lib/Fragment/OutputSectDataFragment.cpp
@@ -24,6 +24,7 @@ size_t OutputSectDataFragment::size() const {
 eld::Expected<void> OutputSectDataFragment::emit(MemoryRegion &Mr, Module &M) {
   ASSERT(paddingSize() == 0,
          "OutputSectDataFragment must not have any padding!");
+
   auto ExpVal = OutSectData.getExpr().evaluateAndReturnError();
   ELDEXP_RETURN_DIAGENTRY_IF_ERROR(ExpVal);
   uint64_t Value = ExpVal.value();

--- a/lib/Script/Expression.cpp
+++ b/lib/Script/Expression.cpp
@@ -443,6 +443,12 @@ void SizeOf::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   Outs << ")";
 }
 eld::Expected<uint64_t> SizeOf::evalImpl() {
+  if (Name == "NEXT_SECTION") {
+    if (ELFSection *Next =
+            ThisModule.getScript().getNextAllocatedOutputSectionForScriptEval())
+      return Next->getAddrAlign();
+    return 0;
+  }
 
   if (Name.size() && Name[0] == ':') {
     // If the name is a segment and we don't have PHDR's. SIZEOF on segment will
@@ -739,6 +745,12 @@ void AlignOf::getSymbols(std::vector<ResolveInfo *> &Symbols) {}
 void AlignOf::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {}
 
 eld::Expected<uint64_t> AlignOf::evalImpl() {
+  if (Name == "NEXT_SECTION") {
+    if (ELFSection *Next =
+            ThisModule.getScript().getNextAllocatedOutputSectionForScriptEval())
+      return Next->getAddrAlign();
+    return 0;
+  }
   // As the section table is populated only during PostLayout, we have to
   // go the other way around to access the section. This is because size of
   // empty

--- a/lib/ScriptParser/ScriptParser.cpp
+++ b/lib/ScriptParser/ScriptParser.cpp
@@ -279,6 +279,11 @@ eld::Expression *ScriptParser::readPrimary() {
   }
   if (Tok == "ADDR") {
     StringRef Name = unquote(readParenLiteral());
+    if (Name == "NEXT_SECTION") {
+      setError(
+          "NEXT_SECTION is only supported as an argument to ALIGNOF or SIZEOF");
+      return make<Integer>(Module, "", 0);
+    }
     // FIXME: Location might be handly for 'undefined section' error.
     return make<Addr>(Module, Name.str());
   }
@@ -338,6 +343,11 @@ eld::Expression *ScriptParser::readPrimary() {
   }
   if (Tok == "LOADADDR") {
     StringRef Name = unquote(readParenLiteral());
+    if (Name == "NEXT_SECTION") {
+      setError(
+          "NEXT_SECTION is only supported as an argument to ALIGNOF or SIZEOF");
+      return make<Integer>(Module, "", 0);
+    }
     return make<LoadAddr>(Module, Name.str());
   }
   if (Tok == "LOG2CEIL") {
@@ -382,6 +392,11 @@ eld::Expression *ScriptParser::readPrimary() {
   // Tok is a symbol name.
   if (Tok.starts_with("\""))
     Tok = unquote(Tok);
+  if (Tok == "NEXT_SECTION") {
+    setError(
+        "NEXT_SECTION is only supported as an argument to ALIGNOF or SIZEOF");
+    return make<Integer>(Module, "", 0);
+  }
   if (!isValidSymbolName(Tok))
     setError("malformed number: " + Tok);
   return make<Symbol>(Module, Tok.str());

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -64,6 +64,7 @@
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
 #include "eld/Script/VersionScript.h"
 #endif
+#include "eld/Script/ScopedScriptEvalContext.h"
 #include "eld/Support/DynamicLibrary.h"
 #include "eld/Support/Memory.h"
 #include "eld/Support/MsgHandling.h"
@@ -1989,6 +1990,7 @@ void GNULDBackend::evaluateAssignments(OutputSectionEntry *out,
                        m_Module.getConfig().options().printTimingStats());
 
   ELFSection *OutSection = out->getSection();
+  ScopedScriptEvalOutputSection Scope(m_Module.getScript(), OutSection);
 
   LDSymbol *dotSymbol = m_Module.getDotSymbol();
 

--- a/test/x86_64/standalone/LinkerScript/NEXT_SECTION/next-section-invalid.s
+++ b/test/x86_64/standalone/LinkerScript/NEXT_SECTION/next-section-invalid.s
@@ -1,0 +1,26 @@
+# UNSUPPORTED: windows
+# REQUIRES: x86
+
+## NEXT_SECTION is only supported as argument to ALIGNOF/SIZEOF.
+
+# RUN: rm -rf %t && split-file %s %t && cd %t
+# RUN: %llvm-mc -filetype=obj -triple=x86_64 a.s -o a.o
+# RUN: %not %link %linkopts -T script.lds a.o -o /dev/null 2>&1 | FileCheck %s
+
+# CHECK: NEXT_SECTION is only supported as an argument to ALIGNOF or SIZEOF
+
+#--- a.s
+.text
+.globl _start
+_start:
+  nop
+
+#--- script.lds
+SECTIONS {
+  . = 0x1000;
+  .text : {
+    __bad = ADDR(NEXT_SECTION);
+    *(.text)
+  }
+}
+

--- a/test/x86_64/standalone/LinkerScript/NEXT_SECTION/next-section.s
+++ b/test/x86_64/standalone/LinkerScript/NEXT_SECTION/next-section.s
@@ -1,0 +1,45 @@
+# UNSUPPORTED: windows
+# REQUIRES: x86
+
+## Test GNU ld's NEXT_SECTION support for ALIGNOF/SIZEOF builtins.
+## NEXT_SECTION refers to the next allocated (SHF_ALLOC) output section after
+## the current output section being evaluated.
+
+# RUN: rm -rf %t && split-file %s %t && cd %t
+# RUN: %llvm-mc -filetype=obj -triple=x86_64 a.s -o a.o
+# RUN: %link %linkopts -T script.lds a.o -o out
+# RUN: %nm -n out | FileCheck %s
+
+# CHECK: {{^0000000000000000}} {{[Dd]}} __data_next_align
+# CHECK: {{^0000000000000000}} {{[Dd]}} __data_next_size
+# CHECK: {{^0000000000000010}} {{[TtDd]}} __text_next_align
+# CHECK: {{^0000000000000010}} {{[TtDd]}} __text_next_size
+
+#--- a.s
+.text
+.globl _start
+_start:
+  nop
+
+.data
+  .p2align 4
+  .quad 0
+
+.section .debug_info,"",@progbits
+  .byte 0
+
+#--- script.lds
+SECTIONS {
+  . = 0x1000;
+  .text : {
+    __text_next_align = ALIGNOF(NEXT_SECTION);
+    __text_next_size = SIZEOF(NEXT_SECTION);
+    *(.text)
+  }
+  .data : {
+    __data_next_align = ALIGNOF(NEXT_SECTION);
+    __data_next_size = SIZEOF(NEXT_SECTION);
+    *(.data)
+  }
+  .debug_info : { *(.debug_info) }
+}


### PR DESCRIPTION
NEXT_SECTION refers to the next allocated (SHF_ALLOC) output section after the current output section being evaluated.

NEXT_SECTION is only supported with ALIGNOF/SIZEOF.

Documented here : https://sourceware.org/binutils/docs/ld/Builtin-Functions.html