### PR TITLE
Use ELD_TARGETS_TO_BUILD when creating eld's symlinks

### DIFF
--- a/tools/eld/CMakeLists.txt
+++ b/tools/eld/CMakeLists.txt
@@ -25,13 +25,12 @@ if (NOT LLVM_ENABLE_IDE)
                            COMPONENT ld.eld)
 endif()
 
-# FIXME: We need to switch to ELD_TARGETS_TO_BUILD after the buildbot upgrade
-if("${LLVM_TARGETS_TO_BUILD}" MATCHES "Hexagon" AND "${TARGET_TRIPLE}" MATCHES
-                                                    "hexagon-unknown-linux")
+if("${ELD_TARGETS_TO_BUILD}" MATCHES "Hexagon" AND "${TARGET_TRIPLE}" MATCHES
+                                                   "hexagon-unknown-linux")
   set(is_hexagon_linux 1)
 endif()
 if(ELD_CREATE_SYMLINKS)
-  foreach(target_name ${LLVM_TARGETS_TO_BUILD})
+  foreach(target_name ${ELD_TARGETS_TO_BUILD})
     string(TOLOWER ${target_name} ld_eld_name)
     if(${is_hexagon_linux})
       set(ld_eld_name "${ld_eld_name}-linux-link")


### PR DESCRIPTION
Currently, symlinks are created based on LLVM_TARGETS_TO_BUILD rather than ELD_TARGETS_TO_BUILD. So, you can end up with eld symlinks for targets that eld was built to exclude if LLVM_TARGETS_TO_BUILD is a superset of ELD_TARGETS_TO_BUILD. Which, isn't particularly helpful (they just error when used).

This is a somewhat niche situation (and we're only hitting this in ex: cpullvm as part of a temporary workaround) but there's a long standing FIXME to improve this (it is ~11 years old at this point!). So, let's see if we can just clean this up finally.