### PR TITLE
Support --reproduce=default and --reproduce-on-fail=default

### DIFF
--- a/docs/userguide/documentation/eld_debugging_guide.rst
+++ b/docs/userguide/documentation/eld_debugging_guide.rst
@@ -570,9 +570,13 @@ Reproducing failures (tarball + mapping file)
 
 ELD can capture a self-contained reproducer for link issues:
 
-* ``--reproduce <tarfilename>``: always produce a tarball
+* ``--reproduce <tarfilename>|default``: always produce a tarball;
+  use ``--reproduce=default`` to name the tar after the output file
+  (``<output>.tar``, where ``<output>`` is the ``-o`` filename, or
+  ``a.out.tar`` if ``-o`` is not given)
 * ``--reproduce-compressed <tarfilename>``: compressed tarball
-* ``--reproduce-on-fail <tarfilename>``: only on failure
+* ``--reproduce-on-fail <tarfilename>|default``: only on failure;
+  use ``--reproduce-on-fail=default`` to name the tar after the output file
 * ``ELD_REPRODUCE_CREATE_TAR``: environment variable that forces reproducer
   creation (uses a temporary tar file if no filename is provided)
 
@@ -597,8 +601,9 @@ ELD installs a default signal handler in ``GnuLdDriver::doLink(...)``:
 
 * Flushes a text map file (if configured).
 * Detects likely plugin crashes and reports them.
-* Writes a temporary ``.sh`` script that appends ``--reproduce build.tar`` to
-  the command line and instructs the user to rerun.
+* Writes a temporary ``.sh`` script that appends ``--reproduce=default``
+  to the original command line; when the user reruns that script the tarball
+  is named ``<output>.tar`` based on the ``-o`` output filename.
 
 This is implemented in ``GnuLdDriver::defaultSignalHandler(...)`` in
 ``lib/LinkerWrapper/GnuLdDriver.cpp``.
@@ -824,7 +829,8 @@ Practical debugging checklist
 
 When a link fails and you need actionable data quickly, try (in order):
 
-1. Add ``--reproduce-on-fail repro.tar`` (or ``--reproduce repro.tar``).
+1. Add ``--reproduce-on-fail=default`` (or ``--reproduce=default``) to get a
+   ``<output>.tar`` tarball automatically; supply an explicit filename if needed.
 2. Add ``--verbose --trace=command-line --trace=files``.
 3. Enable map output: ``-M --Map=layout.map --MapStyle=Text`` (or YAML).
 4. If plugins are involved: ``--plugin-activity-file=plugins.json`` and try

--- a/docs/userguide/documentation/linker_faq.rst
+++ b/docs/userguide/documentation/linker_faq.rst
@@ -247,11 +247,13 @@ Reproducing a failure
 ----------------------
 
 If you are having an issue, and you want to pass the link step for someone else
-to debug, you can use the *--reproduce <tarball>*  option.
+to debug, you can use the ``--reproduce`` option.
 
-The *–-reproduce <tarball>*  option creates a tar ball with all the inputs that
-were fed to the linker, and rewrites the link command to make it easy for users
-to reproduce the problem.
+``--reproduce <tarball>`` creates a tarball with all the inputs that were fed
+to the linker and rewrites the link command so the problem can be reproduced
+elsewhere.  Use ``--reproduce=default`` to automatically name the tarball
+after the output file (``<output>.tar``, where ``<output>`` is the ``-o``
+filename, or ``a.out.tar`` if ``-o`` is not given).
 
 .. note::
 
@@ -262,9 +264,11 @@ to reproduce the problem.
 
     If you are having a link time failure and the problem does not reproduce everytime,
     but in specific builds, it may be because of non determinism in the builds.
-    In that case use the option --reproduce-on-fail.
+    In that case use the option ``--reproduce-on-fail <tarball>``.
+    Use ``--reproduce-on-fail=default`` to name the tar after the output file.
 
-The reproduce-on-fail switch only creates a tarball when the link step fails.
+The ``--reproduce-on-fail`` switch only creates a tarball when the link step
+fails.
 
 Multiple ways to invoke ELD linker
 ------------------------------------

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -956,10 +956,10 @@ def allow_bss_conversion
                "sections in the same segment">,
       Group<grp_extendedopts>;
 defm reproduce : smDash<"reproduce", "reproduce",
-                        "Write a tar file containing input files and command "
-                        "line options to inspect and re-link">,
-                  MetaVarName<"<tarfilename>">,
-                 Group<grp_extendedopts>;
+                       "Write a tar file containing input files and command "
+                       "line options to inspect and re-link">,
+                 MetaVarName<"<tarfilename>|default">,
+                Group<grp_extendedopts>;
 defm reproduce_compressed : smDashWithOpt<"reproduce-compressed", "reproduce_compressed",
                                    "Write compressed tar file in zlib format "
                                    "containing input files and command line "
