### PR TITLE
Add --start-lib/--end-lib command line option

### DIFF
--- a/docs/userguide/documentation/options/options.rst
+++ b/docs/userguide/documentation/options/options.rst
@@ -8,6 +8,54 @@ Common options for all the backends
 
 .. include:: GnuLinkerOptions.rst
 
+Using ``--start-lib`` / ``--end-lib``
+-------------------------------------
+
+``--start-lib`` and ``--end-lib`` let you pass one or more object files and
+have ELD treat them as if they were members of an archive for symbol resolution
+purposes.
+
+Conceptually, ELD packages the object files between ``--start-lib`` and
+``--end-lib`` into an in-memory archive and then processes that archive like a
+normal ``.a`` input.
+
+Thin variant
+^^^^^^^^^^^^
+
+ELD also supports ``--start-lib-thin`` / ``--end-lib-thin``, which packages the
+enclosed object files into an in-memory *thin* archive (member paths are stored
+instead of embedding member bytes).
+
+Linker scripts with archive member patterns
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ELD supports using archive member patterns in linker scripts to match inputs
+from a ``--start-lib`` region.
+
+Internally, ELD assigns a synthetic archive name to each ``--start-lib`` region:
+``<start-lib:1>``, ``<start-lib:2>``, etc., in command-line order.
+Thin regions use ``<start-lib-thin:N>``.
+You can reference these synthetic archive names using the standard
+``archive:member`` pattern syntax in an input section description.
+
+Example::
+
+  $ ld.eld main.o --start-lib foo.o bar.o --end-lib -T script.t -MapStyle txt -Map out.map
+
+  /* script.t */
+  SECTIONS {
+    .foo_out : { "*<start-lib:1>:*foo.o"(.text*) }
+    .bar_out : { "*<start-lib:1>:*bar.o"(.text*) }
+  }
+
+Notes:
+
+* The ``<start-lib:N>`` names are ELD-specific (they do not correspond to a
+  real on-disk archive).
+* If you need a stable archive name for portability, create a real archive
+  (e.g. with ``ar cr libname.a ...``) and match against ``*libname.a:*member.o``
+  patterns in the script.
+
 ARM and AArch64 specific options
 ---------------------------------
 

--- a/include/eld/Diagnostics/DiagCommonKinds.inc
+++ b/include/eld/Diagnostics/DiagCommonKinds.inc
@@ -80,6 +80,12 @@ DIAG(nested_group_not_allowed, DiagnosticEngine::Fatal,
      "Nested --start-group/--end-group not allowed")
 DIAG(mismatched_group, DiagnosticEngine::Fatal,
      "Mismatched --start-group/--end-group")
+DIAG(warn_lib_is_empty, DiagnosticEngine::Warning,
+     "Empty --start-lib --end-lib.")
+DIAG(nested_lib_not_allowed, DiagnosticEngine::Fatal,
+     "Nested --start-lib/--end-lib not allowed")
+DIAG(mismatched_lib, DiagnosticEngine::Fatal,
+     "Mismatched --start-lib/--end-lib")
 DIAG(unsupported_version_node, DiagnosticEngine::Warning,
      "Only anonymous version nodes are supported. Ignoring version script `%0'")
 DIAG(unsupported_dependent_node, DiagnosticEngine::Warning,

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -534,6 +534,12 @@ def u_alias : Joined<["--"], "undefined=">,
 def start_group : Flag<["-", "--"], "start-group">,
                   HelpText<"Start a group">,
                   Group<grp_resolveropt>;
+def start_lib : Flag<["--"], "start-lib">,
+                HelpText<"Start a library">,
+                Group<grp_resolveropt>;
+def start_lib_thin : Flag<["--"], "start-lib-thin">,
+                     HelpText<"Start a thin library">,
+                     Group<grp_resolveropt>;
 def alias_start_group : Flag<["-"], "(">,
                         HelpText<"Start a group">,
                         Group<grp_resolveropt>,
@@ -541,6 +547,12 @@ def alias_start_group : Flag<["-"], "(">,
 def end_group : Flag<["-", "--"], "end-group">,
                 HelpText<"End a group">,
                 Group<grp_resolveropt>;
+def end_lib : Flag<["--"], "end-lib">,
+              HelpText<"End a library">,
+              Group<grp_resolveropt>;
+def end_lib_thin : Flag<["--"], "end-lib-thin">,
+                   HelpText<"End a thin library">,
+                   Group<grp_resolveropt>;
 def alias_end_group : Flag<["-"], ")">,
                       HelpText<"End a group">,
                       Group<grp_resolveropt>,

--- a/include/eld/Input/Input.h
+++ b/include/eld/Input/Input.h
@@ -72,6 +72,10 @@ public:
 
   void setResolvedPath(std::string Path) { ResolvedPath = Path; }
 
+  void setResolvedPathHash(uint64_t Hash) { ResolvedPathHash = Hash; }
+
+  void setMemberNameHash(uint64_t Hash) { MemberNameHash = Hash; }
+
   uint32_t getInputOrdinal() { return InputOrdinal; }
 
   Attribute &getAttribute() { return Attr; }
@@ -151,6 +155,9 @@ public:
 
   static MemoryArea *createMemoryArea(const std::string &Filepath,
                                       DiagnosticEngine *DiagEngine);
+
+  static void cacheMemoryAreaForPath(const std::string &Filepath,
+                                     MemoryArea *Area);
 
 private:
   // Check if a path is valid and emit any errors

--- a/include/eld/Input/InputAction.h
+++ b/include/eld/Input/InputAction.h
@@ -39,6 +39,7 @@ public:
     BStatic,
     DefSym,
     EndGroup,
+    EndLib,
     InputFormat,
     InputFile,
     Namespec,
@@ -47,6 +48,7 @@ public:
     NoWholeArchive,
     Script,
     StartGroup,
+    StartLib,
     WholeArchive,
     JustSymbols,
   };
