### PR TITLE
Add support for generating multiversion documentation

### DIFF
--- a/.github/workflows/docs-multiversion.yaml
+++ b/.github/workflows/docs-multiversion.yaml
@@ -1,0 +1,85 @@
+name: Bulid multi-version docs
+
+on:
+  push:
+    branches: [main]
+    paths: ['docs/**', 'include/**']
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/docs-multiversion.yaml
+
+jobs:
+  build-docs-and-deploy:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout llvm-project
+        uses: actions/checkout@v4
+        with:
+          repository: llvm/llvm-project
+          path: llvm-project
+          ref: main
+
+      - name: Checkout eld
+        uses: actions/checkout@v4
+        with:
+          path: llvm-project/llvm/tools/eld
+          fetch-depth: 0
+
+      - name: Configure workflow environment
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/ConfigureBuildWorkflowENV
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y graphviz doxygen ninja-build
+          pip install -r llvm-project/llvm/tools/eld/docs/userguide/requirements.txt
+
+      - name: Configure CMake
+        run: |
+          cmake -G Ninja -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=$(which clang) \
+            -DCMAKE_CXX_COMPILER=$(which clang++) \
+            -DLLVM_TARGETS_TO_BUILD="ARM;AArch64;RISCV;Hexagon" \
+            -DLLVM_ENABLE_SPHINX=ON \
+            llvm-project/llvm
+
+      - name: Build multi-version docs
+        run: cmake --build build --target eld-docs-multiversion
+
+      - name: Checkout documentation branch
+        uses: actions/checkout@v4
+        with:
+          ref: documentation
+          path: docs-branch
+        continue-on-error: true
+
+      - name: Preserve existing content (dashboard)
+        run: |
+          if [ -d dash ]; then
+            cp -r dash build/tools/eld/docs/multiversion/site/main
+            echo "Preserved dashboard from documentation branch"
+          fi
+
+      - name: Deploy to documentation branch
+        run: |
+          SITE_DIR=$(pwd)/build/tools/eld/docs/multiversion/site
+          cd llvm-project/llvm/tools/eld
+          git config user.name 'github-actions'
+          git config user.email 'github-actions@github.com'
+          git checkout --orphan documentation-update
+          git rm -rf .
+          cp -r ${SITE_DIR}/. .
+          git add .
+          git commit -m "Update multi-version documentation"
+          git push -f origin HEAD:refs/heads/documentation

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,12 +1,12 @@
 name: Generate and Deploy Docs
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'docs/**'
-      - 'include/**'
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - 'docs/**'
+  #     - 'include/**'
   workflow_dispatch:     # Allows manual triggering
 
 permissions:

