### PR TITLE
Refactor iterator APIs to use llvm::make_range

### DIFF
--- a/include/eld/BranchIsland/BranchIsland.h
+++ b/include/eld/BranchIsland/BranchIsland.h
@@ -17,6 +17,7 @@
 #include "eld/SymbolResolver/LDSymbol.h"
 #include "eld/SymbolResolver/ResolveInfo.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/DataTypes.h"
 #include <set>
 #include <string>
@@ -35,17 +36,17 @@ class Relocation;
 class BranchIsland {
 public:
   typedef std::vector<Relocation *> RelocationListType;
-  typedef RelocationListType::iterator reloc_iterator;
+  using RelocationRange = llvm::iterator_range<RelocationListType::iterator>;
 
 public:
   BranchIsland(Stub *Stub);
 
   ~BranchIsland();
 
-  /// relocation iterators of the island
-  reloc_iterator relocBegin() { return Relocations.begin(); }
-
-  reloc_iterator relocEnd() { return Relocations.end(); }
+  /// relocation iterator range of the island
+  RelocationRange getRelocations() {
+    return llvm::make_range(Relocations.begin(), Relocations.end());
+  }
 
   bool canReuseBranchIsland(ResolveInfo *PInfo, int64_t PAddend,
                             bool UseAddends, Stub *PS) {

--- a/include/eld/Input/SearchDirs.h
+++ b/include/eld/Input/SearchDirs.h
@@ -16,6 +16,7 @@
 #include "eld/Input/Input.h"
 #include "eld/Support/Path.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/iterator_range.h"
 #include <string>
 #include <vector>
 
@@ -39,8 +40,7 @@ class SearchDirs {
 
 public:
   typedef std::vector<ELDDirectory *> DirListType;
-  typedef DirListType::iterator iterator;
-  typedef DirListType::const_iterator const_iterator;
+  using DirRange = llvm::iterator_range<DirListType::iterator>;
 
   /// Input type preference for library search.
   enum SearchInputType {
@@ -90,11 +90,13 @@ public:
   const sys::fs::Path &sysroot() const { return SysRoot; }
   bool hasSysRoot() const { return !SysRoot.empty(); }
 
-  // -----  iterators  ----- //
-  const_iterator begin() const { return DirList.begin(); }
-  iterator begin() { return DirList.begin(); }
-  const_iterator end() const { return DirList.end(); }
-  iterator end() { return DirList.end(); }
+  // -----  iterator range  ----- //
+  DirRange getDirectories() {
+    return llvm::make_range(DirList.begin(), DirList.end());
+  }
+  llvm::iterator_range<DirListType::const_iterator> getDirectories() const {
+    return llvm::make_range(DirList.begin(), DirList.end());
+  }
 
   // -----  modifiers  ----- //
   bool insert(const char *PDirectory);

--- a/include/eld/Readers/ELFSection.h
+++ b/include/eld/Readers/ELFSection.h
@@ -20,6 +20,7 @@
 #include "eld/SymbolResolver/LDSymbol.h"
 #include "eld/Target/LDFileFormat.h"
 #include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/iterator_range.h"
 #include <string>
 
 namespace eld {
@@ -251,7 +252,15 @@ public:
 
   bool hasSectionData() const;
 
-  llvm::SmallVectorImpl<Fragment *> &getFragmentList() { return Fragments; }
+  using FragmentRange =
+      llvm::iterator_range<llvm::SmallVectorImpl<Fragment *>::iterator>;
+  using RelocationRange =
+      llvm::iterator_range<llvm::SmallVectorImpl<Relocation *>::iterator>;
+
+  FragmentRange getFragmentList() { return getFragments(); }
+  FragmentRange getFragments() {
+    return llvm::make_range(Fragments.begin(), Fragments.end());
+  }
 
   void splice(llvm::SmallVectorImpl<Fragment *>::iterator Where,
               llvm::SmallVectorImpl<Fragment *> &InputVector,
@@ -259,6 +268,10 @@ public:
     Fragments.insert(Where, InputVector.begin(), InputVector.end());
     if (DoClear)
       InputVector.clear();
+  }
+  void splice(llvm::SmallVectorImpl<Fragment *>::iterator Where,
+              ELFSection &InputSection, bool DoClear = true) {
+    splice(Where, InputSection.Fragments, DoClear);
   }
 
   void addFragment(Fragment *F);
@@ -282,8 +295,18 @@ public:
   void addFragmentAndUpdateSize(Fragment *F);
 
   bool hasRelocData() const { return (!Relocations.empty()); }
+  size_t fragmentCount() const { return Fragments.size(); }
+  Fragment *getFrontFragment() { return Fragments.front(); }
+  Fragment *getBackFragment() { return Fragments.back(); }
 
-  llvm::SmallVectorImpl<Relocation *> &getRelocations() { return Relocations; }
+  RelocationRange getRelocations() {
+    return llvm::make_range(Relocations.begin(), Relocations.end());
+  }
+  size_t getRelocationCount() const { return Relocations.size(); }
+  void clearRelocations() { Relocations.clear(); }
+  void appendRelocations(RelocationRange From) {
+    Relocations.insert(Relocations.end(), From.begin(), From.end());
+  }
 
   void addRelocation(Relocation *R) {
     assert(R);

--- a/lib/BranchIsland/BranchIslandFactory.cpp
+++ b/lib/BranchIsland/BranchIslandFactory.cpp
@@ -321,7 +321,7 @@ BranchIslandFactory::createBranchIsland(Relocation &PReloc, Stub *S,
       ToBeInsertedFrags.push_back(Clone);
 
     if (IsLastFragInSection) {
-      CurNode = MatchedSection->getFragmentList().back();
+      CurNode = MatchedSection->getBackFragment();
       CurNodeIter = MatchedSection->getFragmentList().end();
     }
 

--- a/lib/Core/LinkerScript.cpp
+++ b/lib/Core/LinkerScript.cpp
@@ -392,8 +392,7 @@ eld::Expected<void> LinkerScript::updateChunksOp(
       PluginActLog->addPluginOperation(*Op);
   }
 
-  llvm::SmallVectorImpl<Fragment *> &FragmentsInRule =
-      R->getSection()->getFragmentList();
+  auto FragmentsInRule = R->getSection()->getFragmentList();
   if (layoutInfo || PluginActLog) {
     for (auto &Frag : FragmentsInRule) {
       RemoveChunkPluginOp *Op =

--- a/lib/Fragment/Fragment.cpp
+++ b/lib/Fragment/Fragment.cpp
@@ -69,19 +69,19 @@ uint32_t Fragment::getOffset(DiagnosticEngine *DiagEngine) const {
 bool Fragment::hasOffset() const { return (UnalignedOffset != ~uint32_t(0)); }
 
 llvm::SmallVectorImpl<Fragment *>::iterator Fragment::getIterator() {
-  auto &Fragments = getOwningSection()
-                        ->getMatchedLinkerScriptRule()
-                        ->getSection()
-                        ->getFragmentList();
+  auto Fragments = getOwningSection()
+                       ->getMatchedLinkerScriptRule()
+                       ->getSection()
+                       ->getFragmentList();
   auto *Iter = std::find(Fragments.begin(), Fragments.end(), this);
   return Iter;
 }
 
 Fragment *Fragment::getPrevNode() {
-  auto &Fragments = getOwningSection()
-                        ->getMatchedLinkerScriptRule()
-                        ->getSection()
-                        ->getFragmentList();
+  auto Fragments = getOwningSection()
+                       ->getMatchedLinkerScriptRule()
+                       ->getSection()
+                       ->getFragmentList();
   auto *Begin = Fragments.begin();
   auto *Iter = std::find(Begin, Fragments.end(), this);
   assert(Iter != Fragments.end());
@@ -92,10 +92,10 @@ Fragment *Fragment::getPrevNode() {
 }
 
 Fragment *Fragment::getNextNode() {
-  auto &Fragments = getOwningSection()
-                        ->getMatchedLinkerScriptRule()
-                        ->getSection()
-                        ->getFragmentList();
+  auto Fragments = getOwningSection()
+                       ->getMatchedLinkerScriptRule()
+                       ->getSection()
+                       ->getFragmentList();
   auto *End = Fragments.end();
   auto *Iter = std::find(Fragments.begin(), End, this);
   assert(Iter != Fragments.end());

--- a/lib/LayoutMap/TextLayoutPrinter.cpp
+++ b/lib/LayoutMap/TextLayoutPrinter.cpp
@@ -1367,8 +1367,7 @@ void TextLayoutPrinter::printLayout(eld::Module &Module) {
             printFrag(Module, Cur, F, UseColor);
         }
       }
-      if ((!IS || !IS->getFragmentList().size()) &&
-          !Module.isLinkStateBeforeLayout())
+      if ((!IS || !IS->hasFragments()) && !Module.isLinkStateBeforeLayout())
         continue;
       // Do not print fragments of OutputSectData commands.
       // Fragments and sections of OutputSectData is an internal

--- a/lib/LayoutMap/YamlLayoutPrinter.cpp
+++ b/lib/LayoutMap/YamlLayoutPrinter.cpp
@@ -253,8 +253,8 @@ eld::YamlLayoutPrinter::buildYaml(eld::Module &Module,
       }
       Fragment *Frag = nullptr;
       bool FoundFrag = false;
-      if (IS && IS->getFragmentList().size())
-        Frag = IS->getFragmentList().front();
+      if (IS && IS->hasFragments())
+        Frag = IS->getFrontFragment();
       if (Frag) {
         auto *FragCur = Frag->getIterator();
         auto *FragEnd = Frag->getOwningSection()

--- a/lib/LinkerWrapper/LayoutWrapper.cpp
+++ b/lib/LinkerWrapper/LayoutWrapper.cpp
@@ -57,7 +57,7 @@ LayoutWrapper::getPaddings(eld::plugin::OutputSection &Section) {
                                          itEnd = entry->end();
        it != itEnd; ++it) {
     eld::ELFSection *section = (*it)->getSection();
-    if (!section || !section->getFragmentList().size())
+    if (!section || !section->hasFragments())
       continue;
     // fragment padding
     for (auto &F : (*it)->getSection()->getFragmentList()) {

--- a/lib/LinkerWrapper/PluginADT.cpp
+++ b/lib/LinkerWrapper/PluginADT.cpp
@@ -1244,7 +1244,7 @@ bool LinkerScriptRule::doesExpressionModifyDot() const {
 
 std::vector<plugin::Chunk> LinkerScriptRule::getChunks() const {
   std::vector<plugin::Chunk> CVect;
-  auto &Fragments = m_RuleContainer->getSection()->getFragmentList();
+  auto Fragments = m_RuleContainer->getSection()->getFragmentList();
   for (auto &F : Fragments)
     CVect.push_back(plugin::Chunk(F));
   return CVect;
@@ -1269,13 +1269,12 @@ LinkerScriptRule::updateChunks(std::vector<plugin::Chunk> C, bool Verify) {
     updateChunks(C);
     return LinkerScriptRule::State::Ok;
   }
-  auto &List = m_RuleContainer->getSection()->getFragmentList();
-  if (!List.size())
+  if (!m_RuleContainer->getSection()->hasFragments())
     return LinkerScriptRule::State::NotEmpty;
   m_RuleContainer->clearSections();
   m_RuleContainer->clearFragments();
   for (auto &Chunk : C) {
-    auto &L = m_RuleContainer->getSection()->getFragmentList();
+    auto L = m_RuleContainer->getSection()->getFragmentList();
     if (std::find(L.begin(), L.end(), Chunk.getFragment()) != L.end())
       return LinkerScriptRule::State::DuplicateChunk;
     m_RuleContainer->getSection()->addFragment(Chunk.getFragment());
@@ -1303,7 +1302,7 @@ LinkerScriptRule::State LinkerScriptRule::addChunk(plugin::Chunk C,
     addChunk(C);
     return LinkerScriptRule::State::Ok;
   }
-  auto &L = m_RuleContainer->getSection()->getFragmentList();
+  auto L = m_RuleContainer->getSection()->getFragmentList();
   if (std::find(L.begin(), L.end(), C.getFragment()) != L.end())
     return LinkerScriptRule::State::DuplicateChunk;
   m_RuleContainer->getSection()->addFragment(C.getFragment());
@@ -1326,9 +1325,9 @@ LinkerScriptRule::State LinkerScriptRule::removeChunk(plugin::Chunk C,
     removeChunk(C);
     return LinkerScriptRule::State::Ok;
   }
-  auto &L = m_RuleContainer->getSection()->getFragmentList();
-  if (!L.size())
+  if (!m_RuleContainer->getSection()->hasFragments())
     return LinkerScriptRule::State::Empty;
+  auto L = m_RuleContainer->getSection()->getFragmentList();
   if (std::find(L.begin(), L.end(), C.getFragment()) == L.end())
     return LinkerScriptRule::State::NoChunk;
   removeChunk(C);
@@ -1337,7 +1336,7 @@ LinkerScriptRule::State LinkerScriptRule::removeChunk(plugin::Chunk C,
 
 std::vector<plugin::Chunk> LinkerScriptRule::getChunks(plugin::Section S) {
   std::vector<plugin::Chunk> CVect;
-  auto &Fragments = m_RuleContainer->getSection()->getFragmentList();
+  auto Fragments = m_RuleContainer->getSection()->getFragmentList();
   for (auto &F : Fragments) {
     if (F->getOwningSection() == S.getSection())
       CVect.push_back(plugin::Chunk(F));

--- a/lib/Object/ObjectBuilder.cpp
+++ b/lib/Object/ObjectBuilder.cpp
@@ -209,12 +209,12 @@ bool ObjectBuilder::moveSection(ELFSection *PFrom, ELFSection *PTo) {
   if (AlignFrom > AlignTo)
     PTo->setAddrAlign(AlignFrom);
 
-  if (!PFrom->getFragmentList().size())
+  if (!PFrom->hasFragments())
     return false;
 
   if (PFrom->isWanted())
     PTo->setWanted(true);
-  PTo->splice(PTo->getFragmentList().end(), PFrom->getFragmentList());
+  PTo->splice(PTo->getFragmentList().end(), *PFrom);
   return true;
 }
 
@@ -227,7 +227,7 @@ bool ObjectBuilder::moveIntoOutputSection(ELFSection *PFrom, ELFSection *PTo) {
   if (AlignFrom > AlignTo)
     PTo->setAddrAlign(AlignFrom);
 
-  if (!PFrom->getFragmentList().size())
+  if (!PFrom->hasFragments())
     return false;
 
   if (PFrom->isWanted())

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -1055,7 +1055,7 @@ bool ObjectLinker::createOutputSection(ObjectBuilder &Builder,
       }
       InSect->setAddrAlign(Alignment);
     }
-    if (InSect->getFragmentList().size() && !FirstNonEmptyRule)
+    if (InSect->hasFragments() && !FirstNonEmptyRule)
       FirstNonEmptyRule = *In;
 
     if (Builder.moveIntoOutputSection(InSect, OutSect)) {
@@ -2145,19 +2145,16 @@ bool ObjectLinker::scanRelocations(bool IsPartialLink) {
   if (!IsPartialLink) {
     ELFObjectFile *RelocInput =
         getTargetBackend().getDynamicSectionHeadersInputFile();
-    auto MergeRelocs = [](llvm::SmallVectorImpl<Relocation *> &To,
-                          const llvm::SmallVectorImpl<Relocation *> &From) {
-      To.insert(To.end(), From.begin(), From.end());
+    auto MergeRelocs = [](ELFSection &To, ELFSection &From) {
+      To.appendRelocations(From.getRelocations());
     };
     for (auto &Input : ThisModule->getObjectList())
       if (ELFObjectFile *Obj = llvm::dyn_cast<ELFObjectFile>(Input))
         if (Obj != RelocInput) {
           if (const auto &S = Obj->getRelaDyn())
-            MergeRelocs(RelocInput->getRelaDyn()->getRelocations(),
-                        S->getRelocations());
+            MergeRelocs(*RelocInput->getRelaDyn(), *S);
           if (const auto &S = Obj->getRelaPLT())
-            MergeRelocs(RelocInput->getRelaPLT()->getRelocations(),
-                        S->getRelocations());
+            MergeRelocs(*RelocInput->getRelaPLT(), *S);
         }
   }
 
@@ -2494,10 +2491,8 @@ bool ObjectLinker::relocation(bool EmitRelocs) {
     branch_island_iter Bi = (*Out)->islandsBegin();
     branch_island_iter Be = (*Out)->islandsEnd();
     for (; Bi != Be; ++Bi) {
-      BranchIsland::reloc_iterator Iter, IterEnd = (*Bi)->relocEnd();
-      for (Iter = (*Bi)->relocBegin(); Iter != IterEnd; ++Iter) {
-        (*Iter)->apply(*getTargetBackend().getRelocator());
-      }
+      for (auto *Reloc : (*Bi)->getRelocations())
+        Reloc->apply(*getTargetBackend().getRelocator());
     }
   }
 
@@ -2548,9 +2543,8 @@ void ObjectLinker::syncRelocations(uint8_t *Buffer) {
     branch_island_iter Bi = O->islandsBegin();
     branch_island_iter Be = O->islandsEnd();
     for (; Bi != Be; ++Bi) {
-      BranchIsland::reloc_iterator Iter, IterEnd = (*Bi)->relocEnd();
-      for (Iter = (*Bi)->relocBegin(); Iter != IterEnd; ++Iter)
-        writeRelocationResult(**Iter, Buffer);
+      for (auto *Reloc : (*Bi)->getRelocations())
+        writeRelocationResult(*Reloc, Buffer);
     }
   };
   // sync relocations created by relaxation

--- a/lib/Object/OutputSectionEntry.cpp
+++ b/lib/Object/OutputSectionEntry.cpp
@@ -90,10 +90,9 @@ uint64_t OutputSectionEntry::getTotalTrampolineCount() const {
 }
 
 Fragment *OutputSectionEntry::getFirstFrag() const {
-  if (!FirstNonEmptyRule ||
-      !FirstNonEmptyRule->getSection()->getFragmentList().size())
+  if (!FirstNonEmptyRule || !FirstNonEmptyRule->getSection()->hasFragments())
     return nullptr;
-  return FirstNonEmptyRule->getSection()->getFragmentList().front();
+  return FirstNonEmptyRule->getSection()->getFrontFragment();
 }
 
 RuleContainer *OutputSectionEntry::createDefaultRule(eld::Module &M) {

--- a/lib/Object/RuleContainer.cpp
+++ b/lib/Object/RuleContainer.cpp
@@ -70,7 +70,7 @@ void RuleContainer::dumpMap(llvm::raw_ostream &Ostream) {
 }
 
 bool RuleContainer::hasContent() const {
-  return !MPSection->getFragmentList().empty();
+  return MPSection && MPSection->hasFragments();
 }
 
 RuleContainer *RuleContainer::getNextRuleWithContent() const {
@@ -84,15 +84,13 @@ RuleContainer *RuleContainer::getNextRuleWithContent() const {
 }
 
 Fragment *RuleContainer::getFirstFrag() const {
-  return MPSection && !MPSection->getFragmentList().empty()
-             ? MPSection->getFragmentList().front()
-             : nullptr;
+  return MPSection && MPSection->hasFragments() ? MPSection->getFrontFragment()
+                                                : nullptr;
 }
 
 Fragment *RuleContainer::getLastFrag() const {
-  return MPSection && !MPSection->getFragmentList().empty()
-             ? MPSection->getFragmentList().back()
-             : nullptr;
+  return MPSection && MPSection->hasFragments() ? MPSection->getBackFragment()
+                                                : nullptr;
 }
 
 void RuleContainer::updateMatchedSections(const Module &Module) {

--- a/lib/Readers/ELFSection.cpp
+++ b/lib/Readers/ELFSection.cpp
@@ -184,7 +184,7 @@ Fragment *ELFSection::getFirstFragmentInRule() const {
     return nullptr;
   for (auto &In : *OE) {
     if (In->getSection()->size())
-      return In->getSection()->getFragmentList().front();
+      return In->getSection()->getFrontFragment();
   }
   return nullptr;
 }

--- a/lib/Readers/SFrameSection.cpp
+++ b/lib/Readers/SFrameSection.cpp
@@ -25,10 +25,10 @@ bool SFrameSection::parseSFrameSection() {
     return true;
 
   // Get data from the first fragment (RegionFragment).
-  if (getFragmentList().empty())
+  if (!hasFragments())
     return true;
 
-  auto *RF = llvm::dyn_cast<eld::RegionFragment>(getFragmentList().front());
+  auto *RF = llvm::dyn_cast<eld::RegionFragment>(getFrontFragment());
   if (!RF)
     return false;
 

--- a/lib/Script/ScriptFile.cpp
+++ b/lib/Script/ScriptFile.cpp
@@ -191,8 +191,6 @@ InputToken *ScriptFile::findResolvedFilename(InputToken *input) {
 std::string ScriptFile::findIncludeFile(const std::string &Filename,
                                         bool &Result, bool State) {
   LinkerConfig &Config = ThisModule.getConfig();
-  auto Iterb = Config.directories().begin();
-  auto Itere = Config.directories().end();
   bool HasMapping = Config.options().hasMappingFile();
   Result = true;
 
@@ -229,8 +227,8 @@ std::string ScriptFile::findIncludeFile(const std::string &Filename,
     return Filename;
   }
 
-  for (; Iterb != Itere; ++Iterb) {
-    std::string Path = (*Iterb)->name();
+  for (auto *Dir : Config.directories().getDirectories()) {
+    std::string Path = Dir->name();
     Path += "/";
     Path += Filename;
     if (searchIncludeFile(Filename, Path,

--- a/lib/SymbolResolver/IRBuilder.cpp
+++ b/lib/SymbolResolver/IRBuilder.cpp
@@ -160,14 +160,14 @@ LDSymbol *IRBuilder::addSymbol(InputFile &Input, const std::string &SymbolName,
         FragRef = FragmentRef::null();
     } else {
       if (CurSection->isMergeKind()) {
-        auto *Strings = llvm::cast<MergeStringFragment>(
-            CurSection->getFragmentList().front());
+        auto *Strings =
+            llvm::cast<MergeStringFragment>(CurSection->getFrontFragment());
         FragRef = make<FragmentRef>(*Strings, Value);
       }
       if (!FragRef) {
         FragRef = FragmentRef::null();
         if (CurSection->hasSectionData()) {
-          Fragment *Frag = CurSection->getFragmentList().front();
+          Fragment *Frag = CurSection->getFrontFragment();
           FragRef = make<FragmentRef>(*Frag, Value - CurSection->addr());
         }
       }
@@ -494,7 +494,7 @@ Relocation *IRBuilder::addRelocation(const Relocator *CurRelocator,
 
   FragmentRef *FragRef = FragmentRef::null();
   if (CurSection->hasSectionData()) {
-    Fragment *Frag = CurSection->getFragmentList().front();
+    Fragment *Frag = CurSection->getFrontFragment();
     FragRef = make<FragmentRef>(*Frag, POffset);
   }
   Relocation *Relocation =

--- a/lib/Target/AArch64/AArch64ErrataIslandFactory.cpp
+++ b/lib/Target/AArch64/AArch64ErrataIslandFactory.cpp
@@ -166,7 +166,7 @@ BranchIsland *AArch64ErrataIslandFactory::createAArch64ErrataIsland(
     toBeInsertedFrags.push_back(clone);
 
   if (isLastFragInSection) {
-    curNode = MatchedSection->getFragmentList().back();
+    curNode = MatchedSection->getBackFragment();
     curNodeIter = MatchedSection->getFragmentList().end();
   }
   MatchedSection->splice(curNodeIter, toBeInsertedFrags);

--- a/lib/Target/AArch64/AArch64LDBackend.cpp
+++ b/lib/Target/AArch64/AArch64LDBackend.cpp
@@ -209,9 +209,9 @@ void AArch64LDBackend::doPreLayout() {
     m_pDynamic = make<AArch64ELFDynamic>(*this, config());
 
   if (LinkerConfig::Object != config().codeGenType()) {
-    getRelaPLT()->setSize(getRelaPLT()->getRelocations().size() *
+    getRelaPLT()->setSize(getRelaPLT()->getRelocationCount() *
                           getRelaEntrySize());
-    getRelaDyn()->setSize(getRelaDyn()->getRelocations().size() *
+    getRelaDyn()->setSize(getRelaDyn()->getRelocationCount() *
                           getRelaEntrySize());
     m_Module.addOutputSection(getRelaPLT());
     m_Module.addOutputSection(getRelaDyn());
@@ -695,7 +695,7 @@ AArch64GOT *AArch64LDBackend::createGOT(GOT::GOTType T,
                        m_Module.getPrinter()->traceDynamicLinking()))
     config().raise(Diag::create_got_entry) << R->name();
   // If we are creating a GOT, always create a .got.plt.
-  if (!getGOTPLT()->getFragmentList().size()) {
+  if (!getGOTPLT()->hasFragments()) {
     // TODO: This should be GOT0, not GOTPLT0.
     LDSymbol *Dynamic = m_Module.getNamePool().findSymbol("_DYNAMIC");
     AArch64GOTPLT0::Create(getGOTPLT(),
@@ -774,7 +774,7 @@ AArch64PLT *AArch64LDBackend::createPLT(ELFObjectFile *Obj, ResolveInfo *R,
 
   reportErrorIfPLTIsDiscarded(R);
 
-  if (!getPLT()->getFragmentList().size()) {
+  if (!getPLT()->hasFragments()) {
     AArch64PLT0::Create(*m_Module.getIRBuilder(),
                         createGOT(GOT::GOTPLT0, nullptr, nullptr), getPLT(),
                         nullptr);

--- a/lib/Target/ARM/ARMLDBackend.cpp
+++ b/lib/Target/ARM/ARMLDBackend.cpp
@@ -237,10 +237,10 @@ void ARMGNULDBackend::doPreLayout() {
         continue;
       Last = S;
       if (!Start) {
-        Start = Last->getFragmentList().front();
+        Start = Last->getFrontFragment();
       }
       if (Last)
-        End = Last->getFragmentList().back();
+        End = Last->getBackFragment();
 
       FragmentRef *exidx_start = make<FragmentRef>(*Start, 0);
 
@@ -280,9 +280,9 @@ void ARMGNULDBackend::doPreLayout() {
   // set .got size
   // when building shared object, the .got section is must
   if (LinkerConfig::Object != config().codeGenType()) {
-    getRelaPLT()->setSize(getRelaPLT()->getRelocations().size() *
+    getRelaPLT()->setSize(getRelaPLT()->getRelocationCount() *
                           getRelEntrySize());
-    getRelaDyn()->setSize(getRelaDyn()->getRelocations().size() *
+    getRelaDyn()->setSize(getRelaDyn()->getRelocationCount() *
                           getRelEntrySize());
     m_Module.addOutputSection(getRelaPLT());
     m_Module.addOutputSection(getRelaDyn());
@@ -415,7 +415,7 @@ void ARMGNULDBackend::sortEXIDX() {
       exidx = In->getSection();
     for (auto &F : S->getFragmentList())
       Frags.push_back(F);
-    S->getFragmentList().clear();
+    S->clearFragments();
   }
 
   if (O->getLastRule()) {
@@ -482,11 +482,11 @@ void ARMGNULDBackend::sortEXIDX() {
 
   // Reset EXIDX symbols.
   if (m_pEXIDXStart) {
-    m_pEXIDXStart->fragRef()->setFragment(exidx->getFragmentList().front());
+    m_pEXIDXStart->fragRef()->setFragment(exidx->getFrontFragment());
     m_pEXIDXStart->fragRef()->setOffset(0);
   }
   if (m_pEXIDXEnd) {
-    m_pEXIDXEnd->fragRef()->setFragment(exidx->getFragmentList().back());
+    m_pEXIDXEnd->fragRef()->setFragment(exidx->getBackFragment());
     m_pEXIDXEnd->fragRef()->setOffset(8);
   }
 }
@@ -513,7 +513,7 @@ bool ARMGNULDBackend::readSection(InputFile &pInput, ELFSection *S) {
     if (!AttributeFragment) {
       createAttributeSection(S->getFlags(), S->getAddrAlign());
       AttributeFragment = make<ARMAttributeFragment>(m_pARMAttributeSection);
-      m_pARMAttributeSection->getFragmentList().push_back(AttributeFragment);
+      m_pARMAttributeSection->addFragment(AttributeFragment);
       LayoutInfo *layoutInfo = getModule().getLayoutInfo();
       if (layoutInfo)
         layoutInfo->recordFragment(m_pARMAttributeSection->getInputFile(),
@@ -1048,7 +1048,7 @@ ARMGOT *ARMGNULDBackend::createGOT(GOT::GOTType T, ELFObjectFile *Obj,
                        m_Module.getPrinter()->traceDynamicLinking()))
     config().raise(Diag::create_got_entry) << R->name();
   // If we are creating a GOT, always create a .got.plt.
-  if (!getGOTPLT()->getFragmentList().size()) {
+  if (!getGOTPLT()->hasFragments()) {
     // TODO: This should be GOT0, not GOTPLT0.
     LDSymbol *Dynamic = m_Module.getNamePool().findSymbol("_DYNAMIC");
     ARMGOTPLT0::Create(getGOTPLT(), Dynamic ? Dynamic->resolveInfo() : nullptr);
@@ -1134,7 +1134,7 @@ ARMPLT *ARMGNULDBackend::createPLT(ELFObjectFile *Obj, ResolveInfo *R,
   reportErrorIfPLTIsDiscarded(R);
 
   // If there is no entries GOTPLT and PLT, we dont have a PLT0.
-  if (!getPLT()->getFragmentList().size()) {
+  if (!getPLT()->hasFragments()) {
     ARMPLT0::Create(*m_Module.getIRBuilder(),
                     createGOT(GOT::GOTPLT0, nullptr, nullptr), getPLT(),
                     nullptr);

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -1918,7 +1918,7 @@ bool GNULDBackend::InsertAtSectionToEnd(ELFSection *OutSection,
     OutputSectionFragVector.insert(OutputSectionFragVector.end(),
                                    atSection->getFragmentList().begin(),
                                    atSection->getFragmentList().end());
-    CurRule->getSection()->splice(EndIter, atSection->getFragmentList());
+    CurRule->getSection()->splice(EndIter, *atSection);
   } else {
     return false;
   }
@@ -1975,7 +1975,7 @@ bool GNULDBackend::TryToPlaceAtSection(RuleContainer *In, Fragment *Frag,
     atSectionOffset = atSectionAddress - Section->addr();
   }
   atSection = atSection->getOutputSection()->getLastRule()->getSection();
-  Fragment *First = atSection->getFragmentList().front();
+  Fragment *First = atSection->getFrontFragment();
   typedef llvm::SmallVectorImpl<Fragment *>::iterator FragIter;
   FragIter EndIter = In->getSection()->getFragmentList().end();
   FragIter Iter = Frag ? Frag->getIterator() : EndIter;
@@ -2006,7 +2006,7 @@ bool GNULDBackend::TryToPlaceAtSection(RuleContainer *In, Fragment *Frag,
           << atSectionName << utility::toHex(atSectionAddress)
           << Section->getOutputSection()->name();
 
-    In->getSection()->splice(Iter, atSection->getFragmentList());
+    In->getSection()->splice(Iter, *atSection);
   }
   return InsertedAtSection;
 }
@@ -2139,7 +2139,7 @@ void GNULDBackend::evaluateAssignments(OutputSectionEntry *out,
     }
     bool placedAtSection = false;
     OutputSectionEntry::iterator NextRuleIter = in + 1;
-    if (!InSection->getFragmentList().size()) {
+    if (!InSection->hasFragments()) {
       if (!TryToPlaceAtSection(*in, nullptr, OutSection, atIndex))
         continue;
       placedAtSection = true;
@@ -3489,10 +3489,10 @@ void GNULDBackend::preLayout() {
 
         // size output
         if (llvm::ELF::SHT_REL == output_sect->getType())
-          output_sect->setSize(output_sect->getRelocations().size() *
+          output_sect->setSize(output_sect->getRelocationCount() *
                                getRelEntrySize());
         else if (output_sect->isRela())
-          output_sect->setSize(output_sect->getRelocations().size() *
+          output_sect->setSize(output_sect->getRelocationCount() *
                                getRelaEntrySize());
         else {
           config().raise(Diag::unknown_reloc_section_type)
@@ -4666,8 +4666,8 @@ bool GNULDBackend::RunPluginsAndProcessHelper(
       // Clear all the fragments.
       if (!MatchSections) {
         for (auto &Cur : *O) {
-          Cur->getSection()->getFragmentList().clear();
-          Cur->getSection()->getRelocations().clear();
+          Cur->getSection()->clearFragments();
+          Cur->getSection()->clearRelocations();
         }
       }
 

--- a/lib/Target/Hexagon/HexagonLDBackend.cpp
+++ b/lib/Target/Hexagon/HexagonLDBackend.cpp
@@ -136,12 +136,12 @@ void HexagonLDBackend::doPreLayout() {
     return;
 
   if (getRelaPLT()) {
-    getRelaPLT()->setSize(getRelaPLT()->getRelocations().size() *
+    getRelaPLT()->setSize(getRelaPLT()->getRelocationCount() *
                           getRelaEntrySize());
     m_Module.addOutputSection(getRelaPLT());
   }
   if (getRelaDyn()) {
-    getRelaDyn()->setSize(getRelaDyn()->getRelocations().size() *
+    getRelaDyn()->setSize(getRelaDyn()->getRelocationCount() *
                           getRelaEntrySize());
     m_Module.addOutputSection(getRelaDyn());
   }
@@ -788,7 +788,7 @@ bool HexagonLDBackend::allocateCommonSymbols() {
 
 bool HexagonLDBackend::MoveSectionAndSort(ELFSection *pFrom, ELFSection *pTo) {
   ObjectBuilder builder(config(), m_Module);
-  if (pFrom->getFragmentList().size() == 0)
+  if (!pFrom->hasFragments())
     return true;
 
   if (builder.moveSection(pFrom, pTo)) {
@@ -949,7 +949,7 @@ HexagonGOT *HexagonLDBackend::createGOT(GOT::GOTType T, ELFObjectFile *Obj,
                        m_Module.getPrinter()->traceDynamicLinking()))
     config().raise(Diag::create_got_entry) << R->name();
   // If we are creating a GOT, always create a .got.plt.
-  if (!getGOTPLT()->getFragmentList().size()) {
+  if (!getGOTPLT()->hasFragments()) {
     LDSymbol *Dynamic = m_Module.getNamePool().findSymbol("_DYNAMIC");
     HexagonGOTPLT0::Create(getGOTPLT(),
                            Dynamic ? Dynamic->resolveInfo() : nullptr);
@@ -1028,7 +1028,7 @@ HexagonPLT *HexagonLDBackend::createPLT(ELFObjectFile *Obj, ResolveInfo *R) {
   reportErrorIfPLTIsDiscarded(R);
 
   // If there is no entries GOTPLT and PLT, we dont have a PLT0.
-  if (!hasNow && !getPLT()->getFragmentList().size()) {
+  if (!hasNow && !getPLT()->hasFragments()) {
     HexagonPLT0::Create(*m_Module.getIRBuilder(),
                         createGOT(GOT::GOTPLT0, nullptr, nullptr), getPLT(),
                         nullptr);

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -106,7 +106,7 @@ void RISCVLDBackend::initTargetSections(ObjectBuilder &pBuilder) {
       Module::InternalInputType::Attributes, LDFileFormat::Internal,
       ".riscv.attributes", llvm::ELF::SHT_RISCV_ATTRIBUTES, 0, 1);
   AttributeFragment = make<RISCVAttributeFragment>(m_pRISCVAttributeSection);
-  m_pRISCVAttributeSection->getFragmentList().push_back(AttributeFragment);
+  m_pRISCVAttributeSection->addFragment(AttributeFragment);
   LayoutInfo *layoutInfo = getModule().getLayoutInfo();
   if (layoutInfo)
     layoutInfo->recordFragment(m_pRISCVAttributeSection->getInputFile(),
@@ -185,8 +185,7 @@ bool RISCVLDBackend::DoesOverrideMerge(ELFSection *pSection) const {
 
 ELFSection *RISCVLDBackend::mergeSection(ELFSection *S) {
   if (S->getType() == llvm::ELF::SHT_RISCV_ATTRIBUTES) {
-    RegionFragment *R =
-        llvm::dyn_cast<RegionFragment>(S->getFragmentList().front());
+    RegionFragment *R = llvm::dyn_cast<RegionFragment>(S->getFrontFragment());
     if (R)
       AttributeFragment->updateInfo(
           R->getRegion(), R->getOwningSection()->getInputFile(),
@@ -1022,8 +1021,7 @@ void RISCVLDBackend::mayBeRelax(int relaxation_pass, bool &pFinished) {
         continue;
       if (rs->isDiscard())
         continue;
-      llvm::SmallVectorImpl<Relocation *> &relocList =
-          rs->getLink()->getRelocations();
+      auto relocList = rs->getLink()->getRelocations();
       for (llvm::SmallVectorImpl<Relocation *>::iterator it = relocList.begin();
            it != relocList.end(); ++it) {
         auto relocation = *it;
@@ -1463,17 +1461,17 @@ Relocation::Type RISCVLDBackend::getRemappedInternalRelocationType(
 void RISCVLDBackend::doPreLayout() {
   m_psdata = m_Module.getScript().sectionMap().find(".sdata");
   if (getRelaPLT()) {
-    getRelaPLT()->setSize(getRelaPLT()->getRelocations().size() *
+    getRelaPLT()->setSize(getRelaPLT()->getRelocationCount() *
                           getRelaEntrySize());
     m_Module.addOutputSection(getRelaPLT());
   }
   if (getRelaDyn()) {
-    getRelaDyn()->setSize(getRelaDyn()->getRelocations().size() *
+    getRelaDyn()->setSize(getRelaDyn()->getRelocationCount() *
                           getRelaEntrySize());
     m_Module.addOutputSection(getRelaDyn());
   }
   if (ELFSection *S = getRelaPatch()) {
-    S->setSize(S->getRelocations().size() * getRelaEntrySize());
+    S->setSize(S->getRelocationCount() * getRelaEntrySize());
     m_Module.addOutputSection(S);
   }
 }
@@ -1550,7 +1548,7 @@ RISCVGOT *RISCVLDBackend::createGOT(GOT::GOTType T, ELFObjectFile *Obj,
                        m_Module.getPrinter()->traceDynamicLinking()))
     config().raise(Diag::create_got_entry) << R->name();
   // If we are creating a GOT, always create a .got.plt.
-  if (!getGOTPLT()->getFragmentList().size()) {
+  if (!getGOTPLT()->hasFragments()) {
     LDSymbol *Dynamic = m_Module.getNamePool().findSymbol("_DYNAMIC");
     // TODO: This should be GOT0, not GOTPLT0.
     RISCVGOT::CreateGOT0(getGOT(), Dynamic ? Dynamic->resolveInfo() : nullptr,
@@ -1663,7 +1661,7 @@ RISCVPLT *RISCVLDBackend::createPLT(ELFObjectFile *Obj, ResolveInfo *R) {
   } else {
     if (!config().options().hasNow()) {
       // For lazy binding, create GOTPLT0 and PLT0, if they don't exist.
-      if (getPLT()->getFragmentList().empty())
+      if (!getPLT()->hasFragments())
         RISCVPLT::CreatePLT0(*this, createGOT(GOT::GOTPLT0, Obj, nullptr),
                              getPLT(), is32Bits);
       // Create a static relocation to the PLT0 fragment.

--- a/lib/Target/X86/x86_64LDBackend.cpp
+++ b/lib/Target/X86/x86_64LDBackend.cpp
@@ -128,7 +128,7 @@ bool x86_64LDBackend::finalizeTargetSymbols() {
     m_pIRelativeEnd->setValue(relaPltSec->addr() + relaPltSec->size());
 
     // Associate symbols with the .rela.plt section
-    if (!relaPltSec->getFragmentList().empty()) {
+    if (relaPltSec->hasFragments()) {
       Fragment *firstFrag = *relaPltSec->getFragmentList().begin();
       m_pIRelativeStart->setFragmentRef(make<FragmentRef>(*firstFrag, 0));
       m_pIRelativeEnd->setFragmentRef(
@@ -145,9 +145,9 @@ void x86_64LDBackend::doPreLayout() {
     m_pDynamic = make<x86_64ELFDynamic>(*this, config());
 
   if (LinkerConfig::Object != config().codeGenType()) {
-    getRelaPLT()->setSize(getRelaPLT()->getRelocations().size() *
+    getRelaPLT()->setSize(getRelaPLT()->getRelocationCount() *
                           getRelaEntrySize());
-    getRelaDyn()->setSize(getRelaDyn()->getRelocations().size() *
+    getRelaDyn()->setSize(getRelaDyn()->getRelocationCount() *
                           getRelaEntrySize());
     m_Module.addOutputSection(getRelaPLT());
     m_Module.addOutputSection(getRelaDyn());
@@ -194,7 +194,7 @@ x86_64GOT *x86_64LDBackend::createGOT(GOT::GOTType T, ELFObjectFile *Obj,
                        m_Module.getPrinter()->traceDynamicLinking()))
     config().raise(Diag::create_got_entry) << R->name();
   // If we are creating a GOT, always create a .got.plt.
-  if (!getGOTPLT()->getFragmentList().size()) {
+  if (!getGOTPLT()->hasFragments()) {
     // GOTPLT0 will populate its first 8 bytes with .dynamic address.
     x86_64GOTPLT0::Create(getGOTPLT(), &m_Module);
   }
@@ -269,7 +269,7 @@ x86_64PLT *x86_64LDBackend::createPLT(ELFObjectFile *Obj, ResolveInfo *R,
 
   // Create PLT0 if this is the first PLT entry. PLT0 is the common
   // trampoline that all PLTN entries jump to for symbol resolution.
-  if (!hasNow && !isIRelative && !getPLT()->getFragmentList().size()) {
+  if (!hasNow && !isIRelative && !getPLT()->hasFragments()) {
     x86_64PLT0::Create(*m_Module.getIRBuilder(),
                        createGOT(GOT::GOTPLT0, nullptr, nullptr), getPLT(),
                        nullptr, hasNow);


### PR DESCRIPTION
Replace begin/end iterator plumbing with range-based accessors across BranchIsland, SearchDirs, and ELFSection users.

This adds iterator_range helpers and small section utility methods (e.g. has/getFront/getBack/appendRelocations), and updates call sites to use the new interfaces.

No functional change intended.