### PR TITLE
Reject invalid absolute relocations in PIE/shared links

### DIFF
--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -381,6 +381,8 @@ public:
   /// Target can override this function if needed.
   virtual uint64_t maxBranchOffset() { return (uint64_t)-1; }
 
+  bool isTargetReadOnly(const ELFSection &input) const;
+
   /// checkAndSetHasTextRel - check pSection flag to set HasTextRel
   void checkAndSetHasTextRel(const ELFSection &pSection);
 

--- a/include/eld/Target/Relocator.h
+++ b/include/eld/Target/Relocator.h
@@ -133,6 +133,11 @@ public:
 
   uint32_t getRelocType(std::string Name);
 
+  bool checkPICRelocSupported(const Relocation &reloc) const;
+
+  bool checkDynamicRelocAllowed(const Relocation &reloc,
+                                const ELFSection &section, bool isAbs) const;
+
   /// Get Symbol Name
   std::string getSymbolName(const ResolveInfo *R) const;
 
@@ -159,6 +164,16 @@ private:
   llvm::DenseMap<uint64_t, bool> UndefHits;
 
 protected:
+  bool reportNonPICRelocation(const Relocation &reloc) const;
+
+  virtual bool isPICRelocTypeSupported(const Relocation &reloc) const {
+    return true;
+  }
+
+  virtual bool isDynamicRelocSupported(const Relocation &reloc) const {
+    return true;
+  }
+
   Module &m_Module;
   std::mutex m_RelocMutex;
   std::unordered_map<std::string, uint32_t> RelocNameMap;

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -734,6 +734,10 @@ void ObjectLinker::assignOutputSections(std::vector<eld::InputFile *> &Inputs) {
   ObjectBuilder Builder(ThisConfig, *ThisModule);
   auto Start = std::chrono::steady_clock::now();
   Builder.assignOutputSections(Inputs, MPostLtoPhase);
+  // Refresh matched inputs for each rule before relocation scan. We need this
+  // to infer output properties from script merged inputs before layout is
+  // finalized.
+  RuleContainer::updateMatchedSections(*ThisModule);
   // FIXME: Perhaps transfer entry section ownership to GarbageCollection as
   // Entry sections are only relevant with garbage collection.
   // Currently, entry section are computed even if garbage-collection is not
@@ -742,13 +746,8 @@ void ObjectLinker::assignOutputSections(std::vector<eld::InputFile *> &Inputs) {
   LayoutInfo *LayoutInfo = ThisModule->getLayoutInfo();
   if (LayoutInfo && LayoutInfo->LayoutInfo::showInitialLayout()) {
     TextLayoutPrinter *TextMapPrinter = ThisModule->getTextMapPrinter();
-    if (TextMapPrinter) {
-      // FIXME: ideally, we should not need 'updateMatchedSections' call here.
-      // However, we need it because currently we do not maintain the list of
-      // matched input sections for rule containers consistently.
-      RuleContainer::updateMatchedSections(*ThisModule);
+    if (TextMapPrinter)
       TextMapPrinter->printLayout(*ThisModule);
-    }
   }
   // FIXME: SectionMatcher plugins should not consume time under
   // 'LinkerScriptRuleMatch' timing category!

--- a/lib/Target/AArch64/AArch64Relocator.cpp
+++ b/lib/Target/AArch64/AArch64Relocator.cpp
@@ -161,20 +161,18 @@ bool AArch64Relocator::isRelocSupported(Relocation &pReloc) const {
   return iter->second.func != unsupport;
 }
 
-bool AArch64Relocator::isInvalidReloc(Relocation &pReloc) const {
-  if (!config().isCodeIndep())
-    return false;
-  switch (pReloc.type()) {
+bool AArch64Relocator::isPICRelocTypeSupported(const Relocation &reloc) const {
+  switch (reloc.type()) {
   case llvm::ELF::R_AARCH64_ABS16:
-    return true;
+    return false;
   case llvm::ELF::R_AARCH64_TLSLE_ADD_TPREL_LO12_NC:
   case llvm::ELF::R_AARCH64_TLSLE_ADD_TPREL_LO12:
   case llvm::ELF::R_AARCH64_TLSLE_ADD_TPREL_HI12:
-    return !config().options().isPIE();
+    return config().options().isPIE();
   default:
     break;
   }
-  return false;
+  return true;
 }
 
 bool AArch64Relocator::relocNeedsDynRel(Relocation &pReloc) const {
@@ -188,8 +186,10 @@ bool AArch64Relocator::relocNeedsDynRel(Relocation &pReloc) const {
       return false;
     return true;
   }
-  // Only ABS64 relocations can be dynamic in AArch64
-  bool isAbsReloc = pReloc.type() == llvm::ELF::R_AARCH64_ABS64;
+  bool isAbsReloc = pReloc.type() == llvm::ELF::R_AARCH64_ABS64 ||
+                    pReloc.type() == llvm::ELF::R_AARCH64_ABS32 ||
+                    pReloc.type() == llvm::ELF::R_AARCH64_ABS16 ||
+                    pReloc.type() == llvm::ELF::R_AARCH64_AUTH_ABS64;
   return getTarget().symbolNeedsDynRel(
                    *rsym, (rsym->reserved() & ReservePLT),
                    isAbsReloc);
@@ -246,6 +246,8 @@ void AArch64Relocator::scanLocalReloc(InputFile &pInput, Relocation &pReloc,
     // Reserve an entry in .rel.dyn
     if (config().isCodeIndep() || isAuthAbs) {
       std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
+      if (!checkDynamicRelocAllowed(pReloc, pSection, true))
+        return;
       // set Rel bit
       rsym->setReserved(rsym->reserved() | ReserveRel);
       getTarget().checkAndSetHasTextRel(pSection);
@@ -267,6 +269,8 @@ void AArch64Relocator::scanLocalReloc(InputFile &pInput, Relocation &pReloc,
     // Reserve an entry in .rel.dyn
     if (config().isCodeIndep()) {
       std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
+      if (!checkDynamicRelocAllowed(pReloc, pSection, true))
+        return;
       // set up the dyn rel directly
       helper_DynRel_init(Obj, &pReloc, rsym, pReloc.targetRef()->frag(),
                          pReloc.targetRef()->offset(), pReloc.type(), m_Target);
@@ -392,6 +396,8 @@ void AArch64Relocator::scanGlobalReloc(InputFile &pInput, Relocation &pReloc,
         }
         CopyRelocs.insert(rsym);
       } else {
+        if (!checkDynamicRelocAllowed(pReloc, pSection, true))
+          return;
         // set Rel bit
         rsym->setReserved(rsym->reserved() | ReserveRel);
         getTarget().checkAndSetHasTextRel(pSection);
@@ -603,14 +609,8 @@ void AArch64Relocator::scanRelocation(Relocation &pReloc,
     return;
   }
 
-  if (isInvalidReloc(pReloc)) {
-    std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
-    config().raise(Diag::non_pic_relocation)
-        << getName(pReloc.type()) << pReloc.symInfo()->name()
-        << pReloc.getSourcePath(config().options());
-    m_Target.getModule().setFailure(true);
+  if (!checkPICRelocSupported(pReloc))
     return;
-  }
 
   // rsym - The relocation target symbol
   ResolveInfo *rsym = pReloc.symInfo();

--- a/lib/Target/AArch64/AArch64Relocator.h
+++ b/lib/Target/AArch64/AArch64Relocator.h
@@ -75,7 +75,7 @@ public:
                              const ELFSection &pSection) override;
 
 private:
-  bool isInvalidReloc(Relocation &pReloc) const;
+  bool isPICRelocTypeSupported(const Relocation &reloc) const override;
   bool isRelocSupported(Relocation &pReloc) const;
   bool relocNeedsDynRel(Relocation &pReloc) const;
 

--- a/lib/Target/ARM/ARMRelocator.cpp
+++ b/lib/Target/ARM/ARMRelocator.cpp
@@ -252,10 +252,8 @@ ARMRelocator::ARMRelocator(ARMGNULDBackend &pParent, LinkerConfig &pConfig,
                            Module &pModule)
     : Relocator(pConfig, pModule), m_Target(pParent) {}
 
-bool ARMRelocator::isInvalidReloc(Relocation &pReloc) const {
-  if (!config().isCodeIndep())
-    return false;
-  switch (pReloc.type()) {
+bool ARMRelocator::isPICRelocTypeSupported(const Relocation &reloc) const {
+  switch (reloc.type()) {
   case llvm::ELF::R_ARM_ABS16:
   case llvm::ELF::R_ARM_ABS12:
   case llvm::ELF::R_ARM_THM_ABS5:
@@ -267,13 +265,12 @@ bool ARMRelocator::isInvalidReloc(Relocation &pReloc) const {
   case llvm::ELF::R_ARM_THM_MOVT_ABS:
   case llvm::ELF::R_ARM_TLS_LE12:
   case llvm::ELF::R_ARM_TLS_IE12GP:
-    return true;
+    return false;
   case llvm::ELF::R_ARM_TLS_LE32:
-    return !config().options().isPIE();
+    return config().options().isPIE();
   default:
-    break;
+    return true;
   }
-  return false;
 }
 
 Relocator::Result ARMRelocator::applyRelocation(Relocation &pRelocation) {
@@ -310,14 +307,8 @@ Relocator::Size ARMRelocator::getSize(Relocation::Type pType) const {
   return 32;
 }
 
-/// checkValidReloc - When we attempt to generate a dynamic relocation for
-/// output file, check if the relocation is supported by dynamic linker.
-bool ARMRelocator::checkValidReloc(Relocation &pReloc) const {
-  // If not PIC object, no relocation type is invalid
-  if (!config().isCodeIndep())
-    return true;
-
-  switch (pReloc.type()) {
+bool ARMRelocator::isDynamicRelocSupported(const Relocation &reloc) const {
+  switch (reloc.type()) {
   case llvm::ELF::R_ARM_RELATIVE:
   case llvm::ELF::R_ARM_COPY:
   case llvm::ELF::R_ARM_GLOB_DAT:
@@ -329,12 +320,9 @@ bool ARMRelocator::checkValidReloc(Relocation &pReloc) const {
   case llvm::ELF::R_ARM_TLS_DTPOFF32:
   case llvm::ELF::R_ARM_TLS_TPOFF32:
     return true;
-    break;
-
   default:
     return false;
   }
-  return false;
 }
 
 void ARMRelocator::scanLocalReloc(InputFile &pInput, Relocation::Type Type,
@@ -360,6 +348,8 @@ void ARMRelocator::scanLocalReloc(InputFile &pInput, Relocation::Type Type,
     // Reserve an entry in .rel.dyn
     if (config().isCodeIndep()) {
       std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
+      if (!checkDynamicRelocAllowed(pReloc, pSection, true))
+        return;
       helper_DynRel_init(Obj, &pReloc, rsym, pReloc.targetRef()->frag(),
                          pReloc.targetRef()->offset(),
                          llvm::ELF::R_ARM_RELATIVE, m_Target);
@@ -552,13 +542,8 @@ void ARMRelocator::scanGlobalReloc(InputFile &pInput, Relocation::Type Type,
         }
         CopyRelocs.insert(rsym);
       } else {
-        if (!checkValidReloc(pReloc)) {
-          config().raise(Diag::non_pic_relocation)
-              << (int)pReloc.type() << pReloc.symInfo()->name()
-              << pReloc.getSourcePath(config().options());
-          m_Target.getModule().setFailure(true);
+        if (!checkDynamicRelocAllowed(pReloc, pSection, true))
           return;
-        }
         helper_DynRel_init(Obj, &pReloc, rsym, pReloc.targetRef()->frag(),
                            pReloc.targetRef()->offset(),
                            isSymbolPreemptible ? llvm::ELF::R_ARM_ABS32
@@ -640,13 +625,8 @@ void ARMRelocator::scanGlobalReloc(InputFile &pInput, Relocation::Type Type,
       if (getTarget().symbolNeedsCopyReloc(pReloc, *rsym)) {
         CopyRelocs.insert(rsym);
       } else {
-        if (!checkValidReloc(pReloc)) {
-          config().raise(Diag::non_pic_relocation)
-              << (int)pReloc.type() << pReloc.symInfo()->name()
-              << pReloc.getSourcePath(config().options());
-          m_Target.getModule().setFailure(true);
+        if (!checkDynamicRelocAllowed(pReloc, pSection, false))
           return;
-        }
         rsym->setReserved(rsym->reserved() | ReserveRel);
         getTarget().checkAndSetHasTextRel(pSection);
       }
@@ -805,14 +785,8 @@ void ARMRelocator::scanRelocation(Relocation &pReloc, eld::IRBuilder &pBuilder,
   if (LinkerConfig::Object == config().codeGenType())
     return;
 
-  if (isInvalidReloc(pReloc)) {
-    std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
-    config().raise(Diag::non_pic_relocation)
-        << getName(pReloc.type()) << pReloc.symInfo()->name()
-        << pReloc.getSourcePath(config().options());
-    m_Target.getModule().setFailure(true);
+  if (!checkPICRelocSupported(pReloc))
     return;
-  }
 
   // rsym - The relocation target symbol
   ResolveInfo *rsym = pReloc.symInfo();

--- a/lib/Target/ARM/ARMRelocator.h
+++ b/lib/Target/ARM/ARMRelocator.h
@@ -72,7 +72,7 @@ public:
   }
 
 private:
-  bool isInvalidReloc(Relocation &pType) const;
+  bool isPICRelocTypeSupported(const Relocation &reloc) const override;
   void scanLocalReloc(InputFile &pInput, Relocation::Type, Relocation &pReloc,
                       const ELFSection &pSection);
 
@@ -80,7 +80,7 @@ private:
                        eld::IRBuilder &pBuilder, ELFSection &pSection,
                        CopyRelocs &);
 
-  bool checkValidReloc(Relocation &pReloc) const;
+  bool isDynamicRelocSupported(const Relocation &reloc) const override;
 
   uint32_t relocType() const override { return llvm::ELF::SHT_REL; }
 

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -4085,17 +4085,32 @@ const LDSymbol *GNULDBackend::getEntrySymbol() const {
   return entrySymbol;
 }
 
+bool GNULDBackend::isTargetReadOnly(const ELFSection &input) const {
+  if (!input.isAlloc() || input.isWritable())
+    return false;
+
+  assert(input.getOutputELFSection());
+  if (input.getOutputELFSection()->isWritable())
+    return false;
+
+  assert(input.getOutputSection());
+  for (const RuleContainer *rule : *input.getOutputSection()) {
+    if (rule->getSection()->isWritable())
+      return false;
+    for (const ELFSection *matched : rule->getMatchedInputSections())
+      if (matched->isWritable())
+        return false;
+  }
+  return true;
+}
+
 void GNULDBackend::checkAndSetHasTextRel(const ELFSection &pSection) {
   if (m_bHasTextRel)
     return;
 
   // if the target section of the dynamic relocation is ALLOCATE but is not
   // writable, than we should set DF_TEXTREL
-  const uint32_t flag = pSection.getFlags();
-  if (0 == (flag & llvm::ELF::SHF_WRITE) && (flag & llvm::ELF::SHF_ALLOC))
-    m_bHasTextRel = true;
-
-  return;
+  m_bHasTextRel = isTargetReadOnly(pSection);
 }
 
 /// sortRelocation - sort the dynamic relocations to let dynamic linker

--- a/lib/Target/Hexagon/HexagonRelocator.cpp
+++ b/lib/Target/Hexagon/HexagonRelocator.cpp
@@ -222,14 +222,9 @@ Relocator::Size HexagonRelocator::getSize(Relocation::Type pType) const {
   return 32;
 }
 
-// Check if the relocation is invalid while generating
-// dynamic libraries
-bool HexagonRelocator::isInvalidReloc(Relocation &pReloc) const {
-  // If not PIC object, no relocation type is invalid
-  if (!config().isCodeIndep())
-    return false;
-
-  switch (pReloc.type()) {
+// Check if relocation type is legal in code-independent links.
+bool HexagonRelocator::isPICRelocTypeSupported(const Relocation &reloc) const {
+  switch (reloc.type()) {
   case llvm::ELF::R_HEX_LO16:
   case llvm::ELF::R_HEX_HI16:
   case llvm::ELF::R_HEX_16:
@@ -254,7 +249,7 @@ bool HexagonRelocator::isInvalidReloc(Relocation &pReloc) const {
   case llvm::ELF::R_HEX_IE_32:
   case llvm::ELF::R_HEX_IE_32_6_X:
   case llvm::ELF::R_HEX_IE_16_X:
-    return true;
+    return false;
   case llvm::ELF::R_HEX_TPREL_LO16:
   case llvm::ELF::R_HEX_TPREL_HI16:
   case llvm::ELF::R_HEX_TPREL_32:
@@ -262,9 +257,9 @@ bool HexagonRelocator::isInvalidReloc(Relocation &pReloc) const {
   case llvm::ELF::R_HEX_TPREL_16_X:
   case llvm::ELF::R_HEX_TPREL_11_X:
   case llvm::ELF::R_HEX_TPREL_16:
-    return !config().options().isPIE();
+    return config().options().isPIE();
   default:
-    return false;
+    return true;
   }
 }
 
@@ -288,14 +283,8 @@ void HexagonRelocator::scanRelocation(Relocation &pReloc,
   }
 
   // If we are generating a shared library check for invalid relocations
-  if (isInvalidReloc(pReloc)) {
-    std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
-    config().raise(Diag::non_pic_relocation)
-        << getName(pReloc.type()) << pReloc.symInfo()->name()
-        << pReloc.getSourcePath(config().options());
-    m_Target.getModule().setFailure(true);
+  if (!checkPICRelocSupported(pReloc))
     return;
-  }
 
   // rsym - The relocation target symbol
   ResolveInfo *rsym = pReloc.symInfo();
@@ -365,6 +354,8 @@ void HexagonRelocator::scanLocalReloc(InputFile &InputFile, Relocation &pReloc,
     // Reserve an entry in .rel.dyn
     if (config().isCodeIndep()) {
       std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
+      if (!checkDynamicRelocAllowed(pReloc, pSection, true))
+        return;
       helper_DynRel_init(Obj, &pReloc, rsym, pReloc.targetRef()->frag(),
                          pReloc.targetRef()->offset(),
                          llvm::ELF::R_HEX_RELATIVE, m_Target);
@@ -490,6 +481,8 @@ void HexagonRelocator::scanGlobalReloc(InputFile &InputFile, Relocation &pReloc,
         }
         CopyRelocs.insert(rsym);
       } else {
+        if (!checkDynamicRelocAllowed(pReloc, pSection, true))
+          return;
         helper_DynRel_init(Obj, &pReloc, rsym, pReloc.targetRef()->frag(),
                            pReloc.targetRef()->offset(),
                            isSymbolPreemptible ? llvm::ELF::R_HEX_32

--- a/lib/Target/Hexagon/HexagonRelocator.h
+++ b/lib/Target/Hexagon/HexagonRelocator.h
@@ -74,6 +74,7 @@ protected:
                             HexagonLDBackend &pTarget);
 
 private:
+  bool isPICRelocTypeSupported(const Relocation &reloc) const override;
   virtual void scanLocalReloc(InputFile &pInput, Relocation &pReloc,
                               eld::IRBuilder &pBuilder, ELFSection &pSection);
 
@@ -90,8 +91,6 @@ private:
                     HexagonTLSStub::StubType DynStub);
 
   bool isRelocSupported(Relocation &pReloc) const;
-
-  bool isInvalidReloc(Relocation &pReloc) const;
 
   HexagonLDBackend &m_Target;
   LDSymbol *m_Guard;

--- a/lib/Target/RISCV/RISCVRelocator.cpp
+++ b/lib/Target/RISCV/RISCVRelocator.cpp
@@ -366,28 +366,23 @@ bool RISCVRelocator::isRelocSupported(Relocation &pReloc) const {
   return RelocDescs.count(pReloc.type()) != 0;
 }
 
-// Check if the relocation is invalid while generating
-// dynamic libraries
-bool RISCVRelocator::isInvalidReloc(Relocation &pReloc) const {
-  if (!config().isCodeIndep())
-    return false;
-
-  switch (pReloc.type()) {
+// Check if relocation type is legal in code-independent links.
+bool RISCVRelocator::isPICRelocTypeSupported(const Relocation &reloc) const {
+  switch (reloc.type()) {
   case llvm::ELF::R_RISCV_HI20:
   case llvm::ELF::R_RISCV_LO12_I:
   case llvm::ELF::R_RISCV_LO12_S:
-    return true;
+    return false;
   case llvm::ELF::R_RISCV_TPREL_HI20:
   case llvm::ELF::R_RISCV_TPREL_LO12_I:
   case llvm::ELF::R_RISCV_TPREL_LO12_S:
-    return !config().options().isPIE();
+    return config().options().isPIE();
   case llvm::ELF::R_RISCV_SET_ULEB128:
   case llvm::ELF::R_RISCV_SUB_ULEB128:
-    return m_Target.isSymbolPreemptible(*pReloc.symInfo());
+    return !m_Target.isSymbolPreemptible(*reloc.symInfo());
   default:
-    break;
+    return true;
   }
-  return false;
 }
 
 void RISCVRelocator::scanRelocation(Relocation &pReloc, eld::IRBuilder &pLinker,
@@ -404,15 +399,8 @@ void RISCVRelocator::scanRelocation(Relocation &pReloc, eld::IRBuilder &pLinker,
     return;
   }
 
-  // If we are generating a shared library check for invalid relocations
-  if (isInvalidReloc(pReloc)) {
-    std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
-    config().raise(Diag::non_pic_relocation)
-        << getName(pReloc.type()) << pReloc.symInfo()->name()
-        << pReloc.getSourcePath(config().options());
-    m_Target.getModule().setFailure(true);
+  if (!checkPICRelocSupported(pReloc))
     return;
-  }
 
   auto ProcessOneReloc = [&](Relocation &pReloc) -> void {
     // rsym - The relocation target symbol
@@ -533,6 +521,8 @@ void RISCVRelocator::scanLocalReloc(InputFile &pInput, Relocation &pReloc,
     // Reserve an entry in .rel.dyn
     if (config().isCodeIndep()) {
       std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
+      if (!checkDynamicRelocAllowed(pReloc, pSection, true))
+        return;
       helper_DynRel_init(Obj, &pReloc, rsym, pReloc.targetRef()->frag(),
                          pReloc.targetRef()->offset(),
                          llvm::ELF::R_RISCV_RELATIVE, m_Target);
@@ -651,6 +641,8 @@ void RISCVRelocator::scanGlobalReloc(InputFile &pInputFile, Relocation &pReloc,
         }
         CopyRelocs.insert(rsym);
       } else {
+        if (!checkDynamicRelocAllowed(pReloc, pSection, true))
+          return;
         helper_DynRel_init(
             Obj, &pReloc, rsym, pReloc.targetRef()->frag(),
             pReloc.targetRef()->offset(),

--- a/lib/Target/RISCV/RISCVRelocator.h
+++ b/lib/Target/RISCV/RISCVRelocator.h
@@ -49,6 +49,8 @@ public:
   bool is32bit() const { return config().targets().is32Bits(); }
 
 private:
+  bool isPICRelocTypeSupported(const Relocation &reloc) const override;
+
   virtual void scanLocalReloc(InputFile &pInput, Relocation &pReloc,
                               eld::IRBuilder &pBuilder, ELFSection &pSection);
 
@@ -57,8 +59,6 @@ private:
                                CopyRelocs &);
 
   RISCVGOT *getTLSModuleID(ResolveInfo *R, bool isStatic);
-
-  bool isInvalidReloc(Relocation &pReloc) const;
 
   bool isRelocSupported(Relocation &pReloc) const;
 

--- a/lib/Target/Relocator.cpp
+++ b/lib/Target/Relocator.cpp
@@ -284,6 +284,43 @@ uint32_t Relocator::getRelocType(std::string RelocName) {
   return RelocNameMap[RelocName];
 }
 
+bool Relocator::reportNonPICRelocation(const Relocation &reloc) const {
+  const auto *sym = reloc.symInfo();
+  config().raise(Diag::non_pic_relocation)
+      << getName(reloc.type()) << sym->name()
+      << reloc.getSourcePath(config().options());
+  return false;
+}
+
+bool Relocator::checkPICRelocSupported(const Relocation &reloc) const {
+  if (!config().isCodeIndep())
+    return true;
+  if (isPICRelocTypeSupported(reloc))
+    return true;
+  return reportNonPICRelocation(reloc);
+}
+
+bool Relocator::checkDynamicRelocAllowed(const Relocation &reloc,
+                                         const ELFSection &section,
+                                         bool isAbs) const {
+  if (!config().isCodeIndep())
+    return true;
+
+  // -z text (default) rejects dynamic relocations in read-only output sections.
+  if (section.isAlloc() && getTarget().isTargetReadOnly(section) &&
+      !config().options().textRelocsAllowed())
+    return reportNonPICRelocation(reloc);
+
+  // Truncated absolute relocations cannot be safely represented as dynamic
+  // relocations for 64-bit outputs.
+  if (isAbs && config().targets().is64Bits() && getSize(reloc.type()) < 64)
+    return reportNonPICRelocation(reloc);
+
+  if (!isDynamicRelocSupported(reloc))
+    return reportNonPICRelocation(reloc);
+  return true;
+}
+
 bool Relocator::doDeMangle() const {
   return m_Config.options().shouldDemangle();
 }

--- a/lib/Target/X86/x86_64Relocator.cpp
+++ b/lib/Target/X86/x86_64Relocator.cpp
@@ -69,8 +69,7 @@ Relocator::Size x86_64Relocator::getSize(Relocation::Type pType) const {
   return x86_64Relocs[pType].Size;
 }
 
-// Check if the relocation is invalid
-bool x86_64Relocator::isInvalidReloc(Relocation &pReloc) const {
+bool x86_64Relocator::isRelocSupported(const Relocation &pReloc) const {
 
   switch (pReloc.type()) {
   case llvm::ELF::R_X86_64_NONE:
@@ -95,9 +94,9 @@ bool x86_64Relocator::isInvalidReloc(Relocation &pReloc) const {
   case llvm::ELF::R_X86_64_GOTTPOFF:
   case llvm::ELF::R_X86_64_TLSGD:
   case llvm::ELF::R_X86_64_TLSLD:
-    return false;
+    return true;
   default:
-    return true; // Other Relocations are not supported as of now
+    return false;
   }
 }
 
@@ -109,13 +108,15 @@ void x86_64Relocator::scanRelocation(Relocation &pReloc,
   if (LinkerConfig::Object == config().codeGenType())
     return;
 
-  // If we are generating a shared library check for invalid relocations
-  if (isInvalidReloc(pReloc)) {
-    std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
-    ::llvm::outs() << getName(pReloc.type()) << " not supported currently\n";
-    m_Target.getModule().setFailure(true);
+  if (!isRelocSupported(pReloc)) {
+    config().raise(Diag::unsupported_reloc)
+        << pReloc.type() << pSection.getDecoratedName(config().options())
+        << pInputFile.getInput()->decoratedPath();
     return;
   }
+
+  if (!checkPICRelocSupported(pReloc))
+    return;
 
   // rsym - The relocation target symbol
   ResolveInfo *rsym = pReloc.symInfo();
@@ -252,6 +253,8 @@ void x86_64Relocator::scanLocalReloc(InputFile &pInputFile, Relocation &pReloc,
   case llvm::ELF::R_X86_64_64: {
     if (config().isCodeIndep()) {
       std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
+      if (!checkDynamicRelocAllowed(pReloc, pSection, true))
+        return;
       rsym->setReserved(rsym->reserved() | ReserveRel);
       getTarget().checkAndSetHasTextRel(pSection);
       helper_DynRel_init(Obj, &pReloc, rsym, pReloc.targetRef()->frag(),
@@ -260,6 +263,13 @@ void x86_64Relocator::scanLocalReloc(InputFile &pInputFile, Relocation &pReloc,
     }
     return;
   }
+  case llvm::ELF::R_X86_64_32:
+  case llvm::ELF::R_X86_64_32S:
+  case llvm::ELF::R_X86_64_16:
+  case llvm::ELF::R_X86_64_8:
+    if (config().isCodeIndep())
+      checkDynamicRelocAllowed(pReloc, pSection, true);
+    return;
   case llvm::ELF::R_X86_64_GOTTPOFF: {
     std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
     if (rsym->reserved() & ReserveGOT)
@@ -311,6 +321,8 @@ void x86_64Relocator::scanGlobalReloc(InputFile &pInputFile, Relocation &pReloc,
         return;
       }
       // No copy reloc needed: emit a dynamic relocation as before
+      if (!checkDynamicRelocAllowed(pReloc, pSection, true))
+        return;
       rsym->setReserved(rsym->reserved() | ReserveRel);
       getTarget().checkAndSetHasTextRel(pSection);
       helper_DynRel_init(Obj, &pReloc, rsym, pReloc.targetRef()->frag(),

--- a/lib/Target/X86/x86_64Relocator.h
+++ b/lib/Target/X86/x86_64Relocator.h
@@ -70,7 +70,7 @@ private:
                                eld::IRBuilder &pBuilder, ELFSection &pSection,
                                CopyRelocs &);
 
-  bool isInvalidReloc(Relocation &pReloc) const;
+  bool isRelocSupported(const Relocation &pReloc) const;
 
   x86_64GOT *getTLSModuleID(ResolveInfo *R, bool isStatic = false);
 

--- a/test/AArch64/standalone/ABS64RelocationPIE/ABS64RelocationPIE.test
+++ b/test/AArch64/standalone/ABS64RelocationPIE/ABS64RelocationPIE.test
@@ -1,13 +1,31 @@
 #---ABS64RelocationPIE.test--------------------------- PIE -----------------#
 #BEGIN_COMMENT
-# ABS{32,16} relocations should not create dynamic relocations.
+## ABS32/64 relocations against regular symbols are not valid
+## in PIE links and should be rejected.
+## If the symbol is resolved at link time (eg via --defsym), no
+## dynamic relocation is needed and the link should succeed.
 #END_COMMENT
 #START_TEST
-RUN: %clang %clangopts -target aarch64 -c %p/Inputs/1.s -o %t1.1.o -fPIC
-RUN: %clang %clangopts -target aarch64 -c %p/Inputs/2.s -o %t1.2.o -fPIC
-RUN: %link %linkopts -march aarch64 %t1.1.o %t1.2.o -o %t2.out.1 -pie
-RUN: %link %linkopts -march aarch64 %t1.1.o --defsym foo=0x20 --defsym bar=0x20 -o %t2.out.2 -pie
-RUN: %readelf -r %t2.out.1 | %filecheck %s
-RUN: %readelf -r %t2.out.1 | %filecheck %s
-#CHECK-NOT: RELATIVE
+RUN: %clang %clangopts -target aarch64 -c %p/Inputs/1.s -o %t.abs32.o -fPIC
+RUN: %clang %clangopts -target aarch64 -c %p/Inputs/2.s -o %t.defs.o -fPIC
+RUN: %clang %clangopts -target aarch64 -c %p/Inputs/3.s -o %t.abs64.o -fPIC
+
+RUN: %not %link %linkopts %t.abs32.o %t.defs.o -o %t.abs32.fail -pie 2>&1 \
+RUN:  | %filecheck %s --check-prefix=ERR32
+
+RUN: %link %linkopts %t.abs32.o --defsym foo=0x20 --defsym bar=0x20 -o %t.abs32.ok -pie
+
+RUN: %not %link %linkopts %t.abs64.o %t.defs.o -o %t.abs64.fail -pie 2>&1 \
+RUN:  | %filecheck %s --check-prefix=ERR64
+
+RUN: %link %linkopts %t.abs64.o --defsym foo=0x20 -o %t.abs64.ok -pie
+RUN: %readelf -r %t.abs64.ok | %filecheck %s --check-prefix=NORELOC
+
+ERR32: R_AARCH64_ABS32
+ERR32: recompile with -fPIC
+
+ERR64: R_AARCH64_ABS64
+ERR64: recompile with -fPIC
+
+NORELOC: There are no relocations in this file.
 #END_TEST

--- a/test/AArch64/standalone/ABS64RelocationPIE/Inputs/3.s
+++ b/test/AArch64/standalone/ABS64RelocationPIE/Inputs/3.s
@@ -1,0 +1,2 @@
+.text
+.xword foo

--- a/test/ARM/standalone/CopyReloc/copyreloc.test
+++ b/test/ARM/standalone/CopyReloc/copyreloc.test
@@ -4,7 +4,7 @@
 # not supporting printing AArch64 relocations properly.
 
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -target arm
-RUN: %clang %clangopts -c %p/Inputs/2.c -o %t1.2.o -target arm
+RUN: %clang %clangopts -fPIC -c %p/Inputs/2.c -o %t1.2.o -target arm
 RUN: %link %linkopts -shared %t1.2.o -o %t2.lib2.so -march arm
 RUN: %link %linkopts %t1.1.o %t2.lib2.so -o %t3.out -march arm
 RUN: %readelf -r %t3.out | %filecheck %s

--- a/test/ARM/standalone/IFunc/IFunc.test
+++ b/test/ARM/standalone/IFunc/IFunc.test
@@ -6,8 +6,8 @@ UNSUPPORTED: ndk-build
 # this test only checks setup, now only static linked supported
 #END_COMMENT
 #START_TEST
-RUN: %clang %clangopts -target arm -c %p/Inputs/m.c -o %tm.o
-RUN: %clang %clangopts -target arm -c %p/Inputs/t.c -o %tt.o
+RUN: %clang %clangopts -target arm -fPIC -c %p/Inputs/m.c -o %tm.o
+RUN: %clang %clangopts -target arm -fPIC -c %p/Inputs/t.c -o %tt.o
 RUN: %link %linkopts -march arm %tm.o %tt.o -o %t.out
 RUN: %readelf -a %t.out | %filecheck --check-prefix=STANDALONE %s
 RUN: %link %linkopts -march arm %tm.o %tt.o -pie -o %t2.out

--- a/test/Common/standalone/PIEAbsoluteRelocs/pie-abs32-32.s
+++ b/test/Common/standalone/PIEAbsoluteRelocs/pie-abs32-32.s
@@ -1,0 +1,41 @@
+# REQUIRES: 32BitsArch
+
+## 32-bit targets should reject absolute relocations in pie/shared with -z text.
+## -z notext permits absolute relocations and emits TEXTREL.
+
+# RUN: %clang %clangopts -c %s -o %t.global
+# RUN: %clang %clangopts -c %s -Wa,-defsym,LOCAL=1 -o %t.local
+
+# RUN: %not %link %linkopts -pie -z text %t.global -o %t.g.out 2>&1 \
+# RUN:  | %filecheck %s --check-prefix=ERR
+# RUN: %not %link %linkopts -pie -z text %t.local -o %t.l.out 2>&1 \
+# RUN:  | %filecheck %s --check-prefix=ERR
+# RUN: %not %link %linkopts -shared -z text %t.global -o %t.g.so 2>&1 \
+# RUN:  | %filecheck %s --check-prefix=ERR
+# RUN: %not %link %linkopts -shared -z text %t.local -o %t.l.so 2>&1 \
+# RUN:  | %filecheck %s --check-prefix=ERR
+
+# RUN: %link %linkopts -pie -z notext %t.global -o %t.notext.global.pie
+# RUN: %link %linkopts -pie -z notext %t.local -o %t.notext.local.pie
+
+# RUN: %readelf -d %t.notext.global.pie | %filecheck %s --check-prefix=NOTEXT
+# RUN: %readelf -d %t.notext.local.pie | %filecheck %s --check-prefix=NOTEXT
+
+# ERR: recompile with -fPIC
+
+# NOTEXT: TEXTREL
+
+.ifdef LOCAL
+.section .text.foo
+foo:
+  .word 100
+.text
+  .word foo
+.else
+.section .text.foo
+.globl foo
+foo:
+  .word 100
+.text
+  .word foo
+.endif

--- a/test/Common/standalone/PIEAbsoluteRelocs/pie-abs32-64.s
+++ b/test/Common/standalone/PIEAbsoluteRelocs/pie-abs32-64.s
@@ -1,0 +1,42 @@
+# REQUIRES: 64BitsArch
+
+## 64-bit targets should reject absolute relocations in pie/shared
+## regardless of -z text/notext.
+
+# RUN: %clang %clangopts -c %s -o %t.global
+# RUN: %clang %clangopts -c %s -Wa,-defsym,LOCAL=1 -o %t.local
+
+# RUN: %not %link %linkopts -pie -z text %t.global -o %t.g.text 2>&1 \
+# RUN:  | %filecheck %s --check-prefix=ERR
+# RUN: %not %link %linkopts -pie -z text %t.local -o %t.l.text 2>&1 \
+# RUN:  | %filecheck %s --check-prefix=ERR
+# RUN: %not %link %linkopts -pie -z notext %t.global -o %t.g.notext 2>&1 \
+# RUN:  | %filecheck %s --check-prefix=ERR
+# RUN: %not %link %linkopts -pie -z notext %t.local -o %t.l.notext 2>&1 \
+# RUN:  | %filecheck %s --check-prefix=ERR
+
+# RUN: %not %link %linkopts -shared -z text %t.global -o %t.g.text.so 2>&1 \
+# RUN:  | %filecheck %s --check-prefix=ERR
+# RUN: %not %link %linkopts -shared -z text %t.local -o %t.l.text.so 2>&1 \
+# RUN:  | %filecheck %s --check-prefix=ERR
+# RUN: %not %link %linkopts -shared -z notext %t.global -o %t.g.notext.so 2>&1 \
+# RUN:  | %filecheck %s --check-prefix=ERR
+# RUN: %not %link %linkopts -shared -z notext %t.local -o %t.l.notext.so 2>&1 \
+# RUN:  | %filecheck %s --check-prefix=ERR
+
+# ERR: recompile with -fPIC
+
+.ifdef LOCAL
+.section .text.foo
+foo:
+  .word 100
+.text
+  .word foo
+.else
+.section .text.foo
+.globl foo
+foo:
+  .word 100
+.text
+  .word foo
+.endif

--- a/test/Common/standalone/PIEAbsoluteRelocs/pie-writeable-32.s
+++ b/test/Common/standalone/PIEAbsoluteRelocs/pie-writeable-32.s
@@ -1,0 +1,32 @@
+# REQUIRES: 32BitsArch
+
+## A writable output section may legally receive a dynamic relocation under
+## -z text even if one of the input sections comprising it is read-only.
+
+# RUN: split-file %s %t
+# RUN: %clang %clangopts -c %t/1.s -o %t.o -fPIC
+# RUN: %link %linkopts -shared -z text -T %t/script.t %t.o -o %t.out
+# RUN: %readelf -r %t.out | %filecheck %s --check-prefix=DYNR
+# RUN: %readelf -d %t.out | %filecheck %s --check-prefix=NOTEXTREL
+
+# DYNR: Relocation section '.rel{{a?}}.dyn'
+# NOTEXTREL-NOT: TEXTREL
+
+#--- 1.s
+.section .foo, "a"
+.globl foo
+foo:
+  .word bar
+
+.data
+.hidden bar
+bar:
+  .word 0
+
+#--- script.t
+SECTIONS {
+  .t : {
+    *(.foo)
+    *(.data)
+  }
+}

--- a/test/Common/standalone/StripAllSymbols/Inputs/g.s
+++ b/test/Common/standalone/StripAllSymbols/Inputs/g.s
@@ -1,9 +1,9 @@
 .global foo
 foo:
-.word local
+.word 100
 .global bar
 bar:
-.word local
+.word 200
 .local local
 local:
 .word 100

--- a/test/Common/standalone/StripAllSymbols/StripAllSymbols.test
+++ b/test/Common/standalone/StripAllSymbols/StripAllSymbols.test
@@ -1,4 +1,3 @@
-XFAIL: aarch64
 #---StripAllSymbols.test--------------------------- Executable -----------------#
 
 #BEGIN_COMMENT


### PR DESCRIPTION
Reject invalid absolute relocations in PIE/shared links

ELD currently permits some absolute relocations that should be rejected when producing PIE/shared objects.

ELD would also allow truncated absolute relocations in 64-bit outputs. Now it correctly reports an error.

Symbols fully resolved at link time (eg defsym) should not require a dynamic relocation.

With -z text, reject absolute relocations in PIE/shared links.

With -z notext, split behavior by target bitness:

- 32-bit targets may emit TEXTREL.
- 64-bit targets error on truncated absolute dynamic relocations.

Closes #832.