### PR TITLE
Skip NOLOAD sections in LMA overlap check

### DIFF
--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -3566,10 +3566,12 @@ bool GNULDBackend::postLayout() {
 
   // Finally, check that the load addresses don't overlap. This will usually be
   // the same as the virtual addresses but can be different when using a linker
-  // script with AT().
+  // script with AT(). Skip SHT_NOBITS sections as they have no physical content
+  // in the output file.
   std::vector<SectionOffset> lmas;
   for (ELFSection *sec : outputSections) {
-    if (sec->size() > 0 && (sec->isAlloc() && !sec->isTLS()))
+    if (sec->size() > 0 && (sec->isAlloc() && !sec->isTLS()) &&
+        !sec->isNoBits())
       lmas.push_back({sec, sec->pAddr()});
   }
   checkOverlap("load address", lmas, false);

--- a/test/Common/standalone/linkerscript/OverlapError/noload-lma-overlap.s
+++ b/test/Common/standalone/linkerscript/OverlapError/noload-lma-overlap.s
@@ -1,0 +1,42 @@
+## NOLOAD sections have no physical content in the output file, so their LMA
+## range should not be checked for overlap with loaded sections.
+
+# RUN: split-file %s %t
+# RUN: %clang %clangopts -c %t/1.s -o %t.o
+
+# RUN: %link %linkopts -T %t/script.t %t.o -o %t.elf
+
+# RUN: %readelf -S %t.elf | %filecheck %s --check-prefix=SECTIONS
+
+# SECTIONS: .bss              NOBITS
+# SECTIONS: .noinit           NOBITS
+# SECTIONS: foo               PROGBITS
+
+## foo's LMA is aliased to LOADADDR(.bss) via AT(). Since .bss and
+## .noinit are NOLOAD, this should not trigger an overlap error.
+#--- 1.s
+.section .text, "ax"
+.globl _start
+_start:
+    nop
+
+.section .text.foo, "ax"
+.globl foo
+foo:
+    nop
+
+#--- script.t
+MEMORY
+{
+    RAM      (wx) : ORIGIN = 0x8000, LENGTH = 256K
+    ONDEMAND (rx) : ORIGIN = 0x8000, LENGTH = 8M
+}
+
+SECTIONS
+{
+    .text : { *(.text) } > RAM
+    .bss (NOLOAD) : { BYTE(0xFF) . += 0x100; } > RAM
+    .noinit (NOLOAD) : { . += 0x100; } > RAM
+    . = ALIGN(0x1000);
+    foo (.) : AT(LOADADDR(.bss)) { *(.text.foo) ; . = ALIGN(0x1000); } > ONDEMAND
+}


### PR DESCRIPTION
`SHT_NOBITS` sections have no physical content in the output file, so their LMA range cannot conflict with loaded sections. This fixes false overlap errors when a loaded section's LMA aliases a `NOLOAD` section's address via `AT()` and matches GNU ld.

Fixes #1058