### PR TITLE
[NFC] Fix undefined behavior with misaligned write

### DIFF
--- a/lib/Writers/ELFObjectWriter.cpp
+++ b/lib/Writers/ELFObjectWriter.cpp
@@ -803,15 +803,15 @@ void ELFObjectWriter::emitGroup(ELFSection *S, MemoryRegion &CurRegion) {
         RegionFrag.getRegion().size() / sizeof(llvm::ELF::Elf32_Word);
     // copy the contents
     memcpy(CurRegion.begin() + CurOffset, From, Frag->size());
-    void *GroupData = (void *)(CurRegion.begin() + CurOffset);
+    uint8_t *GroupData = (uint8_t *)(CurRegion.begin() + CurOffset);
     auto *Si = S->getGroupSections().begin();
     auto *Se = S->getGroupSections().end();
     for (size_t Index = 1; Index < GroupDataSize; ++Index) {
       if (Si == Se)
         break;
       uint32_t SectionIdx = (*Si)->getOutputELFSection()->getIndex();
-      std::memcpy((uint8_t *) GroupData + (Index * sizeof(uint32_t)),
-          &SectionIdx, sizeof(uint32_t));
+      std::memcpy(GroupData + (Index * sizeof(llvm::ELF::Elf32_Word)),
+          &SectionIdx, sizeof(llvm::ELF::Elf32_Word));
       ++Si;
     }
     CurOffset += Frag->size();


### PR DESCRIPTION
in emitGroup, there's an integer-sized write that triggers a sanitizer error (writing to an int-sized slot that isn't 4-byte aligned). This patch removes that and uses memcpy instead, to avoid the strict aliasing violation.

The pointer is shifted by Index * sizeof(llvm::ELF::Elf32_Word), which should make sure nothing changes functionally.