### PR TITLE
[build] Fix Build with BUILD_SHARED_LIBS=On

### DIFF
--- a/lib/Object/CMakeLists.txt
+++ b/lib/Object/CMakeLists.txt
@@ -22,4 +22,5 @@ target_link_libraries(
           ELDSupport
           ELDTarget
           LLVMSupport
+          LLVMBitWriter
           LLVMLTO)


### PR DESCRIPTION
llvm::WriteBitcodeToFile is in the LLVMBitWriter library. This needs to explicitly be included in the link libraries when building with `BUILD_SHARED_LIBS=On`, or there will be a link failure.