### PR TITLE
[aarch64] Fix TLS IE/GD support

### DIFF
--- a/lib/Target/AArch64/AArch64LDBackend.cpp
+++ b/lib/Target/AArch64/AArch64LDBackend.cpp
@@ -738,6 +738,17 @@ AArch64GOT *AArch64LDBackend::findEntryInGOT(ResolveInfo *I) const {
   return Entry->second;
 }
 
+void AArch64LDBackend::updateTLSIEGOTOffsets(uint64_t StaticTLSBlockVarOffset) {
+  for (auto &Entry : m_GOTMap) {
+    AArch64GOT *G = Entry.second;
+    if (!G || G->getType() != GOT::TLS_IE ||
+        G->getValueType() != GOT::TLSStaticSymbolValue || !G->symInfo())
+      continue;
+    G->setReservedValue(StaticTLSBlockVarOffset +
+                        G->symInfo()->outSymbol()->value());
+  }
+}
+
 // Create PLT entry.
 AArch64PLT *AArch64LDBackend::createPLT(ELFObjectFile *Obj,
                                                ResolveInfo *R,

--- a/lib/Target/AArch64/AArch64LDBackend.h
+++ b/lib/Target/AArch64/AArch64LDBackend.h
@@ -97,6 +97,8 @@ public:
 
   AArch64GOT *findEntryInGOT(ResolveInfo *) const;
 
+  void updateTLSIEGOTOffsets(uint64_t StaticTLSBlockVarOffset);
+
   // ---  PLT Support ------
   AArch64PLT *createPLT(ELFObjectFile *Obj, ResolveInfo *sym,
                         bool isIRelative = false);

--- a/test/AArch64/standalone/TLS_GD_ALIGN/GDAlign.test
+++ b/test/AArch64/standalone/TLS_GD_ALIGN/GDAlign.test
@@ -1,0 +1,8 @@
+#---GDAlign.test----------------------------------------------------------#
+# Check that TLS GD GOT entries account for TLS block alignment padding.
+RUN: %clang %clangopts -target aarch64 -c %p/Inputs/gd-align.c -o %t.o -fPIC -ftls-model=global-dynamic
+RUN: %link %linkopts -march aarch64 %t.o -o %t.out --no-threads
+RUN: %readelf -x .got %t.out | %filecheck %s
+
+CHECK: .got
+CHECK: 80000000 00000000

--- a/test/AArch64/standalone/TLS_GD_ALIGN/Inputs/gd-align.c
+++ b/test/AArch64/standalone/TLS_GD_ALIGN/Inputs/gd-align.c
@@ -1,0 +1,4 @@
+__thread int a = 12;
+__attribute__((aligned(128))) __thread int b = 13;
+
+int foo(void) { return a; }

--- a/test/AArch64/standalone/TLS_IE_ALIGN/IEAlign.test
+++ b/test/AArch64/standalone/TLS_IE_ALIGN/IEAlign.test
@@ -1,0 +1,8 @@
+#---IEAlign.test----------------------------------------------------------#
+# Check that TLS IE GOT entries account for TLS block alignment padding.
+RUN: %clang %clangopts -target aarch64 -c %p/Inputs/ie-align.c -o %t.o -fPIC -ftls-model=initial-exec
+RUN: %link %linkopts -march aarch64 %t.o -o %t.out --no-threads
+RUN: %readelf -x .got %t.out | %filecheck %s
+
+CHECK: .got
+CHECK: 80000000 00000000

--- a/test/AArch64/standalone/TLS_IE_ALIGN/Inputs/ie-align.c
+++ b/test/AArch64/standalone/TLS_IE_ALIGN/Inputs/ie-align.c
@@ -1,0 +1,4 @@
+__thread int a = 12;
+__attribute__((aligned(128))) __thread int b = 13;
+
+int foo(void) { return a; }


### PR DESCRIPTION
This fixes an issue when object files built with TLS models with large alignments would not produce the right values when used with *static* links

- initial-exec
- global-dynamic

Fix description :
------------------

- AArch64IEGOT was incorrectly created with GOT::TLS_LE
- compute TLS offsets as done in static links to properly set the GOT slots reserved for IE/GD models
- updateTLSIEGOTOffsets() applies the correct static TLS block offset

Resolves #868