### PR TITLE
Make ARM tests independent of the default target triple

### DIFF
--- a/test/ARM/standalone/Relocs/R_ARM_THM_JUMP24/R_ARM_THM_JUMP24.test
+++ b/test/ARM/standalone/Relocs/R_ARM_THM_JUMP24/R_ARM_THM_JUMP24.test
@@ -5,7 +5,7 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang -c %p/Inputs/x.s -o %t1.1.o
-RUN: %link %linkopts -march arm %t1.1.o --defsym arm_callee1=1 -o %t2.out --image-base 0x0
+RUN: %link %linkopts -mtriple armelf %t1.1.o --defsym arm_callee1=1 -o %t2.out --image-base 0x0
 RUN: %objdump -d %t2.out | %filecheck %s
 
 #CHECK:  0: f7ff bffe

--- a/test/ARM/standalone/SegAlign/segalign.test
+++ b/test/ARM/standalone/SegAlign/segalign.test
@@ -1,6 +1,6 @@
 # Check that segment alignment is what is set by the ABI.
 RUN: %clang %clangopts -target arm -c %p/Inputs/bss.c -o %t.o
-RUN: %link %linkopts -march arm %t.o -o %t.out
+RUN: %link %linkopts -mtriple armelf %t.o -o %t.out
 RUN: %readelf -W -l %t.out | %filecheck %s
 
 #CHECK:   LOAD           0x010000 0x00010000 0x00010000 0x00000 0x00004 RW  0x1000

--- a/test/ARM/standalone/TLS_Data/Data.test
+++ b/test/ARM/standalone/TLS_Data/Data.test
@@ -1,6 +1,6 @@
 UNSUPPORTED: ndk-build
 RUN: %yaml2obj %p/Inputs/1.yaml -o %t.o
-RUN: %link %linkopts -march arm -static %t.o -o %t.out
+RUN: %link %linkopts -mtriple armelf -static %t.o -o %t.out
 RUN: %objdump -d %t.out | %filecheck %s --check-prefix=TEXT
 
 #TEXT: 00000000 <foo>:

--- a/test/ARM/standalone/etext/etext.test
+++ b/test/ARM/standalone/etext/etext.test
@@ -1,6 +1,6 @@
 # Checks that the value of etext has been set appropriately.
 RUN: %clang %clangopts -target arm -c %p/Inputs/1.c -o %t1.o
-RUN: %link %linkopts -march arm %t1.o -o %t2.out -z max-page-size=0x1000
+RUN: %link %linkopts -mtriple armelf %t1.o -o %t2.out -z max-page-size=0x1000
 RUN: %readelf -s %t2.out | %grep etext | %filecheck %s
 
 #CHECK:    {{[0-9]+}}: 0000001c     0 NOTYPE  GLOBAL DEFAULT  ABS __etext

--- a/test/ARM/standalone/mergeROData/mergeROData.test
+++ b/test/ARM/standalone/mergeROData/mergeROData.test
@@ -1,12 +1,12 @@
 RUN: %clang %clangopts -target arm -c %p/Inputs/1.c -o %t1.o.noffdf
 RUN: %clang %clangopts -target arm -c %p/Inputs/2.c -o %t2.o.noffdf
-RUN: %link %linkopts -march arm --rosegment --merge-strings  %t1.o.noffdf %t2.o.noffdf -o %t1.out.noffdfms
+RUN: %link %linkopts -mtriple armelf --rosegment --merge-strings  %t1.o.noffdf %t2.o.noffdf -o %t1.out.noffdfms
 RUN: %readelf -S %t1.out.noffdfms | %grep rodata | %filecheck %s -check-prefix=NOFFDFMS
 RUN: %clang %clangopts -target arm -c -ffunction-sections -fdata-sections %p/Inputs/1.c -o %t1.o.ffdf
 RUN: %clang %clangopts -target arm -c -fdata-sections -fdata-sections %p/Inputs/2.c -o %t2.o.ffdf
-RUN: %link %linkopts  -march arm --rosegment %t1.o.ffdf %t2.o.ffdf -o %t1.out.ffdf
+RUN: %link %linkopts  -mtriple armelf --rosegment %t1.o.ffdf %t2.o.ffdf -o %t1.out.ffdf
 RUN: %readelf -p 2 %t1.out.ffdf | %filecheck %s -check-prefix=FFDF
-RUN: %link %linkopts  -march arm --rosegment --gc-sections --entry=main %t1.o.ffdf %t2.o.ffdf -o %t1.out.ffdfgc
+RUN: %link %linkopts  -mtriple armelf --rosegment --gc-sections --entry=main %t1.o.ffdf %t2.o.ffdf -o %t1.out.ffdfgc
 RUN: %readelf -S %t1.out.ffdfgc | %filecheck %s
 
 NOFFDFMS:  [ 2] .rodata           PROGBITS        00001000 002000 000009 01 AMS  0   0  1


### PR DESCRIPTION
This commit makes a few ARM tests independent of the default target triple. The filecheck CHECKs values may change depending upon the default target triple. For example, if arm-unknown-linux is the default triple, then static links use 0x08048000 as the image-base and loads FileHdr and Phdrs by default. On the other hand, if 'arm-unknown-elf' is the default triple, then static links use 0x0 as the image base and does not load FileHdr and Phdrs.