### PR TITLE
Fix incorrect "Plugin Error" when plt/got sections are discarded

### DIFF
--- a/include/eld/Diagnostics/DiagGOTPLT.inc
+++ b/include/eld/Diagnostics/DiagGOTPLT.inc
@@ -15,3 +15,5 @@ DIAG(create_got_entry, DiagnosticEngine::Note,
      "Created GOT Entry for Symbol %0")
 DIAG(create_plt_entry, DiagnosticEngine::Note,
      "Created PLT Entry for Symbol %0")
+DIAG(error_discarded_dynamic_section_required, DiagnosticEngine::Error,
+     "symbol '%0' referenced in file '%1' depends upon discarded %2 section")

--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -660,6 +660,13 @@ public:
   ELFSection *getRelaDyn() const;
   ELFSection *getRelaPLT() const;
 
+  // Report error if GOT/PLT/GOTPLT sections are discarded.
+  // They are used to report the error when the section is required but is
+  // discarded.
+  void reportErrorIfGOTIsDiscarded(ResolveInfo *R) const;
+  void reportErrorIfPLTIsDiscarded(ResolveInfo *R) const;
+  void reportErrorIfGOTPLTIsDiscarded(ResolveInfo *R) const;
+
   virtual LDSymbol *getGOTSymbol() const { return m_pGOTSymbol; }
 
   void recordRelativeReloc(Relocation *R, const Relocation *N) {

--- a/lib/Target/AArch64/AArch64LDBackend.cpp
+++ b/lib/Target/AArch64/AArch64LDBackend.cpp
@@ -734,10 +734,13 @@ AArch64GOT *AArch64LDBackend::createGOT(GOT::GOTType T,
     break;
   }
   if (R) {
-    if (GOT)
+    if (GOT) {
+      reportErrorIfGOTIsDiscarded(R);
       recordGOT(R, G);
-    else
+    } else {
+      reportErrorIfGOTPLTIsDiscarded(R);
       recordGOTPLT(R, G);
+    }
   }
   return G;
 }
@@ -768,6 +771,9 @@ AArch64PLT *AArch64LDBackend::createPLT(ELFObjectFile *Obj, ResolveInfo *R,
                         config().options().traceSymbol(*R)) ||
                        m_Module.getPrinter()->traceDynamicLinking()))
     config().raise(Diag::create_plt_entry) << R->name();
+
+  reportErrorIfPLTIsDiscarded(R);
+
   if (!getPLT()->getFragmentList().size()) {
     AArch64PLT0::Create(*m_Module.getIRBuilder(),
                         createGOT(GOT::GOTPLT0, nullptr, nullptr), getPLT(),

--- a/lib/Target/ARM/ARMLDBackend.cpp
+++ b/lib/Target/ARM/ARMLDBackend.cpp
@@ -1089,10 +1089,13 @@ ARMGOT *ARMGNULDBackend::createGOT(GOT::GOTType T, ELFObjectFile *Obj,
     break;
   }
   if (R) {
-    if (GOT)
+    if (GOT) {
+      reportErrorIfGOTIsDiscarded(R);
       recordGOT(R, G);
-    else
+    } else {
+      reportErrorIfGOTPLTIsDiscarded(R);
       recordGOTPLT(R, G);
+    }
   }
   return G;
 }
@@ -1127,6 +1130,9 @@ ARMPLT *ARMGNULDBackend::createPLT(ELFObjectFile *Obj, ResolveInfo *R,
                         config().options().traceSymbol(*R)) ||
                        m_Module.getPrinter()->traceDynamicLinking()))
     config().raise(Diag::create_plt_entry) << R->name();
