### PR TITLE
[LinkerScript] fix sort constructors

### DIFF
--- a/lib/ScriptParser/ScriptParser.cpp
+++ b/lib/ScriptParser/ScriptParser.cpp
@@ -771,6 +771,7 @@ void ScriptParser::readOutputSectionDescription(llvm::StringRef Tok) {
     } else if (readInclude(Tok)) {
     } else if (readOutputSectionData(Tok)) {
     } else if (readAssignment(Tok)) {
+    } else if (readSortConstructors(Tok)) {
     } else {
       readInputSectionDescription(Tok);
     }

--- a/test/Common/standalone/linkerscript/OverlayCommandBasic/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/OverlayCommandBasic/Inputs/script.t
@@ -3,7 +3,10 @@ ENTRY(_start)
 SECTIONS {
   OVERLAY 0x1000 : AT(0x2000) {
     .ov1 { KEEP(*(.text.ov1)) }
-    .ov2 { KEEP(*(.text.ov2)) }
+    .ov2 {
+           KEEP(*(.text.ov2))
+           SORT(CONSTRUCTORS)
+         }
   }
 
   .after : { KEEP(*(.text.after)) }


### PR DESCRIPTION
Linker needs to read the output sections as part of OVERLAY and also part of reading regular output sections.

The parsing of SORT(CONSTRUCTORS) need to happen at both places.

This is a follow up comment from code-review at

https://github.com/qualcomm/eld/pull/884