### PR TITLE
[X86] Enable Common/LTO tests

### DIFF
--- a/test/Common/LTO/AutoPreserveList/autopreservelist.test
+++ b/test/Common/LTO/AutoPreserveList/autopreservelist.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 # Tests symbols resolved as a result of LTO and what symbols get preserved
 UNSUPPORTED: windows
 RUN: %clang %clangopts -c -flto %p/Inputs/main.c -o %t1.o

--- a/test/Common/LTO/ComOverrideSymIdx/ComOverrideSymIdx.test
+++ b/test/Common/LTO/ComOverrideSymIdx/ComOverrideSymIdx.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 # Check if LTO works for no groups and only archives and bitcodes
 UNSUPPORTED: windows
 RUN: %clang %clangopts %clangg0opts -c -fdata-sections %p/Inputs/1.c -o %t1.o

--- a/test/Common/LTO/CommonSymbols/commonsyms.test
+++ b/test/Common/LTO/CommonSymbols/commonsyms.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 # Tests that common symbols are preserved.
 RUN: %clang %clangopts -c -flto %p/Inputs/1.c -o %t1.o
 RUN: %clang %clangopts -c %p/Inputs/2.c -o %t2.o

--- a/test/Common/LTO/DontPreserveWeakSymbols/dontpreserveweaksymbols.test
+++ b/test/Common/LTO/DontPreserveWeakSymbols/dontpreserveweaksymbols.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 # This tests that linker doesnot preserve weak symbols.
 RUN: %clang %clangopts -c -flto %p/Inputs/t.c -o %t1.weakfoo.o
 RUN: %clang %clangopts -c %p/Inputs/f.c -o %t1.fooundef.o

--- a/test/Common/LTO/ExcludeListAndLTOListEmbeddedBitCode/ExcludeListAndLTOListEmbeddedBitCode.test
+++ b/test/Common/LTO/ExcludeListAndLTOListEmbeddedBitCode/ExcludeListAndLTOListEmbeddedBitCode.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 UNSUPPORTED: aarch64
 #---ExcludeListAndLTOListEmbeddedBitCode.test------------- Executable,LTO -----------------#
 

--- a/test/Common/LTO/GetSetSectionName/GetSetSectionName.test
+++ b/test/Common/LTO/GetSetSectionName/GetSetSectionName.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 
 # Check if LTO works for no groups and only archives and bitcodes
 RUN: %clang %clangopts -c  %p/Inputs/a.c -flto -o %t1

--- a/test/Common/LTO/LTOAsmOpts/ltoasmopts.test
+++ b/test/Common/LTO/LTOAsmOpts/ltoasmopts.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 # Check that LTO passes on assembler options
 RUN: %clang %clangopts -c   %p/Inputs/main.c -o %t1.main.o %clangg0opts
 RUN: %clang %clangopts -c  -flto %p/Inputs/foo.c -o %t1.foo.o %clangg0opts

--- a/test/Common/LTO/LTOChangeScopeFunctions/ltochangescopefunctions.test
+++ b/test/Common/LTO/LTOChangeScopeFunctions/ltochangescopefunctions.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 # Check that the linker handles the case when functions are converted to local.
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o  -flto
 RUN: %clang %clangopts -c %p/Inputs/2.c -o %t1.2.o  -flto

--- a/test/Common/LTO/LTOCommonDefine/ltocommondefine.test
+++ b/test/Common/LTO/LTOCommonDefine/ltocommondefine.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 # There is a need to preserve the common symbol if an ELF file overrides the
 # symbol, which otherwise will change the symbol to local scope having two
 # definitions of the symbol, which needs to be avoided in all cases.

--- a/test/Common/LTO/LTOCommonSymbols/ltocommonsymbols.test
+++ b/test/Common/LTO/LTOCommonSymbols/ltocommonsymbols.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 UNSUPPORTED: riscv32, riscv64
 # Checks that commons are selected from the right files even after LTO.
 RUN: %clang %clangopts -c -flto -ffunction-sections -fdata-sections %p/Inputs/1.c -o %t1.1.o