@@ -967,10 +967,10 @@ defm reproduce_compressed : smDashWithOpt<"reproduce-compressed", "reproduce_com
                             MetaVarName<"<tarfilename>">,
                             Group<grp_extendedopts>;
 defm reproduce_on_fail : smDashWithOpt<"reproduce-on-fail", "reproduce_on_fail",
-                                   "Write reproduce tar file when link fails"
+                                   "Write reproduce tar file when link fails "
                                    "containing input files and command line "
                                    "options to inspect and re-link.">,
-                            MetaVarName<"<tarfilename>">,
+                            MetaVarName<"<tarfilename>|default">,
                             Group<grp_extendedopts>;
 defm mapping_file : smDashWithOpt<"mapping-file", "mapping_file",
                                   "Reproduce link using a mapping file">,

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -1066,10 +1066,15 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
     Config.options().setShowProgressBar();
 
   std::optional<std::string> reproduceFileName;
-  // --reproduce
+  // --reproduce <tarfilename>|default
+  // When the special value "default" is given, the tar filename defaults to
+  // <output>.tar (where <output> is the -o filename, or "a.out" if not set).
   if (llvm::opt::Arg *arg = Args.getLastArg(T::reproduce)) {
     Config.options().setRecordInputfiles();
-    reproduceFileName = arg->getValue();
+    llvm::StringRef val = arg->getValue();
+    reproduceFileName = (val == "default")
+                            ? Config.options().outputFileName() + ".tar"
+                            : val.str();
   }
 
   // --reproduce-compressed
@@ -1079,10 +1084,14 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
     reproduceFileName = arg->getValue();
   }
 
-  // --reproduce-on-fail
+  // --reproduce-on-fail <tarfilename>|default
+  // Same "default" keyword logic as --reproduce.
   if (llvm::opt::Arg *arg = Args.getLastArg(T::reproduce_on_fail)) {
     Config.options().setReproduceOnFail(true);
-    reproduceFileName = arg->getValue();
+    llvm::StringRef val = arg->getValue();
+    reproduceFileName = (val == "default")
+                            ? Config.options().outputFileName() + ".tar"
+                            : val.str();
   }
 
   if (reproduceFileName)
@@ -1789,7 +1798,7 @@ void GnuLdDriver::defaultSignalHandler(void *cookie) {
       commandLine.append(" ");
     }
   }
-  commandLine.append("--reproduce build.tar");
+  commandLine.append("--reproduce=default");
   llvm::SmallString<256> outputPath;
   std::error_code EC =
       llvm::sys::fs::createTemporaryFile("reproduce", "sh", outputPath);

--- a/test/Common/standalone/CommandLine/OutputTarWriter/ReproduceDefaultFilename.test
+++ b/test/Common/standalone/CommandLine/OutputTarWriter/ReproduceDefaultFilename.test
@@ -1,0 +1,12 @@
+#---ReproduceDefaultFilename.test-------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# This checks that --reproduce=default names the tar after the output file
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
+RUN: %link %t1.1.o -o %t2.out --reproduce=default
+RUN: %filecheck %s < %t2.out.tar
+CHECK: mapping.ini
+CHECK: version.txt
+CHECK: response.txt
+#END_TEST

--- a/test/Common/standalone/CommandLine/Reproduce/ReproduceNoFilename.test
+++ b/test/Common/standalone/CommandLine/Reproduce/ReproduceNoFilename.test
@@ -1,0 +1,13 @@
+#UNSUPPORTED: windows, reproduce_fail
+#---ReproduceNoFilename.test----------------- Executable -----------------#
+#BEGIN_COMMENT
+# Checks that --reproduce=default defaults the tar to <output>.tar
+#END_COMMENT
+#START_TEST
+RUN: %rm %t1.1.o
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
+RUN: %link %linkopts %t1.1.o -o %t1.1.out -T %p/Inputs/1.script.t --reproduce=default --dump-response-file %t1.1.response
+RUN: %filecheck %s < %t1.1.response
+CHECK: ReproduceNoFilename.test.tmp1.1.out
+RUN: ls %t1.1.out.tar
+#END_TEST


### PR DESCRIPTION
Add support for the special value "default" for --reproduce and --reproduce-on-fail. When either option is given the value "default", the output tarball is automatically named <output>.tar, where <output> is the -o output filename (or a.out if -o is not given).

  --reproduce=default          -> <output>.tar (always)
  --reproduce-on-fail=default  -> <output>.tar (on failure only)

This avoids the need to spell out the output filename twice on the command line and makes the crash-recovery script generated by defaultSignalHandler self-contained.

docs: update userguide for --reproduce=default and --reproduce-on-fail=default

Document the new "default" keyword for --reproduce and --reproduce-on-fail. When the value "default" is supplied, the tarball is automatically named <output>.tar based on the -o output filename (a.out.tar if -o is omitted).