### PR TITLE
Resolve --defsym absolute symbols at link time in PIE links

### DIFF
--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -3916,11 +3916,11 @@ bool GNULDBackend::symbolNeedsDynRel(const ResolveInfo &pSym, bool pSymHasPLT,
        LinkerConfig::Binary == config().codeGenType()))
     return false;
 
-  // An absolute symbol can be resolved directly if it is either local
-  // or we are linking statically. Otherwise it can still be overridden
-  // at runtime.
+  // An absolute symbol can be resolved directly if it is local,
+  // non-preemptible (e.g. --defsym in a PIE link), or statically linked.
   if (pSym.isAbsolute() &&
-      (pSym.binding() == ResolveInfo::Local || config().isCodeStatic()))
+      (pSym.binding() == ResolveInfo::Local || !isSymbolPreemptible(pSym) ||
+       config().isCodeStatic()))
     return false;
   if (config().isCodeIndep() && isAbsReloc)
     return true;

--- a/test/Common/standalone/DefsymAbsShared/defsym-abs-shared-32.s
+++ b/test/Common/standalone/DefsymAbsShared/defsym-abs-shared-32.s
@@ -1,0 +1,23 @@
+# REQUIRES: 32BitsArch
+
+## A non-preemptible absolute symbol (e.g. --defsym in a PIE link) can
+## be resolved at link time without a dynamic relocation. In a -shared
+## link the symbol is preemptible and a dynamic reloc is expected.
+
+# RUN: %clang %clangopts -c %s -o %t.o
+
+## Shared link: symbol is preemptible, dynamic reloc expected.
+# RUN: %link %linkopts -shared %t.o --defsym foo=0x20 -o %t.so
+# RUN: %readelf -r %t.so | %filecheck %s --check-prefix=SHARED
+
+## PIE link: symbol is non-preemptible, no dynamic reloc needed.
+# RUN: %link %linkopts -pie %t.o --defsym foo=0x20 -o %t.pie
+# RUN: %readelf -r %t.pie | %filecheck %s --check-prefix=PIE
+
+# SHARED: foo
+# PIE-NOT: foo
+
+.data
+.global bar
+bar:
+.word foo

--- a/test/Common/standalone/DefsymAbsShared/defsym-abs-shared-64.s
+++ b/test/Common/standalone/DefsymAbsShared/defsym-abs-shared-64.s
@@ -1,0 +1,23 @@
+# REQUIRES: 64BitsArch
+
+## A non-preemptible absolute symbol (e.g. --defsym in a PIE link) can
+## be resolved at link time without a dynamic relocation. In a -shared
+## link the symbol is preemptible and a dynamic reloc is expected.
+
+# RUN: %clang %clangopts -c %s -o %t.o
+
+## Shared link: symbol is preemptible, dynamic reloc expected.
+# RUN: %link %linkopts -shared %t.o --defsym foo=0x20 -o %t.so
+# RUN: %readelf -r %t.so | %filecheck %s --check-prefix=SHARED
+
+## PIE link: symbol is non-preemptible, no dynamic reloc needed.
+# RUN: %link %linkopts -pie %t.o --defsym foo=0x20 -o %t.pie
+# RUN: %readelf -r %t.pie | %filecheck %s --check-prefix=PIE
+
+# SHARED: foo
+# PIE-NOT: foo
+
+.data
+.global bar
+bar:
+.quad foo


### PR DESCRIPTION
A non-preemptible absolute symbol (e.g. --defsym in a PIE link) can be resolved directly without a dynamic relocation. Previously eld would emit an unnecessary relative reloc for the PIE case. Now it emits no relocation.

In a -shared link the symbol is preemptible so a dynamic relocation is still emitted as before.