### PR TITLE
Add a delay before capturing screenshot for dashboard.

### DIFF
--- a/.github/workflows/update-build-dashboard-data.yml
+++ b/.github/workflows/update-build-dashboard-data.yml
@@ -61,6 +61,7 @@ jobs:
       - name: Generate Build Dashboard Screenshot
         shell: bash
         run: |
+            sleep 20
             DASH_DIR="$(mktemp -d)"
             google-chrome --headless --password-store=basic --disable-features=DbusSecretPortal --screenshot=${DASH_DIR}/dashboard.png --window-size=1240,1240 --virtual-time-budget=2000 https://qualcomm.github.io/eld/dash/dash.html && mogrify -gravity North -chop 0x150 -gravity South -chop 0x85 ${DASH_DIR}/dashboard.png
             ls -l ${DASH_DIR}/


### PR DESCRIPTION
The github pages deployment takes several seconds before the branch updates reflect on published github pages. Add a delay of 20s to allow refresh.

Closes #1001