### PR TITLE
Correctly compute .gnu.hash hashes for versioned symbols

### DIFF
--- a/lib/Fragment/GNUHashFragment.cpp
+++ b/lib/Fragment/GNUHashFragment.cpp
@@ -161,8 +161,14 @@ template <class ELFT> void GNUHashFragment<ELFT>::sortSymbols() {
   if (Mid == DynamicSymbols.end())
     return;
   for (auto I = Mid, E = DynamicSymbols.end(); I != E; ++I) {
-    Symbols.push_back(make<SymbolData>(*I, I - DynamicSymbols.begin(),
-                                       hashGnu(llvm::StringRef((*I)->name()))));
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+    SymbolData *symData = make<SymbolData>(
+        *I, I - DynamicSymbols.begin(), hashGnu((*I)->getNonVersionedName()));
+#else
+    SymbolData *symData = make<SymbolData>(
+        *I, I - DynamicSymbols.begin(), hashGnu(llvm::StringRef((*I)->name())));
+#endif
+    Symbols.push_back(symData);
   }
 
   unsigned NBuckets = calcNBuckets(Symbols.size());

--- a/lib/Readers/DynamicELFReader.cpp
+++ b/lib/Readers/DynamicELFReader.cpp
@@ -274,7 +274,7 @@ eld::Expected<void> DynamicELFReader<ELFT>::readVerNeedSection() {
           reinterpret_cast<const typename ELFT::Vernaux *>(VernAuxBuf);
       uint16_t VersionIdentifier =
           CurVernAux->vna_other & llvm::ELF::VERSYM_VERSION;
-      if (VersionIdentifier > VerNeeds.size())
+      if (VersionIdentifier >= VerNeeds.size())
         VerNeeds.resize(VersionIdentifier + 1);
       VerNeeds[VersionIdentifier] = CurVernAux->vna_name;
       VernAuxBuf += CurVernAux->vna_next;

--- a/test/x86_64/linux/SymbolVersioning/UserFlowTests/Inputs/bar.c
+++ b/test/x86_64/linux/SymbolVersioning/UserFlowTests/Inputs/bar.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+
+/* Tell the linker: when this TU calls bar(), bind it to bar@FOO_1.0,
+   NOT to the default bar@@FOO_2.0.  This is the canonical way for a
+   library to pin itself to a specific symbol version from a dependency. */
+__asm__(".symver bar, bar@FOO_1.0");
+
+/* Forward-declare bar with the version we just pinned. */
+extern void bar(void);
+
+/* bar_wrapper is libbar's public API -- it delegates to the old bar. */
+void bar_wrapper(void) {
+    puts("libbar: bar_wrapper -> calling bar@FOO_1.0 from libfoo:");
+    bar();
+}

--- a/test/x86_64/linux/SymbolVersioning/UserFlowTests/Inputs/foo.c
+++ b/test/x86_64/linux/SymbolVersioning/UserFlowTests/Inputs/foo.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+
+/* ---- foo: single version, lives in FOO_1.0 ---- */
+__asm__(".symver foo_impl, foo@@FOO_1.0");
+void foo_impl(void) {
+    puts("libfoo: foo  [FOO_1.0 - default]");
+}
+
+/* ---- bar: two versions ---- */
+
+/* Old implementation -- bound to FOO_1.0 (non-default '@') */
+__asm__(".symver bar_v1, bar@FOO_1.0");
+void bar_v1(void) {
+    puts("libfoo: bar  [FOO_1.0 - old, non-default]");
+}
+
+/* New implementation -- bound to FOO_2.0 (default '@@') */
+__asm__(".symver bar_v2, bar@@FOO_2.0");
+void bar_v2(void) {
+    puts("libfoo: bar  [FOO_2.0 - new, default]");
+}
+
+/* ---- baz: only in FOO_1.0 ---- */
+__asm__(".symver baz_impl, baz@@FOO_1.0");
+void baz_impl(void) {
+    puts("libfoo: baz  [FOO_1.0 - default]");
+}
+
+/* ---- far: new in FOO_2.0 ---- */
+__asm__(".symver far_impl, far@@FOO_2.0");
+void far_impl(void) {
+    puts("libfoo: far  [FOO_2.0 - default]");
+}
+
+/* ---- car: new in FOO_2.0 ---- */
+__asm__(".symver car_impl, car@@FOO_2.0");
+void car_impl(void) {
+    puts("libfoo: car  [FOO_2.0 - default]");
+}

--- a/test/x86_64/linux/SymbolVersioning/UserFlowTests/Inputs/libfoo.map
+++ b/test/x86_64/linux/SymbolVersioning/UserFlowTests/Inputs/libfoo.map
@@ -1,0 +1,15 @@
+FOO_1.0 {
+    global:
+        foo;   /* single-version symbol, default in FOO_1.0 */
+        bar;   /* old version of bar -- will be superseded in FOO_2.0 */
+        baz;   /* only exists in FOO_1.0, no newer version */
+    local:
+        *;     /* hide everything else */
+};
+
+FOO_2.0 {
+    global:
+        bar;   /* new default version of bar, supersedes FOO_1.0 bar */
+        far;   /* new symbol in FOO_2.0 */
+        car;   /* new symbol in FOO_2.0 */
+} FOO_1.0;     /* FOO_2.0 inherits FOO_1.0 */

--- a/test/x86_64/linux/SymbolVersioning/UserFlowTests/Inputs/main.c
+++ b/test/x86_64/linux/SymbolVersioning/UserFlowTests/Inputs/main.c
@@ -1,0 +1,32 @@
+#include <stdio.h>
+
+/* Symbols from libfoo (default versions resolved by the dynamic linker) */
+extern void foo(void);
+extern void bar(void);   /* will bind to bar@@FOO_2.0 -- the default */
+extern void far(void);
+extern void car(void);
+
+/* Symbol from libbar */
+extern void bar_wrapper(void);
+
+int main(void) {
+    puts("=== main: calling libfoo symbols (default versions) ===");
+
+    /* foo lives only in FOO_1.0, so this calls foo@@FOO_1.0 */
+    foo();
+
+    /* bar has two versions; no annotation here means we get bar@@FOO_2.0 */
+    bar();
+
+    /* far and car are only in FOO_2.0 */
+    far();
+    car();
+
+    puts("\n=== main: calling libbar (which uses bar@FOO_1.0 internally) ===");
+
+    /* bar_wrapper is libbar's exported function; it calls bar@FOO_1.0 */
+    bar_wrapper();
+
+    puts("\nDone.");
+    return 0;
+}

--- a/test/x86_64/linux/SymbolVersioning/UserFlowTests/UserFlowTests.test
+++ b/test/x86_64/linux/SymbolVersioning/UserFlowTests/UserFlowTests.test
@@ -1,0 +1,64 @@
+REQUIRES: symbol_versioning
+#---UserFlowTests.test---------------------------------------#
+#BEGIN_COMMENT
+# This test verifies some end-to-end symbol versioning workflows.
+#END_COMMENT
+#START_TEST
+RUN: %rm %t1.dir && %mkdir %t1.dir
+RUN: %clang %clangopts -o %t1.dir/libfoo.so -fuse-ld=%link %p/Inputs/foo.c -fPIC \
+RUN:   -shared -Wl,--version-script,%p/Inputs/libfoo.map -Wl,-soname,libfoo.so \
+RUN:   -Wl,--hash-style=sysv
+RUN: %clang %clangopts -o %t1.dir/libbar.so -fuse-ld=%link %p/Inputs/bar.c -fPIC \
+RUN:   -shared -L %t1.dir -lfoo -Wl,-soname,libbar.so -Wl,--hash-style=sysv
+RUN: %clang %clangopts -o %t1.main.out -fuse-ld=%link %p/Inputs/main.c \
+RUN:   -L %t1.dir -lfoo -lbar -Wl,-rpath,%t1.dir -Wl,--hash-style=sysv
+RUN: %readelf --dyn-syms %t1.dir/libfoo.so | %filecheck %s --check-prefix=LIBFOO_DYNINFO
+RUN: %readelf --dyn-syms --version-info %t1.dir/libbar.so | %filecheck %s --check-prefix=LIBBAR_DYNINFO
+RUN: %readelf --dyn-syms --version-info %t1.main.out | %filecheck %s --check-prefix=MAIN_DYNINFO
+RUN: %t1.main.out | %filecheck %s --check-prefix=OUTPUT
+
+RUN: %clang %clangopts -o %t1.dir/libfoo.so -fuse-ld=%link %p/Inputs/foo.c -fPIC \
+RUN:   -shared -Wl,--version-script,%p/Inputs/libfoo.map -Wl,-soname,libfoo.so \
+RUN:   -Wl,--hash-style=gnu
+RUN: %clang %clangopts -o %t1.dir/libbar.so -fuse-ld=%link %p/Inputs/bar.c -fPIC \
+RUN:   -shared -L %t1.dir -lfoo -Wl,-soname,libbar.so -Wl,--hash-style=gnu
+RUN: %clang %clangopts -o %t1.main.out -fuse-ld=%link %p/Inputs/main.c \
+RUN:   -L %t1.dir -lfoo -lbar -Wl,-rpath,%t1.dir -Wl,--hash-style=gnu
+RUN: %readelf --dyn-syms %t1.dir/libfoo.so | %filecheck %s --check-prefix=LIBFOO_DYNINFO
+RUN: %readelf --dyn-syms --version-info %t1.dir/libbar.so | %filecheck %s --check-prefix=LIBBAR_DYNINFO
+RUN: %readelf --dyn-syms --version-info %t1.main.out | %filecheck %s --check-prefix=MAIN_DYNINFO
+RUN: %t1.main.out | %filecheck %s --check-prefix=OUTPUT
+
+LIBFOO_DYNINFO-DAG: {{[0-9]}} far@@FOO_2.0
+LIBFOO_DYNINFO-DAG: {{[0-9]}} bar@FOO_1.0
+LIBFOO_DYNINFO-DAG: {{[0-9]}} car@@FOO_2.0
+LIBFOO_DYNINFO-DAG: {{[0-9]}} foo@@FOO_1.0
+LIBFOO_DYNINFO-DAG: {{[0-9]}} bar@@FOO_2.0
+LIBFOO_DYNINFO-DAG: {{[0-9]}} baz@@FOO_1.0
+
+LIBBAR_DYNINFO-DAG: UND bar@FOO_1.0
+LIBBAR_DYNINFO-DAG: {{[0-9]}} bar_wrapper
+LIBBAR_DYNINFO-DAG: Version needs section '.gnu.version_r'
+LIBBAR_DYNINFO-DAG: File: libfoo.so
+LIBBAR_DYNINFO-DAG: Name: FOO_1.0
+
+MAIN_DYNINFO-DAG: UND bar_wrapper
+MAIN_DYNINFO-DAG: UND bar@FOO_2.0
+MAIN_DYNINFO-DAG: UND far@FOO_2.0
+MAIN_DYNINFO-DAG: UND car@FOO_2.0
+MAIN_DYNINFO-DAG: UND foo@FOO_1.0
+MAIN_DYNINFO-DAG: {{[0-9]+}} main
+MAIN_DYNINFO: Version needs section '.gnu.version_r'
+MAIN_DYNINFO: File: libfoo.so
+MAIN_DYNINFO: Name: FOO_1.0
+MAIN_DYNINFO: Name: FOO_2.0
+
+OUTPUT: === main: calling libfoo symbols (default versions) ===
+OUTPUT: libfoo: foo  [FOO_1.0 - default]
+OUTPUT: libfoo: bar  [FOO_2.0 - new, default]
+OUTPUT: libfoo: far  [FOO_2.0 - default]
+OUTPUT: libfoo: car  [FOO_2.0 - default]
+OUTPUT: === main: calling libbar (which uses bar@FOO_1.0 internally) ===
+OUTPUT: libbar: bar_wrapper -> calling bar@FOO_1.0 from libfoo:
+OUTPUT: libfoo: bar  [FOO_1.0 - old, non-default]
+OUTPUT: Done.


### PR DESCRIPTION
This commit fixes the computation of .gnu.hash hash for versioned symbols. We were incorrectly using the versioned name for computing this hash. The .gnu.hash hash for versioned symbol must be computed using the unversioned name.

Reference: DT_GNU_HASH section in https://sourceware.org/gnu-gabi/program-loading-and-dynamic-linking.txt

Additionally, this commit also fixes an out-of-bound index in DynamicELFReader::readVerNeedSection.

Resolves #1033