### PR TITLE
Add --unique/--unique=<section-pattern> option

### DIFF
--- a/docs/userguide/documentation/options/options.rst
+++ b/docs/userguide/documentation/options/options.rst
@@ -56,6 +56,19 @@ Notes:
   (e.g. with ``ar cr libname.a ...``) and match against ``*libname.a:*member.o``
   patterns in the script.
 
+``--unique`` linker option behavior
+-----------------------------------
+
+``--unique``
+  Create a separate output section for every orphan input section (inputs not
+  assigned by a linker script).
+
+``--unique=<section-pattern>``
+  Create a separate output section for every input section whose name matches
+  the glob pattern, but only when the output section name is the same as the
+  input section name. This mirrors GNU ld.bfd behavior (so a linker script that
+  renames the output section will not be affected).
+
 ARM and AArch64 specific options
 ---------------------------------
 

--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -28,6 +28,7 @@
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/Option/ArgList.h"
+#include "llvm/Support/GlobPattern.h"
 #include "llvm/Support/Regex.h"
 #include <set>
 #include <string>
@@ -1015,6 +1016,19 @@ public:
     EmitUniqueOutputSections = Emit;
   }
 
+  // --unique / --unique=SECTION
+  void setEmitUniqueOrphanSections(bool Emit);
+
+  bool shouldEmitUniqueOrphanSections() const;
+
+  // Returns false on invalid glob patterns.
+  bool addUniqueSectionPattern(llvm::StringRef Pattern);
+
+  // Returns true iff --unique=SECTION matches InputSectionName and the output
+  // section name is the same as the input section name (GNU ld.bfd semantics).
+  bool shouldEmitUniqueSection(llvm::StringRef InputSectionName,
+                               llvm::StringRef OutputSectionName) const;
+
   // --reproduce-on-fail support
   void setReproduceOnFail(bool V) { RecordInputFilesOnFail = V; }
 
@@ -1374,6 +1388,8 @@ private:
   bool BDynamicLinker = true;
   std::string DefaultMapStyle = "txt";
   bool EmitUniqueOutputSections = false; // --unique-output-sections
+  bool EmitUniqueOrphanSections = false; // --unique
+  std::vector<llvm::GlobPattern> UniqueSectionPatterns; // --unique=SECTION
   bool BRelaxation = false;              // --relaxation
   llvm::SmallVector<std::string, 8> MapStyles;
   bool GlobalMergeNonAllocStrings = false; // --global-merge-non-alloc-strings

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -270,6 +270,15 @@ def unique_output_sections
     : Flag<["-", "--"], "unique-output-sections">,
       HelpText<"Place each input section in a unique output section">,
       Group<grp_scriptopts>;
+def unique
+    : Flag<["--"], "unique">,
+      HelpText<"Creates a separate output section for every orphan input section">,
+      Group<grp_scriptopts>;
+defm unique_val
+    : smDashOnlyEq<"unique", "unique_val",
+                   "Creates a separate output section for every input section matching SECTION">,
+      MetaVarName<"<section-pattern>">,
+      Group<grp_scriptopts>;
 def global_merge_non_alloc_strings
     : Flag<["--"], "global-merge-non-alloc-strings">,
       HelpText<"merge non-alloc strings across output sections">,

--- a/lib/Config/GeneralOptions.cpp
+++ b/lib/Config/GeneralOptions.cpp
@@ -676,3 +676,36 @@ bool GeneralOptions::traceSymbol(const ResolveInfo &RI) const {
   }
   return false;
 }
