### PR TITLE
Be conservative relaxing CALL to JAL

### DIFF
--- a/test/RISCV/standalone/JALOverflow/Inputs/a.s
+++ b/test/RISCV/standalone/JALOverflow/Inputs/a.s
@@ -1,0 +1,11 @@
+.section .baz,"ax",@progbits
+.global baz1
+baz1:
+call foo
+.global baz2
+baz2:
+.align 16
+call foo
+.global baz3
+baz3:
+call foo

--- a/test/RISCV/standalone/JALOverflow/Inputs/b.s
+++ b/test/RISCV/standalone/JALOverflow/Inputs/b.s
@@ -1,0 +1,5 @@
+.section .foo,"ax",@progbits
+.global foo
+.p2align 12
+foo:
+nop

--- a/test/RISCV/standalone/JALOverflow/Inputs/jal1.t
+++ b/test/RISCV/standalone/JALOverflow/Inputs/jal1.t
@@ -1,0 +1,5 @@
+SECTIONS {
+.baz : { *(.baz) }
+. = 0x100000 - 0x90;
+.foo : { *(.foo) }
+}

--- a/test/RISCV/standalone/JALOverflow/JALOverflow.test
+++ b/test/RISCV/standalone/JALOverflow/JALOverflow.test
@@ -1,0 +1,9 @@
+#---JALOverflow.test------------------------- Executable -------------------#
+#BEGIN_COMMENT
+# Repro for JAL overflow behavior with a linker script that moves the dot.
+#END_COMMENT
+#START_TEST
+RUN: %clang -target riscv64 -c %p/Inputs/a.s -o %t1.a.o
+RUN: %clang -target riscv64 -c %p/Inputs/b.s -o %t1.b.o
+RUN: %link %linkopts -T %p/Inputs/jal1.t %t1.a.o %t1.b.o -Map %t1.map
+#END_TEST


### PR DESCRIPTION
Be conservative when relaxing CALL into JAL/C.J/C.JAL: later relaxations (notably R_RISCV_ALIGN) can increase the final PC-relative distance due to changes in required alignment padding. Add a max alignment "slack" to the offset for the range check so we only relax when the shortened form is guaranteed to remain in-range.

With this change we are able to link the RISCV64 linux kernel.

Resolves #768