### PR TITLE
[zephyr] Record zephyr build status as pass only on success.

### DIFF
--- a/.github/workflows/zephyr-nightly.yml
+++ b/.github/workflows/zephyr-nightly.yml
@@ -173,7 +173,7 @@ jobs:
             zephyr/build/zephyr/zephyr.map
 
       - name: Update build entry
-        if: always() && github.event_name == 'schedule'
+        if: success() && github.event_name == 'schedule'
         uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
         with:
           enabled: true


### PR DESCRIPTION
The post-build status recorder used `always()`, which unconditionally recorded the build as a pass.