### PR TITLE
[LinkerScript] Add support for INSERT AFTER/BEFORE

### DIFF
--- a/docs/userguide/documentation/linker_map_files.rst
+++ b/docs/userguide/documentation/linker_map_files.rst
@@ -230,10 +230,15 @@ consists of.
 .. code-block:: bash
 
    <OutputSectionName> <size> <VMA> # Offset: <offset>, LMA: <LMA>, Alignment: <alignment>, Flags: <SectionFlags>, Type: <SectionType>, Segments: <segments>
+   # INSERT AFTER|BEFORE <anchor-section> # <script:line>
    <Rule_1>
    <Rule_2>
    ...
    <Rule_N>
+
+The INSERT line is present only when the output section was positioned using
+``INSERT AFTER`` or ``INSERT BEFORE`` in a linker script. The trailing script
+context shows the originating linker script location.
 
 <OutputSection> tells output section properties and contains a list
 of :code:`Rule`s. Placement of rules conveys the placement of the rule contents
@@ -483,13 +488,3 @@ Link map in YAML format
      +------------------------+-----------------------------------------------------+
      | CrossReferences        | Cross-reference table for the program               |
      +------------------------+-----------------------------------------------------+
-
-Link map in Binary format
-----------------------------
-    * If you use the :option:`-MapStyle` option to specify "binary" output for the map file, the
-    linker generates a binary file instead of the text file that contains the memory map.
-
-    * "-MapStyle binary" can be used along with other map styles as well.
-
-    * E.g. "-MapStyle txt -MapStyle binary -Map outputfile.map" will produce a text format map
-    file "outputfile.map" and a binary format "xmap.bin" file.

--- a/docs/userguide/documentation/linker_script.rst
+++ b/docs/userguide/documentation/linker_script.rst
@@ -747,7 +747,7 @@ A ``SECTIONS`` command can contain one or more output section descriptions.
        ...
        <output-section-command> <output-section-command>
     }[><region>][AT><lma_region>][:<phdr>...][
-    =<fillexp>]
+    =<fillexp>][INSERT AFTER <section-name> | INSERT BEFORE <section-name>]
 
 Syntax
 ------
@@ -792,6 +792,12 @@ Syntax
 
 <phdr>
     Specifies a program segment for the output section (optional). To assign multiple program segments to an output section, this option can appear more than once in an output section description.
+
+INSERT AFTER <section-name> | INSERT BEFORE <section-name>
+    Requests placing this output section after/before the named output section.
+    The anchor section must exist, or the linker emits an error. Overlay member
+    sections do not support output section epilogues, so INSERT is not allowed
+    inside OVERLAY member blocks.
 
 .. note::
 

--- a/include/eld/Diagnostics/DiagLDScript.inc
+++ b/include/eld/Diagnostics/DiagLDScript.inc
@@ -120,6 +120,8 @@ DIAG(error_dot_lhs_in_non_alloc, DiagnosticEngine::Error,
      "dot expression evaluation in %0 with permissions %1 is not supported")
 DIAG(error_cannot_specify_lma_and_memory_region, DiagnosticEngine::Error,
      "cannot specify AT and LMA memory region for output section : %0 defined in script %1")
