### PR TITLE
Produce diagnostic for segment assignments when no PHDRS present.

### DIFF
--- a/include/eld/Diagnostics/DiagLDScript.inc
+++ b/include/eld/Diagnostics/DiagLDScript.inc
@@ -33,6 +33,8 @@ DIAG(warn_section_no_segment, DiagnosticEngine::Warning,
      "Section %0 does not have segment assignment in linker script.")
 DIAG(fatal_segment_not_defined_ldscript, DiagnosticEngine::Fatal,
      "%0: Segment %1 is not defined in linker script.")
+DIAG(error_phdrs_not_specified_ldscript, DiagnosticEngine::Error,
+     "%0: Section %1 assigned to segment %2 but PHDRS not specified.")
 DIAG(assert_failed, DiagnosticEngine::Error, "Assertion failed %0")
 DIAG(error_printcmd, DiagnosticEngine::Error, "%0: PRINT: %1")
 DIAG(linker_script_uses_phdrs_no_sections, DiagnosticEngine::Error,

--- a/lib/Script/OutputSectDesc.cpp
+++ b/lib/Script/OutputSectDesc.cpp
@@ -44,8 +44,6 @@ OutputSectDesc::OutputSectDesc(const std::string &PName)
   OutputSectDescEpilog.FillExpression = nullptr;
 }
 
-
-
 void OutputSectDesc::dump(llvm::raw_ostream &Outs) const {
   Outs << Name << "\t";
 
@@ -285,6 +283,15 @@ eld::Expected<void> OutputSectDesc::activate(Module &CurModule) {
   // Assignment in an output section
   OutputSectCmds Assignments;
   const LinkerScript &Script = CurModule.getLinkerScript();
+
+  if (OutputSectDescEpilog.hasPhdrs() && !Script.phdrsSpecified()) {
+    for (const auto &PhdrNameToken : OutputSectDescEpilog.phdrs()->tokens()) {
+      return std::make_unique<plugin::DiagnosticEntry>(
+          plugin::DiagnosticEntry(Diag::error_phdrs_not_specified_ldscript,
+                                  {getContext(), Name, PhdrNameToken->name()}));
+    }
+  }
+
   if (OutputSectDescEpilog.OutputSectionMemoryRegion) {
     eld::Expected<eld::ScriptMemoryRegion *> MemRegion = Script.getMemoryRegion(
         OutputSectDescEpilog.OutputSectionMemoryRegion->name(), getContext());

--- a/test/AArch64/standalone/linkerscript/includeFileExpression/script_with_expression.t
+++ b/test/AArch64/standalone/linkerscript/includeFileExpression/script_with_expression.t
@@ -1,8 +1,12 @@
+PHDRS {
+    A PT_LOAD;
+}
+
 SECTIONS
 {
   .data_l1wb_l2uc :
   {
-  } :crap=0
+  } :A=0
   INCLUDE include.lcs
 }
 

--- a/test/ARM/standalone/linkerscript/includeFileExpression/script_with_expression.t
+++ b/test/ARM/standalone/linkerscript/includeFileExpression/script_with_expression.t
@@ -1,8 +1,12 @@
+PHDRS {
+    A PT_LOAD;
+}
+
 SECTIONS
 {
   .data_l1wb_l2uc :
   {
-  } :crap=0
+  } :A=0
   INCLUDE include.lcs
 }
 

--- a/test/Common/standalone/EntrySections/Inputs/1.linker.script
+++ b/test/Common/standalone/EntrySections/Inputs/1.linker.script
@@ -1,3 +1,8 @@
+PHDRS {
+    CODE_SEGMENT PT_LOAD;
+    DATA_SEGMENT PT_LOAD;
+}
+
 SECTIONS {
   CODE_RAM 0x000000 : {
     *(.rodata .rodata*)

--- a/test/Common/standalone/linkerscript/MissingPHDRAssignmentWithoutPHDRS/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/MissingPHDRAssignmentWithoutPHDRS/Inputs/1.c
@@ -1,0 +1,1 @@
+void foo(void) {}

--- a/test/Common/standalone/linkerscript/MissingPHDRAssignmentWithoutPHDRS/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/MissingPHDRAssignmentWithoutPHDRS/Inputs/script.t
@@ -1,0 +1,3 @@
+SECTIONS {
+  .text : { *(.text) } :missing_phdr
+}

--- a/test/Common/standalone/linkerscript/MissingPHDRAssignmentWithoutPHDRS/Inputs/script_no_error.t
+++ b/test/Common/standalone/linkerscript/MissingPHDRAssignmentWithoutPHDRS/Inputs/script_no_error.t
@@ -1,0 +1,7 @@
+PHDRS {
+    A PT_LOAD;
+}
+
+SECTIONS {
+  .text : { *(.text) } :A
+}

--- a/test/Common/standalone/linkerscript/MissingPHDRAssignmentWithoutPHDRS/MissingPHDRAssignmentWithoutPHDRS.test
+++ b/test/Common/standalone/linkerscript/MissingPHDRAssignmentWithoutPHDRS/MissingPHDRAssignmentWithoutPHDRS.test
@@ -1,0 +1,13 @@
+#--MissingPHDRAssignmentWithoutPHDRS.test--------------------- Executable,LS------------------#
+#BEGIN_COMMENT
+# If output sections are assigned to a PHDR without a PHDRS block,
+# linker should produce a diagnostic.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o
+RUN: %not %link %linkopts %t1.o -T %p/Inputs/script.t -o %t.out 2>&1 | %filecheck %s --check-prefix DIAG
+RUN: %link %linkopts %t1.o -T %p/Inputs/script_no_error.t -o %t.out
+#END_TEST
+
+#DIAG: Error: {{.*script.t}}: Section .text assigned to segment missing_phdr
+#DIAG: but PHDRS not specified

--- a/test/Common/standalone/linkerscript/includeFileExpression/script_with_expression.t
+++ b/test/Common/standalone/linkerscript/includeFileExpression/script_with_expression.t
@@ -1,8 +1,12 @@
+PHDRS {
+    A PT_LOAD;
+}
+
 SECTIONS
 {
   .data_l1wb_l2uc :
   {
-  } :crap=0
+  } :A=0
   INCLUDE include.lcs
 }
 

--- a/test/Hexagon/linux/linkerscript/includeFileExpression/script_with_expression.t
+++ b/test/Hexagon/linux/linkerscript/includeFileExpression/script_with_expression.t
@@ -1,8 +1,12 @@
+PHDRS {
+    A PT_LOAD;
+}
+
 SECTIONS
 {
   .data_l1wb_l2uc :
   {
-  } :crap=0
+  } :A=0
   INCLUDE include.lcs
 }
 

--- a/test/Hexagon/standalone/linkerscript/includeFileExpression/script_with_expression.t
+++ b/test/Hexagon/standalone/linkerscript/includeFileExpression/script_with_expression.t
@@ -1,8 +1,12 @@
+PHDRS {
+    A PT_LOAD;
+}
+
 SECTIONS
 {
   .data_l1wb_l2uc :
   {
-  } :crap=0
+  } :A=0
   INCLUDE include.lcs
 }
 


### PR DESCRIPTION
Produce a diagnostic if sections are assigned to a segment when PHDRS are not being used in the linker script.

Fixes #348