### PR TITLE
[NFC] Move InputType::Archive and DynObj to SearchDirs::SearchInputType

### DIFF
--- a/include/eld/Input/SearchDirs.h
+++ b/include/eld/Input/SearchDirs.h
@@ -42,6 +42,13 @@ public:
   typedef DirListType::iterator iterator;
   typedef DirListType::const_iterator const_iterator;
 
+  /// Input type preference for library search.
+  enum SearchInputType {
+    Archive,
+    DynObj,
+    Script,
+  };
+
 public:
   SearchDirs(DiagnosticEngine *Diag) : DiagEngine(Diag) {}
 
@@ -52,7 +59,7 @@ public:
 
   // find - give a namespec, return a real path of the shared object.
   const sys::fs::Path *find(const std::string &PNamespec,
-                            Input::InputType PPreferType) const;
+                            SearchInputType PPreferType) const;
 
   const eld::sys::fs::Path *findLibrary(llvm::StringRef Type,
                                         std::string LibraryName,

--- a/lib/Input/Input.cpp
+++ b/lib/Input/Input.cpp
@@ -106,7 +106,8 @@ bool Input::resolvePath(const LinkerConfig &PConfig) {
       ResolvedPath->append(FileName);
     }
     if (!llvm::sys::fs::exists(ResolvedPath->native())) {
-      const sys::fs::Path *P = PSearchDirs.find(FileName, Input::Script);
+      const sys::fs::Path *P =
+          PSearchDirs.find(FileName, SearchDirs::SearchInputType::Script);
       if (P != nullptr)
         ResolvedPath = *P;
     }
@@ -115,11 +116,13 @@ bool Input::resolvePath(const LinkerConfig &PConfig) {
     const sys::fs::Path *NameSpecPath = nullptr;
     if (Attr.isStatic()) {
       // with --static, we must search an archive.
-      NameSpecPath = PSearchDirs.find(FileName, Input::Archive);
+      NameSpecPath =
+          PSearchDirs.find(FileName, SearchDirs::SearchInputType::Archive);
     } else {
       // otherwise, with --Bdynamic, we can find either an archive or a
       // shared object.
-      NameSpecPath = PSearchDirs.find(FileName, Input::DynObj);
+      NameSpecPath =
+          PSearchDirs.find(FileName, SearchDirs::SearchInputType::DynObj);
     }
     if (nullptr == NameSpecPath) {
       DiagEngine->raise(Diag::err_cannot_find_namespec) << FileName;

--- a/lib/Input/SearchDirs.cpp
+++ b/lib/Input/SearchDirs.cpp
@@ -41,11 +41,23 @@ constexpr inline llvm::StringRef foundString(bool Found) {
   return Found ? "found" : "not found";
 }
 
-bool checkInputFile(Input::InputType Type, llvm::StringRef NameSpec,
+llvm::StringRef toString(SearchDirs::SearchInputType Type) {
+  switch (Type) {
+  case SearchDirs::SearchInputType::Archive:
+    return "archive";
+  case SearchDirs::SearchInputType::DynObj:
+    return "dynamic object";
+  case SearchDirs::SearchInputType::Script:
+    return "linker script";
+  }
+  llvm_unreachable("SearchDirs::SearchInputType out of range");
+}
+
+bool checkInputFile(SearchDirs::SearchInputType Type, llvm::StringRef NameSpec,
                     llvm::StringRef FileName, DiagnosticEngine *DiagEngine) {
   bool Found = llvm::sys::fs::exists(FileName);
   DiagEngine->raise(Diag::verbose_trying_input_file)
-      << FileName << Input::toString(Type) << NameSpec << foundString(Found);
+      << FileName << toString(Type) << NameSpec << foundString(Found);
   return Found;
 }
 
@@ -64,31 +76,30 @@ bool checkLibraryOrConfigFile(llvm::StringRef Type, llvm::StringRef LibraryName,
 // Non-member functions
 //===----------------------------------------------------------------------===//
 static inline bool SpecToFilename(const std::string &pSpec, std::string &pFile,
-                                  uint32_t pType) {
+                                  SearchDirs::SearchInputType pType) {
   bool StartsWithColon = (pSpec.c_str()[0] == ':');
   pFile.clear();
   if (StartsWithColon) {
     pFile = pSpec.substr(1, pSpec.length());
     return true;
   }
-  if (pType == Input::Script) {
+  if (pType == SearchDirs::SearchInputType::Script) {
     pFile = pSpec;
     return false;
-  } else {
-    pFile = "lib";
-    pFile += pSpec;
-    switch (pType) {
-    case Input::DynObj:
-      pFile += ".so";
-      break;
-    case Input::Archive:
-      pFile += ".a";
-      break;
-    default:
-      break;
-    }
-    return false;
   }
+  pFile = "lib";
+  pFile += pSpec;
+  switch (pType) {
+  case SearchDirs::SearchInputType::DynObj:
+    pFile += ".so";
+    break;
+  case SearchDirs::SearchInputType::Archive:
+    pFile += ".a";
+    break;
+  case SearchDirs::SearchInputType::Script:
+    llvm_unreachable("Script case already handled above");
+  }
+  return false;
 }
 
 //===----------------------------------------------------------------------===//
@@ -115,7 +126,7 @@ bool SearchDirs::insert(const sys::fs::Path &PPath) {
 }
 
 const eld::sys::fs::Path *SearchDirs::find(const std::string &pNamespec,
-                                           Input::InputType pType) const {
+                                           SearchInputType pType) const {
   std::string File;
   bool hasNamespace = false;
   hasNamespace = SpecToFilename(pNamespec, File, pType);
@@ -128,11 +139,12 @@ const eld::sys::fs::Path *SearchDirs::find(const std::string &pNamespec,
     std::string fileName = dirName + "/" + File;
     if (checkInputFile(pType, pNamespec, fileName, DiagEngine))
       return make<eld::sys::fs::Path>(fileName);
-    if (Input::DynObj == pType && !hasNamespace) {
+    if (SearchDirs::SearchInputType::DynObj == pType && !hasNamespace) {
       // we should also try linking with archives if we dont find a DSO
-      SpecToFilename(pNamespec, fileName, Input::Archive);
+      SpecToFilename(pNamespec, fileName, SearchDirs::SearchInputType::Archive);
       fileName = dirName + "/" + fileName;
-      if (checkInputFile(Input::Archive, pNamespec, fileName, DiagEngine))
+      if (checkInputFile(SearchDirs::SearchInputType::Archive, pNamespec,
+                         fileName, DiagEngine))
         return make<eld::sys::fs::Path>(fileName);
     }
   } // end of for

--- a/lib/Script/ScriptAction.cpp
+++ b/lib/Script/ScriptAction.cpp
@@ -16,6 +16,7 @@
 #include "eld/Script/ScriptAction.h"
 #include "eld/Config/LinkerConfig.h"
 #include "eld/Input/LinkerScriptFile.h"
+#include "eld/Input/SearchDirs.h"
 #include "eld/Support/MsgHandling.h"
 #include "llvm/Support/FileSystem.h"
 
@@ -34,7 +35,8 @@ bool ScriptAction::activate(InputBuilder &PBuilder) {
   std::string Path = Name;
   auto &SearchDirs = ThisConfig.directories();
   if (!llvm::sys::fs::exists(Path)) {
-    const sys::fs::Path *Res = SearchDirs.find(Path, Input::Script);
+    const sys::fs::Path *Res =
+        SearchDirs.find(Path, eld::SearchDirs::SearchInputType::Script);
     if (Res == nullptr) {
       switch (ScriptFileKind) {
       case ScriptFile::LDScript:


### PR DESCRIPTION
This commit moves InputType::Archive and InputType::DynObj to a newly created enum SearchDirs::SearchInputType. Input::InputType::Archive and Input::InputType::DynObj were very misleading because we create no inputs of these types. Additionally, one of the other InputType enum value is Namespec, making it theoretically possible for an input to be both Namespec and Archive/DynObj. This is wrong because Type-like enum values should be disjoint.