### PR TITLE
Add REQUIRES: shell to LTOTempObjNotWritable test

### DIFF
--- a/test/Common/LTO/LTOTempObjNotWritable/LTOTempObjNotWritable.test
+++ b/test/Common/LTO/LTOTempObjNotWritable/LTOTempObjNotWritable.test
@@ -1,3 +1,4 @@
+REQUIRES: shell
 #---LTOTempObjNotWritable.test--------------------- Executable,LTO -------------#
 #BEGIN_COMMENT
 # Test that the correct error message is printed when the temporary


### PR DESCRIPTION
The LTOTempObjNotWritable test fails on Windows because cmd.exe does not support the shell‑specific syntax used in the test. In particular, cmd.exe interprets the parentheses around %not as separate tokens, leading to incorrect command parsing.

This change adds a REQUIRES: shell directive to the test, marking it as unsupported in environments that lack a Bash‑like shell.