### PR TITLE
UndefinedBehaviorSanitizer: signed integer overflow issue

### DIFF
--- a/lib/Target/RISCV/RISCVHelper.h
+++ b/lib/Target/RISCV/RISCVHelper.h
@@ -240,7 +240,8 @@ template <typename T> T encodeUJ(T Result) {
 }
 
 inline int32_t encodeU_HI20(int32_t Result) {
-  return (Result + 0x800) & 0xFFFFF000;
+  uint32_t U = static_cast<uint32_t>(Result);
+  return static_cast<int32_t>((U + 0x800u) & 0xFFFFF000u);
 }
 
 template <typename T> T encodeU_ABS20(T Result) {


### PR DESCRIPTION
runtime error: signed integer overflow: 2147483628 + 2048 cannot be represented in type 'int' fix