--- a/test/Common/LTO/LTOCommonSymbolsPreserve/LTOCommonSymbolsPreserve.test
+++ b/test/Common/LTO/LTOCommonSymbolsPreserve/LTOCommonSymbolsPreserve.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 #---LTOCommonSymbolsPreserve.test----------------- Executable,LTO ------------------#
 #BEGIN_COMMENT
 #Linker asserts because a symbol preserved is not bitcode. This is because when

--- a/test/Common/LTO/LTOCommonsLinkerScript/LTOCommonsLinkerScript.test
+++ b/test/Common/LTO/LTOCommonsLinkerScript/LTOCommonsLinkerScript.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 #---LTOCommonsLinkerScript.test--------------------- Executable,LTO,LS ------------------#
 #BEGIN_COMMENT
 # This tests that commons that have been specified by linker script rules are

--- a/test/Common/LTO/LTODontPreserveUndef/ltodontpreserve.test
+++ b/test/Common/LTO/LTODontPreserveUndef/ltodontpreserve.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 # Tests that the linker should not be preserving a undefined symbol.
 RUN: %clang %clangopts -c %p/Inputs/1.c -flto -o %t1.1.o
 RUN: %clang %clangopts -c %p/Inputs/2.c -o %t1.2.o

--- a/test/Common/LTO/LTOGroups/ltogroups.test
+++ b/test/Common/LTO/LTOGroups/ltogroups.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 
 # Check if LTO works for no groups and only archives and bitcodes
 RUN: %clang %clangopts -c  %p/Inputs/a.c -flto -o %t1

--- a/test/Common/LTO/LTOGroupsBitCode/ltogroupbitcode.test
+++ b/test/Common/LTO/LTOGroupsBitCode/ltogroupbitcode.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 # This test, checks that LTO is able to handle a .o within a group.
 RUN: %clang %clangopts -c -flto %p/Inputs/a.c -o %t1.a.o
 RUN: %clang %clangopts -c -flto %p/Inputs/b1.c -o %t1.b1.o

--- a/test/Common/LTO/LTOGroupsNoMerge/ltogroupsnomerge.test
+++ b/test/Common/LTO/LTOGroupsNoMerge/ltogroupsnomerge.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 
 # This test, checks that LTO is able to handle a .o within a group.
 RUN: %clang %clangopts -c -flto %p/Inputs/a.c -o %t1.a.o

--- a/test/Common/LTO/LTOGroupsObj/ltogroupobj.test
+++ b/test/Common/LTO/LTOGroupsObj/ltogroupobj.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 
 # This test, checks that LTO is able to handle a .o within a group.
 RUN: %clang %clangopts -c -flto %p/Inputs/a.c -o %t1.a.o

--- a/test/Common/LTO/LTOGroupsWithPreserve/ltogroupswithpreserve.test
+++ b/test/Common/LTO/LTOGroupsWithPreserve/ltogroupswithpreserve.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 
 # This test, checks that LTO is able to handle a .o within a group and create a
 # proper preserve list

--- a/test/Common/LTO/LTOInternalizeCommonsNoLS/LTOInternalizeCommonsNoLS.test
+++ b/test/Common/LTO/LTOInternalizeCommonsNoLS/LTOInternalizeCommonsNoLS.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 #---LTOInternalizeCommonsNoLS.test------------------ Executable,LTO ---------------------#
 #BEGIN_COMMENT
 # This tests that LTO will internalize commons if there is no linker script. Other

--- a/test/Common/LTO/LTONoGroupArchives/ltonogrouparchives.test
+++ b/test/Common/LTO/LTONoGroupArchives/ltonogrouparchives.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 
 # Check if LTO works for no groups and only archives and bitcodes
 RUN: %clang %clangopts -c  %p/Inputs/a.c -flto -o %t1

--- a/test/Common/LTO/LTONoGroupObjs/ltonogroupobjs.test
+++ b/test/Common/LTO/LTONoGroupObjs/ltonogroupobjs.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 # Check if LTO works for no groups and only object files and bitcode
 RUN: %clang %clangopts -c  %p/Inputs/a.c -flto -o %t1
 RUN: %clang %clangopts -c  %p/Inputs/b1.c -o %t2

