### PR TITLE
[AArch64] Fix pointer mismatch for ifunc fn for adrp-add and abs relocs

### DIFF
--- a/docs/DeveloperDocs/AArch64/IFunc.md
+++ b/docs/DeveloperDocs/AArch64/IFunc.md
@@ -1,0 +1,214 @@
+# GNU IFunc support with AArch64
+
+GNU IFunc functionality enables a developer to provide multiple implementations
+of a function and a resolver function that selects which implementation to use at runtime.
+It is typically used for selecting the most optimized implementation for a given CPU / runtime.
+The resolver function is called once at the start of the application runtime and then the
+selected implementation is fixed.
+
+Example:
+
+```c
+__attribute__((ifunc("foo_resolver")))
+int foo(int);
+
+int foo_impl(int u) {
+  return u;
+}
+
+int (*foo_resolver())(int) {
+  return foo_impl;
+}
+
+int bar(int u) {
+  int v = foo(u); // Calls the function that is returned by foo_resolver
+}
+```
+
+## Static linking
+
+eld generates a PLT slot for each ifunc symbol. Each PLT slot has a corresponding
+GOTPLT slot. This model is very similar to how preemptible dynamic symbols are handled.
+However, instead of doing symbol resolution at runtime to fill the GOTPLT slot, the runtime
+calls the corresponding resolver function to fill the GOTPLT slot.
+
+For the case of static executables, libc plays the role of runtime and takes on a task that is typically
+unusual for a libc -- resolve symbols and patch the binary at runtime with the resolution information.
+
+eld emits `R_AARCH64_IRELATIVE` relocations in `.rela.plt` section, and `__rela_iplt_start` and
+`__rela_iplt_end` symbols that store the start and end addresses of `.rela.plt` section.
+
+The tiny-loader in the libc process the `R_AARCH64_IRELATIVE` relocations by
+iterating over the [`__rela_iplt_start`, `__rela_iplt_end`) range.
+
+```
+Relocation section '.rela.plt' at offset 0x190 contains 6 entries:
+    Offset             Info             Type               Symbol's Value
+0000000000490000  0000000000000408 R_AARCH64_IRELATIVE               4358c0
+0000000000490008  0000000000000408 R_AARCH64_IRELATIVE               40db20
+```
+
+The symbol value of `IRELATIVE` relocations contains the IFunc resolver address, and
+the relocation offset points to the GOTPLT slot for the IFunc symbol. For each relocation,
+the tiny-loader in the libc calls the IFunc resolver and stores the result in the GOTPLT slot.
+
+Note that there is no lazy binding here.
+
+### Direct reference to an IFunc symbol
+
+Direct references to an IFunc symbol are resolved to the PLT slot of the IFunc symbol.
+
+```
+// global variable!
+// R_AARCH64_ABS64
+int (*foo_gp)(int) = foo;
+```
+
+eld will resolve `R_AARCH64_ABS64` relocation to the address of PLT[foo].
+
+### GOT references to an IFunc symbol
+
+GOT references to an IFunc symbol are resolved to the GOTPLT slot of the IFunc symbol
+when there is no direct references to the IFunc symbol. When there is a direct reference
+to the IFunc symbol, then the GOT references to the IFunc symbols gets resolved to the
+GOT slot of the IFunc symbol.
+
+Let's see why:
+
+Case 1: PIC code and no direct reference
+
+```c
+// foo is an ifunc symbol!
+int main() {
+  // adrp x0, :got:foo ;  R_AARCH64_GOT_PAGE
+  // ldr x0, [x0, :got_lo12:foo] ; R_AARCH64_LD64_GOT_LO12_NC
+  int (*foo_lp)(int) = foo;
+}
+```
+
+Here eld will resolve `adrp + ldr` relocation pair to the address of GOTPLT[foo].
+Hence, `ldr` will load the address that is stored in the GOTPLT[foo]. Hence,
+`foo_lp` will store the address of the resolved function. With this design, there
+is no indirection penalty for calls to `foo_lp`.
+
+Case 2: PIC code and direct reference
+
+```c
+// foo is an ifunc symbol!
+
+// R_AARCH64_ABS64
+int (*foo_gp)(int) = foo;
+
+int main() {
+  // adrp x0, :got:foo ;  R_AARCH64_GOT_PAGE
+  // ldr x0, [x0, :got_lo12:foo] ; R_AARCH64_LD64_GOT_LO12_NC
+  int (*foo_lp)(int) = foo;
+}
+```
+
+Here eld will resolve `ABS64` to the address of PLT[foo]. With this, calls to `foo_gp` will
+work as expected. Note that we cannot resolve `ABS64` to the address of
+the resolved function because at link time we cannot know the resolved function.
+
+Now, if we resolve `adrp + ldr` relocation pair as before, then `foo_lp` will store the address of
+the resolved function. This is a problem because `foo_gp` and `foo_lp`, both pointers to the same
+function `foo`, have different values.
+
+To resolve this, whenever their is a direct reference to an ifunc symbol `foo`,
+eld creates an additional GOT slot for `foo`, and fill that with the address of
+the PLT[foo], and resolve all GOT references of `foo` to the GOT[foo] instead of the GOTPLT[foo].
+With this design, `foo_lp` will store the address of PLT[foo], the same as `foo_gp`. Hence,
+no pointer inequality issue.
+
+### IFunc behaviour across all relocations
+
+To describe IFunc behavior for all relocations, we categorize the relocations
+into the following categories:
+
+- Absolute / PC-relative data relocations
+- GOT-related data relocations
+- Control flow relocations
+- GOT-related instruction relocations
+- Absolute / PC-relative address-forming relocations
+- Absolute / PC-relative load/store relocations.
+- General computation relocation
+
+The relocations which are not supported by GNU for IFunc symbols are annotated with
+NotSupportedInGNULDForIFunc. The GNU toolchain that is used for verifying this is:
+aarch64-none-linux-gnu-gcc (Arm GNU Toolchain 15.2.Rel1 (Build arm-15.86)) 15.2.1 20251203
+
+
+#### Absolute / PC-relative data relocations
+
+Resolves to PLT[IFuncSymbol]. Sets HasDirectReference[IFuncSymbol] to true.
+
+- R_AARCH64_ABS{16, 32, 64}
+
+Not handled currently.
+
+[!IMPORTANT]
+They should be resolved to PLT[IFuncSymbol] as well!
+
+- R_AARCH64_PREL{16, 32, 64} (NotSupportedInGNULDForIFunc)
+- R_AARCH64_PLT32 (UNSUPPORTED)
+
+#### GOT-related data relocations
+
+- GOTREL{32, 64} (UNSUPPORTED)
+- GOTPCREL32 (UNSUPPORTED)
+
+#### Control flow relocations
+
+Resolves to PLT[IFuncSymbol].
+
+- TSTBR14
+- CONDBR19
+- JUMP26
+- CALL26
+
+#### GOT-related instruction relocations
+
+Resolves-to / uses GOTPLT[IFuncSymbol] if there is no direct reference to
+IFuncSymbol; otherwise uses GOT[IFuncSymbol].
+
+- R_AARCH64_ADR_GOT_PAGE
+- R_AARCH64_LD{32,64}_GOT_LO12_NC (LD32 variant UNSUPPORTED)
+- R_AARCH64_LD{32,64}_GOTPAGE_LO15 (LD32 variant UNSUPPORTED)
+- R_AARCH64_GOT_LD_PREL19 (UNSUPPORTED)
+- AUTH-ABI GOT relocations (UNSUPPORTED)
+- R_AARCH64_MOVW_GOTOFF_G{0,1}{_NC} (UNSUPPORTED)
+
+#### Absolute / PC-relative address-forming relocations
+
+- R_AARCH64_ADR_PREL_LO21 (NotSupportedInGNULDForIFunc)
+- R_AARCH64_ADR_PREL_PG_HI21{_NC}
+
+Resolves to PLT[IFuncSymbol]. Sets HasDirectReference[IFuncSymbol] to true.
+
+- R_AARCH64_MOVW_UABS_G{0,1,2,3}{_NC} (NotSupportedInGNULDForIFunc)
+- R_AARCH64_SABS_G{0,1,2,3} (NotSupportedInGNULDForIFunc)
+- MOVW_PREL_G{0, 1, 2, 3}{_NC} (UNSUPPORTED)
+
+Resolves to IFuncSymbol.
+
+[!IMPORTANT]
+FIXME: We should perhaps resolve these relocations to the PLT[IFuncSymbol]
+instead of the IFuncSymbol for ensuring pointer equality.
+
+#### Absolute / PC-relative load/store relocations
+
+- LD_PREL_LO19 (NotSupportedInGNULDForIFunc)
+- LDST{8, 16, 32, 64, 128}_ABS_LO12_NC (NotSupportedInGNULDForIFunc)
+
+These relocations does not make sense with IFunc symbols. Loading value
+at a function address is an invalid behavior, and so is storing a value
+at a function address.
+
+[!IMPORTANT]
+FIXME: It should be an error to use these relocations with IFunc symbols.
+
+#### General computation relocation
+
+- R_AARCH64_ADD_ABS_LO12_NC
+
+Resolves to PLT[IFuncSymbol]. Set HasDirectReference[IFuncSymbol].

