### PR TITLE
Fix LTOTempObjNotWritable test for Windows compatibility

### DIFF
--- a/test/Common/LTO/LTOTempObjNotWritable/LTOTempObjNotWritable.test
+++ b/test/Common/LTO/LTOTempObjNotWritable/LTOTempObjNotWritable.test
@@ -11,15 +11,11 @@ RUN: mkdir -p %t1.out.llvm-lto.1.o
 RUN: mkdir -p %t2.out.llvm-lto.0.o
 RUN: mkdir -p %t2.out.llvm-lto.1.o
 
-### TODO: remove ( .. || true) around linker invocation when it no longer
-### aborts on these errors. There is no consistent way to handle the crash
-### because it crashes only in some code paths when doing LTO.
-
 RUN: %clang %clangopts -c %p/Inputs/1.c -O2 -ffunction-sections -flto -o %t1.o
-RUN: (%not %link %linkopts --save-temps %t1.o -o %t1.out 2>&1 || true) | %filecheck %s
+RUN: %not --crash %link %linkopts --save-temps %t1.o -o %t1.out 2>&1 | %filecheck %s
 
 RUN: %clang %clangopts -c %p/Inputs/1.c -O2 -ffunction-sections -flto=thin -o %t2.o
-RUN: (%not %link %linkopts --save-temps %t2.o -o %t2.out 2>&1 || true) | %filecheck %s
+RUN: %not --crash %link %linkopts --save-temps %t2.o -o %t2.out 2>&1 | %filecheck %s
 
 CHECK: cannot compile code generator object
 CHECK: .out.llvm-lto.{{[0-9]+}}.o: {{Is a directory|is a directory}}


### PR DESCRIPTION
Replace the bash-specific `( ... || true)` subshell syntax with
`%not --crash` to properly handle the expected linker crash/abort
when LTO temp object files cannot be written. The `( ... || true)`
pattern fails on Windows CMD where `(` is not a valid command.

not --crash treats both:
- clean” failures (non‑zero exit code),
- crashes/aborts as an expected failure condition for the test.

With the above change, No subshell grouping or true needed and test works on
Windows cmd/lit shell as well.