--- a/cmake/modules/BuildMultiVersionDocs.cmake
+++ b/cmake/modules/BuildMultiVersionDocs.cmake
@@ -1,0 +1,122 @@
+# BuildMultiVersionDocs.cmake
+#
+# Provides CMake targets for building multi-version ELD documentation.
+#
+# This module creates git worktrees for each configured version, builds
+# the eld-docs target for each, and assembles a combined site with a
+# landing page and version selector.
+#
+# Variables (user-configurable):
+#   ELD_DOC_VERSIONS - List of "branch:label:display_name" specs
+#                      Example: "main:main:Main (dev);release/22.x:22.x:Release 22.x"
+#   ELD_DOC_STABLE   - Which version the "stable" symlink points to (default: 22.x)
+#
+# Targets created:
+#   eld-docs-all-releases  - Builds documentation for all configured versions
+#   eld-docs-<name>        - Builds documentation for a single version
+#   eld-docs-assemble      - Generates landing page and symlinks (depends on all versions)
+#   eld-docs-multiversion  - Convenience target: builds all + assembles
+#
+# Output:
+#   ${CMAKE_BINARY_DIR}/tools/eld/docs/multiversion/site/
+#     ├── index.html -> main/
+#     ├── versions.json
+#     ├── stable -> <ELD_DOC_STABLE>
+#     ├── main/
+#     └── 22.x/
+
+function(eld_add_multiversion_doc_targets)
+    if(NOT DEFINED ELD_SOURCE_DIR)
+        message(FATAL_ERROR "ELD_SOURCE_DIR must be defined before calling eld_add_multiversion_doc_targets")
+    endif()
+
+    find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+    set(ELD_DOC_VERSIONS
+        "main:main:Main (dev)"
+        "release/22.x:22.x:Release 22.x"
+        CACHE STRING "Semicolon-separated list of 'branch:label:display_name' for multi-version docs")
+
+    set(ELD_DOC_STABLE "22.x"
+        CACHE STRING "Version that 'stable' symlink points to")
+
+    set(ELD_MULTIVERSION_SCRIPTS_DIR "${ELD_SOURCE_DIR}/docs/multiversion")
+    set(ELD_MULTIVERSION_WORK_DIR "${CMAKE_BINARY_DIR}/tools/eld/docs/multiversion")
+    set(ELD_MULTIVERSION_SITE_DIR "${ELD_MULTIVERSION_WORK_DIR}/site")
+
+    # LLVM_SOURCE_DIR points to llvm/ subdirectory; parent is llvm-project root
+    get_filename_component(ELD_LLVM_REPO_ROOT "${LLVM_SOURCE_DIR}/.." ABSOLUTE)
+    if(NOT DEFINED LLVM_SOURCE_DIR OR NOT EXISTS "${ELD_LLVM_REPO_ROOT}/llvm/CMakeLists.txt")
+        message(WARNING "LLVM_SOURCE_DIR not set or invalid")
+        message(WARNING "Multi-version docs target will not be available")
+        return()
+    endif()
+
+    set(version_targets "")
+
+    foreach(version_spec IN LISTS ELD_DOC_VERSIONS)
+        # Parse "branch:label" (display_name is handled by Python)
+        string(REPLACE ":" ";" parts "${version_spec}")
+        list(LENGTH parts num_parts)
+
+        if(num_parts LESS 2)
+            message(WARNING "Invalid version spec (need at least branch:label): ${version_spec}")
+            continue()
+        endif()
+
+        list(GET parts 0 branch)
+        list(GET parts 1 label)
+
+        # Create target for this version
+        # Each version gets its own work directory to allow parallel builds
+        set(target_name "eld-docs-${label}")
+        set(version_work_dir "${ELD_MULTIVERSION_WORK_DIR}/_work/${label}")
+
+        add_custom_target(${target_name}
+            COMMAND ${Python3_EXECUTABLE}
+                "${ELD_MULTIVERSION_SCRIPTS_DIR}/build_docs.py"
+                --branch "${branch}"
+                --eld-repo "${ELD_SOURCE_DIR}"
+                --llvm-repo "${ELD_LLVM_REPO_ROOT}"
+                --work-dir "${version_work_dir}"
+                --output-dir "${ELD_MULTIVERSION_SITE_DIR}/${label}"
+            WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+            COMMENT "Building ELD docs: ${branch} -> ${label}"
+            USES_TERMINAL
+            VERBATIM
+        )
+
+        list(APPEND version_targets ${target_name})
+    endforeach()
+
+    # Main target that builds all versions
+    add_custom_target(eld-docs-all-releases
+        DEPENDS ${version_targets}
+        COMMENT "Building all ELD documentation versions"
+    )
+
+    add_custom_target(eld-docs-assemble
+        DEPENDS eld-docs-all-releases
+        COMMAND ${Python3_EXECUTABLE}
+            "${ELD_MULTIVERSION_SCRIPTS_DIR}/assemble_site.py"
+            --site-dir "${ELD_MULTIVERSION_SITE_DIR}"
+            --versions-spec "${ELD_DOC_VERSIONS}"
+            --stable "${ELD_DOC_STABLE}"
+        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+        COMMENT "Assembling multi-version documentation site"
+        USES_TERMINAL
+        VERBATIM
+    )
+
+    # Convenience target that does everything
+    add_custom_target(eld-docs-multiversion
+        DEPENDS eld-docs-assemble
+        COMMENT "Multi-version documentation complete: ${ELD_MULTIVERSION_SITE_DIR}"
+    )
+
+    message(STATUS "Multi-version docs target: eld-docs-all-releases")
+    message(STATUS "  Versions: ${ELD_DOC_VERSIONS}")
+    message(STATUS "  Stable: ${ELD_DOC_STABLE}")
+    message(STATUS "  Output: ${ELD_MULTIVERSION_SITE_DIR}")
+
+endfunction()

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(design)
 add_subdirectory(userguide)
