### PR TITLE
Add REQUIRES: shell to patch tests using shell-specific syntax

### DIFF
--- a/test/Common/standalone/Patching/Patch/Patch.test
+++ b/test/Common/standalone/Patching/Patch/Patch.test
@@ -1,3 +1,4 @@
+REQUIRES: shell
 #---PatchPLT.test-------------- Executable------------------------#
 #BEGIN_COMMENT
 #Test creation of PLT/GOT slots for patchable symbols.

--- a/test/Common/standalone/Patching/PatchPatchPLT/PatchPatchPLT_FuncPtrCode.test
+++ b/test/Common/standalone/Patching/PatchPatchPLT/PatchPatchPLT_FuncPtrCode.test
@@ -1,3 +1,4 @@
+REQUIRES: shell
 #---PatchPLT.test-------------- Executable------------------------#
 #BEGIN_COMMENT
 #Test creation of PLT/GOT slots for patchable symbols.

--- a/test/Common/standalone/Patching/PatchPatchPLT/PatchPatchPLT_FuncPtrData.test
+++ b/test/Common/standalone/Patching/PatchPatchPLT/PatchPatchPLT_FuncPtrData.test
@@ -1,3 +1,4 @@
+REQUIRES: shell
 #---PatchPatchPLT.test-------------- Executable------------------------#
 #BEGIN_COMMENT
 #Test creation of PLT/GOT slots for patchable symbols.


### PR DESCRIPTION
Some patch-related lit tests rely on shell-specific command groupings using ; inside (...). This syntax is not supported by cmd.exe on Windows and causes the tests to fail in environments without a POSIX‑compatible shell.
This change adds REQUIRES: shell to the following tests to explicitly mark them as requiring a bash‑like shell:

Patch.test
PatchPatchPLT_FuncPtrCode.test
PatchPatchPLT_FuncPtrData.test

This ensures the tests are skipped on unsupported environments rather than failing unexpectedly.