--- a/include/eld/Diagnostics/DiagRelocations.inc
+++ b/include/eld/Diagnostics/DiagRelocations.inc
@@ -75,3 +75,7 @@ DIAG(resolve_undef_weak_guard, DiagnosticEngine::Warning,
 DIAG(error_relocations_plugin, DiagnosticEngine::Error, "unable to apply relocations")
 DIAG(verbose_remapped_internal_reloc, DiagnosticEngine::Verbose,
      "Remapped Internal Relocation %0 to %1 in section %2")
+DIAG(warn_unsupported_reloc_for_ifunc, DiagnosticEngine::Warning,
+     "Unsupported relocation %0 used for STT_GNU_IFUNC symbol '%1'")
+DIAG(warn_invalid_reloc_for_ifunc, DiagnosticEngine::Warning,
+     "Invalid relocation %0 used for STT_GNU_IFUNC symbol '%1'")

--- a/include/eld/SymbolResolver/ResolveInfo.h
+++ b/include/eld/SymbolResolver/ResolveInfo.h
@@ -149,6 +149,18 @@ public:
     return ((ThisBitField & PatchableMask) == PatchableMask);
   }
 
+  void setIFuncDirectRef() { ThisBitField |= IFuncDirectRefFlag; }
+
+  bool hasIFuncDirectRef() const {
+    return ((ThisBitField & IFuncDirectRefMask) == IFuncDirectRefMask);
+  }
+
+  void setIFuncNeedsGOT() { ThisBitField |= IFuncNeedsGOTFlag; }
+
+  bool hasIFuncNeedsGOT() const {
+    return ((ThisBitField & IFuncNeedsGOTMask) == IFuncNeedsGOTMask);
+  }
+
   // -----  observers  ----- //
   bool isNull() const;
 
@@ -314,14 +326,19 @@ private:
   static const uint32_t PreserveOffset = 18;
   static const uint32_t PreserveMask = 1 << PreserveOffset;
 
-  // FIXME: offset 19 can be used here!
+  static const uint32_t IFuncDirectRefOffset = 19;
+  static const uint32_t IFuncDirectRefMask = 1 << IFuncDirectRefOffset;
+
   static const uint32_t PatchableOffset = 20;
   static const uint32_t PatchableMask = 1 << PatchableOffset;
 
+  static const uint32_t IFuncNeedsGOTOffset = 21;
+  static const uint32_t IFuncNeedsGOTMask = 1 << IFuncNeedsGOTOffset;
+
   static const uint32_t InfoMask = 0xF;
 