+
+void GeneralOptions::setEmitUniqueOrphanSections(bool Emit) {
+  EmitUniqueOrphanSections = Emit;
+}
+
+bool GeneralOptions::shouldEmitUniqueOrphanSections() const {
+  return EmitUniqueOrphanSections;
+}
+
+bool GeneralOptions::addUniqueSectionPattern(llvm::StringRef Pattern) {
+  // GNU-compatibility: "\" is an invalid glob pattern and should not match
+  // anything.
+  if (Pattern == "\\")
+    return true;
+  auto E = llvm::GlobPattern::create(Pattern);
+  if (!E) {
+    llvm::consumeError(E.takeError());
+    return false;
+  }
+  UniqueSectionPatterns.push_back(std::move(*E));
+  return true;
+}
+
+bool GeneralOptions::shouldEmitUniqueSection(
+    llvm::StringRef InputSectionName, llvm::StringRef OutputSectionName) const {
+  if (InputSectionName.empty())
+    return false;
+  if (InputSectionName != OutputSectionName)
+    return false;
+  return llvm::any_of(UniqueSectionPatterns, [&](const llvm::GlobPattern &Pat) {
+    return Pat.match(InputSectionName);
+  });
+}

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -1143,6 +1143,17 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
       Config.raise(Diag::unique_output_sections_unsupported);
   }
 
+  // --unique / --unique=SECTION (GNU ld.bfd compatible)
+  if (Args.hasArg(T::unique))
+    Config.options().setEmitUniqueOrphanSections(true);
+
+  for (auto *Arg : Args.filtered(T::unique_val)) {
+    if (!Config.options().addUniqueSectionPattern(Arg->getValue())) {
+      Config.raise(Diag::invalid_option) << Arg->getValue() << "unique";
+      return false;
+    }
+  }
+
   // --global-merge-non-alloc-strings
   if (Args.hasArg(T::global_merge_non_alloc_strings))
     Config.options().enableGlobalStringMerge();