@@ -141,6 +143,25 @@ public:
   }
 };
 
+/// StartLibAction
+class StartLibAction : public InputAction {
+public:
+  explicit StartLibAction(DiagnosticPrinter *Printer, bool IsThin = false);
+
+  bool activate(InputBuilder &) override;
+
+  virtual ~StartLibAction() {}
+
+  static bool classof(const InputAction *I) {
+    return I->getInputActionKind() == InputAction::InputActionKind::StartLib;
+  }
+
+  bool isThin() const { return IsThin; }
+
+private:
+  bool IsThin = false;
+};
+
 /// EndGroupAction
 class EndGroupAction : public InputAction {
 public:
@@ -152,6 +173,20 @@ public:
 
   static bool classof(const InputAction *I) {
     return I->getInputActionKind() == InputAction::InputActionKind::EndGroup;
+  }
+};
+
+/// EndLibAction
+class EndLibAction : public InputAction {
+public:
+  explicit EndLibAction(DiagnosticPrinter *Printer);
+
+  bool activate(InputBuilder &) override;
+
+  virtual ~EndLibAction() {}
+
+  static bool classof(const InputAction *I) {
+    return I->getInputActionKind() == InputAction::InputActionKind::EndLib;
   }
 };
 

--- a/include/eld/Input/InputBuilder.h
+++ b/include/eld/Input/InputBuilder.h
@@ -19,6 +19,7 @@
 #include "eld/Script/WildcardPattern.h"
 #include "eld/Support/MemoryArea.h"
 #include "llvm/ADT/StringSet.h"
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -60,6 +61,10 @@ public:
 
   void exitGroup();
 
+  void enterLib(bool IsThin = false);
+
+  void exitLib();
+
   void makeBStatic();
 
   Attribute &getAttributes() { return Attr; }
@@ -82,6 +87,7 @@ private:
   Attribute Attr;
   const LinkerConfig &Config;
   std::vector<Attribute> AttrStack;
+  uint64_t NextLibId = 0;
 };
 
 } // end of namespace eld

--- a/include/eld/Input/InputTree.h
+++ b/include/eld/Input/InputTree.h
@@ -13,13 +13,15 @@
 #ifndef ELD_INPUT_INPUTTREE_H
 #define ELD_INPUT_INPUTTREE_H
 
+#include <cstdint>
+
 namespace eld {
 
 class Input;
 
 class Node {
 public:
-  enum Kind { File, GroupStart, GroupEnd };
+  enum Kind { File, GroupStart, GroupEnd, LibStart, LibEnd };
 
   Node(Kind K) : NodeKind(K) {}
 
@@ -128,6 +130,32 @@ public:
   GroupEnd() : Node(Node::GroupEnd) {}
 
   static bool classof(const Node *N) { return (N->kind() == Node::GroupEnd); }
+};
+
+class LibStart : public Node {
+public:
+  explicit LibStart(const Attribute &Attr, bool IsThin, uint64_t Id)
+      : Node(Node::LibStart), Attr(Attr), IsThin(IsThin), Id(Id) {}
+
+  const Attribute &getAttribute() const { return Attr; }
+
+  bool isThin() const { return IsThin; }
+
+  uint64_t getId() const { return Id; }
+
+  static bool classof(const Node *N) { return (N->kind() == Node::LibStart); }
+
+private:
+  Attribute Attr;
+  bool IsThin = false;
+  uint64_t Id = 0;
+};
+
+class LibEnd : public Node {
+public:
+  LibEnd() : Node(Node::LibEnd) {}
+
+  static bool classof(const Node *N) { return (N->kind() == Node::LibEnd); }
 };
 } // namespace eld
 

