### PR TITLE
Create nightly Zephyr workflow for riscv32

### DIFF
--- a/.github/workflows/zephyr-nightly.yml
+++ b/.github/workflows/zephyr-nightly.yml
@@ -1,0 +1,201 @@
+name: Zephyr Nightly with ELD
+
+on:
+  # pull_request: {} # Uncomment only to test this WF file update.
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+jobs:
+  zephyr-build-and-test:
+    if: github.repository == 'qualcomm/eld' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    env:
+      ZEPHYR_WORKSPACE: ${{ github.workspace }}/zephyrproject
+
+    steps:
+      - name: Checkout eld
+        uses: actions/checkout@v4
+        with:
+          path: llvm-project/llvm/tools/eld
+
+      - name: Record pre-build entry
+        if: github.event_name == 'schedule'
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "pre-"
+          workflow-name: "zephyr"
+          record-mode: "record"
+          status: "fail"
+          run-id: ${{github.run_id}}
+          arch-name: "riscv32"
+          branch-name: "main"
+
+      - name: Install dependencies
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libc++-dev libc++abi-dev libclang-rt-20-dev \
+            git cmake ninja-build gperf dfu-util device-tree-compiler wget \
+            python3-dev python3-pip python3-setuptools python3-tk python3-venv python3-wheel xz-utils \
+            file make gcc gcc-multilib g++-multilib libsdl2-dev libmagic1 qemu-system-riscv32
+
+          python3 -m venv ${{ env.ZEPHYR_WORKSPACE }}/.venv
+          . ${{ env.ZEPHYR_WORKSPACE }}/.venv/bin/activate
+          python -m pip install -U pip
+          python -m pip install -U west semver patool
+
+          cd ${{ github.workspace }}
+          west init -m https://github.com/zephyrproject-rtos/zephyr --mr main ${{ env.ZEPHYR_WORKSPACE }}
+          cd ${{ env.ZEPHYR_WORKSPACE }}
+          west update
+          west zephyr-export
+          west packages pip --install
+
+      - name: Fetch nightly toolchain
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/FetchNightlyToolset
+
+      - name: Set up Zephyr environment
+        run: |
+          echo "ZEPHYR_VENV=${{ env.ZEPHYR_WORKSPACE }}/.venv" >> $GITHUB_ENV
+
+      - name: Install Zephyr SDK
+        run: |
+          cd ${{ env.ZEPHYR_WORKSPACE }}
+          . ${{ env.ZEPHYR_WORKSPACE }}/.venv/bin/activate
+          west sdk install -t riscv64-zephyr-elf
+
+      - name: Install RISC-V toolchain payload
+        run: |
+          SDK_DIR=$(ls -d "$HOME"/zephyr-sdk-* 2>/dev/null | head -n 1)
+          if [ -z "$SDK_DIR" ]; then
+            echo "Failed to locate Zephyr SDK under $HOME"
+            ls -la "$HOME" || true
+            exit 1
+          fi
+          cd "$SDK_DIR"
+          ./setup.sh -t riscv64-zephyr-elf
+
+          PICOLIBC_SYSROOT=${SDK_DIR}/riscv64-zephyr-elf/picolibc
+          PICOLIBC_LIB_DIR=${PICOLIBC_SYSROOT}/riscv64-zephyr-elf/lib/rv32imac_zicsr_zifencei/ilp32
+          GCC_INSTALL_DIR=${PICOLIBC_SYSROOT}/lib/gcc/riscv64-zephyr-elf/12.2.0
+
+          if [ ! -d "$PICOLIBC_SYSROOT" ]; then
+            echo "Failed to locate picolibc sysroot: $PICOLIBC_SYSROOT"
+            find "${SDK_DIR}/riscv64-zephyr-elf" -maxdepth 2 -type d || true
+            exit 1
+          fi
+
+          if [ ! -d "$PICOLIBC_LIB_DIR" ]; then
+            echo "Failed to locate picolibc multilib dir: $PICOLIBC_LIB_DIR"
+            find "${PICOLIBC_SYSROOT}/riscv64-zephyr-elf/lib" -maxdepth 4 -type d || true
+            exit 1
+          fi
+
+          if [ ! -d "$GCC_INSTALL_DIR" ]; then
+            echo "Failed to locate gcc install dir: $GCC_INSTALL_DIR"
+            find "${PICOLIBC_SYSROOT}/lib/gcc/riscv64-zephyr-elf" -maxdepth 3 -type d || true
+            exit 1
+          fi
+
+          echo "ELD_SDK_DIR=$SDK_DIR" >> $GITHUB_ENV
+          echo "ELD_PICOLIBC_SYSROOT=$PICOLIBC_SYSROOT" >> $GITHUB_ENV
+          echo "ELD_PICOLIBC_LIB_DIR=$PICOLIBC_LIB_DIR" >> $GITHUB_ENV
+          echo "ELD_GCC_INSTALL_DIR=$GCC_INSTALL_DIR" >> $GITHUB_ENV
+
+      - name: Download and apply ELD support patch
+        run: |
+          cd ${{ env.ZEPHYR_WORKSPACE }}/zephyr
+          curl -L https://github.com/zephyrproject-rtos/zephyr/pull/103778.patch -o eld-support.patch
+          git apply eld-support.patch
+
+      - name: Set up environment for ELD
+        run: |
+          echo "ZEPHYR_BASE=${{ env.ZEPHYR_WORKSPACE }}/zephyr" >> $GITHUB_ENV
+
+      - name: Build hello_world for qemu_riscv32 with ELD
+        run: |
+          cd ${{ env.ZEPHYR_WORKSPACE }}/zephyr
+          . ${{ env.ZEPHYR_WORKSPACE }}/.venv/bin/activate
+          west build -p always -b qemu_riscv32 samples/hello_world -- \
+            -DZEPHYR_SDK_INSTALL_DIR=${{ env.ELD_SDK_DIR }} \
+            -DZEPHYR_TOOLCHAIN_VARIANT=llvm \
+            -DLLVM_TOOLCHAIN_PATH=${{ github.workspace }}/inst \
+            -DTOOLCHAIN_HAS_PICOLIBC=ON \
+            -DSYSROOT_DIR=${{ env.ELD_PICOLIBC_SYSROOT }} \
+            -DTOOLCHAIN_C_FLAGS=--gcc-install-dir=${{ env.ELD_GCC_INSTALL_DIR }} \
+            -DCONFIG_LLVM_USE_ELD=y \
+            -DCONFIG_PICOLIBC_USE_TOOLCHAIN=y \
+            -DCONFIG_COMPILER_RT_RTLIB=n \
+            -DCONFIG_LIBGCC_RTLIB=y \
+            -DCMAKE_EXE_LINKER_FLAGS="-L${{ env.ELD_PICOLIBC_LIB_DIR }}"
+
+      - name: Run hello_world on QEMU
+        run: |
+          cd ${{ env.ZEPHYR_WORKSPACE }}/zephyr
+          . ${{ env.ZEPHYR_WORKSPACE }}/.venv/bin/activate
+          set -o pipefail
+          timeout -k 1s 5s west build -t run 2>&1 | tee run_output.log || true
+          if grep -q "Hello World" run_output.log; then
+            echo "✓ hello_world executed successfully"
+          else
+            echo "✗ hello_world did not produce expected output"
+            exit 1
+          fi
+
+      - name: Run twister tests for qemu_riscv32 with ELD
+        run: |
+          cd ${{ env.ZEPHYR_WORKSPACE }}/zephyr
+          . ${{ env.ZEPHYR_WORKSPACE }}/.venv/bin/activate
+          ./scripts/twister -W -p qemu_riscv32 \
+            --inline-logs \
+            --timestamps \
+            -j 2 \
+            -v \
+            -x ZEPHYR_SDK_INSTALL_DIR=${{ env.ELD_SDK_DIR }} \
+            -x ZEPHYR_TOOLCHAIN_VARIANT=llvm \
+            -x LLVM_TOOLCHAIN_PATH=${{ github.workspace }}/inst \
+            -x TOOLCHAIN_HAS_PICOLIBC=y \
+            -x SYSROOT_DIR=${{ env.ELD_PICOLIBC_SYSROOT }} \
+            -x TOOLCHAIN_C_FLAGS=--gcc-install-dir=${{ env.ELD_GCC_INSTALL_DIR }} \
+            -x CONFIG_LLVM_USE_ELD=y \
+            -x TOOLCHAIN_HAS_NEWLIB=n \
+            -x CONFIG_PICOLIBC_USE_TOOLCHAIN=y \
+            -x CONFIG_COMPILER_RT_RTLIB=n \
+            -x CONFIG_LIBGCC_RTLIB=y \
+            -x CMAKE_EXE_LINKER_FLAGS="-L${{ env.ELD_PICOLIBC_LIB_DIR }}"
+
+      - name: Upload twister results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: zephyr-twister-results
+          path: |
+            ${{ env.ZEPHYR_WORKSPACE }}/zephyr/twister-out/twister.log
+            ${{ env.ZEPHYR_WORKSPACE }}/zephyr/twister-out/twister.json
+
+      - name: Upload build artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: zephyr-build-artifacts
+          path: |
+            ${{ env.ZEPHYR_WORKSPACE }}/zephyr/build/zephyr/zephyr.elf
+            ${{ env.ZEPHYR_WORKSPACE }}/zephyr/build/zephyr/zephyr.map
+
+      - name: Update build entry
+        if: always() && github.event_name == 'schedule'
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "post-"
+          workflow-name: "zephyr"
+          record-mode: "update"
+          status: "pass"
+          run-id: ${{github.run_id}}
+          arch-name: "riscv32"
+          branch-name: "main"


### PR DESCRIPTION
Add a nightly GitHub Actions workflow that builds Zephyr and runs tests using the ELD nightly toolchain.

Use picolibc and libgcc from the Zephyr SDK because the nightly toolchain does not ship compiler-rt or C libraries.

Follow-ups:
- Filter known-failing tests so the workflow can pass.
- Support remaining targets.
- Use docker to simplify installing dependencies.