### PR TITLE
Make PluginActivityLogFile.test windows compatible

### DIFF
--- a/test/Common/Plugin/PluginActivityLogFile/PluginActivityLogFile.test
+++ b/test/Common/Plugin/PluginActivityLogFile/PluginActivityLogFile.test
@@ -134,13 +134,13 @@ PLUGIN_ACT:   ]
 PLUGINS_INFO: "Plugins": [
 PLUGINS_INFO:     {
 PLUGINS_INFO-DAG:       "Autloaded": false,
-PLUGINS_INFO-DAG:       "Library": "{{.*}}libPluginActivityLogPlugin{{.*}}",
+PLUGINS_INFO-DAG:       "Library": "{{.*}}PluginActivityLogPlugin{{.*}}",
 PLUGINS_INFO-DAG:       "Name": "OutSectIterPluginActLog",
 PLUGINS_INFO-DAG:       "RegisteredCommandLineOptions": []
 PLUGINS_INFO:     }
 PLUGINS_INFO:     {
 PLUGINS_INFO-DAG:       "Autloaded": false,
-PLUGINS_INFO-DAG:       "Library": "{{.*}}libPluginActivityLogPlugin{{.*}}",
+PLUGINS_INFO-DAG:       "Library": "{{.*}}PluginActivityLogPlugin{{.*}}",
 PLUGINS_INFO-DAG:       "Name": "LPPluginActLog",
 PLUGINS_INFO-DAG:       "RegisteredCommandLineOptions": [
 PLUGINS_INFO-DAG:         {


### PR DESCRIPTION
This commit improves PluginActivityLogFile.test such that it is windows compatible. The plugin/library names used in the test were linux-specific.