--- a/test/Common/LTO/LTOPreserveCommonSymbolReference/LTOPreserveCommonSymbolReference.test
+++ b/test/Common/LTO/LTOPreserveCommonSymbolReference/LTOPreserveCommonSymbolReference.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 #---LTOPreserveCommonSymbolReference.test---------------------- Executable,LTO  --------------#
 #BEGIN_COMMENT
 # Test that Linker is preserving the symbol defined in bitcode, when the symbol

--- a/test/Common/LTO/LTOSymDef/LTOSymDef.test
+++ b/test/Common/LTO/LTOSymDef/LTOSymDef.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 UNSUPPORTED: iu
 #---LTOSymDef.test--------------------- Executable,LTO,LS------------------#
 

--- a/test/Common/LTO/LTOTraceTest/LTOTraceTest.test
+++ b/test/Common/LTO/LTOTraceTest/LTOTraceTest.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 #---LTOTraceTest.test-------------------------------------------------#
 #BEGIN_COMMENT
 # Print same traces for lto using --trace-lto and -trace=lto

--- a/test/Common/LTO/LTOUndefInBitCodeAndELF/ltoundefinbitcodeandelf.test
+++ b/test/Common/LTO/LTOUndefInBitCodeAndELF/ltoundefinbitcodeandelf.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 # Check that the linker is able to preserve a symbol if the symbol is undefined
 # in ELF and Bitcode
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o  -flto

--- a/test/Common/LTO/LinkerScript/LTOMissingSections/ltomissingsections.test
+++ b/test/Common/LTO/LinkerScript/LTOMissingSections/ltomissingsections.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 # This tests that LTO doesnot miss default sections in the output.
 RUN: %clang %clangopts -c -flto %p/Inputs/main.c -o %t1.main.o  -ffunction-sections %clangg0opts
 RUN: %clang %clangopts -c -flto %p/Inputs/foo.c -o %t1.foo.o  -ffunction-sections %clangg0opts

--- a/test/Common/LTO/LinkerScriptBCPreserveOrigin/LinkerScriptBCPreserveOrigin.test
+++ b/test/Common/LTO/LinkerScriptBCPreserveOrigin/LinkerScriptBCPreserveOrigin.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 #---LinkerScriptBCPreserveOrigin.test----------------------- Executable,LTO --------------------#
 #BEGIN_COMMENT
 # Check if LTO works for no groups and only archives and bitcodes

--- a/test/Common/LTO/OverrideDefineFromCommon1/OverrideDefineFromCommon1.test
+++ b/test/Common/LTO/OverrideDefineFromCommon1/OverrideDefineFromCommon1.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 # If namepool has common and archive has defined, include member. If member has
 # common dont include it.
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o

--- a/test/Common/LTO/OverrideDefineFromCommon2/OverrideDefineFromCommon2.test
+++ b/test/Common/LTO/OverrideDefineFromCommon2/OverrideDefineFromCommon2.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 # If namepool has common and archive has defined, include member. If member has
 # common dont include it.
 RUN: %clang %clangopts -c -flto %p/Inputs/1.c -o %t1.o

--- a/test/Common/LTO/PreserveFile/preservefile.test
+++ b/test/Common/LTO/PreserveFile/preservefile.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 # Check if LTO works for no groups and only archives and bitcodes
 RUN: %clang %clangopts -c  %p/Inputs/a.c -flto -o %t1
 RUN: %clang %clangopts -c  %p/Inputs/b.c -flto -o %t2

--- a/test/Common/LTO/PreserveFileDOS/PreserveFileDOS.test
+++ b/test/Common/LTO/PreserveFileDOS/PreserveFileDOS.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 #---PreserveFileDOS.test----------------------- Executable,LTO --------------------#
 #BEGIN_COMMENT
 # This test checks that files can be read in DOS mode too.

--- a/test/Common/LTO/PreserveSym/preservesym.test
+++ b/test/Common/LTO/PreserveSym/preservesym.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 
 # Check if LTO works for no groups and only archives and bitcodes
 RUN: %clang %clangopts -c  %p/Inputs/a.c -flto -o %t1

