### PR TITLE
fix: deduplicate DT_NEEDED entries by SONAME

### DIFF
--- a/include/eld/Config/LinkerConfig.h
+++ b/include/eld/Config/LinkerConfig.h
@@ -81,6 +81,7 @@ public:
     std::optional<bool> EnableAttributeMixWarnings;
     std::optional<bool> EnableArchiveFileWarnings;
     std::optional<bool> EnableLinkerScriptMemoryWarnings;
+    std::optional<bool> EnableDynamicWarnings;
     std::optional<bool> EnableBadDotAssignmentWarnings;
     std::optional<bool> EnableWholeArchiveWarnings;
     std::optional<bool> EnableCommandLineWarnings;
@@ -331,6 +332,18 @@ public:
             *WarnOpt.EnableLinkerScriptMemoryWarnings);
   }
 
+  bool hasShowDynamicWarnings() const {
+    return WarnOpt.EnableDynamicWarnings.has_value();
+  }
+
+  bool showDynamicWarnings() const {
+    return (hasShowDynamicWarnings() && *WarnOpt.EnableDynamicWarnings);
+  }
+
+  void setShowDynamicWarnings(bool Option = true) {
+    WarnOpt.EnableDynamicWarnings = Option;
+  }
+
   bool showBadDotAssignmentWarnings() const {
     return (hasBadDotAssignmentsWarnings() &&
             *WarnOpt.EnableBadDotAssignmentWarnings);
@@ -358,6 +371,7 @@ public:
     WarnOpt.EnableBadDotAssignmentWarnings = true;
     WarnOpt.EnableWholeArchiveWarnings = true;
     WarnOpt.EnableOSABIWarnings = true;
+    WarnOpt.EnableDynamicWarnings = true;
   }
 
   void setShowLinkerScriptWarning(bool Option) {

--- a/include/eld/Config/LinkerConfig.h
+++ b/include/eld/Config/LinkerConfig.h
@@ -86,6 +86,7 @@ public:
     std::optional<bool> EnableAttributeMixWarnings;
     std::optional<bool> EnableArchiveFileWarnings;
     std::optional<bool> EnableLinkerScriptMemoryWarnings;
+    std::optional<bool> EnableDynamicWarnings;
     std::optional<bool> EnableBadDotAssignmentWarnings;
     std::optional<bool> EnableWholeArchiveWarnings;
     std::optional<bool> EnableCommandLineWarnings;
@@ -343,6 +344,18 @@ public:
             *WarnOpt.EnableLinkerScriptMemoryWarnings);
   }
 