+
+  reportErrorIfPLTIsDiscarded(R);
+
   // If there is no entries GOTPLT and PLT, we dont have a PLT0.
   if (!getPLT()->getFragmentList().size()) {
     ARMPLT0::Create(*m_Module.getIRBuilder(),

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -1623,6 +1623,37 @@ ELFSection *GNULDBackend::getRelaPLT() const {
   return m_DynamicSectionHeadersInputFile->getRelaPLT();
 }
 
+void GNULDBackend::reportErrorIfGOTIsDiscarded(ResolveInfo *R) const {
+  ELFSection *GOT = getGOT();
+  if (GOT && GOT->isIgnore()) {
+    llvm::StringRef SymName = R->name();
+    std::string FileName = R->resolvedOrigin()->getInput()->getName();
+    config().raise(Diag::error_discarded_dynamic_section_required)
+        << SymName << FileName << ".got";
+  }
+}
+
+void GNULDBackend::reportErrorIfPLTIsDiscarded(ResolveInfo *R) const {
+  ELFSection *PLT = getPLT();
+  if (PLT && PLT->isIgnore()) {
+    llvm::StringRef SymName = R->name();
+    std::string FileName = R->resolvedOrigin()->getInput()->getName();
+
+    config().raise(Diag::error_discarded_dynamic_section_required)
+        << SymName << FileName << ".plt";
+  }
+}
+
+void GNULDBackend::reportErrorIfGOTPLTIsDiscarded(ResolveInfo *R) const {
+  ELFSection *GOTPLT = getGOTPLT();
+  if (GOTPLT && GOTPLT->isIgnore()) {
+    llvm::StringRef SymName = R->name();
+    std::string FileName = R->resolvedOrigin()->getInput()->getName();
+    config().raise(Diag::error_discarded_dynamic_section_required)
+        << SymName << FileName << ".got.plt";
+  }
+}
+
 // Patching sections.
 ELFSection *GNULDBackend::getGOTPatch() const {
   return m_DynamicSectionHeadersInputFile->getGOTPatch();

--- a/lib/Target/Hexagon/HexagonLDBackend.cpp
+++ b/lib/Target/Hexagon/HexagonLDBackend.cpp
@@ -988,10 +988,13 @@ HexagonGOT *HexagonLDBackend::createGOT(GOT::GOTType T, ELFObjectFile *Obj,
     break;
   }
   if (R) {
-    if (GOT)
+    if (GOT) {
+      reportErrorIfGOTIsDiscarded(R);
       recordGOT(R, G);
-    else
+    } else {
+      reportErrorIfGOTPLTIsDiscarded(R);
       recordGOTPLT(R, G);
+    }
   }
   return G;
 }
@@ -1021,6 +1024,9 @@ HexagonPLT *HexagonLDBackend::createPLT(ELFObjectFile *Obj, ResolveInfo *R) {
                         config().options().traceSymbol(*R)) ||
                        m_Module.getPrinter()->traceDynamicLinking()))
     config().raise(Diag::create_plt_entry) << R->name();
+
+  reportErrorIfPLTIsDiscarded(R);
+
   // If there is no entries GOTPLT and PLT, we dont have a PLT0.
   if (!hasNow && !getPLT()->getFragmentList().size()) {
     HexagonPLT0::Create(*m_Module.getIRBuilder(),

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -1599,10 +1599,13 @@ RISCVGOT *RISCVLDBackend::createGOT(GOT::GOTType T, ELFObjectFile *Obj,
     break;
   }
   if (R) {
-    if (GOT)
+    if (GOT) {
+      reportErrorIfGOTIsDiscarded(R);
       recordGOT(R, G);
-    else
+    } else {
+      reportErrorIfGOTPLTIsDiscarded(R);
       recordGOTPLT(R, G);
+    }
   }
   return G;
 }
@@ -1630,6 +1633,9 @@ RISCVPLT *RISCVLDBackend::createPLT(ELFObjectFile *Obj, ResolveInfo *R) {
        config().options().traceSymbol(*R)) ||
       m_Module.getPrinter()->traceDynamicLinking())
     config().raise(Diag::create_plt_entry) << R->name();
+
+  reportErrorIfPLTIsDiscarded(R);
+
   RISCVGOT *G = createGOT(GOT::GOTPLTN, Obj, R);
   RISCVPLT *P = RISCVPLT::CreatePLTN(G, Obj->getPLT(), R, is32Bits);
   recordPLT(R, P);

--- a/lib/Target/X86/x86_64LDBackend.cpp
+++ b/lib/Target/X86/x86_64LDBackend.cpp
@@ -227,10 +227,13 @@ x86_64GOT *x86_64LDBackend::createGOT(GOT::GOTType T, ELFObjectFile *Obj,
     break;
   }
   if (R) {
-    if (GOT)
+    if (GOT) {
+      reportErrorIfGOTIsDiscarded(R);
       recordGOT(R, G);
-    else
+    } else {
+      reportErrorIfGOTPLTIsDiscarded(R);
       recordGOTPLT(R, G);
+    }
   }
   return G;
 }
@@ -261,6 +264,8 @@ x86_64PLT *x86_64LDBackend::createPLT(ELFObjectFile *Obj, ResolveInfo *R,
                         config().options().traceSymbol(*R)) ||
                        m_Module.getPrinter()->traceDynamicLinking()))
     config().raise(Diag::create_plt_entry) << R->name();