+add_subdirectory(multiversion)

--- a/docs/multiversion/CMakeLists.txt
+++ b/docs/multiversion/CMakeLists.txt
@@ -1,0 +1,4 @@
+if(LLVM_ENABLE_SPHINX)
+    include(BuildMultiVersionDocs)
+    eld_add_multiversion_doc_targets()
+endif()

--- a/docs/multiversion/assemble_site.py
+++ b/docs/multiversion/assemble_site.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+Assemble multi-version ELD documentation site.
+
+Creates the landing page (index.html), version manifest (versions.json),
+and stable symlink for the multi-version documentation site.
+
+Usage:
+    assemble_site.py --site-dir <path> --versions-spec <specs> --stable <version>
+
+Example:
+    assemble_site.py --site-dir ./site \
+        --versions-spec "main:main:Main (dev);release/22.x:22.x:Release 22.x" \
+        --stable "22.x"
+
+Version spec format: "branch:label:display_name" (display_name is optional, defaults to label)
+Multiple specs are separated by semicolons.
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).parent
+TEMPLATES_DIR = SCRIPT_DIR / "templates"
+
+
+def load_template(name: str) -> str:
+    """Load a template file from the templates directory."""
+    template_path = TEMPLATES_DIR / name
+    return template_path.read_text()
+
+
+def parse_version_specs(specs_str: str, stable_version: str) -> list[dict[str, Any]]:
+    """
+    Parse version specs from CMake format into version dictionaries.
+
+    Args:
+        specs_str: Semicolon-separated "branch:label:display_name" specs
+        stable_version: Which label should be marked as stable
+
+    Returns:
+        List of version dicts with path, display_name, stable, and dev flags
+    """
+    versions = []
+    for spec in specs_str.split(";"):
+        spec = spec.strip()
+        if not spec:
+            continue
+
+        parts = spec.split(":")
+        if len(parts) < 2:
+            print(f"WARNING: Invalid version spec (need at least branch:label): {spec}")
+            continue
+
+        branch = parts[0]
+        label = parts[1]
+        display_name = parts[2] if len(parts) >= 3 else label
+
+        version: dict[str, Any] = {
+            "path": label,
+            "display_name": display_name,
+        }
+
+        if label == stable_version:
+            version["stable"] = True
+        if label == "main":
+            version["dev"] = True
+
+        versions.append(version)
+
+    return versions
+
+
+def find_stable_version(versions: list[dict[str, Any]]) -> str | None:
+    """Find the version marked as stable in the versions list."""
+    for v in versions:
+        if v.get("stable"):
+            return v["path"]
+    return None
+
+
+def generate_index_html(redirect_target: str, output_path: Path) -> None:
+    """Generate index.html that instantly redirects to the main docs."""
+    if output_path.is_symlink():
+        output_path.unlink()
+    elif output_path.exists():
+        output_path.unlink()
+
+    html = f'''<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script>window.location.replace("./{redirect_target}/");</script>
+<noscript><meta http-equiv="refresh" content="0; url=./{redirect_target}/"></noscript>
+</head>
+</html>
+'''
+    output_path.write_text(html)
+    print(f"Generated: {output_path} (redirects to {redirect_target}/)")
+
+
+def generate_versions_html(versions: list[dict[str, Any]], output_path: Path) -> None:
+    """Generate the version selector page with links to all versions."""
+    versions_template = load_template("versions.html")
+    version_link_template = load_template("version_link.html")
+
+    version_links = []
+    for v in versions:
+        badge = ""
+        if v.get("stable"):
+            badge = '\n                        <span class="badge badge-stable">stable</span>'
+        elif v.get("dev"):
+            badge = '\n                        <span class="badge badge-dev">dev</span>'
+
+        version_links.append(version_link_template.format(
+            path=v["path"],
+            display_name=v["display_name"],
+            badge=badge,
+        ))
+
+    html = versions_template.format(version_links="".join(version_links))
+    output_path.write_text(html)
+    print(f"Generated: {output_path}")
+
+
+def generate_versions_json(versions: list[dict[str, Any]], stable: str | None, output_path: Path) -> None:
+    """Generate the versions manifest JSON file."""
+    manifest = {
+        "versions": versions,
+        "stable": stable,
+        "default": "stable" if stable else versions[0]["path"] if versions else None,
+    }
+    output_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    print(f"Generated: {output_path}")
+
+
+def create_stable_symlink(site_dir: Path, stable_target: str) -> None:
+    """Create the 'stable' symlink pointing to the stable version directory."""
+    stable_link = site_dir / "stable"
+
+    if stable_link.is_symlink():
+        stable_link.unlink()
+    elif stable_link.exists():
+        raise RuntimeError(f"'stable' exists but is not a symlink: {stable_link}")
+
+    target_dir = site_dir / stable_target
+    if not target_dir.exists():
+        print(f"WARNING: Target directory does not exist yet: {target_dir}")
+
+    os.symlink(stable_target, stable_link)
+    print(f"Created symlink: stable -> {stable_target}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Assemble multi-version ELD documentation site",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--site-dir", required=True, type=Path,
+        help="Site output directory containing version subdirectories"
+    )
+    parser.add_argument(
+        "--versions-spec", required=True,
+        help="Semicolon-separated 'branch:label:display_name' specs"
+    )
+    parser.add_argument(
+        "--stable", required=True,
+        help="Which label should be marked as stable"
+    )
+
+    args = parser.parse_args()
+
+    try:
+        site_dir = args.site_dir.resolve()
+        versions = parse_version_specs(args.versions_spec, args.stable)
+
+        if not versions:
+            raise ValueError("No valid version specs provided")
+
+        stable = find_stable_version(versions)
+
+        site_dir.mkdir(parents=True, exist_ok=True)
+
+        redirect_target = "main"
+        generate_index_html(redirect_target, site_dir / "index.html")
+        generate_versions_html(versions, site_dir / "versions.html")
+        generate_versions_json(versions, stable, site_dir / "versions.json")
+
+        if stable:
+            create_stable_symlink(site_dir, stable)
+        else:
+            print("WARNING: No version marked as stable, skipping stable symlink")
+
+        nojekyll = site_dir / ".nojekyll"
+        nojekyll.touch()
+        print(f"Created: {nojekyll}")
+
+        print(f"\nSite assembled successfully: {site_dir}")
+        return 0
+
+    except Exception as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/multiversion/build_docs.py
+++ b/docs/multiversion/build_docs.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+Build ELD documentation for a specific branch using git worktrees.
+
+This script creates git worktrees for both llvm-project and eld repositories,
+configures a CMake build, and builds the eld-docs target. The resulting HTML
+documentation is copied to the specified output directory.
+
+Usage:
+    build_docs.py --branch <branch> \
+                  --eld-repo <path> --llvm-repo <path> \
+                  --work-dir <path> --output-dir <path>
+
+Example:
+    build_docs.py --branch main \
+                  --eld-repo /path/to/eld --llvm-repo /path/to/llvm-project \
+                  --work-dir /tmp/docs-build --output-dir /tmp/site
+"""
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run(cmd: list, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess:
+    """Run a command and print it for visibility."""
+    print(f"+ {' '.join(str(c) for c in cmd)}", flush=True)
+    return subprocess.run(cmd, cwd=cwd, check=check)
+
+
+def create_worktree(repo_path: Path, worktree_path: Path, branch: str) -> None:
+    """Create a git worktree for the specified branch (detached)."""
+    run(["git", "worktree", "prune"], cwd=repo_path, check=False)
+
+    if worktree_path.exists():
+        # Check if it's already a worktree for this repo
+        result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if str(worktree_path) in result.stdout:
+            print(f"Worktree already exists: {worktree_path}")
+            run(["git", "fetch", "origin", branch], cwd=worktree_path, check=False)
+            run(["git", "checkout", "--detach", f"origin/{branch}"], cwd=worktree_path)
+            return
+        else:
+            print(f"Removing stale directory: {worktree_path}")
+            shutil.rmtree(worktree_path)
+
+    worktree_path.parent.mkdir(parents=True, exist_ok=True)
+
+    run(["git", "fetch", "origin", branch], cwd=repo_path, check=False)
+    run(["git", "worktree", "add", "--detach", str(worktree_path), f"origin/{branch}"], cwd=repo_path)
+
+
+def build_docs(
+    eld_branch: str,
+    eld_repo: Path,
+    llvm_repo: Path,
+    work_dir: Path,
+    output_dir: Path,
+) -> Path:
+    """
+    Build documentation for a specific ELD branch.
+
+    Args:
+        eld_branch: Git branch of ELD to build docs for
+        eld_repo: Path to the ELD git repository
+        llvm_repo: Path to the llvm-project git repository
+        work_dir: Working directory for worktrees and builds
+        output_dir: Output directory for the final HTML docs
+
+    Returns:
+        Path to the output HTML directory
+    """
+    # Paths - use fixed names within work_dir
+    llvm_worktree = work_dir / "llvm-project"
+    eld_worktree = llvm_worktree / "llvm" / "tools" / "eld"
+    build_dir = work_dir / "obj"
+
+    print(f"\n{'=' * 70}")
+    print(f"Building docs for ELD branch '{eld_branch}'")
+    print(f"  Work dir: {work_dir}")
+    print(f"  Output dir: {output_dir}")
+    print(f"{'=' * 70}\n")
+
+    # Step 1: Create LLVM worktree (detached, always use main)
+    print("\n[Step 1/5] Creating LLVM worktree...")
+    create_worktree(llvm_repo, llvm_worktree, "main")
+
+    # Step 2: Create ELD worktree inside LLVM
+    print("\n[Step 2/5] Creating ELD worktree...")
+    eld_tools_dir = llvm_worktree / "llvm" / "tools"
+    eld_tools_dir.mkdir(parents=True, exist_ok=True)
+    create_worktree(eld_repo, eld_worktree, eld_branch)
+
+    # Step 3: Configure CMake
+    print("\n[Step 3/5] Configuring CMake...")
+    build_dir.mkdir(parents=True, exist_ok=True)
+
+    cmake_args = [
+        "cmake",
+        "-G", "Ninja",
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DLLVM_ENABLE_SPHINX=ON",
+        "-DLLVM_TARGETS_TO_BUILD=ARM;AArch64;RISCV;Hexagon",
+        "-DCMAKE_C_COMPILER=clang", "-DCMAKE_CXX_COMPILER=clang++",
+        str(llvm_worktree / "llvm"),
+    ]
+
+    run(cmake_args, cwd=build_dir)
+
+    # Step 4: Build eld-docs
+    print("\n[Step 4/5] Building eld-docs...")
+    run(["ninja", "eld-docs"], cwd=build_dir)
+
+    # Step 5: Copy output
+    print("\n[Step 5/5] Copying output...")
+    html_src = build_dir / "tools" / "eld" / "docs" / "userguide" / "html"
+
+    if not html_src.exists():
+        raise RuntimeError(f"HTML output not found: {html_src}")
+
+    output_dir.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(html_src, output_dir, dirs_exist_ok=True)
+
+    print(f"\n{'=' * 70}")
+    print(f"SUCCESS: Docs built at: {output_dir}")
+    print(f"{'=' * 70}\n")
+
+    return output_dir
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build ELD documentation for a specific branch using git worktrees",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--branch", required=True,
+        help="ELD branch to build (e.g., 'main', 'release/22.x')"
+    )
+    parser.add_argument(
+        "--eld-repo", required=True, type=Path,
+        help="Path to ELD git repository"
+    )
+    parser.add_argument(
+        "--llvm-repo", required=True, type=Path,
+        help="Path to llvm-project git repository"
+    )
+    parser.add_argument(
+        "--work-dir", required=True, type=Path,
+        help="Working directory for worktrees and builds"
+    )
+    parser.add_argument(
+        "--output-dir", required=True, type=Path,
+        help="Output directory for HTML docs"
+    )
+
+    args = parser.parse_args()
+
+    try:
+        build_docs(
+            eld_branch=args.branch,
+            eld_repo=args.eld_repo.resolve(),
+            llvm_repo=args.llvm_repo.resolve(),
+            work_dir=args.work_dir.resolve(),
+            output_dir=args.output_dir.resolve(),
+        )
+        return 0
+    except subprocess.CalledProcessError as e:
+        print(f"\nERROR: Command failed with exit code {e.returncode}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"\nERROR: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/multiversion/templates/version_link.html
+++ b/docs/multiversion/templates/version_link.html
@@ -1,0 +1,8 @@
+            <li>
+                <a href="./{path}/" class="version-link">
+                    <span class="version-info">
+                        <span class="version-name">{display_name}</span>{badge}
+                    </span>
+                    <span class="arrow">&rarr;</span>
+                </a>
+            </li>

--- a/docs/multiversion/templates/versions.html
+++ b/docs/multiversion/templates/versions.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>ELD Documentation - All Versions</title>
+    <style>
+        * {{ box-sizing: border-box; margin: 0; padding: 0; }}
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
+            background: #f8f9fa;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }}
+        .container {{
+            max-width: 480px;
+            padding: 48px 32px;
+            text-align: center;
+        }}
+        h1 {{
+            font-size: 2rem;
+            font-weight: 600;
+            color: #1a1a1a;
+            margin-bottom: 8px;
+        }}
+        .subtitle {{
+            color: #6b7280;
+            font-size: 0.95rem;
+            margin-bottom: 40px;
+        }}
+        .version-list {{
+            list-style: none;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }}
+        .version-link {{
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 16px 20px;
+            background: #fff;
+            border: 1px solid #e5e7eb;
+            border-radius: 8px;
+            text-decoration: none;
+            color: #1a1a1a;
+            transition: border-color 0.15s, box-shadow 0.15s;
+        }}
+        .version-link:hover {{
+            border-color: #3b82f6;
+            box-shadow: 0 2px 8px rgba(59, 130, 246, 0.1);
+        }}
+        .version-info {{
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }}
+        .version-name {{
+            font-weight: 500;
+        }}
+        .badge {{
+            font-size: 0.7rem;
+            font-weight: 500;
+            padding: 3px 8px;
+            border-radius: 4px;
+            text-transform: uppercase;
+            letter-spacing: 0.02em;
+        }}
+        .badge-stable {{
+            background: #dcfce7;
+            color: #166534;
+        }}
+        .badge-dev {{
+            background: #fef3c7;
+            color: #92400e;
+        }}
+        .arrow {{
+            color: #9ca3af;
+            font-size: 1.1rem;
+        }}
+        .footer {{
+            margin-top: 48px;
+            font-size: 0.8rem;
+            color: #9ca3af;
+        }}
+        .footer a {{
+            color: #6b7280;
+            text-decoration: none;
+        }}
+        .footer a:hover {{
+            text-decoration: underline;
+        }}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>ELD Documentation</h1>
+        <p class="subtitle">Select a version</p>
+        <ul class="version-list">
+{version_links}
+        </ul>
+        <p class="footer">
+            <a href="https://github.com/qualcomm/eld">GitHub</a>
+        </p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
This commit add supports for generating multiversion documentation. The
new targets added that enable this functionality are:

- `eld-docs-<release>` // <release> can be one of the releases such as 22.x, and main.
- `eld-docs-all-releases` // Builds all releases
- `eld-docs-assemble` // Combines all the version documentation and generates the version selector page.
- `eld-docs-multiversion` // eld-docs-all-releases + eld-docs-assemble

`eld-docs-<release>` creates the documentation by creating an eld
worktree in ${BUILD_DIR}/tools/eld/docs/multiversion/_work/${release}
with the requested release checked out. Please note that we cannot use
the original source repository to generate documentations of different
releases.

In the generated docs:

- the homepage (`/`), and `/main` will display the `main` branch
  documentation.
- `/22.x` and `/stable` will display the `release/22.x` branch documentation.
- `/versions.html` will display a basic documentation version selector
  menu.

I have hosted the multiversion documentation here https://parth-07.github.io/eld/ to help with reviewing the functionality.
Version selector page: https://parth-07.github.io/eld/versions.html.