### PR TITLE
Produce diagnostic for segment assignments when no PHDRS present.

### DIFF
--- a/lib/Target/CreateProgramHeaders.hpp
+++ b/lib/Target/CreateProgramHeaders.hpp
@@ -28,6 +28,18 @@ bool GNULDBackend::createProgramHdrs() {
   uint64_t segAlign = abiPageSize();
   m_NumReservedSegments = 0;
 
+  if (!m_Module.getScript().phdrsSpecified()) {
+    for (auto &OutSection : script.sectionMap()) {
+      if (!OutSection->epilog().hasPhdrs())
+        continue;
+      for (const auto &PhdrNameToken : *OutSection->epilog().phdrs()) {
+        config().raise(Diag::fatal_segment_not_defined_ldscript)
+            << OutSection->name() << PhdrNameToken->name();
+        return false;
+      }
+    }
+  }
+
   bool linkerScriptHasMemoryCommand = m_Module.getScript().hasMemoryCommand();
 
   if (linkerScriptHasMemoryCommand)

--- a/test/AArch64/standalone/linkerscript/includeFileExpression/script_with_expression.t
+++ b/test/AArch64/standalone/linkerscript/includeFileExpression/script_with_expression.t
@@ -1,8 +1,12 @@
+PHDRS {
+    A PT_LOAD;
+}
+
 SECTIONS
 {
   .data_l1wb_l2uc :
   {
-  } :crap=0
+  } :A=0
   INCLUDE include.lcs
 }
 

--- a/test/ARM/standalone/linkerscript/includeFileExpression/script_with_expression.t
+++ b/test/ARM/standalone/linkerscript/includeFileExpression/script_with_expression.t
@@ -1,8 +1,12 @@
+PHDRS {
+    A PT_LOAD;
+}
+
 SECTIONS
 {
   .data_l1wb_l2uc :
   {
-  } :crap=0
+  } :A=0
   INCLUDE include.lcs
 }
 

--- a/test/Common/standalone/EntrySections/Inputs/1.linker.script
+++ b/test/Common/standalone/EntrySections/Inputs/1.linker.script
@@ -1,3 +1,8 @@
+PHDRS {
+    CODE_SEGMENT PT_LOAD;
+    DATA_SEGMENT PT_LOAD;
+}
+
 SECTIONS {
   CODE_RAM 0x000000 : {
     *(.rodata .rodata*)

--- a/test/Common/standalone/linkerscript/MissingPHDRAssignmentWithoutPHDRS/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/MissingPHDRAssignmentWithoutPHDRS/Inputs/1.c
@@ -1,0 +1,2 @@
+void foo(void) {}
+

--- a/test/Common/standalone/linkerscript/MissingPHDRAssignmentWithoutPHDRS/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/MissingPHDRAssignmentWithoutPHDRS/Inputs/script.t
@@ -1,0 +1,3 @@
+SECTIONS {
+  .text : { *(.text) } :missing_phdr
+}

--- a/test/Common/standalone/linkerscript/MissingPHDRAssignmentWithoutPHDRS/Inputs/script_no_error.t
+++ b/test/Common/standalone/linkerscript/MissingPHDRAssignmentWithoutPHDRS/Inputs/script_no_error.t
@@ -1,0 +1,7 @@
+PHDRS {
+    A PT_LOAD;
+}
+
+SECTIONS {
+  .text : { *(.text) } :A
+}

--- a/test/Common/standalone/linkerscript/MissingPHDRAssignmentWithoutPHDRS/MissingPHDRAssignmentWithoutPHDRS.test
+++ b/test/Common/standalone/linkerscript/MissingPHDRAssignmentWithoutPHDRS/MissingPHDRAssignmentWithoutPHDRS.test
@@ -1,0 +1,12 @@
+#--MissingPHDRAssignmentWithoutPHDRS.test--------------------- Executable,LS------------------#
+#BEGIN_COMMENT
+# If output sections are assigned to a PHDR without a PHDRS block,
+# linker should produce a diagnostic.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o
+RUN: %not %link %linkopts %t1.o -T %p/Inputs/script.t -o %t.out 2>&1 | %filecheck %s --check-prefix DIAG
+RUN: %link %linkopts %t1.o -T %p/Inputs/script_no_error.t -o %t.out
+#END_TEST
+
+#DIAG: .text: Segment missing_phdr is not defined in linker script

--- a/test/Common/standalone/linkerscript/includeFileExpression/script_with_expression.t
+++ b/test/Common/standalone/linkerscript/includeFileExpression/script_with_expression.t
@@ -1,8 +1,12 @@
+PHDRS {
+    A PT_LOAD;
+}
+
 SECTIONS
 {
   .data_l1wb_l2uc :
   {
-  } :crap=0
+  } :A=0
   INCLUDE include.lcs
 }
 

--- a/test/Hexagon/standalone/linkerscript/includeFileExpression/script_with_expression.t
+++ b/test/Hexagon/standalone/linkerscript/includeFileExpression/script_with_expression.t
@@ -1,8 +1,12 @@
+PHDRS {
+    A PT_LOAD;
+}
+
 SECTIONS
 {
   .data_l1wb_l2uc :
   {
-  } :crap=0
+  } :A=0
   INCLUDE include.lcs
 }
 


### PR DESCRIPTION
Produce a diagnostic if sections are assigned to a segment when PHDRS aren't being used in the linker script.

Fixes #348