### PR TITLE
RISC-V: Fix output ordering in TLS_DESC test

### DIFF
--- a/test/lld/ELF/riscv-tlsdesc-relax.test
+++ b/test/lld/ELF/riscv-tlsdesc-relax.test
@@ -49,8 +49,8 @@ RUN: %objdump --no-show-raw-insn -M no-aliases -h -d %t.a.pie.ie | FileCheck %s 
 GD4:      .got     {{0*}}14 {{0*}}20c0 DATA
 GD8:      .got     {{0*}}28 {{0*}}20c0 DATA
 
-GD-REL4:      {{0*}}20cc {{0*}}030c       R_RISCV_TLSDESC {{0*}}7ff b + 0
-GD-REL8:      {{0*}}20d8 {{0*}}030000000c R_RISCV_TLSDESC {{0*}}7ff b + 0
+GD-REL4:      {{0*}}20cc {{[[:xdigit:]]+}}0c       R_RISCV_TLSDESC {{0*}}7ff b + 0
+GD-REL8:      {{0*}}20d8 {{[[:xdigit:]]+}}0c       R_RISCV_TLSDESC {{0*}}7ff b + 0
 
 ## Notes re. comparing the output to lld:
 ## - .got does not have the initial entry, so its size and all offsets are 8
@@ -182,8 +182,8 @@ LEA-NEXT:         c.add   a0, tp
 IE4:      .got     {{0*}}10 {{0*}}120e0 DATA
 IE8:      .got     {{0*}}20 {{0*}}120e0 DATA
 
-IE-REL4:   {{0*}}120e4 {{0*}}010a       R_RISCV_TLS_TPREL32 {{0+}} b + 0
-IE-REL8:   {{0*}}120e8 {{0*}}010000000b R_RISCV_TLS_TPREL64 {{0+}} b + 0
+IE-REL4:   {{0*}}120e4 {{[[:xdigit:]]+}}0a       R_RISCV_TLS_TPREL32 {{0+}} b + 0
+IE-REL8:   {{0*}}120e8 {{[[:xdigit:]]+}}0b       R_RISCV_TLS_TPREL64 {{0+}} b + 0
 
 IE-LABEL: <foo>:
 IE-NORELAX-NEXT: addi    zero, zero, 0x0 

--- a/test/lld/ELF/riscv-tlsdesc.test
+++ b/test/lld/ELF/riscv-tlsdesc.test
@@ -40,9 +40,9 @@ RUN: %objdump --no-show-raw-insn -M no-aliases -Rd %t.a1 | FileCheck -D#%x,XLEN=
 
 ## The order of symbols and GOT slots is different than produced by lld.
 GD-RELA:      .rela.dyn
-GD-RELA-NEXT:   0x{{0*}}[[#%X,0x2880+mul(XLEN,5)]] R_RISCV_TLSDESC - 0x7FF{{$}}
-GD-RELA-NEXT:   0x{{0*}}[[#%X,0x2880+mul(XLEN,7)]] R_RISCV_TLSDESC c 0x0{{$}}
-GD-RELA-NEXT:   0x{{0*}}[[#%X,0x2880+mul(XLEN,3)]] R_RISCV_TLSDESC a 0x0{{$}}
+GD-RELA-DAG:   0x{{0*}}[[#%X,0x2880+mul(XLEN,5)]] R_RISCV_TLSDESC - 0x7FF{{$}}
+GD-RELA-DAG:   0x{{0*}}[[#%X,0x2880+mul(XLEN,7)]] R_RISCV_TLSDESC c 0x0{{$}}
+GD-RELA-DAG:   0x{{0*}}[[#%X,0x2880+mul(XLEN,3)]] R_RISCV_TLSDESC a 0x0{{$}}
 GD-RELA-NEXT: }
 GD-RELA-GOT4:      Hex dump of section '.got':
 GD-RELA-GOT4-NEXT: 0x{{0*}}[[#%x,0x2880]] 00000000 00000000 00000000 00000000
@@ -151,8 +151,8 @@ IE8-NEXT:        ld      a0, 0x58(a0)
 IE-NEXT:         add     a0, a0, tp
 
 IEA:       OFFSET           TYPE                     VALUE
-IEA4-NEXT: {{0*}}2340 R_RISCV_TLS_TPREL[[#%d,mul(XLEN,8)]]      c
-IEA8-NEXT: {{0*}}2348 R_RISCV_TLS_TPREL[[#%d,mul(XLEN,8)]]      c
+IEA4-DAG:  {{0*}}2340 R_RISCV_TLS_TPREL[[#%d,mul(XLEN,8)]]      c
+IEA8-DAG:  {{0*}}2348 R_RISCV_TLS_TPREL[[#%d,mul(XLEN,8)]]      c
 IEA-EMPTY:
 ## riscv32: &.got[c]-. = 0x2340 - 0x1258 = 0x10e8
 ## &.got[c]-. = 0x2348 - 0x1258 = 0x10f0


### PR DESCRIPTION
Fixes #930.