### PR TITLE
Support -z separate-loadable-segments

### DIFF
--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -49,7 +49,7 @@ public:
 
   typedef llvm::StringMap<uint64_t> AddressMapType;
 
-  enum class SeparateSegmentKind { None, Code };
+  enum class SeparateSegmentKind { None, Code, Loadable };
 
   enum StripSymbolMode {
     KeepAllSymbols,

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -890,7 +890,8 @@ defm dash_z
           "\t\t\t-z=text : Do not permit relocations in read-only segments (default)\n"
           "\t\t\t-z=notext : Allow relocations in read-only segments\n"
           "\t\t\t-z=separate-code : Create separate code segment\n"
-          "\t\t\t-z=no-separate-code : Do not create separate code segment\n">,
+          "\t\t\t-z=no-separate-code : Do not create separate code segment\n"
+          "\t\t\t-z=separate-loadable-segments : Create separate loadable segments\n">,
       MetaVarName<"<extended-opts>">,
       Group<grp_extendedopts>;
 def no_align_segments : Flag<["--"], "no-align-segments">,

--- a/include/eld/Input/ZOption.h
+++ b/include/eld/Input/ZOption.h
@@ -42,6 +42,7 @@ public:
     NoExecStack,
     NoGnuStack,
     SeparateCode,
+    SeparateLoadableSegments,
     NoSeparateCode,
     NoRelro,
     Now,

--- a/lib/Config/GeneralOptions.cpp
+++ b/lib/Config/GeneralOptions.cpp
@@ -95,11 +95,14 @@ bool GeneralOptions::addZOption(const ZOption &POption) {
   case ZOption::NoGnuStack:
     NoGnuStack = true;
     break;
-  case eld::ZOption::SeparateCode:
+  case ZOption::SeparateCode:
     setSeparateSegmentKind(SeparateSegmentKind::Code);
     break;
-  case eld::ZOption::NoSeparateCode:
+  case ZOption::NoSeparateCode:
     setSeparateSegmentKind(SeparateSegmentKind::None);
+    break;
+  case ZOption::SeparateLoadableSegments:
+    setSeparateSegmentKind(SeparateSegmentKind::Loadable);
     break;
   case ZOption::Global:
     BGlobal = true;

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -758,6 +758,8 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
       ZKind = eld::ZOption::SeparateCode;
     else if (ZOpt == "noseparate-code")
       ZKind = eld::ZOption::NoSeparateCode;
+    else if (ZOpt == "separate-loadable-segments")
+      ZKind = eld::ZOption::SeparateLoadableSegments;
     else if (ZOpt == "execstack")
       ZKind = eld::ZOption::ExecStack;
     else if (ZOpt == "nodelete") {

--- a/lib/Target/CreateProgramHeaders.hpp
+++ b/lib/Target/CreateProgramHeaders.hpp
@@ -196,6 +196,8 @@ bool GNULDBackend::createProgramHdrs() {
       return true;
     if (!ShouldSeparate)
       return false;
+    if (SeparateKind == GeneralOptions::SeparateSegmentKind::Loadable)
+      return true;
     if (!prevOut)
       return false;
     auto PrevSegIt = _segmentsForSection.find(prevOut);

--- a/test/lld/ELF/separate-segments.s
+++ b/test/lld/ELF/separate-segments.s
@@ -21,10 +21,9 @@
 # CODE-NEXT: LOAD 0x003000 0x0000000000003000 0x0000000000003000 0x000001 0x000001 R   0x1000
 # CODE-NEXT: LOAD 0x003008 0x0000000000003008 0x0000000000003008 0x0000f1 0x0000f1 RW  0x1000
 
-## TODO:
 ## -z separate-loadable-segments makes all segments separate.
-# %link -pie --no-align-segments --rosegment %t.o -z separate-loadable-segments -o %t
-# llvm-readelf -l %t | FileCheck --check-prefix=ALL %s
+# RUN: %link -pie --no-align-segments --rosegment %t.o -z separate-loadable-segments -o %t
+# RUN: llvm-readelf -l %t | FileCheck --check-prefix=ALL %s
 # ALL:      LOAD 0x000000 0x0000000000000000 0x0000000000000000 0x000200 0x000200 R E 0x1000
 # ALL-NEXT: LOAD 0x001000 0x0000000000001000 0x0000000000001000 0x000044 0x000044 R   0x1000
 # ALL-NEXT: LOAD 0x002000 0x0000000000002000 0x0000000000002000 0x000001 0x000001 R E 0x1000


### PR DESCRIPTION
-z separate-loadable-segments places all load  segments in their own pages disjoint from any other segments.

Closes #833, #696