### PR TITLE
Revert "Fix LTOTempObjNotWritable test for Windows compatibility"

### DIFF
--- a/test/Common/LTO/LTOTempObjNotWritable/LTOTempObjNotWritable.test
+++ b/test/Common/LTO/LTOTempObjNotWritable/LTOTempObjNotWritable.test
@@ -11,11 +11,15 @@ RUN: mkdir -p %t1.out.llvm-lto.1.o
 RUN: mkdir -p %t2.out.llvm-lto.0.o
 RUN: mkdir -p %t2.out.llvm-lto.1.o
 
+### TODO: remove ( .. || true) around linker invocation when it no longer
+### aborts on these errors. There is no consistent way to handle the crash
+### because it crashes only in some code paths when doing LTO.
+
 RUN: %clang %clangopts -c %p/Inputs/1.c -O2 -ffunction-sections -flto -o %t1.o
-RUN: %not --crash %link %linkopts --save-temps %t1.o -o %t1.out 2>&1 | %filecheck %s
+RUN: (%not %link %linkopts --save-temps %t1.o -o %t1.out 2>&1 || true) | %filecheck %s
 
 RUN: %clang %clangopts -c %p/Inputs/1.c -O2 -ffunction-sections -flto=thin -o %t2.o
-RUN: %not --crash %link %linkopts --save-temps %t2.o -o %t2.out 2>&1 | %filecheck %s
+RUN: (%not %link %linkopts --save-temps %t2.o -o %t2.out 2>&1 || true) | %filecheck %s
 
 CHECK: cannot compile code generator object
 CHECK: .out.llvm-lto.{{[0-9]+}}.o: {{Is a directory|is a directory}}


### PR DESCRIPTION
Causes test failures in CPULLVM github workflows.