--- a/lib/Object/ObjectBuilder.cpp
+++ b/lib/Object/ObjectBuilder.cpp
@@ -596,6 +596,15 @@ bool ObjectBuilder::shouldCreateNewSection(ELFSection *target,
   if (!target || ThisConfig.options().shouldEmitUniqueOutputSections())
     return true;
 
+  const OutputSectionEntry *Out = I->getOutputSection();
+  const bool IsOrphan = (Out == nullptr);
+  if (IsOrphan && ThisConfig.options().shouldEmitUniqueOrphanSections())
+    return true;
+
+  llvm::StringRef OutputName = IsOrphan ? I->name() : Out->name();
+  if (ThisConfig.options().shouldEmitUniqueSection(I->name(), OutputName))
+    return true;
+
   if (I->name().find("@") != llvm::StringRef::npos)
     return true;
 

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -2900,7 +2900,26 @@ bool GNULDBackend::placeOutputSections() {
         outBegin = sectionMap.begin();
         outEnd = sectionMap.end();
         outMatched = sectionMap.end();
-        if (!m_Module.getConfig().options().shouldEmitUniqueOutputSections()) {
+        OutputSectionEntry *CurOutSection = elem->getOutputSection();
+        bool CurOutSectionInMap = false;
+        if (CurOutSection) {
+          for (out = outBegin; out != outEnd; ++out) {
+            if (*out == CurOutSection) {
+              CurOutSectionInMap = true;
+              break;
+            }
+          }
+        }
+
+        // If the section already has an output section entry that isn't in the
+        // script's section map, treat it as an orphan so we don't overwrite an
+        // existing entry with the same name (used by
+        // --unique/--unique=SECTION).
+        const bool TreatAsOrphanToPreserveUniqueness =
+            CurOutSection && !CurOutSectionInMap;
+
+        if (!m_Module.getConfig().options().shouldEmitUniqueOutputSections() &&
+            !TreatAsOrphanToPreserveUniqueness) {
           for (out = outBegin; out != outEnd; ++out) {
             bool matched = false;
             if ((elem)->name().compare((*out)->name()) == 0) {
@@ -2953,7 +2972,8 @@ bool GNULDBackend::placeOutputSections() {
           if (pair.first && pair.first->isDiscard())
             (elem)->setKind(LDFileFormat::Null);
           else {
-            if (!isNonDymSymbolStringTableSection(elem))
+            if (!TreatAsOrphanToPreserveUniqueness &&
+                !isNonDymSymbolStringTableSection(elem))
               isError |= handleOrphanSection(elem);
             orphans.push_back(elem);
           }

--- a/test/Common/standalone/Unique/Inputs/a.s
+++ b/test/Common/standalone/Unique/Inputs/a.s
@@ -1,0 +1,5 @@
+.section .foo,"a"
+.globl sym_a
+sym_a:
+  .long 1
+

--- a/test/Common/standalone/Unique/Inputs/b.s
+++ b/test/Common/standalone/Unique/Inputs/b.s
@@ -1,0 +1,5 @@
+.section .foo,"a"
+.globl sym_b
+sym_b:
+  .long 2
+

--- a/test/Common/standalone/Unique/Inputs/script_allfuncs.t
+++ b/test/Common/standalone/Unique/Inputs/script_allfuncs.t
@@ -1,0 +1,4 @@
+SECTIONS {
+  allfuncs : { *(.foo) }
+}
+

--- a/test/Common/standalone/Unique/Inputs/script_foo.t
+++ b/test/Common/standalone/Unique/Inputs/script_foo.t
@@ -1,0 +1,4 @@
+SECTIONS {
+  .foo : { *(.foo) }
+}
+

--- a/test/Common/standalone/Unique/Unique.test
+++ b/test/Common/standalone/Unique/Unique.test
@@ -1,0 +1,32 @@
+#---Unique.test--------------------------- Executable -----------------------#
+#BEGIN_COMMENT
+# Checks GNU ld.bfd compatible --unique/--unique=SECTION behavior.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/a.s -o %t.a.o
+RUN: %clang %clangopts -c %p/Inputs/b.s -o %t.b.o
+
+# Orphan sections: --unique splits, default merges.
+RUN: %link %linkopts -r %t.a.o %t.b.o -o %t.orphan.default.o
+RUN: %readelf -SW %t.orphan.default.o | %filecheck %s --check-prefix=ORPHAN_MERGED
+RUN: %link %linkopts -r --unique %t.a.o %t.b.o -o %t.orphan.unique.o
+RUN: %readelf -SW %t.orphan.unique.o | %filecheck %s --check-prefix=ORPHAN_UNIQUE
+
+# Explicit output section with same name: --unique has no effect, --unique=.foo splits.
+RUN: %link %linkopts -r -T %p/Inputs/script_foo.t --unique %t.a.o %t.b.o -o %t.script.foo.uniqueflag.o
+RUN: %readelf -SW %t.script.foo.uniqueflag.o | %filecheck %s --check-prefix=SCRIPT_FLAG_NOEFFECT
+RUN: %link %linkopts -r -T %p/Inputs/script_foo.t --unique=.foo %t.a.o %t.b.o -o %t.script.foo.uniqueval.o
+RUN: %readelf -SW %t.script.foo.uniqueval.o | %filecheck %s --check-prefix=SCRIPT_VAL_EFFECT
+
+# Output section name differs from input section name: --unique=.foo has no effect.
+RUN: %link %linkopts -r -T %p/Inputs/script_allfuncs.t --unique=.foo %t.a.o %t.b.o -o %t.script.allfuncs.uniqueval.o
+RUN: %readelf -SW %t.script.allfuncs.uniqueval.o | %filecheck %s --check-prefix=SCRIPT_DIFFERENT_OUTPUT
+
+ORPHAN_MERGED: {{.*}}.foo {{.*}} 000008 {{.*}}
+ORPHAN_UNIQUE: {{.*}}.foo {{.*}} 000004 {{.*}}
+ORPHAN_UNIQUE: {{.*}}.foo {{.*}} 000004 {{.*}}
+SCRIPT_FLAG_NOEFFECT: {{.*}}.foo {{.*}} 000008 {{.*}}
+SCRIPT_VAL_EFFECT: {{.*}}.foo {{.*}} 000004 {{.*}}
+SCRIPT_VAL_EFFECT: {{.*}}.foo {{.*}} 000004 {{.*}}
+SCRIPT_DIFFERENT_OUTPUT: {{.*}}allfuncs {{.*}} 000008 {{.*}}
+#END_TEST


### PR DESCRIPTION
Create a separate output section for every input section whose name matches the glob pattern, but only when the output section name is the same as the input section name. This mirrors GNU ld.bfd behavior (so a linker script that renames the output section will not be affected).