-  // Bits are from 0-20.
-  static const uint32_t ResolveMask = 0x1FFFFF;
+  // Bits are from 0-21.
+  static const uint32_t ResolveMask = 0x3FFFFF;
 
 public:
   static const uint32_t GlobalFlag = 0 << GlobalOffset;
@@ -343,6 +360,8 @@ public:
   static const uint32_t InbitcodeFlag = 1 << InBitcodeOffset;
   static const uint32_t PreserveFlag = 1 << PreserveOffset;
   static const uint32_t PatchableFlag = 1 << PatchableOffset;
+  static const uint32_t IFuncDirectRefFlag = 1 << IFuncDirectRefOffset;
+  static const uint32_t IFuncNeedsGOTFlag = 1 << IFuncNeedsGOTOffset;
   ResolveInfo();
   ResolveInfo(llvm::StringRef SymbolName);
   ~ResolveInfo();

--- a/lib/Target/AArch64/AArch64LDBackend.cpp
+++ b/lib/Target/AArch64/AArch64LDBackend.cpp
@@ -574,6 +574,33 @@ bool AArch64LDBackend::finalizeTargetSymbols() {
   return true;
 }
 
+bool AArch64LDBackend::finalizeScanRelocations() {
+  if (!config().isCodeStatic())
+    return true;
+
+  ELFObjectFile *Obj = getDynamicSectionHeadersInputFile();
+  if (!Obj)
+    return true;
+
+  for (auto &[symInfo, plt] : m_PLTMap) {
+    if (!symInfo->isIFunc() || !symInfo->hasIFuncDirectRef() ||
+        !symInfo->hasIFuncNeedsGOT())
+      continue;
+
+    AArch64GOT *G = AArch64GOT::Create(Obj->getGOT(), symInfo);
+
+    FragmentRef *PLTFragRef = make<FragmentRef>(*plt, 0);
+    Relocation *r = Relocation::Create(llvm::ELF::R_AARCH64_ABS64, 64,
+                                       make<FragmentRef>(*G, 0), 0);
+    Obj->getGOT()->addRelocation(r);
+    r->modifyRelocationFragmentRef(PLTFragRef);
+
+    recordGOT(symInfo, G);
+    symInfo->setReserved(symInfo->reserved() | Relocator::ReserveGOT);
+  }
+  return true;
+}
+
 void AArch64LDBackend::setupStaticTCBForTLSSupport() {
   if (!config().isCodeStatic())
     return;

--- a/lib/Target/AArch64/AArch64LDBackend.h
+++ b/lib/Target/AArch64/AArch64LDBackend.h
@@ -75,6 +75,9 @@ public:
   /// finalizeTargetSymbols - finalize the symbol value
   bool finalizeTargetSymbols() override;
 
+  /// Currently is only used to create GOT entries for ifunc with direct refs
+  bool finalizeScanRelocations() override;
+
   void setOptions() override;
 
   void initSegmentFromLinkerScript(ELFSegment *pSegment) override;

--- a/lib/Target/AArch64/AArch64Relocator.cpp
+++ b/lib/Target/AArch64/AArch64Relocator.cpp
@@ -346,14 +346,14 @@ void AArch64Relocator::scanGlobalReloc(InputFile &pInput, Relocation &pReloc,
   ELFObjectFile *Obj = llvm::dyn_cast<ELFObjectFile>(&pInput);
   // rsym - The relocation target symbol
   ResolveInfo *rsym = pReloc.symInfo();
+  if (rsym && rsym->isIFunc() && config().isCodeStatic())
+    return handleScanForNonPreemptibleIFunc(pReloc, Obj);
   switch (pReloc.type()) {
   case llvm::ELF::R_AARCH64_AUTH_ABS64:
   case llvm::ELF::R_AARCH64_ABS16:
   case llvm::ELF::R_AARCH64_ABS32:
   case llvm::ELF::R_AARCH64_ABS64: {
     std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
-    if (handleScanForNonPreemptibleIFunc(rsym, Obj))
-      return;
     bool isAuthAbs = pReloc.type() == llvm::ELF::R_AARCH64_AUTH_ABS64;
     // Absolute relocation type, symbol may needs PLT entry or
     // dynamic relocation entry
@@ -450,8 +450,6 @@ void AArch64Relocator::scanGlobalReloc(InputFile &pInput, Relocation &pReloc,
   case llvm::ELF::R_AARCH64_JUMP26:
   case llvm::ELF::R_AARCH64_CALL26: {
     std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
-    if (handleScanForNonPreemptibleIFunc(rsym, Obj))
-      return;
     // return if we already create plt for this symbol
     if (rsym->reserved() & ReservePLT)
       return;
@@ -474,8 +472,6 @@ void AArch64Relocator::scanGlobalReloc(InputFile &pInput, Relocation &pReloc,
   case llvm::ELF::R_AARCH64_ADR_PREL_PG_HI21:
   case R_AARCH64_ADR_PREL_PG_HI21_NC: {
     std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
-    if (handleScanForNonPreemptibleIFunc(rsym, Obj))
-      return;
     if (relocNeedsDynRel(pReloc)) {
       if (getTarget().symbolNeedsCopyReloc(pReloc, *rsym)) {
         // check if the option -z nocopyreloc is given
@@ -509,8 +505,6 @@ void AArch64Relocator::scanGlobalReloc(InputFile &pInput, Relocation &pReloc,
   case llvm::ELF::R_AARCH64_LD64_GOT_LO12_NC:
   case llvm::ELF::R_AARCH64_LD64_GOTPAGE_LO15: {
     std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
-    if (handleScanForNonPreemptibleIFunc(rsym, Obj))
-      return;
     // Symbol needs GOT entry, reserve entry in .got
     // return if we already create GOT for this symbol
     if (rsym->reserved() & ReserveGOT)
@@ -968,9 +962,14 @@ Relocator::Result adr_got_page(Relocation &pReloc, AArch64Relocator &pParent) {
   }
   Relocator::Address GOT_S;
   if (LLVM_UNLIKELY(isStaticIFunc)) {
-    AArch64PLT *PLT = pParent.getTarget().findEntryInPLT(symInfo);
-    ASSERT(PLT, "Must not be null!");
-    GOT_S = PLT->getGOT()->getAddr(DiagEngine);
+    AArch64GOT *G = pParent.getTarget().findEntryInGOT(pReloc.symInfo());
+    if (G)
+      GOT_S = G->getAddr(pParent.config().getDiagEngine());
+    else {
+      AArch64PLT *PLT = pParent.getTarget().findEntryInPLT(symInfo);
+      ASSERT(PLT, "Must not be null!");
+      GOT_S = PLT->getGOT()->getAddr(pParent.config().getDiagEngine());
+    }
   } else {
     GOT_S = pParent.getTarget()
                 .findEntryInGOT(pReloc.symInfo())
@@ -1001,9 +1000,14 @@ Relocator::Result ld64_got_lo12(Relocation &pReloc, AArch64Relocator &pParent) {
   Relocator::Address GOT_S;
 
   if (LLVM_UNLIKELY(isStaticIFunc)) {
-    AArch64PLT *PLT = pParent.getTarget().findEntryInPLT(symInfo);
-    ASSERT(PLT, "Must not be null!");
-    GOT_S = PLT->getGOT()->getAddr(pParent.config().getDiagEngine());
+    AArch64GOT *G = pParent.getTarget().findEntryInGOT(pReloc.symInfo());
+    if (G)
+      GOT_S = G->getAddr(pParent.config().getDiagEngine());
+    else {
+      AArch64PLT *PLT = pParent.getTarget().findEntryInPLT(symInfo);
+      ASSERT(PLT, "Must not be null!");
+      GOT_S = PLT->getGOT()->getAddr(pParent.config().getDiagEngine());
+    }
   } else {
     GOT_S = pParent.getTarget()
                 .findEntryInGOT(pReloc.symInfo())
@@ -1305,14 +1309,103 @@ Relocator::Result copyInstruction(Relocation &pReloc,
   return Relocator::OK;
 }
 
-bool AArch64Relocator::handleScanForNonPreemptibleIFunc(ResolveInfo *symInfo,
+void AArch64Relocator::handleScanForNonPreemptibleIFunc(Relocation &R,
                                                         ELFObjectFile *Obj) {
-  if (!symInfo || !symInfo->isIFunc() || !config().isCodeStatic())
-    return false;
-  if (symInfo->reserved() & Relocator::ReservePLT)
+  std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
+  ResolveInfo *RI = R.symInfo();
+  Relocator::Type RType = R.type();
+  bool isValidRelocForIFunc =
+      isGOTBasedInstrRelocation(RType) || isAbsDataRelocation(RType) ||
+      isPRelAdrRelocation(RType) || isControlFlowRelocation(RType);
+  if (!isValidRelocForIFunc) {
+    config().raise(Diag::warn_invalid_reloc_for_ifunc)
+        << getName(R.type())
+        << RI->getDecoratedName(config().options().shouldDemangle());
+  }
+
+  if (isUnsupportedIFuncRelocation(R.type())) {
+    config().raise(Diag::warn_unsupported_reloc_for_ifunc)
+        << getName(R.type())
+        << RI->getDecoratedName(config().options().shouldDemangle());
+  }
+  if (isGOTBasedInstrRelocation(R.type()))
+    RI->setIFuncNeedsGOT();
+  if (isAbsDataRelocation(R.type()) || isPRelAdrRelocation(R.type()))
+    RI->setIFuncDirectRef();
+  if (RI->reserved() & Relocator::ReservePLT)
+    return;
+  m_Target.createPLT(Obj, RI, /*isIRelative=*/true);
+  m_Target.defineIRelativeRange(*RI);
+  RI->setReserved(RI->reserved() | Relocator::ReservePLT);
+}
+
+bool AArch64Relocator::isGOTBasedInstrRelocation(
+    Relocation::Type relocType) const {
+  switch (relocType) {
+  case llvm::ELF::R_AARCH64_ADR_GOT_PAGE:
+  case llvm::ELF::R_AARCH64_LD64_GOT_LO12_NC:
+  case llvm::ELF::R_AARCH64_LD64_GOTPAGE_LO15:
     return true;
-  m_Target.createPLT(Obj, symInfo, /*isIRelative=*/true);
-  m_Target.defineIRelativeRange(*symInfo);
-  symInfo->setReserved(symInfo->reserved() | ReservePLT);
-  return true;
+  // These relocations are UNSUPPORTED for now!
+  case llvm::ELF::R_AARCH64_GOT_LD_PREL19:
+  case llvm::ELF::R_AARCH64_MOVW_GOTOFF_G0:
+  case llvm::ELF::R_AARCH64_MOVW_GOTOFF_G0_NC:
+  case llvm::ELF::R_AARCH64_MOVW_GOTOFF_G1:
+  case llvm::ELF::R_AARCH64_MOVW_GOTOFF_G1_NC:
+  case llvm::ELF::R_AARCH64_MOVW_GOTOFF_G2:
+  case llvm::ELF::R_AARCH64_MOVW_GOTOFF_G2_NC:
+  case llvm::ELF::R_AARCH64_MOVW_GOTOFF_G3:
+    llvm_unreachable("Unsupported relocations should not reach here!");
+  }
+  return false;
+}
+
+bool AArch64Relocator::isAbsDataRelocation(Relocation::Type relocType) const {
+  switch (relocType) {
+  case llvm::ELF::R_AARCH64_ABS16:
+  case llvm::ELF::R_AARCH64_ABS32:
+  case llvm::ELF::R_AARCH64_ABS64:
+    return true;
+  }
+  return false;
+}
+
+bool AArch64Relocator::isPRelAdrRelocation(Relocation::Type relocType) const {
+  switch (relocType) {
+  case llvm::ELF::R_AARCH64_ADR_PREL_PG_HI21:
+  case R_AARCH64_ADR_PREL_PG_HI21_NC:
+  case llvm::ELF::R_AARCH64_ADR_PREL_LO21:
+  case llvm::ELF::R_AARCH64_ADD_ABS_LO12_NC:
+    return true;
+  }
+  return false;
+}
+
+bool AArch64Relocator::isUnsupportedIFuncRelocation(
+    Relocation::Type relocType) const {
+  switch (relocType) {
+  case llvm::ELF::R_AARCH64_MOVW_GOTOFF_G0:
+  case llvm::ELF::R_AARCH64_MOVW_GOTOFF_G0_NC:
+  case llvm::ELF::R_AARCH64_MOVW_GOTOFF_G1:
+  case llvm::ELF::R_AARCH64_MOVW_UABS_G1_NC:
+  case llvm::ELF::R_AARCH64_MOVW_GOTOFF_G2:
+  case llvm::ELF::R_AARCH64_MOVW_GOTOFF_G3:
+  case llvm::ELF::R_AARCH64_PREL16:
+  case llvm::ELF::R_AARCH64_PREL32:
+  case llvm::ELF::R_AARCH64_PREL64:
+    return true;
+  }
+  return false;
+}
+
+bool AArch64Relocator::isControlFlowRelocation(
+    Relocation::Type relocType) const {
+  switch (relocType) {
+  case llvm::ELF::R_AARCH64_CALL26:
+  case llvm::ELF::R_AARCH64_JUMP26:
+  case llvm::ELF::R_AARCH64_CONDBR19:
+  case llvm::ELF::R_AARCH64_TSTBR14:
+    return true;
+  }
+  return false;
 }

--- a/lib/Target/AArch64/AArch64Relocator.cpp
+++ b/lib/Target/AArch64/AArch64Relocator.cpp
@@ -154,8 +154,11 @@ bool AArch64Relocator::isRelocSupported(Relocation &pReloc) const {
       (type != R_AARCH64_COPY_INSN))
     return false;
 
-  assert(ApplyFunctions.find(type) != ApplyFunctions.end());
-  return true;
+  auto iter = ApplyFunctions.find(type);
+
+  assert(iter != ApplyFunctions.end());
+
+  return iter->second.func != unsupport;
 }
 
 bool AArch64Relocator::isInvalidReloc(Relocation &pReloc) const {

--- a/lib/Target/AArch64/AArch64Relocator.h
+++ b/lib/Target/AArch64/AArch64Relocator.h
@@ -86,13 +86,21 @@ private:
                        eld::IRBuilder &pBuilder, ELFSection &pSection,
                        CopyRelocs &);
 
-  bool handleScanForNonPreemptibleIFunc(ResolveInfo *symInfo,
-                                        ELFObjectFile *Obj);
+  void handleScanForNonPreemptibleIFunc(Relocation &R, ELFObjectFile *Obj);
+
+  bool isGOTBasedInstrRelocation(Relocation::Type relocType) const;
+
+  bool isAbsDataRelocation(Relocation::Type relocType) const;
+
+  bool isPRelAdrRelocation(Relocation::Type relocType) const;
+
+  bool isUnsupportedIFuncRelocation(Relocation::Type relocType) const;
+
+  bool isControlFlowRelocation(Relocation::Type relocType) const;
 
 private:
   AArch64LDBackend &m_Target;
 };
 
 } // namespace eld
-
 #endif

--- a/test/AArch64/linux/IFuncs/IFuncs.test
+++ b/test/AArch64/linux/IFuncs/IFuncs.test
@@ -42,10 +42,10 @@ CHECK3: {{0+}}2000 <foogp>:
 CHECK3: 2000: {{.*}} .word 0x{{0+}}[[#%x,PLT_START+0x20]]
 
 CHECK4: .plt PROGBITS [[#%x,PLT_START:]]
-CHECK4: .got.plt PROGBITS {{0+}}2008
+CHECK4: .got PROGBITS {{0+}}[[#%x,GOT_START:]]
 CHECK4: <main>:
-CHECK4: adrp x8, 0x2000
-CHECK4: ldr	x8, [x8, #0x20]
+CHECK4: adrp x8, 0x[[#%x,GOT_PAGE_START:]]
+CHECK4: ldr	x8, [x8, #0x{{0*}}[[#%x,GOT_START-GOT_PAGE_START]]
 CHECK4: Disassembly of section .data:
 CHECK4: {{0+}}2000 <foogp>:
 CHECK4: 2000: {{.*}} .word 0x{{0+}}[[#%x,PLT_START+0x20]]

--- a/test/AArch64/standalone/IFuncInvalidRelocations/IFuncInvalidRelocations.test
+++ b/test/AArch64/standalone/IFuncInvalidRelocations/IFuncInvalidRelocations.test
@@ -1,0 +1,11 @@
+#---IFuncUnsupportedRelocations.test-------------- Executable --------------------#
+#BEGIN_COMMENT
+# This test checks that eld reports errors for relocations that are
+# invalid for IFunc symbols.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o -target aarch64-linux-gnu %p/Inputs/1.c -c
+RUN: %clang %clangopts -o %t1.ldr.o -target aarch64-linux-gnu %p/Inputs/ldr.s -c
+RUN: %link %linkopts -o %t1.ldr.out %t1.1.o %t1.ldr.o 2>&1 | %filecheck %s --check-prefix=LDR
+
+LDR: Warning: Invalid relocation R_AARCH64_LD_PREL_LO19 used for STT_GNU_IFUNC symbol 'foo'

--- a/test/AArch64/standalone/IFuncInvalidRelocations/Inputs/1.c
+++ b/test/AArch64/standalone/IFuncInvalidRelocations/Inputs/1.c
@@ -1,0 +1,5 @@
+int foo_impl(int u, int v) { return 1; }
+
+int (*foo_resolver())(int, int) { return foo_impl; }
+
+__attribute__((ifunc("foo_resolver"))) int foo(int, int);

--- a/test/AArch64/standalone/IFuncInvalidRelocations/Inputs/ldr.s
+++ b/test/AArch64/standalone/IFuncInvalidRelocations/Inputs/ldr.s
@@ -1,0 +1,5 @@
+  .section .text,"ax",%progbits
+  .global get_foo
+  get_foo:
+    ldr x0, foo
+    ret

--- a/test/AArch64/standalone/IFuncPointerEquality/IFuncPointerEquality.test
+++ b/test/AArch64/standalone/IFuncPointerEquality/IFuncPointerEquality.test
@@ -1,0 +1,89 @@
+#---IFuncPointerEquality.test-------------- Executable --------------------#
+#BEGIN_COMMENT
+# This tests that pointers to the same ifunc function have the same address.
+# When an ifunc has both direct references (such as global pointer initialization)
+# and GOT-relative references, both should resolve to the ifunc symbol's
+# PLT slot address. To properly resolve GOT relocations for this case, the linker
+# creates a .got entry that points to the PLT entry for the ifunc.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.main.nopic.o -target aarch64-linux-gnu %p/Inputs/main.c -c -fno-pic
+RUN: %clang %clangopts -o %t1.main.pic.o -target aarch64-linux-gnu %p/Inputs/main.c -c -fPIC
+RUN: SECTION_ADDR_LINK_OPTS="--section-start .text=0x1000 --section-start .data=0x2000 \
+RUN:   --section-start .got=0x3000 --section-start .plt=0x4000"
+
+RUN: %clang %clangopts -o %t1.adrp-add.o -target aarch64-linux-gnu %p/Inputs/adrp-add.s -c
+RUN: %link %linkopts -o %t1.adrp-add.nopic.out %t1.main.nopic.o %t1.adrp-add.o ${SECTION_ADDR_LINK_OPTS}
+RUN: %link %linkopts -o %t1.adrp-add.pic.out %t1.main.pic.o %t1.adrp-add.o ${SECTION_ADDR_LINK_OPTS}
+RUN: ( %objdump -dr %t1.adrp-add.nopic.out --disassemble-symbols=main,get_foo_from_outside && %readelf -S %t1.adrp-add.nopic.out ) | %filecheck %s --check-prefix=NO_GOT_REF
+RUN: ( %objdump -dr %t1.adrp-add.pic.out --disassemble-symbols=main,get_foo_from_outside && %readelf -x .got %t1.adrp-add.pic.out ) | %filecheck %s --check-prefix=GOT_AND_DIRECT_REF
+
+RUN: %clang %clangopts -o %t1.adrp-ldr.o -target aarch64-linux-gnu %p/Inputs/adrp-ldr.s -c
+RUN: %link %linkopts -o %t1.adrp-ldr.nopic.out %t1.main.nopic.o %t1.adrp-ldr.o ${SECTION_ADDR_LINK_OPTS}
+RUN: %link %linkopts -o %t1.adrp-ldr.pic.out %t1.main.pic.o %t1.adrp-ldr.o ${SECTION_ADDR_LINK_OPTS}
+RUN: ( %objdump -dr %t1.adrp-ldr.nopic.out --disassemble-symbols=main,get_foo_from_outside && %readelf -x .got %t1.adrp-ldr.nopic.out ) | %filecheck %s --check-prefix=DIRECT_AND_GOT_REF
+RUN: ( %objdump -dr %t1.adrp-ldr.pic.out --disassemble-symbols=main,get_foo_from_outside && %readelf -x .got.plt %t1.adrp-ldr.pic.out ) | %filecheck %s --check-prefix=GOT_AND_GOT_REF
+
+RUN: %clang %clangopts -o %t1.adr.o -target aarch64-linux-gnu %p/Inputs/adr.s -c
+RUN: %link %linkopts -o %t1.adr.nopic.out %t1.main.nopic.o %t1.adr.o ${SECTION_ADDR_LINK_OPTS}
+RUN: %link %linkopts -o %t1.adr.pic.out %t1.main.pic.o %t1.adr.o ${SECTION_ADDR_LINK_OPTS}
+RUN: ( %objdump -dr %t1.adr.nopic.out --disassemble-symbols=main,get_foo_from_outside && %readelf -S %t1.adr.nopic.out ) | %filecheck %s --check-prefix=NO_GOT_REF_ADR
+RUN: ( %objdump -dr %t1.adr.pic.out --disassemble-symbols=main,get_foo_from_outside && %readelf -x .got %t1.adr.pic.out ) | %filecheck %s --check-prefix=GOT_AND_DIRECT_REF_ADR
+#END_TEST
+
+NO_GOT_REF: <main>:
+NO_GOT_REF: adrp x8, 0x4000
+NO_GOT_REF: add x8, x8, #0x[[#%x,PLT_OFFSET:]]
+NO_GOT_REF: bl {{.*}} <get_foo_from_outside>
+NO_GOT_REF: <get_foo_from_outside>:
+NO_GOT_REF: adrp	x0, 0x4000
+NO_GOT_REF: add	x0, x0, #0x[[#%x,PLT_OFFSET]]
+NO_GOT_REF-NOT: .got PROGBITS
+
+GOT_AND_DIRECT_REF: <main>:
+GOT_AND_DIRECT_REF: adrp x8, 0x3000
+GOT_AND_DIRECT_REF: ldr x8, [x8]
+GOT_AND_DIRECT_REF: bl {{.*}} <get_foo_from_outside>
+GOT_AND_DIRECT_REF: <get_foo_from_outside>:
+GOT_AND_DIRECT_REF: adrp	x0, 0x4000
+GOT_AND_DIRECT_REF: add	x0, x0, #0x20
+GOT_AND_DIRECT_REF: Hex dump of section '.got':
+GOT_AND_DIRECT_REF: {{.*}}3000 2040{{0+}}
+
+DIRECT_AND_GOT_REF: <main>:
+DIRECT_AND_GOT_REF: adrp x8, 0x4000
+DIRECT_AND_GOT_REF: add x8, x8, #0x[[#%x,PLT_OFFSET:]]
+DIRECT_AND_GOT_REF: bl {{.*}} <get_foo_from_outside>
+DIRECT_AND_GOT_REF: <get_foo_from_outside>:
+DIRECT_AND_GOT_REF: adrp	x0, 0x3000
+DIRECT_AND_GOT_REF: ldr	x0, [x0]
+DIRECT_AND_GOT_REF: Hex dump of section '.got':
+DIRECT_AND_GOT_REF: {{.*}}3000 2040{{0+}}
+
+GOT_AND_GOT_REF: <main>:
+GOT_AND_GOT_REF: adrp x8, 0x3000
+GOT_AND_GOT_REF: ldr x8, [x8, #0x[[#%x,GOTPLT_OFFSET:0x20]]]
+GOT_AND_GOT_REF: bl {{.*}} <get_foo_from_outside>
+GOT_AND_GOT_REF: <get_foo_from_outside>:
+GOT_AND_GOT_REF: adrp	x0, 0x3000
+GOT_AND_GOT_REF: ldr	x0, [x0, #0x[[#%x,GOTPLT_OFFSET]]]
+GOT_GOT_REF: Hex dump of section '.got.plt':
+GOT_GOT_REF: 0x{{0+}}3008
+GOT_GOT_REF: 0x{{0+}}3018
+
+NO_GOT_REF_ADR: <main>:
+NO_GOT_REF_ADR: adrp x8, 0x4000
+NO_GOT_REF_ADR: add x8, x8, #0x[[#%x,PLT_OFFSET:]]
+NO_GOT_REF_ADR: bl {{.*}} <get_foo_from_outside>
+NO_GOT_REF_ADR: <get_foo_from_outside>:
+NO_GOT_REF_ADR: adr	x0, 0x4020
+NO_GOT_REF_ADR-NOT: .got PROGBITS
+
+GOT_AND_DIRECT_REF_ADR: <main>:
+GOT_AND_DIRECT_REF_ADR: adrp x8, 0x3000
+GOT_AND_DIRECT_REF_ADR: ldr x8, [x8]
+GOT_AND_DIRECT_REF_ADR: bl {{.*}} <get_foo_from_outside>
+GOT_AND_DIRECT_REF_ADR: <get_foo_from_outside>:
+GOT_AND_DIRECT_REF_ADR: adr	x0, 0x4020
+GOT_AND_DIRECT_REF_ADR: Hex dump of section '.got':
+GOT_AND_DIRECT_REF_ADR: {{.*}}3000 2040{{0+}}

--- a/test/AArch64/standalone/IFuncPointerEquality/Inputs/adr.s
+++ b/test/AArch64/standalone/IFuncPointerEquality/Inputs/adr.s
@@ -1,0 +1,9 @@
+  .section .text,"ax",%progbits
+  .global get_foo_from_outside
+  .type get_foo_from_outside, %function
+
+get_foo_from_outside:
+  adr x0, foo
+  ret
+
+  .size get_foo_from_outside, .-get_foo_from_outside

--- a/test/AArch64/standalone/IFuncPointerEquality/Inputs/adrp-add.s
+++ b/test/AArch64/standalone/IFuncPointerEquality/Inputs/adrp-add.s
@@ -1,0 +1,10 @@
+  .section .text,"ax",%progbits
+  .global get_foo_from_outside
+  .type get_foo_from_outside, %function
+
+get_foo_from_outside:
+  adrp x0, foo
+  add x0, x0, #:lo12:foo
+  ret
+
+  .size get_foo_from_outside, .-get_foo_from_outside

--- a/test/AArch64/standalone/IFuncPointerEquality/Inputs/adrp-ldr.s
+++ b/test/AArch64/standalone/IFuncPointerEquality/Inputs/adrp-ldr.s
@@ -1,0 +1,10 @@
+  .section .text,"ax",%progbits
+  .global get_foo_from_outside
+  .type get_foo_from_outside, %function
+
+get_foo_from_outside:
+  adrp x0, :got:foo
+  ldr x0, [x0, #:got_lo12:foo]
+  ret
+
+  .size get_foo_from_outside, .-get_foo_from_outside

--- a/test/AArch64/standalone/IFuncPointerEquality/Inputs/main.c
+++ b/test/AArch64/standalone/IFuncPointerEquality/Inputs/main.c
@@ -1,0 +1,13 @@
+char *foo_impl() { return "foo"; }
+
+static char *(*foo_resolver())(void) { return foo_impl; }
+
+char *foo() __attribute__((ifunc("foo_resolver")));
+
+char *(*get_foo_from_outside())();
+
+int main() {
+  char *(*foo_lp)() = foo;
+  char *(*foo_outside)() = get_foo_from_outside();
+  return foo == foo_lp && foo_lp == foo_outside;
+}

--- a/test/AArch64/standalone/IFuncUnsupportedRelocations/IFuncUnsupportedRelocations.test
+++ b/test/AArch64/standalone/IFuncUnsupportedRelocations/IFuncUnsupportedRelocations.test
@@ -1,0 +1,14 @@
+#---IFuncUnsupportedRelocations.test-------------- Executable --------------------#
+#BEGIN_COMMENT
+# This test checks that eld reports errors for relocations that are currently
+# not support for IFunc symbols.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o -target aarch64-linux-gnu %p/Inputs/1.c -c
+RUN: %clang %clangopts -o %t1.mov.o -target aarch64-linux-gnu %p/Inputs/mov.s -c
+RUN: %link %linkopts -o %t1.mov.out %t1.1.o %t1.mov.o 2>&1 | %filecheck %s --check-prefix=MOV
+RUN: %clang %clangopts -o %t1.prel.o -target aarch64-linux-gnu %p/Inputs/prel.s -c
+RUN: %link %linkopts -o %t1.prel.out %t1.1.o %t1.prel.o 2>&1 | %filecheck %s --check-prefix=PREL
+
+MOV: Warning: Unsupported relocation R_AARCH64_MOVW_UABS_G1_NC used for STT_GNU_IFUNC symbol 'foo'
+PREL: Warning: Unsupported relocation R_AARCH64_PREL64 used for STT_GNU_IFUNC symbol 'foo'

--- a/test/AArch64/standalone/IFuncUnsupportedRelocations/Inputs/1.c
+++ b/test/AArch64/standalone/IFuncUnsupportedRelocations/Inputs/1.c
@@ -1,0 +1,5 @@
+int foo_impl(int u, int v) { return 1; }
+
+int (*foo_resolver())(int, int) { return foo_impl; }
+
+__attribute__((ifunc("foo_resolver"))) int foo(int, int);

--- a/test/AArch64/standalone/IFuncUnsupportedRelocations/Inputs/mov.s
+++ b/test/AArch64/standalone/IFuncUnsupportedRelocations/Inputs/mov.s
@@ -1,0 +1,8 @@
+  .section .text,"ax",%progbits
+  .global get_foo
+  get_foo:
+    movz x0, #:abs_g0_nc:foo
+    movk x0, #:abs_g1_nc:foo
+    movk x0, #:abs_g2_nc:foo
+    movk x0, #:abs_g3:foo
+    ret

--- a/test/AArch64/standalone/IFuncUnsupportedRelocations/Inputs/prel.s
+++ b/test/AArch64/standalone/IFuncUnsupportedRelocations/Inputs/prel.s
@@ -1,0 +1,4 @@
+  .section .data,"aw",%progbits
+  .global foo_gp
+  foo_gp:
+    .quad foo - .

--- a/test/AArch64/standalone/UnsupportedRelocation/Inputs/1.s
+++ b/test/AArch64/standalone/UnsupportedRelocation/Inputs/1.s
@@ -1,0 +1,5 @@
+  .section .text,"ax",%progbits
+  .global _start
+_start:
+  ldr x0, :got:foo
+  ret

--- a/test/AArch64/standalone/UnsupportedRelocation/Inputs/2.s
+++ b/test/AArch64/standalone/UnsupportedRelocation/Inputs/2.s
@@ -1,0 +1,5 @@
+  .section ".data","aw",%progbits
+  .global foo
+foo:
+  .reloc foo, R_AARCH64_GOTREL64, bar
+  .quad 0

--- a/test/AArch64/standalone/UnsupportedRelocation/UnsupportedRelocation.test
+++ b/test/AArch64/standalone/UnsupportedRelocation/UnsupportedRelocation.test
@@ -1,0 +1,14 @@
+#---UnsuportedRelocation.test--------- Executable --------------------#
+#BEGIN_COMMENT
+# The test checks that the unsupported relocation error is emitted for
+# unsupported relocations.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.s -c
+RUN: %not %link %linkopts -o %t1.1.out %t1.1.o 2>&1 | %filecheck %s --check-prefix=GOT_LD_PREL19
+RUN: %clang %clangopts -o %t1.2.o %p/Inputs/2.s -c
+RUN: %not %link %linkopts -o %t1.2.out %t1.2.o 2>&1 | %filecheck %s --check-prefix=GOTPREL
+#END_TEST
+
+GOT_LD_PREL19: Fatal: Found unsupported reloc type 309 in section .rela.text in input file
+GOTPREL: Fatal: Found unsupported reloc type 307 in section .rela.data in input file


### PR DESCRIPTION
This commit fixes pointer inequality in pointers to the same ifunc
symbol when adrp-add relocation pair and abs relocations are used. Let's understand the issue in more detail using the below example:

```cpp
char *foo_impl() { return "foo"; }

static char *(*foo_resolver())(void) { return foo_impl; }

char *foo() __attribute__((ifunc("foo_resolver")));

char *(*foogp)() = foo;

int main() {
  char *(*foop)() = foo;
}
```

`foogp` and `foop` pointers both point to the same function `foo`. However, their values were different. The root cause was improper handling of the underlying relocations when the symbol is of type ifunc.

```
char *(*foogp)() = foo; // R_AARCH64_ABS64
// ...
char *(*foop)() = foo; // R_AARCH64_ADR_GOT_PAGE + R_AARCH64_LD64_GOT_LO12_NC
```

Previously, the linker resolved the R_AARCH64_ABS64 relocation here to the plt slot of foo, let's refer to it as plt[foo], and the GOT-relocations were resolved to the .got.plt slot of foo, let's refer to it as .got.plt[foo]. As a result, foogp stores the address of plt[foo] and foop stores the contents of .got.plt[foo], that is, the address of the resolved function foo. Clearly, the two values are different.

We resolve this issue by creating a got slot for foo when the foo has both an absolute reference and a GOT-reference. The got slot of foo is filled by the linker and stores the address of plt[foo]. With this, both the absolute-reference and got-reference to an ifunc symbol results in the same address. Please note that:

- we do not create .got slot of foo when we only have an absolute reference to foo because .got slot is unnecessary in this case, and
- we do not create .got slot of foo when we only have a GOT-reference because in this case we can directly use .got.plt slot and access the function directly without any indirection penalty or the pointer-inequality bug.

Additionally, this PR adds a developer guide docs/DeveloperDocs/AArch64/IFunc.md
that details the eld behavior for GNU IFunc functionality on AArch64
target.

Resolves #913