### PR TITLE
Mark LTOGC and ltobitcode test unsupported for x86

### DIFF
--- a/test/Common/LTO/LTOBitCode/ltobitcode.test
+++ b/test/Common/LTO/LTOBitCode/ltobitcode.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 # Check that LTO doesnot preserve undefined symbols from bitcode.
 RUN: %clang %clangopts -c  %p/Inputs/main.c -o %t1.main.o
 RUN: %clang %clangopts -c -flto %p/Inputs/foo.c -o %t1.foo.o

--- a/test/Common/LTO/LTOGC/LTOGC.test
+++ b/test/Common/LTO/LTOGC/LTOGC.test
@@ -1,3 +1,4 @@
+UNSUPPORTED: x86
 #---LTOGC.test--------------------- Executable --------------------#
 #BEGIN_COMMENT
 #This test checks LTO with garbage-collection.


### PR DESCRIPTION
This commit marks LTOGC and ltobitcode test unsupported for x86 because these tests are failing for x86.