### PR TITLE
Use -G0 for DotForwReference.test

### DIFF
--- a/test/Common/standalone/DotForwReference/DotForwReference.test
+++ b/test/Common/standalone/DotForwReference/DotForwReference.test
@@ -4,20 +4,20 @@
 # SECTIONS is handled correctly.
 #END_COMMENT
 #START_TEST
-RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
-RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.1.t
+RUN: %clang %clangg0opts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
+RUN: %link %linkg0opts -o %t1.1.out %t1.1.o -T %p/Inputs/script.1.t
 RUN: %readelf -S %t1.1.out | %filecheck %s
-RUN: %link %linkopts -o %t1.1.phdr.out %t1.1.o -T %p/Inputs/script.1.phdr.t
+RUN: %link %linkg0opts -o %t1.1.phdr.out %t1.1.o -T %p/Inputs/script.1.phdr.t
 RUN: %readelf -S %t1.1.phdr.out | %filecheck %s
-RUN: %link %linkopts -o %t1.2.out %t1.1.o -T %p/Inputs/script.2.t 2>&1 \
+RUN: %link %linkg0opts -o %t1.2.out %t1.1.o -T %p/Inputs/script.2.t 2>&1 \
 RUN:   --trace=assignments | %filecheck %s --allow-empty --check-prefix TRACE
 RUN: %readelf -S %t1.2.out | %filecheck %s --check-prefix CHECK2
-RUN: %link %linkopts -o %t1.2.phdr.out %t1.1.o -T %p/Inputs/script.2.phdr.t 2>&1 \
+RUN: %link %linkg0opts -o %t1.2.phdr.out %t1.1.o -T %p/Inputs/script.2.phdr.t 2>&1 \
 RUN:   --trace=assignments | %filecheck %s --allow-empty --check-prefix TRACE
 RUN: %readelf -S %t1.2.phdr.out | %filecheck %s --check-prefix CHECK2
-RUN: %link %linkopts -o %t1.1.3.out %t1.1.o -T %p/Inputs/script.3.t 2>&1 \
+RUN: %link %linkg0opts -o %t1.1.3.out %t1.1.o -T %p/Inputs/script.3.t 2>&1 \
 RUN:   | %filecheck %s --check-prefix=NON_CONVERGENCE_NOTE
-RUN: %link %linkopts -o %t1.1.3.out %t1.1.o -T %p/Inputs/script.3.phdr.t 2>&1 \
+RUN: %link %linkg0opts -o %t1.1.3.out %t1.1.o -T %p/Inputs/script.3.phdr.t 2>&1 \
 RUN:   | %filecheck %s --check-prefix=NON_CONVERGENCE_NOTE
 #END_TEST
 


### PR DESCRIPTION
This commit modifies the DotForwReference test to use -G0 option for compiling and linking. This is required to fix test failures when the compiler is built with small-data option ON as default.