### PR TITLE
Disable sanitizer builder for PRs

### DIFF
--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -1,7 +1,7 @@
 name: Nightly sanitizer check
 
 on:
-  pull_request: {} # Uncomment only to test this WF file update.
+  # pull_request: {} # Uncomment only to test this WF file update.
   schedule:
     - cron: '0 7 * * *'  # Runs daily at 1:00 AM CST
   workflow_dispatch:     # Allows manual triggering


### PR DESCRIPTION
This commit restores the original behavior of the sanitizer builder to not run on PRs. The builder was accidentally enabled for PRs during recent debugging of the builder.