### PR TITLE
Fix: use actual content size for LMA overlap check

### DIFF
--- a/include/eld/Diagnostics/DiagLDScript.inc
+++ b/include/eld/Diagnostics/DiagLDScript.inc
@@ -28,8 +28,7 @@ DIAG(promoting_bss_to_progbits, DiagnosticEngine::Note,
      "Section %0(%1) is before %2(%3), Promoting %0 to PROGBITS")
 DIAG(undefined_symbol_in_linker_script, DiagnosticEngine::Fatal,
      "%0: Error: undefined symbol '%1' referenced in expression")
-DIAG(error_sect_invalid, DiagnosticEngine::Error,
-     "%0: Invalid section '%1'")
+DIAG(error_sect_invalid, DiagnosticEngine::Error, "%0: Invalid section '%1'")
 DIAG(warn_section_no_segment, DiagnosticEngine::Warning,
      "Section %0 does not have segment assignment in linker script.")
 DIAG(fatal_segment_not_defined_ldscript, DiagnosticEngine::Fatal,
@@ -68,7 +67,8 @@ DIAG(error_linker_script, DiagnosticEngine::Error, "%0")
 DIAG(note_linker_script, DiagnosticEngine::Note, "%0")
 DIAG(reading_dynamic_list, DiagnosticEngine::Verbose, "Dynamic List[%0] : %1")
 DIAG(reading_extern_list, DiagnosticEngine::Verbose, "Extern List[%0] : %1")
-DIAG(error_parsing_version_script, DiagnosticEngine::Error, "Error parsing version script %0")
+DIAG(error_parsing_version_script, DiagnosticEngine::Error,
+     "Error parsing version script %0")
 DIAG(fatal_divide_by_zero, DiagnosticEngine::Fatal,
      "%0: division by zero in expression %1")
 DIAG(fatal_modulo_by_zero, DiagnosticEngine::Fatal,
@@ -76,7 +76,8 @@ DIAG(fatal_modulo_by_zero, DiagnosticEngine::Fatal,
 DIAG(error_experimental_not_supported, DiagnosticEngine::Error,
      "Linker has only experimental support for handling %0")
 DIAG(error_memory_region_exceeded_limit, DiagnosticEngine::Error,
-     "Memory region %0 exceeded limit while adding section %1 : overflowed by 0x%2 bytes")
+     "Memory region %0 exceeded limit while adding section %1 : overflowed by "
+     "0x%2 bytes")
 DIAG(error_memory_region_empty, DiagnosticEngine::Error,
      "Missing name for memory region, name cannot be empty")
 DIAG(error_duplicate_memory_region, DiagnosticEngine::Error,
@@ -109,7 +110,8 @@ DIAG(warn_forward_reference, DiagnosticEngine::Warning,
 DIAG(warn_output_data_truncated, DiagnosticEngine::Warning,
      "Output data value 0x%0 was truncated to %1 bits for type %2")
 DIAG(error_section_overlap, DiagnosticEngine::Error,
-     "section %0 %1 range overlaps with %2 \n\t >>> %3 range is %4 \n\t >>> %5 range is %6")
+     "section %0 %1 range overlaps with %2 \n\t >>> %3 range is %4 \n\t >>> %5 "
+     "range is %6")
 DIAG(error_exp_mem_region_not_found, DiagnosticEngine::Error,
      "Cannot find memory region %1 in script %0")
 DIAG(warn_provide_sym_redecl, DiagnosticEngine::Warning,
@@ -119,20 +121,26 @@ DIAG(internal_err_tok_input_or_group, DiagnosticEngine::InternalError,
 DIAG(error_dot_lhs_in_non_alloc, DiagnosticEngine::Error,
      "dot expression evaluation in %0 with permissions %1 is not supported")
 DIAG(error_cannot_specify_lma_and_memory_region, DiagnosticEngine::Error,
-     "cannot specify AT and LMA memory region for output section : %0 defined in script %1")
+     "cannot specify AT and LMA memory region for output section : %0 defined "
+     "in script %1")
 DIAG(error_insert_output_section, DiagnosticEngine::Error,
      "Cannot INSERT output section %0 %1 %2 in script %3")
 DIAG(warn_non_power_of_2_value_to_align_builtin, DiagnosticEngine::Warning,
      "%0: non-power-of-2 value 0x%1 passed to ALIGN builtin function")
-DIAG(warn_subalign_less_than_section_alignment, DiagnosticEngine::Warning,
-     "SUBALIGN(0x%0) is less than the section alignment (0x%1) for section '%2'")
-DIAG(error_non_power_of_2_value_to_align_output_section, DiagnosticEngine::Error,
-     "%0: non-power-of-2 value 0x%1 passed to ALIGN in '%2' output section description, value must "
+DIAG(
+    warn_subalign_less_than_section_alignment, DiagnosticEngine::Warning,
+    "SUBALIGN(0x%0) is less than the section alignment (0x%1) for section '%2'")
+DIAG(error_non_power_of_2_value_to_align_output_section,
+     DiagnosticEngine::Error,
+     "%0: non-power-of-2 value 0x%1 passed to ALIGN in '%2' output section "
+     "description, value must "
      "be 0 or a power of 2")
 DIAG(warn_linker_script, DiagnosticEngine::Warning, "%0")
 DIAG(warn_memory_region_has_zero_size, DiagnosticEngine::Warning,
      "%0: Memory region '%1' has zero size")
 DIAG(error_empty_pt_tls_segment, DiagnosticEngine::Error,
-      "TLS segments are empty")
+     "TLS segments are empty")
 DIAG(internal_error_null_expression, DiagnosticEngine::InternalError,
      "Trying to evaluate null expression")
+DIAG(warn_address_not_aligned, DiagnosticEngine::Warning,
+     "address (0x%0) of section %1 is not a multiple of alignment (%2)")

--- a/lib/Target/CreateProgramHeaders.hpp
+++ b/lib/Target/CreateProgramHeaders.hpp
@@ -499,17 +499,22 @@ bool GNULDBackend::createProgramHdrs() {
           alignAddress(pma, cur->getAddrAlign());
       } else if (!prev || !disconnect_lma_vma) {
         pma = vma;
-        alignAddress(pma, cur->getAddrAlign());
+        // Only align LMA if VMA is also aligned
+        if (vma % cur->getAddrAlign() == 0)
+          alignAddress(pma, cur->getAddrAlign());
       } else if ((last_section_needs_new_segment) && (!disconnect_lma_vma)) {
         // If the LMA and VMA are disconnected, the physical address should
         // always be taken as the difference of the current virtual address
         // minus the previous virtual address.
         pma = prev->pAddr() + prev->size();
-        alignAddress(pma, cur->getAddrAlign());
+        // Only align LMA if VMA is also aligned
+        if (vma % cur->getAddrAlign() == 0)
+          alignAddress(pma, cur->getAddrAlign());
       } else {
         vmaoffset = vma - (prev->addr() + prev->size());
         pma = prev->pAddr() + prev->size() + vmaoffset;
-        alignAddress(pma, cur->getAddrAlign());
+        if (cur->getAddrAlign() > 0 && vma % cur->getAddrAlign() == 0)
+          alignAddress(pma, cur->getAddrAlign());
       }
 
       // FIXME : remove this option alignSegmentsToPage
@@ -599,7 +604,8 @@ bool GNULDBackend::createProgramHdrs() {
           alignAddress(pma, cur->getAddrAlign());
       } else if (!prev || !disconnect_lma_vma) {
         pma = vma;
-        alignAddress(pma, cur->getAddrAlign());
+        if (cur->getAddrAlign() > 0 && vma % cur->getAddrAlign() == 0)
+          alignAddress(pma, cur->getAddrAlign());
       } else {
         vmaoffset = vma - (prev->addr() + prev->size());
         pma = prev->pAddr() + prev->size() + vmaoffset;

--- a/lib/Target/CreateScriptProgramHeaders.hpp
+++ b/lib/Target/CreateScriptProgramHeaders.hpp
@@ -319,13 +319,17 @@ bool GNULDBackend::createScriptProgramHdrs() {
       ScriptMemoryRegion &R = (*out)->epilog().lmaRegion();
       pma = R.getPhysicalAddr(*out);
       if (!(*out)->prolog().hasAlignWithInput() && !hasLMARegion)
-        alignAddress(pma, cur->getAddrAlign());
+        if (cur->getAddrAlign() > 0 && vma % cur->getAddrAlign() == 0)
+          alignAddress(pma, cur->getAddrAlign());
     } else if (hasFixedLMA) {
       // If the current segment has a fixed LMA address, then
       curLoadSegment->fixedLMA()->evaluateAndRaiseError();
       pma = curLoadSegment->fixedLMA()->result();
     } else {
-      alignAddress(pma, cur->getAddrAlign());
+      // Only align LMA if VMA is also aligned to prevent
+      // LMA/VMA divergence when user sets unaligned address
+      if (cur->getAddrAlign() > 0 && vma % cur->getAddrAlign() == 0)
+        alignAddress(pma, cur->getAddrAlign());
     }
 
     cur->setPaddr(pma);

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -893,8 +893,8 @@ void GNULDBackend::sizeDynNamePools() {
 
   if (GNUVerNeedSection) {
     if (DP->traceSymbolVersioning())
-      config().raise(Diag::trace_creating_symbol_versioning_fragment) <<
-          GNUVerNeedSection->name();
+      config().raise(Diag::trace_creating_symbol_versioning_fragment)
+          << GNUVerNeedSection->name();
     GNUVerNeedFragment *F = make<GNUVerNeedFragment>(GNUVerNeedSection);
     bool is32Bits = config().targets().is32Bits();
     if (is32Bits)
@@ -3557,8 +3557,16 @@ bool GNULDBackend::postLayout() {
   // ranges in the file.
   std::vector<SectionOffset> vmas;
   for (ELFSection *sec : outputSections) {
-    if (sec->size() > 0 && (sec->isAlloc() && !sec->isTLS()))
+    if (sec->size() > 0 && (sec->isAlloc() && !sec->isTLS())) {
+      // Warn if section address is not a multiple of aligment
+      // Same behaviour as LLD
+      if (sec->addr() % sec->getAddrAlign() != 0 &&
+          config().showLinkerScriptWarnings())
+        config().raise(Diag::warn_address_not_aligned)
+            << utility::toHex(static_cast<uint64_t>(sec->addr())) << sec->name()
+            << sec->getAddrAlign();
       vmas.push_back({sec, sec->addr()});
+    }
   }
   checkOverlap("virtual address", vmas, true);
 
@@ -3569,8 +3577,9 @@ bool GNULDBackend::postLayout() {
   std::vector<SectionOffset> lmas;
   for (ELFSection *sec : outputSections) {
     if (sec->size() > 0 && (sec->isAlloc() && !sec->isTLS()) &&
-        !sec->isNoBits())
+        !sec->isNoBits()) {
       lmas.push_back({sec, sec->pAddr()});
+    }
   }
   checkOverlap("load address", lmas, false);
   return true;
@@ -3580,7 +3589,6 @@ std::string GNULDBackend::rangeToString(uint64_t addr, uint64_t len) {
   return "[0x" + llvm::utohexstr(addr) + ", 0x" +
          llvm::utohexstr(addr + len - 1) + "]";
 }
-
 // Check whether sections overlap for a specific address range (file offsets,
 // load and virtual addresses).
 void GNULDBackend::checkOverlap(llvm::StringRef name,
@@ -3828,8 +3836,7 @@ GNULDBackend::postProcessing(llvm::FileOutputBuffer &pOutput) {
                          m_Module.getConfig().options().printTimingStats());
     MemoryRegion region =
         getFileOutputRegion(pOutput, 0, pOutput.getBufferSize());
-    eld::Expected<void> expEmit =
-        m_pSFrameFragment->emit(region, getModule());
+    eld::Expected<void> expEmit = m_pSFrameFragment->emit(region, getModule());
     ELDEXP_RETURN_DIAGENTRY_IF_ERROR(expEmit);
   }
   {
@@ -5576,7 +5583,8 @@ void GNULDBackend::assignOutputVersionIDs() {
       continue;
     if (!DynObjFile->hasSymbolVersioningInfo())
       continue;
-    uint16_t InputVersionID = DynObjFile->getSymbolVersionID(sym->getSymbolIndex());
+    uint16_t InputVersionID =
+        DynObjFile->getSymbolVersionID(sym->getSymbolIndex());
     if (InputVersionID == llvm::ELF::VER_NDX_LOCAL ||
         InputVersionID == llvm::ELF::VER_NDX_GLOBAL)
       continue;

--- a/test/Common/standalone/linkerscript/LMAOverlapAlignment/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/LMAOverlapAlignment/Inputs/1.c
@@ -1,0 +1,9 @@
+//===- 1.c ----------------------------------------------------------------===//
+// Part of the eld Project, under the BSD License
+// See https://github.com/qualcomm/eld/LICENSE.txt for license information.
+// SPDX-License-Identifier: BSD-3-Clause
+//===----------------------------------------------------------------------===//
+extern int u1;
+int foo() { return 1; }
+int bar() { return 3; }
+int baz() { return 5; }

--- a/test/Common/standalone/linkerscript/LMAOverlapAlignment/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/LMAOverlapAlignment/Inputs/script.t
@@ -1,0 +1,14 @@
+SECTIONS {
+  u1 = 0x1001;
+  foo u1 : {
+    *(.text.foo)
+  }
+  u2 = u1 + SIZEOF(foo);
+  bar u2 : {
+    *(.text.bar)
+  }
+  u3 = u2 + SIZEOF(bar);
+  baz u3 : {
+    *(.text.baz)
+  }
+}

--- a/test/Common/standalone/linkerscript/LMAOverlapAlignment/LMAOverlapAlignment.test
+++ b/test/Common/standalone/linkerscript/LMAOverlapAlignment/LMAOverlapAlignment.test
@@ -1,0 +1,12 @@
+#---LMAOverlapAlignment.test--------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# Test that ELD does not emit a false load address range overlap error when
+# section address is not aligned. ELD should emit a warning matching LLD
+# behavior and LMA should equal VMA. (issue #621)
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangg0opts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t -Wlinker-script 2>&1 | %filecheck %s
+#CHECK: Warning: address (0x1001) of section foo is not a multiple of alignment
+#CHECK-NOT: Fatal
+#END_TEST

--- a/test/Common/standalone/linkerscript/LMAOverlapAlignmentPHDRS/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/LMAOverlapAlignmentPHDRS/Inputs/1.c
@@ -1,0 +1,9 @@
+//===- 1.c ----------------------------------------------------------------===//
+// Part of the eld Project, under the BSD License
+// See https://github.com/qualcomm/eld/LICENSE.txt for license information.
+// SPDX-License-Identifier: BSD-3-Clause
+//===----------------------------------------------------------------------===//
+extern int u1;
+int foo() { return 1; }
+int bar() { return 3; }
+int baz() { return 5; }

--- a/test/Common/standalone/linkerscript/LMAOverlapAlignmentPHDRS/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/LMAOverlapAlignmentPHDRS/Inputs/script.t
@@ -1,0 +1,11 @@
+PHDRS {
+  text PT_LOAD;
+}
+SECTIONS {
+  u1 = 0x1001;
+  foo u1 : { *(.text.foo) } :text
+  u2 = u1 + SIZEOF(foo);
+  bar u2 : { *(.text.bar) } :text
+  u3 = u2 + SIZEOF(bar);
+  baz u3 : { *(.text.baz) } :text
+}

--- a/test/Common/standalone/linkerscript/LMAOverlapAlignmentPHDRS/LMAOverlapAlignmentPHDRS.test
+++ b/test/Common/standalone/linkerscript/LMAOverlapAlignmentPHDRS/LMAOverlapAlignmentPHDRS.test
@@ -1,0 +1,12 @@
+#---LMAOverlapAlignmentPHDRS.test--------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# Test that ELD does not emit a false load address range overlap error when
+# section address is not aligned with PHDRS command. Tests createScriptProgramHdrs
+# path. (issue #621)
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangg0opts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t -Wlinker-script 2>&1 | %filecheck %s
+#CHECK: Warning: address (0x1001) of section foo is not a multiple of alignment
+#CHECK-NOT: Fatal
+#END_TEST


### PR DESCRIPTION
## Problem
Fixes #621

ELD incorrectly emits a load address range overlap error when VMA/LMA are not congruent with respect to section alignment.

## Fix
Introduced `getContentSize()` which calculates actual content size  by summing only non-`FillFragment` sizes, excluding alignment padding.
The LMA overlap check now uses `getContentSize()` instead of  `sec->size()` to correctly detect real overlaps


## Testing
Added a lit test that verifies ELD does not emit a false load address  range overlap error when VMA/LMA are non-congruent due to alignment.
