### PR TITLE
[NFC] Remove redundant *Relocator destructor definitions

### DIFF
--- a/include/eld/Target/Relocator.h
+++ b/include/eld/Target/Relocator.h
@@ -73,7 +73,7 @@ public:
   Relocator(LinkerConfig &pConfig, Module &pModule)
       : m_Config(pConfig), m_Module(pModule) {}
 
-  virtual ~Relocator() = 0;
+  virtual ~Relocator() = default;
 
   /// apply - general apply function
   virtual Result applyRelocation(Relocation &pRelocation) = 0;

--- a/lib/Target/AArch64/AArch64Relocator.cpp
+++ b/lib/Target/AArch64/AArch64Relocator.cpp
@@ -147,8 +147,6 @@ AArch64Relocator::AArch64Relocator(AArch64LDBackend &pParent,
                                    LinkerConfig &pConfig, Module &pModule)
     : Relocator(pConfig, pModule), m_Target(pParent) {}
 
-AArch64Relocator::~AArch64Relocator() {}
-
 bool AArch64Relocator::isRelocSupported(Relocation &pReloc) const {
   Relocation::Type type = pReloc.type();
   // valid types are 0x0, 0x100-0x244

--- a/lib/Target/AArch64/AArch64Relocator.h
+++ b/lib/Target/AArch64/AArch64Relocator.h
@@ -47,7 +47,6 @@ class AArch64Relocator : public Relocator {
 public:
   AArch64Relocator(AArch64LDBackend &pParent, LinkerConfig &pConfig,
                    Module &pModule);
-  ~AArch64Relocator();
 
   Result applyRelocation(Relocation &pRelocation) override;
 

--- a/lib/Target/ARM/ARMRelocator.cpp
+++ b/lib/Target/ARM/ARMRelocator.cpp
@@ -252,8 +252,6 @@ ARMRelocator::ARMRelocator(ARMGNULDBackend &pParent, LinkerConfig &pConfig,
                            Module &pModule)
     : Relocator(pConfig, pModule), m_Target(pParent) {}
 
-ARMRelocator::~ARMRelocator() {}
-
 bool ARMRelocator::isInvalidReloc(Relocation &pReloc) const {
   if (!config().isCodeIndep())
     return false;

--- a/lib/Target/ARM/ARMRelocator.h
+++ b/lib/Target/ARM/ARMRelocator.h
@@ -27,7 +27,6 @@ class ARMRelocator : public Relocator {
 public:
   ARMRelocator(ARMGNULDBackend &pParent, LinkerConfig &pConfig,
                Module &pModule);
-  ~ARMRelocator();
 
   Result applyRelocation(Relocation &pRelocation) override;
 

--- a/lib/Target/Hexagon/HexagonRelocator.cpp
+++ b/lib/Target/Hexagon/HexagonRelocator.cpp
@@ -189,8 +189,6 @@ HexagonRelocator::HexagonRelocator(HexagonLDBackend &pParent,
   }
 }
 
-HexagonRelocator::~HexagonRelocator() {}
-
 Relocator::Result HexagonRelocator::applyRelocation(Relocation &pRelocation) {
   Relocation::Type type = pRelocation.type();
 

--- a/lib/Target/Hexagon/HexagonRelocator.h
+++ b/lib/Target/Hexagon/HexagonRelocator.h
@@ -29,7 +29,6 @@ class HexagonRelocator : public Relocator {
 public:
   HexagonRelocator(HexagonLDBackend &pParent, LinkerConfig &pConfig,
                    Module &pModule);
-  ~HexagonRelocator();
 
   Result applyRelocation(Relocation &pRelocation) override;
 

--- a/lib/Target/RISCV/RISCVRelocator.cpp
+++ b/lib/Target/RISCV/RISCVRelocator.cpp
@@ -238,8 +238,6 @@ RISCVRelocator::RISCVRelocator(RISCVLDBackend &Backend, LinkerConfig &pConfig,
   }
 }
 
-RISCVRelocator::~RISCVRelocator() {}
-
 namespace {
 
 /// helper_Rela_init - Get an relocation entry in .rela.dyn

--- a/lib/Target/RISCV/RISCVRelocator.h
+++ b/lib/Target/RISCV/RISCVRelocator.h
@@ -25,7 +25,6 @@ class RISCVRelocator : public Relocator {
 public:
   RISCVRelocator(RISCVLDBackend &pParent, LinkerConfig &pConfig,
                  Module &pModule);
-  ~RISCVRelocator();
 
   Result applyRelocation(Relocation &pRelocation) override;
 

--- a/lib/Target/Relocator.cpp
+++ b/lib/Target/Relocator.cpp
@@ -33,8 +33,6 @@ using namespace eld;
 //===----------------------------------------------------------------------===//
 // Relocator
 //===----------------------------------------------------------------------===//
-Relocator::~Relocator() {}
-
 void Relocator::partialScanRelocation(Relocation &pReloc,
                                       const ELFSection &pSection) {
   // if we meet a section symbol

--- a/lib/Target/Template/TemplateRelocator.cpp
+++ b/lib/Target/Template/TemplateRelocator.cpp
@@ -35,8 +35,6 @@ TemplateRelocator::TemplateRelocator(TemplateLDBackend &pParent,
   }
 }
 
-TemplateRelocator::~TemplateRelocator() {}
-
 Relocator::Result TemplateRelocator::applyRelocation(Relocation &pRelocation) {
   Relocation::Type type = pRelocation.type();
 

--- a/lib/Target/Template/TemplateRelocator.h
+++ b/lib/Target/Template/TemplateRelocator.h
@@ -25,7 +25,6 @@ class TemplateRelocator : public Relocator {
 public:
   TemplateRelocator(TemplateLDBackend &pParent, LinkerConfig &pConfig,
                     Module &pModule);
-  ~TemplateRelocator();
 
   Result applyRelocation(Relocation &pRelocation);
 

--- a/lib/Target/X86/x86_64Relocator.cpp
+++ b/lib/Target/X86/x86_64Relocator.cpp
@@ -35,8 +35,6 @@ x86_64Relocator::x86_64Relocator(x86_64LDBackend &pParent,
   }
 }
 
-x86_64Relocator::~x86_64Relocator() {}
-
 Relocator::Result x86_64Relocator::applyRelocation(Relocation &pRelocation) {
   Relocation::Type type = pRelocation.type();
 

--- a/lib/Target/X86/x86_64Relocator.h
+++ b/lib/Target/X86/x86_64Relocator.h
@@ -29,7 +29,6 @@ class x86_64Relocator : public Relocator {
 public:
   x86_64Relocator(x86_64LDBackend &pParent, LinkerConfig &pConfig,
                   Module &pModule);
-  ~x86_64Relocator();
 
   Result applyRelocation(Relocation &pRelocation) override;
 


### PR DESCRIPTION
This commit removes redundant Relocator destructor definitions. Explicit destructor definition can inhibit optimizations.