### PR TITLE
Mark lld/ELF/opt-remarks.ll test unsupported for hexagon

### DIFF
--- a/test/lld/ELF/opt-remarks.ll
+++ b/test/lld/ELF/opt-remarks.ll
@@ -1,3 +1,4 @@
+; UNSUPPORTED: hexagon
 ; RUN: %opt --mtriple=%triple --data-layout=%datalayout %s -o %t.o
 ; RUN: %rm -f %t.yaml %t1.yaml %t.hot.yaml %t.t300.yaml %t.t301.yaml
 


### PR DESCRIPTION
This commit marks the lld/ELF/opt-remarks.ll test unsupported for hexagon to unblock builders.