### PR TITLE
Fix: preserve parentheses around output section VMA

### DIFF
--- a/lib/ScriptParser/ScriptParser.cpp
+++ b/lib/ScriptParser/ScriptParser.cpp
@@ -870,8 +870,10 @@ OutputSectDesc::Prolog ScriptParser::readOutputSectDescPrologue() {
   Prologue.init();
   if (peek(LexState::Expr) != ":") {
     if (consume("(")) {
-      if (!readOutputSectTypeAndPermissions(Prologue, peek()))
+      if (!readOutputSectTypeAndPermissions(Prologue, peek())){
         Prologue.OutputSectionVMA = readExpr();
+        Prologue.OutputSectionVMA->setParen();
+      }
       expect(")");
     } else if (peek() == "{") {
       expect(":");

--- a/test/Common/Plugin/BasicLinkerScriptGenerator/Inputs/script.VMAWithParen.t
+++ b/test/Common/Plugin/BasicLinkerScriptGenerator/Inputs/script.VMAWithParen.t
@@ -1,0 +1,4 @@
+SECTIONS {
+  .text (0x1000) : { *(.text*) }
+}
+LINKER_PLUGIN("BasicLinkerScriptGenerator", "BasicLinkerScriptGenerator")

--- a/test/Common/Plugin/BasicLinkerScriptGenerator/VMASectionParen.test
+++ b/test/Common/Plugin/BasicLinkerScriptGenerator/VMASectionParen.test
@@ -1,0 +1,14 @@
+#---VMASectionParen.test----------------------- Executable,LS --------------------#
+#BEGIN_COMMENT
+# This test checks that parentheses around output section VMA are
+# preserved when the linker script is printed/dumped by the plugin.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -L%libsdir/test -T %p/Inputs/script.VMAWithParen.t 2>&1 | %filecheck %s
+#CHECK: SECTIONS {
+#CHECK:   .text (0x1000)  : {
+#CHECK:     *(.text*)
+#CHECK:   }
+#CHECK: }
+#END_TEST


### PR DESCRIPTION
## Problem
Fixes #338

## Fix
Call `setParen()` on the VMA expression when parentheses are detected:
```cpp
if (consume("(")) {
  if (!readOutputSectTypeAndPermissions(Prologue, peek())) {
    Prologue.OutputSectionVMA = readExpr();
    Prologue.OutputSectionVMA->setParen();  // ← added
  }
  expect(")");
}
```

## Testing
Added a lit test that verifies parentheses are preserved in the plugin output.