+
+  reportErrorIfPLTIsDiscarded(R);
 
   // Create PLT0 if this is the first PLT entry. PLT0 is the common
   // trampoline that all PLTN entries jump to for symbol resolution.

--- a/test/Common/standalone/DiscardDynamicSections/DiscardDynamicSections.test
+++ b/test/Common/standalone/DiscardDynamicSections/DiscardDynamicSections.test
@@ -1,0 +1,24 @@
+#---DiscardDynamicSections.test-------------- Executable, LS ----------------#
+#BEGIN_COMMENT
+# This test verifies that the linker emits a proper error message when dynamic
+# sections (.got, .plt, .got.plt) are discarded via /DISCARD/ in a linker
+# script and there is a relocation that points to these sections.
+#END_COMMENT
+#START_TEST
+# Test 1: Discard .got section
+RUN: %clang %clangopts -o %t1.got.o %p/Inputs/got.c -c -fPIC
+RUN: %not %link %linkopts -o %t1.got.out %t1.got.o -T %p/Inputs/discard-got.t 2>&1 | %filecheck %s --check-prefix=GOT
+
+# Test 2: Discard .plt section - need shared library to trigger PLT
+RUN: %clang %clangopts -o %t1.plt.o %p/Inputs/plt.c -c -fPIC
+RUN: %clang %clangopts -o %t1.bar.o %p/Inputs/bar.c -c -fPIC
+RUN: %link %linkopts -o %t1.bar.so %t1.bar.o -shared
+RUN: %not %link %linkopts -o %t1.plt.out %t1.plt.o %t1.bar.so -T %p/Inputs/discard-plt.t 2>&1 | %filecheck %s --check-prefix=PLT
+
+# Test 3: Discard .got.plt section
+RUN: %not %link %linkopts -o %t1.gotplt.out %t1.plt.o %t1.bar.so -T %p/Inputs/discard-gotplt.t 2>&1 | %filecheck %s --check-prefix=GOTPLT
+#END_TEST
+
+GOT: Error: symbol '{{.*}}' referenced in file '{{.*}}' depends upon discarded .got section
+PLT: Error: symbol '{{.*}}' referenced in file '{{.*}}' depends upon discarded .plt section
+GOTPLT: Error: symbol '{{.*}}' referenced in file '{{.*}}' depends upon discarded .got.plt section

--- a/test/Common/standalone/DiscardDynamicSections/Inputs/bar.c
+++ b/test/Common/standalone/DiscardDynamicSections/Inputs/bar.c
@@ -1,0 +1,1 @@
+void bar(void) {}

--- a/test/Common/standalone/DiscardDynamicSections/Inputs/discard-got.t
+++ b/test/Common/standalone/DiscardDynamicSections/Inputs/discard-got.t
@@ -1,0 +1,4 @@
+SECTIONS {
+  .text : { *(.text) }
+  /DISCARD/ : { *(.got) *(got*) }
+}

--- a/test/Common/standalone/DiscardDynamicSections/Inputs/discard-gotplt.t
+++ b/test/Common/standalone/DiscardDynamicSections/Inputs/discard-gotplt.t
@@ -1,0 +1,4 @@
+SECTIONS {
+  .text : { *(.text) }
+  /DISCARD/ : { *(.got.plt) }
+}

--- a/test/Common/standalone/DiscardDynamicSections/Inputs/discard-plt.t
+++ b/test/Common/standalone/DiscardDynamicSections/Inputs/discard-plt.t
@@ -1,0 +1,4 @@
+SECTIONS {
+  .text : { *(.text) }
+  /DISCARD/ : { *(.plt) }
+}

--- a/test/Common/standalone/DiscardDynamicSections/Inputs/got.c
+++ b/test/Common/standalone/DiscardDynamicSections/Inputs/got.c
@@ -1,0 +1,2 @@
+int a = 10;
+int foo() { return a; }

--- a/test/Common/standalone/DiscardDynamicSections/Inputs/plt.c
+++ b/test/Common/standalone/DiscardDynamicSections/Inputs/plt.c
@@ -1,0 +1,2 @@
+extern void bar(void);
+void foo(void) { bar(); }


### PR DESCRIPTION
This commit fixes the incorrect `Plugin Error` when the real cause is that the .plt/.got/.plt.got sections are required but are explicitly discarded. This patch fixes this issue by reporting the correct error.

Resolves #959