### PR TITLE
Prioritize runtime PATH over PATH captured at CMake configuration time

### DIFF
--- a/test/lld/ELF/lit.local.cfg
+++ b/test/lld/ELF/lit.local.cfg
@@ -1,0 +1,9 @@
+import os
+
+# Merge the runtime PATH (set at test-run time) into the configured PATH
+# so that tool resolution via which() reflects the current environment
+# rather than the PATH captured at CMake configuration time.
+# This ensures tools like rm are resolved from the runtime PATH first.
+if 'PATH' in os.environ:
+    config.environment['PATH'] = os.path.pathsep.join(
+        (os.environ['PATH'], config.environment['PATH']))


### PR DESCRIPTION
In downstream Windows buildbots, several tests are currently failing with errors such as:

`C:/gnuwin32/bin/rm.exe: cannot lstat ...`

This happens because gnuwin32 appears earlier in the PATH captured during the CMake configuration step, even though the buildbot ensures that msys/2.0/usr/bin is placed before gnuwin32 at test execution time. However, the lit configuration currently prefers the PATH recorded during CMake setup rather than the PATH available at runtime.

While this can be considered an infrastructure issue and addressed at that level, this patch updates the local lit configuration to resolve the problem for the upcoming release.

The following tests are expected to be fixed by this change:

eld :: lld/ELF/emit-asm.ll
eld :: lld/ELF/obj-path.test
eld :: lld/ELF/thinlto.test