### PR TITLE
x86 is a 64 bit target

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -123,7 +123,7 @@ if getattr(config, 'has_symbol_versioning', 'false') == 'true':
     config.available_features.add('symbol_versioning')
 
 # `config.eld_targets_to_build` is actually the name of the test config
-# for a single target, eg. 'hexgaon_default'.
+# for a single target, eg. 'hexagon_default'.
 config.test_target = config.eld_targets_to_build.split('_', 1)[0]
 
 if config.test_target.lower() in {"riscv64", "aarch64", "x86"}:


### PR DESCRIPTION
x86 needs to be counted as a 64-bit target for
tests that are intended only to run on 64/32 bit
targets to work properly.