+  bool hasShowDynamicWarnings() const {
+    return WarnOpt.EnableDynamicWarnings.has_value();
+  }
+
+  bool showDynamicWarnings() const {
+    return (hasShowDynamicWarnings() && *WarnOpt.EnableDynamicWarnings);
+  }
+
+  void setShowDynamicWarnings(bool Option = true) {
+    WarnOpt.EnableDynamicWarnings = Option;
+  }
+
   bool showBadDotAssignmentWarnings() const {
     return (hasBadDotAssignmentsWarnings() &&
             *WarnOpt.EnableBadDotAssignmentWarnings);
@@ -379,6 +392,7 @@ public:
     WarnOpt.EnableWholeArchiveWarnings = true;
     WarnOpt.EnableOSABIWarnings = true;
     WarnOpt.EnableVersionScriptWarnings = true;
+    WarnOpt.EnableDynamicWarnings = true;
   }
 
   void setShowLinkerScriptWarning(bool Option) {

--- a/include/eld/Diagnostics/DiagReaders.inc
+++ b/include/eld/Diagnostics/DiagReaders.inc
@@ -54,7 +54,7 @@ DIAG(discard_reloc_section_map, DiagnosticEngine::Note,
 DIAG(input_file_has_zero_size, DiagnosticEngine::Note,
      "Input file %0 has no contents")
 DIAG(string_not_null_terminated, DiagnosticEngine::Error,
-    "%0: string is not null terminated")
+     "%0: string is not null terminated")
 DIAG(invalid_elf_class, DiagnosticEngine::Error,
      "Invalid ELF file %0 for target %1")
 DIAG(fatal_big_endian_target, DiagnosticEngine::Fatal,
@@ -79,7 +79,8 @@ DIAG(error_failed_to_read_thin_archive_mem, DiagnosticEngine::Error,
 DIAG(warn_whole_archive_enabled, DiagnosticEngine::Warning,
      "'whole-archive' enabled for '%0'")
 DIAG(warn_archive_mem_repeated_content, DiagnosticEngine::Warning,
-     "Archive member '%0:%1' at index %2 has same content as archive member '%0:%3' "
+     "Archive member '%0:%1' at index %2 has same content as archive member "
+     "'%0:%3' "
      "at index %4")
 DIAG(verbose_performing_archive_symbol_resolution, DiagnosticEngine::Verbose,
      "Performing symbol resolution for archive '%0'")
@@ -97,7 +98,7 @@ DIAG(error_patch_invalid_symbol, DiagnosticEngine::Error,
 DIAG(warning_abi_differences, DiagnosticEngine::Warning,
      "'%0' has OS/ABI set to %1, previously seen %2")
 DIAG(error_unknown_target_emulation, DiagnosticEngine::Error,
-  "target emulation unknown: -m or at least one .o file required")
+     "target emulation unknown: -m or at least one .o file required")
 DIAG(error_target_not_found, DiagnosticEngine::Error,
      "Target not registered : %0")
 DIAG(error_emulation_failed_for_target, DiagnosticEngine::Error,
@@ -110,7 +111,8 @@ DIAG(error_failed_to_find_driver, DiagnosticEngine::Error,
      "No driver found for target : %0")
 DIAG(fatal_unsupported_bit_code_file, DiagnosticEngine::Fatal,
      "Unsupported architecture %0 in LLVM Bitcode file : %1")
-DIAG(note_empty_archive, DiagnosticEngine::Note,
-     "Empty archive file: '%0'")
+DIAG(note_empty_archive, DiagnosticEngine::Note, "Empty archive file: '%0'")
 DIAG(sframe_read_error, DiagnosticEngine::Error,
      "SFrame Read Error : %0 from file %1")
+DIAG(warn_duplicate_soname, DiagnosticEngine::Warning,
+     "'%0' and '%1' have the same SONAME '%2'")

--- a/include/eld/Diagnostics/DiagReaders.inc
+++ b/include/eld/Diagnostics/DiagReaders.inc
@@ -56,7 +56,7 @@ DIAG(discard_reloc_section_map, DiagnosticEngine::Note,
 DIAG(input_file_has_zero_size, DiagnosticEngine::Note,
      "Input file %0 has no contents")
 DIAG(string_not_null_terminated, DiagnosticEngine::Error,
-    "%0: string is not null terminated")
+     "%0: string is not null terminated")
 DIAG(invalid_elf_class, DiagnosticEngine::Error,
      "Invalid ELF file %0 for target %1")
 DIAG(fatal_big_endian_target, DiagnosticEngine::Fatal,
@@ -81,7 +81,8 @@ DIAG(error_failed_to_read_thin_archive_mem, DiagnosticEngine::Error,
 DIAG(warn_whole_archive_enabled, DiagnosticEngine::Warning,
      "'whole-archive' enabled for '%0'")
 DIAG(warn_archive_mem_repeated_content, DiagnosticEngine::Warning,
-     "Archive member '%0:%1' at index %2 has same content as archive member '%0:%3' "
+     "Archive member '%0:%1' at index %2 has same content as archive member "
+     "'%0:%3' "
      "at index %4")
 DIAG(verbose_performing_archive_symbol_resolution, DiagnosticEngine::Verbose,
      "Performing symbol resolution for archive '%0'")
@@ -94,7 +95,7 @@ DIAG(verbose_reusing_archive_file_info, DiagnosticEngine::Verbose,
 DIAG(warning_abi_differences, DiagnosticEngine::Warning,
      "'%0' has OS/ABI set to %1, previously seen %2")
 DIAG(error_unknown_target_emulation, DiagnosticEngine::Error,
-  "target emulation unknown: -m or at least one .o file required")
+     "target emulation unknown: -m or at least one .o file required")
 DIAG(error_target_not_found, DiagnosticEngine::Error,
      "Target not registered : %0")
 DIAG(error_emulation_failed_for_target, DiagnosticEngine::Error,
@@ -107,7 +108,8 @@ DIAG(error_failed_to_find_driver, DiagnosticEngine::Error,
      "No driver found for target : %0")
 DIAG(fatal_unsupported_bit_code_file, DiagnosticEngine::Fatal,
      "Unsupported architecture %0 in LLVM Bitcode file : %1")
-DIAG(note_empty_archive, DiagnosticEngine::Note,
-     "Empty archive file: '%0'")
+DIAG(note_empty_archive, DiagnosticEngine::Note, "Empty archive file: '%0'")
 DIAG(sframe_read_error, DiagnosticEngine::Error,
      "SFrame Read Error : %0 from file %1")
+DIAG(warn_duplicate_soname, DiagnosticEngine::Warning,
+     "'%0' and '%1' have the same SONAME '%2'")

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -1018,6 +1018,8 @@ def W : Joined<["-"], "W">,
              "with different values for OS/ABI\n"
              "\t\t\t -W[no-]version-script : display warnings detected while "
              "processing version scripts\n"
+             "\t\t\t -W[no-]dynamic : display a warning when multiple shared "
+             "libraries with the same SONAME are linked\n"
             >,
         Group<grp_diagopts>;
 

--- a/include/eld/Object/ObjectLinker.h
+++ b/include/eld/Object/ObjectLinker.h
@@ -598,6 +598,7 @@ private:
       MMemoryAreaToArchiveFileMap;
 
   std::vector<ArchiveMemberReportRecord> ArchiveRecordsForReport;
+  llvm::StringMap<std::string> MSonameToFile;
 };
 
 } // end namespace eld

--- a/lib/Config/LinkerConfig.cpp
+++ b/lib/Config/LinkerConfig.cpp
@@ -233,6 +233,14 @@ bool LinkerConfig::setWarningOption(llvm::StringRef WarnOption) {
     setShowLinkerScriptMemoryWarning(false);
     return true;
   }
+  if (WarnOpt == "dynamic") {
+    setShowDynamicWarnings(true);
+    return true;
+  }
+  if (WarnOpt == "no-dynamic") {
+    setShowDynamicWarnings(false);
+    return true;
+  }
   if (WarnOpt == "bad-dot-assignments") {
     setShowBadDotAssginmentsWarning(true);
     return true;

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -3854,12 +3854,21 @@ bool ObjectLinker::readAndProcessInput(Input *Input, bool IsPostLto) {
         ThisConfig.raiseDiagEntry(std::move(ExpRead.error()));
       return false;
     }
-#ifdef ELD_ENABLE_SYMBOL_VERSIONING
     ELFDynObjectFile *DynObjFile = llvm::cast<ELFDynObjectFile>(CurInput);
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
     if (DynObjFile->hasSymbolVersioningInfo())
       getTargetBackend().setShouldEmitVersioningSections(true);
 #endif
+    std::string SOName = DynObjFile->getSOName();
+    std::string FilePath = CurInput->getInput()->decoratedPath();
     ThisModule->getDynLibraryList().push_back(CurInput);
+    if (!MSonameToFile.count(SOName)) {
+      MSonameToFile[SOName] = FilePath;
+    } else if (MSonameToFile[SOName] != FilePath &&
+               ThisConfig.showDynamicWarnings()) {
+      ThisConfig.raise(Diag::warn_duplicate_soname)
+          << MSonameToFile[SOName] << FilePath << SOName;
+    }
   } else if (CurInput->getKind() == InputFile::GNUArchiveFileKind) {
     eld::RegisterTimer T("Read Archive Files", "Read all Input files",
                          ThisConfig.options().printTimingStats());

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -988,7 +988,7 @@ void GNULDBackend::sizeDynamic() {
     std::string fileName = dynObjFile->getInput()->getFileName();
     if (sonameToFile.count(SOName)) {
       // Only warn when different files have the same SONAME
-      if (sonameToFile[SOName] != fileName)
+      if (sonameToFile[SOName] != fileName && config().showDynamicWarnings())
         config().raise(Diag::warn_duplicate_soname)
             << sonameToFile[SOName] << fileName << SOName;
       continue;

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -979,18 +979,24 @@ void GNULDBackend::sizeDynamic() {
   }
 
   // add DT_NEEDED
-  std::unordered_set<MemoryArea *> addedLibs;
+  llvm::StringMap<std::string> sonameToFile;
   for (auto &lib : m_Module.getDynLibraryList()) {
-    if (llvm::dyn_cast<ELFFileBase>(lib)->isELFNeeded()) {
-      const ELFDynObjectFile *dynObjFile = llvm::cast<ELFDynObjectFile>(lib);
-      if (addedLibs.count(dynObjFile->getInput()->getMemArea()))
-        continue;
-      addedLibs.insert(dynObjFile->getInput()->getMemArea());
-      std::size_t SONameOffset =
-          FileFormat->addStringToDynStrTab(dynObjFile->getSOName());
-      auto DTEntry = dynamic()->reserveNeedEntry();
-      DTEntry->setValue(llvm::ELF::DT_NEEDED, SONameOffset);
+    if (!llvm::dyn_cast<ELFFileBase>(lib)->isELFNeeded())
+      continue;
+    const ELFDynObjectFile *dynObjFile = llvm::cast<ELFDynObjectFile>(lib);
+    std::string SOName = dynObjFile->getSOName();
+    std::string fileName = dynObjFile->getInput()->getFileName();
+    if (sonameToFile.count(SOName)) {
+      // Only warn when different files have the same SONAME
+      if (sonameToFile[SOName] != fileName)
+        config().raise(Diag::warn_duplicate_soname)
+            << sonameToFile[SOName] << fileName << SOName;
+      continue;
     }
+    sonameToFile[SOName] = fileName;
+    std::size_t SONameOffset = FileFormat->addStringToDynStrTab(SOName);
+    auto DTEntry = dynamic()->reserveNeedEntry();
+    DTEntry->setValue(llvm::ELF::DT_NEEDED, SONameOffset);
   }
 
   // add DT_RUNPATH

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -1125,7 +1125,7 @@ void GNULDBackend::sizeDynamic() {
   }
 
   // add DT_NEEDED
-  std::unordered_set<MemoryArea *> addedLibs;
+  llvm::StringMap<std::string> sonameToFile;
   for (auto &lib : m_Module.getDynLibraryList()) {
     if (llvm::dyn_cast<ELFFileBase>(lib)->isELFNeeded()) {
       const ELFDynObjectFile *dynObjFile = llvm::cast<ELFDynObjectFile>(lib);
@@ -1138,6 +1138,10 @@ void GNULDBackend::sizeDynamic() {
       DTEntry->tag = llvm::ELF::DT_NEEDED;
       DTEntry->value = SONameOffset;
     }
+    sonameToFile[SOName] = fileName;
+    std::size_t SONameOffset = FileFormat->addStringToDynStrTab(SOName);
+    auto DTEntry = dynamic()->reserveNeedEntry();
+    DTEntry->setValue(llvm::ELF::DT_NEEDED, SONameOffset);
   }
 
   // add DT_RUNPATH

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -1125,23 +1125,18 @@ void GNULDBackend::sizeDynamic() {
   }
 
   // add DT_NEEDED
-  llvm::StringMap<std::string> sonameToFile;
+  llvm::StringSet<> addedSONAMEs;
   for (auto &lib : m_Module.getDynLibraryList()) {
-    if (llvm::dyn_cast<ELFFileBase>(lib)->isELFNeeded()) {
-      const ELFDynObjectFile *dynObjFile = llvm::cast<ELFDynObjectFile>(lib);
-      if (addedLibs.count(dynObjFile->getInput()->getMemArea()))
-        continue;
-      addedLibs.insert(dynObjFile->getInput()->getMemArea());
-      std::size_t SONameOffset =
-          m_pDynStrFrag->addString(dynObjFile->getSOName());
-      auto DTEntry = dynamic()->reserveNeedEntry();
-      DTEntry->tag = llvm::ELF::DT_NEEDED;
-      DTEntry->value = SONameOffset;
-    }
-    sonameToFile[SOName] = fileName;
-    std::size_t SONameOffset = FileFormat->addStringToDynStrTab(SOName);
+    if (!llvm::dyn_cast<ELFFileBase>(lib)->isELFNeeded())
+      continue;
+    const ELFDynObjectFile *dynObjFile = llvm::cast<ELFDynObjectFile>(lib);
+    std::string SOName = dynObjFile->getSOName();
+    if (!addedSONAMEs.insert(SOName).second)
+      continue;
+    std::size_t SONameOffset = m_pDynStrFrag->addString(SOName);
     auto DTEntry = dynamic()->reserveNeedEntry();
-    DTEntry->setValue(llvm::ELF::DT_NEEDED, SONameOffset);
+    DTEntry->tag = llvm::ELF::DT_NEEDED;
+    DTEntry->value = SONameOffset;
   }
 
   // add DT_RUNPATH

--- a/test/Common/standalone/DtNeededSonameDedup/DtNeededSonameDedup.test
+++ b/test/Common/standalone/DtNeededSonameDedup/DtNeededSonameDedup.test
@@ -3,13 +3,14 @@
 # Test that DT_NEEDED entries are deduplicated by SONAME.
 # When multiple shared libraries with the same SONAME are linked,
 # only one DT_NEEDED entry should be emitted.
+# Warning is only shown with -Wdynamic flag.
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -fPIC -c %p/Inputs/1.c -o %t1.1.o
 RUN: %link %linkopts %t1.1.o -o %t1.lib1.so -shared -soname=foo
 RUN: %link %linkopts %t1.1.o -o %t1.lib2.so -shared -soname=foo
-RUN: %link %linkopts %t1.lib1.so %t1.lib2.so -o %t1.out 2>&1 | %filecheck %s --check-prefix=WARN
-RUN: %readelf --dynamic %t1.out | %filecheck %s --check-prefix=NEEDED
+RUN: %link %linkopts %t1.lib1.so %t1.lib2.so -o %t1.out -Wdynamic 2>&1 | %filecheck %s --check-prefix=WARN
+RUN: %readelf --dynamic %t1.out 2>&1 | %filecheck %s --check-prefix=NEEDED
 #WARN: have the same SONAME 'foo'
 #NEEDED: Shared library: [foo]
 #NEEDED-NOT: Shared library: [foo]

--- a/test/Common/standalone/DtNeededSonameDedup/DtNeededSonameDedup.test
+++ b/test/Common/standalone/DtNeededSonameDedup/DtNeededSonameDedup.test
@@ -1,0 +1,16 @@
+#---DtNeededSonameDedup.test--------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# Test that DT_NEEDED entries are deduplicated by SONAME.
+# When multiple shared libraries with the same SONAME are linked,
+# only one DT_NEEDED entry should be emitted.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -fPIC -c %p/Inputs/1.c -o %t1.1.o
+RUN: %link %linkopts %t1.1.o -o %t1.lib1.so -shared -soname=foo
+RUN: %link %linkopts %t1.1.o -o %t1.lib2.so -shared -soname=foo
+RUN: %link %linkopts %t1.lib1.so %t1.lib2.so -o %t1.out 2>&1 | %filecheck %s --check-prefix=WARN
+RUN: %readelf --dynamic %t1.out | %filecheck %s --check-prefix=NEEDED
+#WARN: have the same SONAME 'foo'
+#NEEDED: Shared library: [foo]
+#NEEDED-NOT: Shared library: [foo]
+#END_TEST

--- a/test/Common/standalone/DtNeededSonameDedup/DtNeededSonameDedup.test
+++ b/test/Common/standalone/DtNeededSonameDedup/DtNeededSonameDedup.test
@@ -3,13 +3,14 @@
 # Test that DT_NEEDED entries are deduplicated by SONAME.
 # When multiple shared libraries with the same SONAME are linked,
 # only one DT_NEEDED entry should be emitted.
+# Warning is shown with -Wdynamic flag when different files share same SONAME.
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -fPIC -c %p/Inputs/1.c -o %t1.1.o
 RUN: %link %linkopts %t1.1.o -o %t1.lib1.so -shared -soname=foo
 RUN: %link %linkopts %t1.1.o -o %t1.lib2.so -shared -soname=foo
-RUN: %link %linkopts %t1.lib1.so %t1.lib2.so -o %t1.out 2>&1 | %filecheck %s --check-prefix=WARN
-RUN: %readelf --dynamic %t1.out | %filecheck %s --check-prefix=NEEDED
+RUN: %link %linkopts %t1.lib1.so %t1.lib2.so -o %t1.out -Wdynamic 2>&1 | %filecheck %s --check-prefix=WARN
+RUN: %readelf --dynamic %t1.out 2>&1 | %filecheck %s --check-prefix=NEEDED
 #WARN: have the same SONAME 'foo'
 #NEEDED: Shared library: [foo]
 #NEEDED-NOT: Shared library: [foo]

--- a/test/Common/standalone/DtNeededSonameDedup/DtNeededSonameNoWarn.test
+++ b/test/Common/standalone/DtNeededSonameDedup/DtNeededSonameNoWarn.test
@@ -1,0 +1,15 @@
+#---DtNeededSonameNoWarn.test--------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# Test that no warning is emitted when -Wdynamic is not passed,
+# even when multiple shared libraries with the same SONAME are linked.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -fPIC -c %p/Inputs/1.c -o %t1.1.o
+RUN: %link %linkopts %t1.1.o -o %t1.lib1.so -shared -soname=foo
+RUN: %link %linkopts %t1.1.o -o %t1.lib2.so -shared -soname=foo
+RUN: %link %linkopts %t1.lib1.so %t1.lib2.so -o %t1.out 2>&1 | %filecheck %s --check-prefix=NOWARN --allow-empty
+RUN: %readelf --dynamic %t1.out 2>&1 | %filecheck %s --check-prefix=NEEDED
+#NOWARN-NOT: have the same SONAME 'foo'
+#NEEDED: Shared library: [foo]
+#NEEDED-NOT: Shared library: [foo]
+#END_TEST

--- a/test/Common/standalone/DtNeededSonameDedup/DtNeededSonameSameFile.test
+++ b/test/Common/standalone/DtNeededSonameDedup/DtNeededSonameSameFile.test
@@ -1,0 +1,14 @@
+#---DtNeededSonameSameFile.test--------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# Test that no warning is emitted when the same shared library
+# is listed twice on the command line, even with -Wdynamic.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -fPIC -c %p/Inputs/1.c -o %t1.1.o
+RUN: %link %linkopts %t1.1.o -o %t1.lib1.so -shared -soname=foo
+RUN: %link %linkopts %t1.lib1.so %t1.lib1.so -o %t1.out -Wdynamic 2>&1 | %filecheck %s --check-prefix=NOWARN --allow-empty
+RUN: %readelf --dynamic %t1.out 2>&1 | %filecheck %s --check-prefix=NEEDED
+#NOWARN-NOT: have the same SONAME 'foo'
+#NEEDED: Shared library: [foo]
+#NEEDED-NOT: Shared library: [foo]
+#END_TEST

--- a/test/Common/standalone/DtNeededSonameDedup/Inputs/1.c
+++ b/test/Common/standalone/DtNeededSonameDedup/Inputs/1.c
@@ -1,0 +1,1 @@
+int bar() { return 1; }


### PR DESCRIPTION
## Problem
Fixes #50 

When multiple shared libraries with the same SONAME are passed to the linker, ELD emits duplicate DT_NEEDED entries for the same SONAME.

## Fix

Deduplicate by SONAME string instead of file pointer using `llvm::StringSet<>`. This matches the behavior of `ld.lld` and `ld.bfd`.

## Testing
Verified manually using the reproducer from issue #50.
