### PR TITLE
Remove fd-qualified redirect from LSGMemoryRegionAlias.test

### DIFF
--- a/test/Common/Plugin/BasicLinkerScriptGenerator/LSGMemoryRegionAlias.test
+++ b/test/Common/Plugin/BasicLinkerScriptGenerator/LSGMemoryRegionAlias.test
@@ -5,7 +5,7 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
-RUN: %link %linkopts -o %t1.1.out %t1.1.o -L%libsdir/test -T %p/Inputs/script.MemoryRegionAlias.t 1>%t1.script.lsg.t
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -L%libsdir/test -T %p/Inputs/script.MemoryRegionAlias.t >%t1.script.lsg.t
 RUN: %filecheck %s < %t1.script.lsg.t
 1RUN: %link %linkopts -o %t1.1.lsg.out %t1.1.o -L%libsdir/test -T %t1.script.lsg.t
 #END_TEST


### PR DESCRIPTION
lit uses an internal shell when a POSIX shell is unavailable like on windows specific environments.

The internal shell does not support file‑descriptor–qualified redirects such as 1>, but does support basic > redirection.

This patch removes the explicit 1 since it is redundant and breaks the test on Windows.