--- a/test/Common/LTO/StoreComFile/StoreComFile.test
+++ b/test/Common/LTO/StoreComFile/StoreComFile.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 UNSUPPORTED: ndk-build
 # Check if LTO works for no groups and only archives and bitcodes
 RUN: %clang %clangopts %clangg0opts -c -fdata-sections %p/Inputs/1.c -o %t1.o

--- a/test/Common/LTO/ThinLTOCommonSymbols/ThinLTOCommonSymbols.test
+++ b/test/Common/LTO/ThinLTOCommonSymbols/ThinLTOCommonSymbols.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 #---ThinLTOCommonSymbols.test------------------------------ Executable,LS,LTO ---------------------#
 #BEGIN_COMMENT
 #Linker misplaces a symbol with ThinLTO.

--- a/test/Common/LTO/Verbose/verbose.test
+++ b/test/Common/LTO/Verbose/verbose.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 UNSUPPORTED: ndk-build
 # Check if LTO works for no groups and only archives and bitcodes
 RUN: %clang %clangopts -c  %p/Inputs/a.c -flto -o %t1

--- a/test/Common/LTO/WeakSymbol/preserveweak.test
+++ b/test/Common/LTO/WeakSymbol/preserveweak.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 # This checks that the linker is still able to preserve the weak symbol.
 RUN: %clang %clangopts -c -flto %p/Inputs/t.c -o %t1.t.o
 RUN: %clang %clangopts -c  %p/Inputs/f.c -o %t1.f.o

--- a/test/Common/LTO/WholeArchiveLTO/wholeArchiveLTO.test
+++ b/test/Common/LTO/WholeArchiveLTO/wholeArchiveLTO.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 
 # Test that LTO handles whole archive without reporting duplicate symbols
 RUN: %clang %clangopts -c %p/Inputs/main.c -flto -o %t1.main.o

--- a/test/Common/LTO/WrapSymbols/WrapSymbols.test
+++ b/test/Common/LTO/WrapSymbols/WrapSymbols.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 #---WrapSymbols.test----------------------- Executable,LTO --------------------#
 #BEGIN_COMMENT
 # This test supports wrap symbols in Bitcode. If the definition is in the

--- a/test/Common/LTO/WrapSymbolsBinding/WrapSymbolsBinding.test
+++ b/test/Common/LTO/WrapSymbolsBinding/WrapSymbolsBinding.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 #---WrapSymbolsBinding.test----------------------- Executable,LTO --------------------#
 #BEGIN_COMMENT
 # This tests that the linker is restoring bindings of wrapped symbols.

--- a/test/Common/LTO/WrapSymbolsDynamicLibrary/WrapSymbolsDynamicLibrary.test
+++ b/test/Common/LTO/WrapSymbolsDynamicLibrary/WrapSymbolsDynamicLibrary.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 UNSUPPORTED: iu
 #---WrapSymbolsDynamicLibrary.test------------------------------ Executable ---------------------#
 

--- a/test/Common/LTO/WrapSymbolsResolution/WrapSymbolsResolution.test
+++ b/test/Common/LTO/WrapSymbolsResolution/WrapSymbolsResolution.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 #---WrapSymbolsResolution.test----------------------- Executable,LTO --------------------#
 #BEGIN_COMMENT
 # This tests that the linker is not including symbols from an archive library

--- a/test/Common/LTO/WrapSymbolsUndefReference/WrapSymbolsUndefReference.test
+++ b/test/Common/LTO/WrapSymbolsUndefReference/WrapSymbolsUndefReference.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 UNSUPPORTED: iu, riscv32, riscv64
 #---WrapSymbolsUndefReference.test----------------------- Executable,SharedLibrary,LTO --------------------#
 

--- a/test/Common/LTO/lit.local.cfg
+++ b/test/Common/LTO/lit.local.cfg
@@ -1,2 +1,0 @@
-if 'X86' in config.eld_targets_to_build:
-    config.unsupported = True


### PR DESCRIPTION
Make the tests that fail as UNSUPPORTED, and start looking into the tests that fail and enable them.

With this change, all tests are enabled for the targets supported by ELD.