### PR TITLE
[CI] Don't run Nightly Workflows on Forks

### DIFF
--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build-windows:
+    if: github.repository == 'qualcomm/eld'
     runs-on: windows-latest
     permissions:
       contents: read

--- a/.github/workflows/clang-cross-schedule.yml
+++ b/.github/workflows/clang-cross-schedule.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   gate:
     runs-on: self-hosted
+    if: github.repository == 'qualcomm/eld'
     outputs:
       run_fetch: ${{ steps.gate.outputs.run_fetch }}
     steps:
@@ -20,7 +21,7 @@ jobs:
 
   fetch:
     needs: gate
-    if: needs.gate.outputs.run_fetch == 'true'
+    if: github.repository == 'qualcomm/eld' && needs.gate.outputs.run_fetch == 'true'
     uses: ./.github/workflows/clang-cross-download.yml
     with:
       runner: self-hosted

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   generate-docs:
+    if: github.repository == 'qualcomm/eld'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/nightly-musl-builder.yml
+++ b/.github/workflows/nightly-musl-builder.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   test-musl-x86_64:
+    if: github.repository == 'qualcomm/eld'
     runs-on: ubuntu-latest
     env:
       ELD_SOURCE_DIR: llvm-project/llvm/tools/eld
@@ -115,6 +116,7 @@ jobs:
           branch-name: "${{env.BUILD_BRANCH}}"
 
   test-musl:
+    if: github.repository == 'qualcomm/eld'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build-and-runtest-nightly:
+    if: github.repository == 'qualcomm/eld'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/picolibc-builder.yml
+++ b/.github/workflows/picolibc-builder.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build-and-test:
     name: ${{ matrix.arch.name }}
+    if: github.repository == 'qualcomm/eld'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/reviter.yml
+++ b/.github/workflows/reviter.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-and-runtest-with-reverse-iterators:
     runs-on: ubuntu-latest
+    if: github.repository == 'qualcomm/eld'
 
     steps:
       - name: Set up Clang 20

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-and-runtest-with-asan-ubsan:
     runs-on: self-hosted
+    if: github.repository == 'qualcomm/eld'
 
     steps:
       - name: Build and Test with Clang and show versions

--- a/.github/workflows/update-build-dashboard-data.yml
+++ b/.github/workflows/update-build-dashboard-data.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   update-dashboard-data:
     runs-on: ubuntu-latest
+    if: github.repository == 'qualcomm/eld'
 
     steps:
       - name: Checkout ELD


### PR DESCRIPTION
These are a bunch of ELD workflows that relate to ELD testing, and that downstream forks should not be running.

When `qualcomm/eld` is forked, then the fork gets a `main` branch that matches the `qualcomm/eld` `main` branch at the time it was forked, and because this is the fork's default branch, it cannot be deleted. This prevents spamming people's notifications with failing nightly build notifications which aren't relevant.