+DIAG(error_insert_output_section, DiagnosticEngine::Error,
+     "Cannot INSERT output section %0 %1 %2 in script %3")
 DIAG(warn_non_power_of_2_value_to_align_builtin, DiagnosticEngine::Warning,
      "%0: non-power-of-2 value 0x%1 passed to ALIGN builtin function")
 DIAG(error_non_power_of_2_value_to_align_output_section, DiagnosticEngine::Error,

--- a/include/eld/LayoutMap/TextLayoutPrinter.h
+++ b/include/eld/LayoutMap/TextLayoutPrinter.h
@@ -142,6 +142,8 @@ public:
   void printMemoryRegions(GNULDBackend const &Backend,
                           const OutputSectionEntry *OS);
 
+  void printInsertPlacement(const OutputSectionEntry *OS) const;
+
   void printMergeString(MergeableString *S, Module &M) const;
 
   void printIsFileHeaderLoadedInfo(bool IsLoaded, bool UseColor);

--- a/include/eld/Object/ObjectLinker.h
+++ b/include/eld/Object/ObjectLinker.h
@@ -455,6 +455,7 @@ private:
   void fixMergeStringRelocations() const;
 
   void reportPendingPluginRuleInsertions() const;
+  void reportPendingScriptSectionInsertions() const;
 
   /// Finalizes the output section flags.
   ///

--- a/include/eld/Object/OutputSectionEntry.h
+++ b/include/eld/Object/OutputSectionEntry.h
@@ -164,6 +164,8 @@ public:
 
   void setOverlayDesc(OverlayDesc *O) { ThisOverlayDesc = O; }
 
+  const OutputSectDesc *getOutputSectDesc() const { return OutputSectionDesc; }
+
   // ----------------------Reuse trampolines optimization---------------
   std::vector<BranchIsland *>
   getBranchIslandsForSymbol(ResolveInfo *PSym) const {

--- a/include/eld/Object/SectionMap.h
+++ b/include/eld/Object/SectionMap.h
@@ -152,6 +152,9 @@ public:
   /// if any; Otherwise returns nullptr.
   OutputSectionEntry *findOutputSectionEntry(const std::string &Name);
 
+  bool moveOutputSection(OutputSectionEntry *Section,
+                         llvm::StringRef AnchorName, bool InsertAfter);
+
   bool doesRuleMatchWithSection(const RuleContainer &R, const Section &S,
                                 bool DoNotUseRmName) const;
 

--- a/include/eld/Script/OutputSectDesc.h
+++ b/include/eld/Script/OutputSectDesc.h
@@ -176,6 +176,8 @@ public:
   };
 
   struct Epilog {
+    enum class InsertPlacement { None, Before, After };
+
     bool hasRegion() const { return OutputSectionMemoryRegion != nullptr; }
     const eld::ScriptMemoryRegion &region() const {
       assert(hasRegion());
@@ -231,6 +233,19 @@ public:
 
     Expression *fillExp() const { return FillExpression; }
 
+    bool hasInsert() const {
+      return InsertPosition != InsertPlacement::None && InsertTarget != nullptr;
+    }
+
+    InsertPlacement insertPlacement() const { return InsertPosition; }
+
+    const StrToken *insertTarget() const { return InsertTarget; }
+
+    void setInsert(InsertPlacement Placement, const StrToken *Target) {
+      InsertPosition = Placement;
+      InsertTarget = Target;
+    }
+
     // FIXME : remove this if not needed
     bool operator==(const Epilog &RHS) const {
       /* FIXME: currently I don't check the real content */
@@ -243,6 +258,10 @@ public:
       if (ScriptPhdrs != RHS.ScriptPhdrs)
         return false;
       if (FillExpression != RHS.FillExpression)
+        return false;
+      if (InsertPosition != RHS.InsertPosition)
+        return false;
+      if (InsertTarget != RHS.InsertTarget)
         return false;
       return true;
     }
@@ -263,6 +282,8 @@ public:
     ScriptMemoryRegion *ScriptLMAMemoryRegion = nullptr;
     mutable StringList *ScriptPhdrs = nullptr;
     Expression *FillExpression = nullptr;
+    InsertPlacement InsertPosition = InsertPlacement::None;
+    const StrToken *InsertTarget = nullptr;
   };
 
   typedef std::vector<ScriptCommand *> OutputSectCmds;

--- a/include/eld/ScriptParser/ScriptLexer.h
+++ b/include/eld/ScriptParser/ScriptLexer.h
@@ -163,6 +163,7 @@ protected:
   // the expression parsing behavior to not split '/DISCARD/' into multiple
   // tokens when expression parsing is happening in output section epilogue.
   bool MInOutputSectEpilogue = false;
+  bool MInOverlayMemberEpilogue = false;
 
   // The current buffer and parent buffers due to INCLUDE.
   Buffer CurBuf;

--- a/lib/LayoutMap/TextLayoutPrinter.cpp
+++ b/lib/LayoutMap/TextLayoutPrinter.cpp
@@ -116,6 +116,8 @@ void TextLayoutPrinter::printOnlyLayoutSection(GNULDBackend const &Backend,
   if (UseColor)
     outputStream().resetColor();
 
+  printInsertPlacement(OS);
+
   auto Info = ThisLayoutInfo->getPluginInfo().find(Section);
   if (Info == ThisLayoutInfo->getPluginInfo().end())
     return;
@@ -239,6 +241,23 @@ void TextLayoutPrinter::printMemoryRegions(GNULDBackend const &Backend,
   outputStream() << "]";
 }
 
+void TextLayoutPrinter::printInsertPlacement(
+    const OutputSectionEntry *OS) const {
+  const auto &Epilog = OS->epilog();
+  if (!Epilog.hasInsert())
+    return;
+  outputStream() << "# INSERT "
+                 << (Epilog.insertPlacement() ==
+                             OutputSectDesc::Epilog::InsertPlacement::After
+                         ? "AFTER "
+                         : "BEFORE ")
+                 << Epilog.insertTarget()->name();
+  const auto *Desc = OS->getOutputSectDesc();
+  if (Desc && Desc->hasInputFileInContext())
+    outputStream() << " # " << Desc->getContext();
+  outputStream() << "\n";
+}
+
 // Print section information like name, address, offset, size, alignment,
 // etc. based on the section type.
 void TextLayoutPrinter::printSection(GNULDBackend const &Backend,
@@ -293,6 +312,8 @@ void TextLayoutPrinter::printSection(GNULDBackend const &Backend,
 
   if (UseColor)
     outputStream().resetColor();
+
+  printInsertPlacement(OS);
 
   if (OS->getTotalTrampolineCount()) {
     outputStream() << "# NumTrampolines: " << OS->getTotalTrampolineCount();

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -1308,6 +1308,7 @@ bool ObjectLinker::mergeSections() {
   }
 
   reportPendingPluginRuleInsertions();
+  reportPendingScriptSectionInsertions();
 
   {
     eld::RegisterTimer T("Create Output Section", "Merge Sections",
@@ -4066,6 +4067,25 @@ void ObjectLinker::reportPendingPluginRuleInsertions() const {
       ThisConfig.raise(Diag::warn_pending_rule_insertion)
           << Ss.str() << LW->getPlugin()->getPluginName()
           << R->desc()->getOutputDesc().name();
+    }
+  }
+}
+
+void ObjectLinker::reportPendingScriptSectionInsertions() const {
+  const LinkerScript &Script = ThisModule->getLinkerScript();
+  const auto &PendingInsertions = Script.getPendingOutputSectionInsertions();
+  for (const auto &Insertion : PendingInsertions) {
+    if (Insertion.Context) {
+      ThisConfig.raise(Diag::error_insert_output_section)
+          << Insertion.SectionName
+          << (Insertion.InsertAfter ? "AFTER" : "BEFORE")
+          << Insertion.AnchorName << Insertion.Context;
+    } else {
+      std::string ContextString = "<unknown>";
+      ThisConfig.raise(Diag::error_insert_output_section)
+          << Insertion.SectionName
+          << (Insertion.InsertAfter ? "AFTER" : "BEFORE")
+          << Insertion.AnchorName << ContextString;
     }
   }
 }

--- a/test/Common/standalone/linkerscript/InsertAfterBefore/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/InsertAfterBefore/Inputs/1.c
@@ -1,0 +1,21 @@
+__attribute__((section(".text.anchor"), noinline, used)) int anchor_fn(void) {
+  return 1;
+}
+
+__attribute__((section(".text.before"), noinline, used)) int before_fn(void) {
+  return 2;
+}
+
+__attribute__((section(".text.after1"), noinline, used)) int after1_fn(void) {
+  return 3;
+}
+
+__attribute__((section(".text.after2"), noinline, used)) int after2_fn(void) {
+  return 4;
+}
+
+int data_value = 5;
+
+__attribute__((section(".text.anchor"), noinline, used)) int main(void) {
+  return anchor_fn() + before_fn() + after1_fn() + after2_fn() + data_value;
+}

--- a/test/Common/standalone/linkerscript/InsertAfterBefore/Inputs/2.c
+++ b/test/Common/standalone/linkerscript/InsertAfterBefore/Inputs/2.c
@@ -1,0 +1,30 @@
+__attribute__((section(".text.anchor"), noinline, used)) int anchor_fn(void) {
+  return 1;
+}
+
+__attribute__((section(".text.beforeA"), noinline, used)) int beforeA_fn(void) {
+  return 2;
+}
+
+__attribute__((section(".text.beforeB"), noinline, used)) int beforeB_fn(void) {
+  return 3;
+}
+
+__attribute__((section(".text.afterA"), noinline, used)) int afterA_fn(void) {
+  return 4;
+}
+
+__attribute__((section(".text.afterB"), noinline, used)) int afterB_fn(void) {
+  return 5;
+}
+
+__attribute__((section(".text.afterC"), noinline, used)) int afterC_fn(void) {
+  return 6;
+}
+
+int data_value = 7;
+
+__attribute__((section(".text.anchor"), noinline, used)) int main(void) {
+  return anchor_fn() + beforeA_fn() + beforeB_fn() + afterA_fn() + afterB_fn() +
+         afterC_fn() + data_value;
+}

--- a/test/Common/standalone/linkerscript/InsertAfterBefore/Inputs/3.c
+++ b/test/Common/standalone/linkerscript/InsertAfterBefore/Inputs/3.c
@@ -1,0 +1,19 @@
+__attribute__((section(".text.anchor"), noinline, used)) int anchor_fn(void) {
+  return 1;
+}
+
+__attribute__((section(".text.before"), noinline, used)) int before_fn(void) {
+  return 2;
+}
+
+__attribute__((section(".text.after1"), noinline, used)) int after1_fn(void) {
+  return 3;
+}
+
+__attribute__((section(".text.after2"), noinline, used)) int after2_fn(void) {
+  return 4;
+}
+
+__attribute__((section(".text.anchor"), noinline, used)) int main(void) {
+  return anchor_fn() + before_fn() + after1_fn() + after2_fn();
+}

--- a/test/Common/standalone/linkerscript/InsertAfterBefore/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/InsertAfterBefore/Inputs/script.t
@@ -1,0 +1,7 @@
+SECTIONS {
+  .text.after1 : { *(.text.after1) } INSERT AFTER .text.anchor
+  .text.before : { *(.text.before) } INSERT BEFORE .text.anchor
+  .text.anchor : { *(.text.anchor) }
+  .text.after2 : { *(.text.after2) } INSERT AFTER .text.anchor
+  .data : { *(.data) }
+}

--- a/test/Common/standalone/linkerscript/InsertAfterBefore/Inputs/script_include_after.t
+++ b/test/Common/standalone/linkerscript/InsertAfterBefore/Inputs/script_include_after.t
@@ -1,0 +1,2 @@
+.text.after1 : { *(.text.after1) } INSERT AFTER .text.anchor
+INCLUDE "script_include_after_extra.t"

--- a/test/Common/standalone/linkerscript/InsertAfterBefore/Inputs/script_include_after_extra.t
+++ b/test/Common/standalone/linkerscript/InsertAfterBefore/Inputs/script_include_after_extra.t
@@ -1,0 +1,1 @@
+.text.after2 : { *(.text.after2) } INSERT AFTER .text.anchor

--- a/test/Common/standalone/linkerscript/InsertAfterBefore/Inputs/script_include_before.t
+++ b/test/Common/standalone/linkerscript/InsertAfterBefore/Inputs/script_include_before.t
@@ -1,0 +1,1 @@
+.text.before : { *(.text.before) } INSERT BEFORE .text.anchor

--- a/test/Common/standalone/linkerscript/InsertAfterBefore/Inputs/script_include_main.t
+++ b/test/Common/standalone/linkerscript/InsertAfterBefore/Inputs/script_include_main.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  INCLUDE "script_include_before.t"
+  .text.anchor : { *(.text.anchor) }
+  INCLUDE "script_include_after.t"
+  .data : { *(.data) }
+}

--- a/test/Common/standalone/linkerscript/InsertAfterBefore/Inputs/script_missing.t
+++ b/test/Common/standalone/linkerscript/InsertAfterBefore/Inputs/script_missing.t
@@ -1,0 +1,4 @@
+SECTIONS {
+  .text.after1 : { *(.text.after1) } INSERT AFTER .missing
+  .text.anchor : { *(.text.anchor) }
+}

--- a/test/Common/standalone/linkerscript/InsertAfterBefore/Inputs/script_multi_after.t
+++ b/test/Common/standalone/linkerscript/InsertAfterBefore/Inputs/script_multi_after.t
@@ -1,0 +1,7 @@
+SECTIONS {
+  .text.afterA : { *(.text.afterA) } INSERT AFTER .text.anchor
+  .text.afterB : { *(.text.afterB) } INSERT AFTER .text.anchor
+  .text.afterC : { *(.text.afterC) } INSERT AFTER .text.anchor
+  .text.anchor : { *(.text.anchor) }
+  .data : { *(.data) }
+}

--- a/test/Common/standalone/linkerscript/InsertAfterBefore/Inputs/script_multi_before.t
+++ b/test/Common/standalone/linkerscript/InsertAfterBefore/Inputs/script_multi_before.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  .text.beforeA : { *(.text.beforeA) } INSERT BEFORE .text.anchor
+  .text.beforeB : { *(.text.beforeB) } INSERT BEFORE .text.anchor
+  .text.anchor : { *(.text.anchor) }
+  .data : { *(.data) }
+}

--- a/test/Common/standalone/linkerscript/InsertAfterBefore/InsertAfterBefore.test
+++ b/test/Common/standalone/linkerscript/InsertAfterBefore/InsertAfterBefore.test
@@ -1,0 +1,14 @@
+# Verify INSERT AFTER/BEFORE output section ordering.
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o %clangg0opts
+RUN: %link %linkopts %t1.o -o %t2.out -T %p/Inputs/script.t
+RUN: %readelf -S -W %t2.out | %filecheck %s --check-prefix=ORDER
+
+# ORDER: .text.before
+# ORDER: .text.anchor
+# ORDER: .text.after1
+# ORDER: .text.after2
+# ORDER: .data
+
+# Verify INSERT fails for a missing anchor.
+RUN: %not %link %linkopts %t1.o -o %t2.bad.out -T %p/Inputs/script_missing.t 2>&1 | %filecheck %s --check-prefix=BAD
+# BAD: Cannot INSERT output section .text.after1 AFTER .missing

--- a/test/Common/standalone/linkerscript/InsertAfterBefore/InsertAfterBeforeInclude.test
+++ b/test/Common/standalone/linkerscript/InsertAfterBefore/InsertAfterBeforeInclude.test
@@ -1,0 +1,9 @@
+# INSERT ordering when output sections come from included scripts.
+RUN: %clang %clangopts -c %p/Inputs/3.c -o %t1.o %clangg0opts
+RUN: %link %linkopts %t1.o -L %p/Inputs/ -o %t2.out -T %p/Inputs/script_include_main.t
+RUN: %readelf -S -W %t2.out | %filecheck %s --check-prefix=INCLUDE
+
+# INCLUDE: .text.before
+# INCLUDE: .text.anchor
+# INCLUDE: .text.after1
+# INCLUDE: .text.after2

--- a/test/Common/standalone/linkerscript/InsertAfterBefore/InsertAfterBeforeMap.test
+++ b/test/Common/standalone/linkerscript/InsertAfterBefore/InsertAfterBeforeMap.test
@@ -1,0 +1,11 @@
+# Verify INSERT AFTER/BEFORE annotations in the text map file.
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o %clangg0opts
+RUN: %link -MapStyle txt %linkopts %t1.o -o %t2.out -T %p/Inputs/script.t -Map %t2.map
+RUN: %filecheck %s < %t2.map
+
+# CHECK: .text.before
+# CHECK: # INSERT BEFORE .text.anchor # {{.*}}script.t
+# CHECK: .text.after1
+# CHECK: # INSERT AFTER .text.anchor # {{.*}}script.t
+# CHECK: .text.after2
+# CHECK: # INSERT AFTER .text.anchor # {{.*}}script.t

--- a/test/Common/standalone/linkerscript/InsertAfterBefore/InsertAfterBeforeMore.test
+++ b/test/Common/standalone/linkerscript/InsertAfterBefore/InsertAfterBeforeMore.test
@@ -1,0 +1,15 @@
+# Extra coverage for INSERT AFTER/BEFORE ordering.
+RUN: %clang %clangopts -c %p/Inputs/2.c -o %t1.o %clangg0opts
+RUN: %link %linkopts %t1.o -o %t2.out -T %p/Inputs/script_multi_after.t
+RUN: %readelf -S -W %t2.out | %filecheck %s --check-prefix=MULTI_AFTER
+RUN: %link %linkopts %t1.o -o %t3.out -T %p/Inputs/script_multi_before.t
+RUN: %readelf -S -W %t3.out | %filecheck %s --check-prefix=MULTI_BEFORE
+
+# MULTI_AFTER: .text.anchor
+# MULTI_AFTER: .text.afterA
+# MULTI_AFTER: .text.afterB
+# MULTI_AFTER: .text.afterC
+
+# MULTI_BEFORE: .text.beforeA
+# MULTI_BEFORE: .text.beforeB
+# MULTI_BEFORE: .text.anchor

--- a/test/Common/standalone/linkerscript/OverlayInsertAfterWarn/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/OverlayInsertAfterWarn/Inputs/1.c
@@ -1,0 +1,2 @@
+__attribute__((section(".text.anchor"))) int anchor(void) { return 0; }
+__attribute__((section(".text.ovl1"))) int overlay_func(void) { return 1; }

--- a/test/Common/standalone/linkerscript/OverlayInsertAfterWarn/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/OverlayInsertAfterWarn/Inputs/script.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  .text.anchor : { *(.text.anchor) }
+  OVERLAY 0x1000 : {
+    .ovl1 { *(.text.ovl1) } INSERT AFTER .text.anchor
+  }
+}

--- a/test/Common/standalone/linkerscript/OverlayInsertAfterWarn/OverlayInsertAfterWarn.test
+++ b/test/Common/standalone/linkerscript/OverlayInsertAfterWarn/OverlayInsertAfterWarn.test
@@ -1,0 +1,10 @@
+#---OverlayInsertAfterWarn.test----------------- Executable,LS----------------#
+#BEGIN_COMMENT
+# Verify that INSERT AFTER inside OVERLAY members emits a warning.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.o -c %p/Inputs/1.c
+RUN: %link %linkopts -Wlinker-script -o %t1.out %t1.o -T %p/Inputs/script.t 2>&1 | %filecheck %s
+
+CHECK: Warning: {{.*}}Inputs/script.t:{{[0-9]+}}: INSERT is not supported inside OVERLAY member blocks
+#END_TEST


### PR DESCRIPTION
INSERT AFTER <section-name> | INSERT BEFORE <section-name>

Requests placing this output section after/before the named output section. The anchor section must exist, or the linker emits an error. Overlay member sections do not support output section epilogues, so INSERT is not allowed inside OVERLAY member blocks.