--- a/include/eld/LayoutMap/LayoutInfo.h
+++ b/include/eld/LayoutMap/LayoutInfo.h
@@ -92,6 +92,8 @@ public:
     SkippedRescan,
     StartGroup,
     EndGroup,
+    StartLib,
+    EndLib,
   };
 
   struct Stats {

--- a/include/eld/Object/LibReader.h
+++ b/include/eld/Object/LibReader.h
@@ -1,0 +1,46 @@
+//===- LibReader.h---------------------------------------------------------===//
+// Part of the eld Project, under the BSD License
+// See https://github.com/qualcomm/eld/LICENSE.txt for license information.
+// SPDX-License-Identifier: BSD-3-Clause
+//===----------------------------------------------------------------------===//
+//
+//                     The MCLinker Project
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef ELD_OBJECT_LIBREADER_H
+#define ELD_OBJECT_LIBREADER_H
+
+#include "eld/Core/Module.h"
+
+namespace eld {
+
+class LinkerConfig;
+class ObjectLinker;
+
+/** \class LibReader
+ *  \brief LibReader handles the LibStart/LibEnd Node in InputTree
+ *
+ *  Lib nodes are created by the command line options --start-lib and --end-lib.
+ *  All inputs in between are packaged into an in-memory archive and then
+ *  processed as a normal archive input.
+ */
+class LibReader {
+public:
+  LibReader(Module &M, ObjectLinker *ObjLinker);
+
+  ~LibReader();
+
+  bool readLib(InputBuilder::InputIteratorT &Node, InputBuilder &Builder,
+               LinkerConfig &Config, bool IsPostLtoPhase = false);
+
+private:
+  Module &MModule;
+  ObjectLinker *MObjLinker = nullptr;
+};
+
+} // namespace eld
+
+#endif

--- a/include/eld/Object/ObjectLinker.h
+++ b/include/eld/Object/ObjectLinker.h
@@ -49,6 +49,7 @@ class ELFExecutableFileReader;
 class ExecWriter;
 class GNULDBackend;
 class GroupReader;
+class LibReader;
 class Input;
 class InputTree;
 class IRBuilder;
@@ -226,6 +227,8 @@ public:
   ArchiveParser *getArchiveParser() const { return ArchiveParser; }
 
   GroupReader *getGroupReader() const { return GroupReader; }
+
+  LibReader *getLibReader() const { return LibReader; }
 
   ScriptReader *getScriptReader() const { return ScriptReader; }
 
@@ -483,6 +486,7 @@ private:
   ELFExecObjParser *ELFExecObjParser = nullptr;
   BinaryFileParser *BinaryFileParser = nullptr;
   GroupReader *GroupReader = nullptr;
+  LibReader *LibReader = nullptr;
   ScriptReader *ScriptReader = nullptr;
   ELFObjectWriter *ObjWriter = nullptr;
   BitcodeReader *MPBitcodeReader = nullptr;

--- a/lib/Input/Input.cpp
+++ b/lib/Input/Input.cpp
@@ -203,3 +203,8 @@ MemoryArea *Input::createMemoryArea(const std::string &Filepath,
   ResolvedPathToMemoryAreaMap[Filepath] = InputMem;
   return InputMem;
 }
+
+void Input::cacheMemoryAreaForPath(const std::string &Filepath,
+                                   MemoryArea *Area) {
+  ResolvedPathToMemoryAreaMap[Filepath] = Area;
+}

--- a/lib/Input/InputAction.cpp
+++ b/lib/Input/InputAction.cpp
@@ -79,6 +79,17 @@ bool StartGroupAction::activate(InputBuilder &PBuilder) {
 }
 
 //===----------------------------------------------------------------------===//
+// StartLibAction
+//===----------------------------------------------------------------------===//
+StartLibAction::StartLibAction(DiagnosticPrinter *Printer, bool IsThin)
+    : InputAction(InputAction::StartLib, Printer), IsThin(IsThin) {}
+
+bool StartLibAction::activate(InputBuilder &PBuilder) {
+  PBuilder.enterLib(IsThin);
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
 // EndGroupAction
 //===----------------------------------------------------------------------===//
 EndGroupAction::EndGroupAction(DiagnosticPrinter *Printer)
@@ -86,6 +97,17 @@ EndGroupAction::EndGroupAction(DiagnosticPrinter *Printer)
 
 bool EndGroupAction::activate(InputBuilder &PBuilder) {
   PBuilder.exitGroup();
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+// EndLibAction
+//===----------------------------------------------------------------------===//
+EndLibAction::EndLibAction(DiagnosticPrinter *Printer)
+    : InputAction(InputAction::EndLib, Printer) {}
+
+bool EndLibAction::activate(InputBuilder &PBuilder) {
+  PBuilder.exitLib();
   return true;
 }
 

--- a/lib/Input/InputBuilder.cpp
+++ b/lib/Input/InputBuilder.cpp
@@ -48,6 +48,12 @@ void InputBuilder::enterGroup() { Tree.push_back(make<GroupStart>()); }
 
 void InputBuilder::exitGroup() { Tree.push_back(make<GroupEnd>()); }
 
+void InputBuilder::enterLib(bool IsThin) {
+  Tree.push_back(make<LibStart>(Attr, IsThin, ++NextLibId));
+}
+
+void InputBuilder::exitLib() { Tree.push_back(make<LibEnd>()); }
+
 bool InputBuilder::setMemory(Input &PInput, void *PMemBuffer, size_t PSize) {
   MemoryArea *MemBufCopy = MemoryArea::CreateCopy(
       llvm::StringRef(static_cast<const char *>(PMemBuffer), PSize));

--- a/lib/LayoutMap/LayoutInfo.cpp
+++ b/lib/LayoutMap/LayoutInfo.cpp
@@ -261,6 +261,10 @@ std::string LayoutInfo::getStringFromLoadSequence(InputSequenceT Ist) {
     return "START GROUP";
   case EndGroup:
     return "END GROUP";
+  case StartLib:
+    return "START LIB";
+  case EndLib:
+    return "END LIB";
   }
 
   Input *Input = Ist.Input;

--- a/lib/Object/CMakeLists.txt
+++ b/lib/Object/CMakeLists.txt
@@ -2,6 +2,7 @@ llvm_add_library(
   ELDObject
   STATIC
   GroupReader.cpp
+  LibReader.cpp
   ScriptMemoryRegion.cpp
   ObjectBuilder.cpp
   ObjectLinker.cpp

--- a/lib/Object/LibReader.cpp
+++ b/lib/Object/LibReader.cpp
@@ -1,0 +1,129 @@
+//===- LibReader.cpp-------------------------------------------------------===//
+// Part of the eld Project, under the BSD License
+// See https://github.com/qualcomm/eld/LICENSE.txt for license information.
+// SPDX-License-Identifier: BSD-3-Clause
+//===----------------------------------------------------------------------===//
+//
+//                     The MCLinker Project
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "eld/Object/LibReader.h"
+#include "eld/Config/LinkerConfig.h"
+#include "eld/Input/Input.h"
+#include "eld/Input/InputTree.h"
+#include "eld/Object/ObjectLinker.h"
+#include "eld/Support/MemoryArea.h"
+#include "eld/Support/RegisterTimer.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/Object/Archive.h"
+#include "llvm/Object/ArchiveWriter.h"
+
+using namespace eld;
+
+LibReader::LibReader(Module &M, ObjectLinker *ObjLinker)
+    : MModule(M), MObjLinker(ObjLinker) {}
+
+LibReader::~LibReader() {}
+
+static std::string getStartLibArchiveName(bool IsThin, uint64_t Id) {
+  llvm::StringRef Prefix = IsThin ? "<start-lib-thin:" : "<start-lib:";
+  return (llvm::Twine(Prefix) + llvm::Twine(Id) + ">").str();
+}
+
+bool LibReader::readLib(InputBuilder::InputIteratorT &CurNode,
+                        InputBuilder &Builder, LinkerConfig &Config,
+                        bool IsPostLtoPhase) {
+  LayoutInfo *layoutInfo = MModule.getLayoutInfo();
+  Attribute LibAttr;
+  bool IsThin = false;
+  uint64_t LibId = 0;
+  bool ReuseArchiveOnly = false;
+  MemoryArea *CachedArchiveArea = nullptr;
+
+  if (layoutInfo)
+    layoutInfo->recordInputActions(LayoutInfo::StartLib, nullptr);
+
+  std::vector<llvm::NewArchiveMember> Members;
+  llvm::SmallVector<std::string, 0> MemberNames;
+
+  // Build archive members from the in-between inputs.
+  while ((*CurNode)->kind() != Node::LibEnd) {
+    if (const auto *Start = llvm::dyn_cast<LibStart>(*CurNode)) {
+      LibAttr = Start->getAttribute();
+      IsThin = Start->isThin();
+      LibId = Start->getId();
+      if (IsPostLtoPhase) {
+        std::string ArchiveName = getStartLibArchiveName(IsThin, LibId);
+        CachedArchiveArea =
+            Input::getMemoryAreaForPath(ArchiveName, Config.getDiagEngine());
+        if (CachedArchiveArea)
+          ReuseArchiveOnly = true;
+      }
+      ++CurNode;
+      continue;
+    }
+
+    FileNode *Node = llvm::dyn_cast<FileNode>(*CurNode);
+    if (!Node) {
+      ++CurNode;
+      continue;
+    }
+
+    if (ReuseArchiveOnly) {
+      ++CurNode;
+      continue;
+    }
+
+    Input *Input = Node->getInput();
+    if (!Input->resolvePath(Config))
+      return false;
+
+    if (IsThin)
+      MemberNames.push_back(Input->getResolvedPath().getFullPath());
+    else
+      MemberNames.push_back(Input->getResolvedPath().filename().native());
+    llvm::NewArchiveMember NM(Input->getMemoryBufferRef());
+    NM.MemberName = MemberNames.back();
+    Members.push_back(std::move(NM));
+
+    ++CurNode;
+  }
+
+  if (layoutInfo)
+    layoutInfo->recordInputActions(LayoutInfo::EndLib, nullptr);
+
+  std::string ArchiveName = getStartLibArchiveName(IsThin, LibId);
+  MemoryArea *MemArea = CachedArchiveArea;
+  if (!MemArea) {
+    eld::RegisterTimer T("Build --start-lib archive", "Read all Input files",
+                         Config.options().printTimingStats());
+    llvm::Expected<std::unique_ptr<llvm::MemoryBuffer>> ExpArchiveBuf =
+        llvm::writeArchiveToBuffer(Members,
+                                   llvm::SymtabWritingMode::NormalSymtab,
+                                   llvm::object::Archive::K_GNU,
+                                   /*Deterministic=*/true, /*Thin=*/IsThin);
+    if (!ExpArchiveBuf) {
+      plugin::DiagnosticEntry DiagEntry =
+          Config.getDiagEngine()->convertToDiagEntry(ExpArchiveBuf.takeError());
+      Config.raiseDiagEntry(
+          std::make_unique<plugin::DiagnosticEntry>(std::move(DiagEntry)));
+      return false;
+    }
+    MemArea = make<MemoryArea>(std::move(*ExpArchiveBuf));
+    Input::cacheMemoryAreaForPath(ArchiveName, MemArea);
+  }
+
+  auto *ArchiveInput =
+      make<Input>(ArchiveName, LibAttr, Config.getDiagEngine(), Input::Default);
+  ArchiveInput->setResolvedPath(ArchiveName);
+  ArchiveInput->setResolvedPathHash(Input::computeFilePathHash(ArchiveName));
+  ArchiveInput->setMemberNameHash(Input::computeFilePathHash(ArchiveName));
+  ArchiveInput->setMemArea(MemArea);
+
+  return MObjLinker->readAndProcessInput(ArchiveInput, IsPostLtoPhase);
+}

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -29,6 +29,7 @@
 #include "eld/LayoutMap/LayoutInfo.h"
 #include "eld/LayoutMap/TextLayoutPrinter.h"
 #include "eld/Object/GroupReader.h"
+#include "eld/Object/LibReader.h"
 #include "eld/Object/ObjectBuilder.h"
 #include "eld/Object/SectionMap.h"
 #include "eld/PluginAPI/LinkerPlugin.h"
@@ -43,9 +44,9 @@
 #include "eld/Readers/ELFSection.h"
 #include "eld/Readers/EhFrameHdrSection.h"
 #include "eld/Readers/EhFrameSection.h"
-#include "eld/Readers/SFrameSection.h"
 #include "eld/Readers/ObjectReader.h"
 #include "eld/Readers/Relocation.h"
+#include "eld/Readers/SFrameSection.h"
 #include "eld/Script/Assignment.h"
 #include "eld/Script/InputSectDesc.h"
 #include "eld/Script/OutputSectData.h"
@@ -139,6 +140,7 @@ bool ObjectLinker::initialize() {
   // SymDef Reader.
   SymDefReader = createSymDefReader();
   GroupReader = make<eld::GroupReader>(*ThisModule, this);
+  LibReader = make<eld::LibReader>(*ThisModule, this);
   ScriptReader = make<eld::ScriptReader>();
   ObjWriter = createWriter();
 
@@ -250,6 +252,15 @@ bool ObjectLinker::readInputs(const std::vector<Node *> &InputVector) {
       getGroupReader()->readGroup(Begin,
                                   ThisModule->getIRBuilder()->getInputBuilder(),
                                   ThisConfig, MPostLtoPhase);
+      continue;
+    }
+
+    if ((*Begin)->kind() == Node::LibStart) {
+      eld::RegisterTimer T("Read Start Lib and End Lib", "Read all Input files",
+                           ThisConfig.options().printTimingStats());
+      getLibReader()->readLib(Begin,
+                              ThisModule->getIRBuilder()->getInputBuilder(),
+                              ThisConfig, MPostLtoPhase);
       continue;
     }
 

--- a/test/Common/LTO/StartLibEndLib/Inputs/bar.c
+++ b/test/Common/LTO/StartLibEndLib/Inputs/bar.c
@@ -1,0 +1,1 @@
+int bar() { return 2; }

--- a/test/Common/LTO/StartLibEndLib/Inputs/baz.c
+++ b/test/Common/LTO/StartLibEndLib/Inputs/baz.c
@@ -1,0 +1,1 @@
+int baz() { return 3; }

--- a/test/Common/LTO/StartLibEndLib/Inputs/foo.c
+++ b/test/Common/LTO/StartLibEndLib/Inputs/foo.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/Common/LTO/StartLibEndLib/Inputs/main.c
+++ b/test/Common/LTO/StartLibEndLib/Inputs/main.c
@@ -1,0 +1,4 @@
+extern int foo();
+extern int bar();
+
+int main() { return foo() + bar(); }

--- a/test/Common/LTO/StartLibEndLib/StartLibEndLibLTO.test
+++ b/test/Common/LTO/StartLibEndLib/StartLibEndLibLTO.test
@@ -1,0 +1,17 @@
+#---StartLibEndLibLTO.test------------------------- Executable -------------------#
+#BEGIN_COMMENT
+# Checks --start-lib/--end-lib with LTO. The "Build --start-lib archive" timer
+# must appear only once, even though LTO triggers a post-LTO rescan phase.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -flto -c %p/Inputs/foo.c -o %t.foo.o
+RUN: %clang %clangopts -flto -c %p/Inputs/bar.c -o %t.bar.o
+RUN: %clang %clangopts -flto -c %p/Inputs/baz.c -o %t.baz.o
+RUN: %clang %clangopts -flto -c %p/Inputs/main.c -o %t.main.o
+
+RUN: %link %linkopts %t.main.o --start-lib %t.foo.o %t.bar.o %t.baz.o --end-lib -o %t.out -print-timing-stats 2>&1 | %filecheck %s -check-prefix=TIMING
+
+#TIMING: Build --start-lib archive
+#TIMING-NOT: Build --start-lib archive
+#END_TEST
+

--- a/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/bar.c
+++ b/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/bar.c
@@ -1,0 +1,1 @@
+int bar() { return 7; }

--- a/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/bar_calls_baz.c
+++ b/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/bar_calls_baz.c
@@ -1,0 +1,3 @@
+extern int baz_impl();
+
+int bar_calls_baz() { return baz_impl() + 2; }

--- a/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/bar_sel.c
+++ b/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/bar_sel.c
@@ -1,0 +1,1 @@
+int bar_sel() { return 2; }

--- a/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/baz.c
+++ b/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/baz.c
@@ -1,0 +1,1 @@
+int baz() { return 3; }

--- a/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/baz_impl.c
+++ b/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/baz_impl.c
@@ -1,0 +1,1 @@
+int baz_impl() { return 3; }

--- a/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/foo.c
+++ b/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/foo.c
@@ -1,0 +1,1 @@
+int foo() { return 42; }

--- a/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/foo_calls_bar.c
+++ b/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/foo_calls_bar.c
@@ -1,0 +1,3 @@
+extern int bar_calls_baz();
+
+int foo_calls_bar() { return bar_calls_baz() + 1; }

--- a/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/foo_sel.c
+++ b/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/foo_sel.c
@@ -1,0 +1,1 @@
+int foo_sel() { return 1; }

--- a/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/main.c
+++ b/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/main.c
@@ -1,0 +1,3 @@
+extern int foo();
+
+int main() { return foo(); }

--- a/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/main_foo_only.c
+++ b/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/main_foo_only.c
@@ -1,0 +1,3 @@
+extern int foo();
+
+int main() { return foo(); }

--- a/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/main_group.c
+++ b/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/main_group.c
@@ -1,0 +1,3 @@
+extern int foo_calls_bar();
+
+int main() { return foo_calls_bar(); }

--- a/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/main_multi.c
+++ b/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/main_multi.c
@@ -1,0 +1,4 @@
+extern int foo();
+extern int bar();
+
+int main() { return foo() + bar(); }

--- a/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/main_script.c
+++ b/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/main_script.c
@@ -1,0 +1,4 @@
+extern int foo_sel();
+extern int bar_sel();
+
+int main() { return foo_sel() + bar_sel(); }

--- a/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/startlib_archive_pattern.t
+++ b/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/startlib_archive_pattern.t
@@ -1,0 +1,7 @@
+SECTIONS
+{
+  .foo_out : { "*<start-lib:1>:*foo_sel.o"(.text.foo_sel) }
+  .bar_out : { "*<start-lib:1>:*bar_sel.o"(.text.bar_sel) }
+  .text : { *(.text*) }
+}
+

--- a/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/startlib_thin_archive_pattern.t
+++ b/test/Common/standalone/CommandLine/StartLibEndLib/Inputs/startlib_thin_archive_pattern.t
@@ -1,0 +1,7 @@
+SECTIONS
+{
+  .foo_out : { "*<start-lib-thin:1>:*foo_sel.o"(.text.foo_sel) }
+  .bar_out : { "*<start-lib-thin:1>:*bar_sel.o"(.text.bar_sel) }
+  .text : { *(.text*) }
+}
+

--- a/test/Common/standalone/CommandLine/StartLibEndLib/StartLibEndLib.test
+++ b/test/Common/standalone/CommandLine/StartLibEndLib/StartLibEndLib.test
@@ -1,0 +1,54 @@
+#---StartLibEndLib.test--------------------------- Executable --------------------#
+#BEGIN_COMMENT
+# This checks --start-lib/--end-lib parsing and basic functionality.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/foo.c -o %t.foo.o
+RUN: %clang %clangopts -c %p/Inputs/main.c -o %t.main.o
+RUN: %clang %clangopts -c %p/Inputs/bar.c -o %t.bar.o
+RUN: %clang %clangopts -c %p/Inputs/baz.c -o %t.baz.o
+RUN: %clang %clangopts -c %p/Inputs/main_multi.c -o %t.main_multi.o
+RUN: %clang %clangopts -c %p/Inputs/main_foo_only.c -o %t.main_foo_only.o
+RUN: %clang %clangopts -c %p/Inputs/foo_calls_bar.c -o %t.fcb.o
+RUN: %clang %clangopts -c %p/Inputs/bar_calls_baz.c -o %t.bcb.o
+RUN: %clang %clangopts -c %p/Inputs/baz_impl.c -o %t.baz_impl.o
+RUN: %clang %clangopts -c %p/Inputs/main_group.c -o %t.main_group.o
+RUN: %ar cr %aropts %t.libbar.a %t.bcb.o
+RUN: %clang %clangopts -c %p/Inputs/foo_sel.c -o %t.foo_sel.o -ffunction-sections
+RUN: %clang %clangopts -c %p/Inputs/bar_sel.c -o %t.bar_sel.o -ffunction-sections
+RUN: %clang %clangopts -c %p/Inputs/main_script.c -o %t.main_script.o -ffunction-sections
+
+RUN: %not %link -o %t.mismatch.out %linkopts --start-lib %t.foo.o 2>&1 | %filecheck %s -check-prefix=MISMATCH
+RUN: %not %link -o %t.nested.out %linkopts --start-lib --start-lib %t.foo.o --end-lib --end-lib %t.main.o 2>&1 | %filecheck %s -check-prefix=NEST
+
+RUN: %link -o %t.ok.out %linkopts %t.main.o --start-lib %t.foo.o --end-lib
+RUN: %nm %t.ok.out | %filecheck %s -check-prefix=SYM
+
+RUN: %link -o %t.multi.out %linkopts %t.main_multi.o --start-lib %t.foo.o %t.bar.o %t.baz.o --end-lib
+RUN: %nm %t.multi.out | %filecheck %s -check-prefix=MULTI-SYM -implicit-check-not=baz
+
+RUN: %link -o %t.whole.out %linkopts %t.main_foo_only.o --whole-archive --start-lib %t.foo.o %t.bar.o %t.baz.o --end-lib --no-whole-archive
+RUN: %nm %t.whole.out | %filecheck %s -check-prefix=WHOLE-SYM
+
+RUN: %link -o %t.script.out %linkopts %t.main_script.o --start-lib %t.foo_sel.o %t.bar_sel.o --end-lib -T %p/Inputs/startlib_archive_pattern.t -MapStyle txt -Map %t.script.map.txt
+RUN: %filecheck %s -check-prefix=SCRIPT-MAP < %t.script.map.txt
+
+RUN: %link -o %t.group.out %linkopts %t.main_group.o --start-group --start-lib %t.fcb.o %t.baz_impl.o --end-lib %t.libbar.a --end-group
+RUN: %nm %t.group.out | %filecheck %s -check-prefix=GROUPSYM
+
+#MISMATCH: Mismatched --start-lib/--end-lib
+#NEST: Nested --start-lib/--end-lib not allowed
+#SYM: foo
+#MULTI-SYM-DAG: foo
+#MULTI-SYM-DAG: bar
+#WHOLE-SYM-DAG: foo
+#WHOLE-SYM-DAG: bar
+#WHOLE-SYM-DAG: baz
+#SCRIPT-MAP: .foo_out
+#SCRIPT-MAP: "*<start-lib:1>:*foo_sel.o"
+#SCRIPT-MAP: .bar_out
+#SCRIPT-MAP: "*<start-lib:1>:*bar_sel.o"
+#GROUPSYM-DAG: foo_calls_bar
+#GROUPSYM-DAG: bar_calls_baz
+#GROUPSYM-DAG: baz_impl
+#END_TEST

--- a/test/Common/standalone/CommandLine/StartLibEndLib/StartLibEndLibThin.test
+++ b/test/Common/standalone/CommandLine/StartLibEndLib/StartLibEndLibThin.test
@@ -1,0 +1,34 @@
+#---StartLibEndLibThin.test----------------------- Executable --------------------#
+#BEGIN_COMMENT
+# This checks --start-lib-thin/--end-lib-thin functionality.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/foo.c -o %t.foo.o
+RUN: %clang %clangopts -c %p/Inputs/bar.c -o %t.bar.o
+RUN: %clang %clangopts -c %p/Inputs/baz.c -o %t.baz.o
+RUN: %clang %clangopts -c %p/Inputs/main_multi.c -o %t.main_multi.o
+
+RUN: %link -o %t.multi.out %linkopts %t.main_multi.o --start-lib-thin %t.foo.o %t.bar.o %t.baz.o --end-lib-thin
+RUN: %nm %t.multi.out | %filecheck %s -check-prefix=MULTI-SYM-THIN -implicit-check-not=baz
+
+RUN: %clang %clangopts -c %p/Inputs/main_foo_only.c -o %t.main_foo_only.o
+RUN: %link -o %t.whole.out %linkopts %t.main_foo_only.o --whole-archive --start-lib-thin %t.foo.o %t.bar.o %t.baz.o --end-lib-thin --no-whole-archive
+RUN: %nm %t.whole.out | %filecheck %s -check-prefix=WHOLE-SYM-THIN
+
+RUN: %clang %clangopts -c %p/Inputs/foo_sel.c -o %t.foo_sel.o -ffunction-sections
+RUN: %clang %clangopts -c %p/Inputs/bar_sel.c -o %t.bar_sel.o -ffunction-sections
+RUN: %clang %clangopts -c %p/Inputs/main_script.c -o %t.main_script.o -ffunction-sections
+RUN: %link -o %t.script.out %linkopts %t.main_script.o --start-lib-thin %t.foo_sel.o %t.bar_sel.o --end-lib-thin -T %p/Inputs/startlib_thin_archive_pattern.t -MapStyle txt -Map %t.script.map.txt
+RUN: %filecheck %s -check-prefix=SCRIPT-MAP-THIN < %t.script.map.txt
+
+#MULTI-SYM-THIN-DAG: foo
+#MULTI-SYM-THIN-DAG: bar
+#WHOLE-SYM-THIN-DAG: foo
+#WHOLE-SYM-THIN-DAG: bar
+#WHOLE-SYM-THIN-DAG: baz
+#SCRIPT-MAP-THIN: .foo_out
+#SCRIPT-MAP-THIN: "*<start-lib-thin:1>:*foo_sel.o"
+#SCRIPT-MAP-THIN: .bar_out
+#SCRIPT-MAP-THIN: "*<start-lib-thin:1>:*bar_sel.o"
+#END_TEST
+


### PR DESCRIPTION
--start-lib and --end-lib let you pass one or more object files and have ELD treat them as if they were members of an archive for symbol resolution purposes.

Conceptually, ELD packages the object files between --start-lib and --end-lib into an in-memory archive and then processes that archive like a normal .a input.

ELD also supports --start-lib-thin / --end-lib-thin, which packages the enclosed object files into an in-memory *thin* archive (member paths are stored instead of embedding member bytes).