### PR TITLE
Fix stack-buffer-overflow sanitizer issue in AUIPC_JALR_TO_XQCI.test

### DIFF
--- a/include/eld/Fragment/RegionFragmentEx.h
+++ b/include/eld/Fragment/RegionFragmentEx.h
@@ -36,7 +36,7 @@ public:
 
   static bool classof(const RegionFragmentEx *) { return true; }
 
-  bool replaceInstruction(uint32_t Offset, Relocation *Reloc, uint32_t Instr,
+  bool replaceInstruction(uint32_t Offset, Relocation *Reloc, uint8_t *Instr,
                           uint8_t Size);
   void deleteInstruction(uint32_t Offset, uint32_t Size);
   void addRequiredNops(uint32_t Offset, uint32_t NumNopsToAdd);

--- a/lib/Fragment/RegionFragmentEx.cpp
+++ b/lib/Fragment/RegionFragmentEx.cpp
@@ -22,8 +22,8 @@ RegionFragmentEx::RegionFragmentEx(const char *Buf, size_t Sz, ELFSection *O,
 RegionFragmentEx::~RegionFragmentEx() {}
 
 bool RegionFragmentEx::replaceInstruction(uint32_t Offset, Relocation *Reloc,
-                                          uint32_t Instr, uint8_t Size) {
-  std::memcpy((void *)(Data + Offset), &Instr, Size);
+                                          uint8_t *Instr, uint8_t Size) {
+  std::memcpy((void *)(Data + Offset), Instr, Size);
   return true;
 }
 

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -313,7 +313,7 @@ bool RISCVLDBackend::doRelaxationCall(Relocation *reloc) {
                  ->getInput()
                  ->decoratedPath();
 
-    region->replaceInstruction(offset, reloc, c_j, 2);
+    region->replaceInstruction(offset, reloc, reinterpret_cast<uint8_t *>(&c_j), 2);
     reloc->setTargetData(c_j);
     reloc->setType(llvm::ELF::R_RISCV_RVC_JUMP);
     relaxDeleteBytes("RISCV_CALL_C", *region, offset + 2, 6,
@@ -326,7 +326,7 @@ bool RISCVLDBackend::doRelaxationCall(Relocation *reloc) {
     // Replace the instruction to JAL
     uint32_t jal = 0x6fu | rd << 7;
 
-    region->replaceInstruction(offset, reloc, jal, 4 /* Replace bytes */);
+    region->replaceInstruction(offset, reloc, reinterpret_cast<uint8_t *>(&jal), 4);
     reloc->setTargetData(jal);
     reloc->setType(llvm::ELF::R_RISCV_JAL);
     // Delete the next instruction
@@ -345,7 +345,7 @@ bool RISCVLDBackend::doRelaxationCall(Relocation *reloc) {
     const char *msg =
         (rd == 1) ? "R_RISCV_CALL_QC_E_JAL" : "R_RISCV_CALL_QC_E_J";
 
-    region->replaceInstruction(offset, reloc, qc_e_j, 6);
+    region->replaceInstruction(offset, reloc, reinterpret_cast<uint8_t *>(&qc_e_j), 6);
     reloc->setTargetData(qc_e_j);
     reloc->setType(ELF::riscv::internal::R_RISCV_QC_E_CALL_PLT);
     relaxDeleteBytes(msg, *region, offset + 6, 2, reloc->symInfo()->name());
@@ -406,7 +406,7 @@ bool RISCVLDBackend::doRelaxationQCCall(Relocation *reloc) {
                  ->getInput()
                  ->decoratedPath();
 
-    region->replaceInstruction(offset, reloc, compressed, 2);
+    region->replaceInstruction(offset, reloc, reinterpret_cast<uint8_t *>(&compressed), 2);
     // Replace the reloc to R_RISCV_RVC_JUMP
     reloc->setType(llvm::ELF::R_RISCV_RVC_JUMP);
     reloc->setTargetData(compressed);
@@ -418,7 +418,7 @@ bool RISCVLDBackend::doRelaxationQCCall(Relocation *reloc) {
   // Replace the instruction to JAL
   unsigned rd = isTailCall ? /*x0*/ 0 : /*ra*/ 1;
   uint32_t jal_instr = 0x6fu | rd << 7;
-  region->replaceInstruction(offset, reloc, jal_instr, 4);
+  region->replaceInstruction(offset, reloc, reinterpret_cast<uint8_t *>(&jal_instr), 4);
   // Replace the reloc to R_RISCV_JAL
   reloc->setType(llvm::ELF::R_RISCV_JAL);
   reloc->setTargetData(jal_instr);
@@ -622,7 +622,7 @@ bool RISCVLDBackend::doRelaxationQCELi(Relocation *reloc, Relocator::DWord G) {
   if (canRelaxQcLi) {
     uint32_t qc_li = 0x0000001bu | rd << 7;
 
-    region->replaceInstruction(offset, reloc, qc_li, 4);
+    region->replaceInstruction(offset, reloc, reinterpret_cast<uint8_t *>(&qc_li), 4);
     reloc->setTargetData(qc_li);
     reloc->setType(ELF::riscv::internal::R_RISCV_QC_ABS20_U);
     relaxDeleteBytes(msg, *region, offset + 4, 2, reloc->symInfo()->name());
@@ -634,7 +634,7 @@ bool RISCVLDBackend::doRelaxationQCELi(Relocation *reloc, Relocator::DWord G) {
     unsigned rs = 3; // x3 = gp
     uint32_t addi = 0x00000013u | (rd << 7) | (rs << 15);
 
-    region->replaceInstruction(offset, reloc, addi, 4);
+    region->replaceInstruction(offset, reloc, reinterpret_cast<uint8_t *>(&addi), 4);
     reloc->setTargetData(addi);
     reloc->setType(ELF::riscv::internal::R_RISCV_GPREL_I);
     relaxDeleteBytes(msg, *region, offset + 4, 2, reloc->symInfo()->name());
@@ -669,7 +669,9 @@ bool RISCVLDBackend::doRelaxationTLSDESC(Relocation &R, bool Relax) {
     else {
       // Otherwise, the instruction is replaced with a NOP.
       reportMissedRelaxation(RelaxType, *region, offset, 4, Sym.name());
-      region->replaceInstruction(offset, &R, NOP, 4);
+      uint32_t NOPi32 = static_cast<uint32_t>(NOP);
+      region->replaceInstruction(
+          offset, &R, reinterpret_cast<uint8_t *>(&NOPi32), 4);
     }
     R.setType(llvm::ELF::R_RISCV_NONE);
     return Relaxed;


### PR DESCRIPTION
This commit fixes stack-buffer-overflow sanitizer issue in AUIPIC_JALR_TO_XQCI.test. The root cause was that the QC_E_J relaxation patch 6 bytes instruction but the 'Instr' parameter of 'RegionFragmentEx::replaceInstruction' that stores the updated instruction is only of 4 bytes.