### PR TITLE
eld: implement --remap-inputs and --remap-inputs-file

### DIFF
--- a/docs/userguide/CommandLineOptionsSupplements/remap-inputs-file.rst.in
+++ b/docs/userguide/CommandLineOptionsSupplements/remap-inputs-file.rst.in
@@ -1,0 +1,12 @@
+Read remap rules from ``<file>``.
+
+Each non-empty line in the file is one rule in either format:
+
+| ``pattern=replacement``
+| ``pattern replacement``
+
+Lines beginning with ``#`` and blank lines are ignored. Inline ``#`` comments
+are also supported.
+
+Rules from this file are appended to the same ordered remap list used by
+:option:`--remap-inputs`.

--- a/docs/userguide/CommandLineOptionsSupplements/remap-inputs.rst.in
+++ b/docs/userguide/CommandLineOptionsSupplements/remap-inputs.rst.in
@@ -1,0 +1,16 @@
+Rules are evaluated in command-line order; the first matching rule wins.
+The pattern supports wildcard matching.
+
+Example:
+
+| ``--remap-inputs=foo.o=bar.o``
+| ``--remap-inputs=*foo.o=build/alt/bar.o``
+
+Remapping is applied before path search/open, including linker-script
+``INPUT(...)``, ``GROUP(...)``, and ``INCLUDE`` processing.
+
+How to tell remapping is active:
+
+| ``--verbose`` prints: ``Remapping input file <old> to <new>``.
+| Text map output (``-MapStyle txt``) annotates remapped entries with
+| ``# remapped from <original-name>``.

--- a/docs/userguide/documentation/options/options.rst
+++ b/docs/userguide/documentation/options/options.rst
@@ -8,6 +8,63 @@ Common options for all the backends
 
 .. include:: GnuLinkerOptions.rst
 
+Input remapping options
+-----------------------
+
+``--remap-inputs`` and ``--remap-inputs-file`` let you redirect input file
+names before ELD opens them.
+
+``--remap-inputs``
+^^^^^^^^^^^^^^^^^^
+
+Use ``--remap-inputs=<pattern>=<replacement>`` (or
+``--remap-inputs <pattern>=<replacement>``) to add one remap rule.
+
+Rules are evaluated in command-line order and the first matching rule wins.
+``<pattern>`` supports wildcard matching.
+
+Example::
+
+  $ ld.eld main.o foo.o --remap-inputs=foo.o=bar.o -T script.t
+
+In this example, any reference to ``foo.o`` is resolved as ``bar.o``.
+
+``--remap-inputs-file``
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Use ``--remap-inputs-file=<file>`` (or ``--remap-inputs-file <file>``) to
+load remap rules from a text file.
+
+Each non-empty line in ``<file>`` defines one rule, either as:
+
+* ``pattern=replacement``
+* ``pattern replacement``
+
+Lines starting with ``#`` (or text after ``#`` on a line) are treated as
+comments.
+
+Example::
+
+  # remap.txt
+  *foo.o build/alt/bar.o
+  libold.a=libnew.a
+
+  $ ld.eld main.o foo.o libold.a --remap-inputs-file=remap.txt -T script.t
+
+Notes:
+
+* Remapping is applied before path search/open, including linker-script
+  ``INPUT(...)``, ``GROUP(...)``, and ``INCLUDE`` processing.
+* ``--remap-inputs`` and ``--remap-inputs-file`` rules share one ordered rule
+  list; whichever matching rule appears first is applied.
+* To confirm remapping happened:
+
+  - Use ``--verbose`` to see diagnostics such as
+    ``Remapping input file <old> to <new>``.
+  - In text map output (``-MapStyle txt``), input/load lines and linker-script
+    include tracking lines are annotated with
+    ``# remapped from <original-name>`` when remapping is applied.
+
 Using ``--start-lib`` / ``--end-lib``
 -------------------------------------
 

--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -105,6 +105,13 @@ public:
   typedef DynListType::const_iterator const_dyn_list_iterator;
 
   typedef ExcludeLIBSType ExtList;
+
+  struct RemapEntry {
+    std::string Pattern;
+    std::string Replacement;
+  };
+  typedef std::vector<RemapEntry> RemapInputsType;
+
   typedef ExtList::iterator ext_list_iterator;
   typedef ExtList::const_iterator const_ext_list_iterator;
 
@@ -597,6 +604,10 @@ public:
 
   const DynListType &getVersionScripts() const { return VersionScripts; }
   DynListType &getVersionScripts() { return VersionScripts; }
+
+  // ---- remap input file names ---- //
+  const RemapInputsType &getRemapInputs() const { return RemapInputs; }
+  RemapInputsType &getRemapInputs() { return RemapInputs; }
 
   // ---- add extern symbols from list file ---- //
   const ExtList &getExternList() const { return ExternList; }
@@ -1327,6 +1338,7 @@ private:
   DynListType DynList;               // --dynamic-list files
   DynListType VersionScripts;        // --version-script files
   DynListType ExternList;            // --extern-list files
+  RemapInputsType RemapInputs;       // --remap-inputs entries
   std::string Filter;
   std::string MapFile; // Mapfile
   std::string TarFile; // --reproduce output tarfile name

--- a/include/eld/Diagnostics/DiagCommonKinds.inc
+++ b/include/eld/Diagnostics/DiagCommonKinds.inc
@@ -192,3 +192,7 @@ DIAG(err_patch_not_static, DiagnosticEngine::Error,
      "Patching is only supported for static linking")
 DIAG(error_invalid_target2, DiagnosticEngine::Error,
      "unknown --target2 option: %0")
+DIAG(err_remap_inputs_bad_format, DiagnosticEngine::Error,
+     "invalid --remap-inputs value %0: expected pattern=filename")
+DIAG(err_remap_inputs_file_not_found, DiagnosticEngine::Error,
+     "cannot open --remap-inputs-file %0: %1")

--- a/include/eld/Diagnostics/DiagVerbose.inc
+++ b/include/eld/Diagnostics/DiagVerbose.inc
@@ -168,3 +168,5 @@ DIAG(verbose_loaded_plugin_config, DiagnosticEngine::Verbose,
 DIAG(verbose_infer_target, DiagnosticEngine::Verbose,
      "Inferred target : %0")
 DIAG(verbose_sframe_log, DiagnosticEngine::Verbose, "SFrame Handling : %0")
+DIAG(verbose_remap_input, DiagnosticEngine::Verbose,
+     "Remapping input file %0 to %1")

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -1380,3 +1380,12 @@ defm input_format : smDashTwoWithOpt<"b", "format", "input_format",
                       "Supported values: binary,default">,
                     MetaVarName<"<input-format>">,
                     Group<grp_input_formats>;
+
+defm remap_inputs : EEq<"remap-inputs",
+                        "Remap input file names (pattern=filename)">,
+                    MetaVarName<"<pattern=filename>">,
+                    Group<grp_input_formats>;
+defm remap_inputs_file : EEq<"remap-inputs-file",
+                             "Read input file name remappings from file">,
+                         MetaVarName<"<file>">,
+                         Group<grp_input_formats>;

--- a/include/eld/Input/Input.h
+++ b/include/eld/Input/Input.h
@@ -66,6 +66,13 @@ public:
   const std::string getFileName() const { return FileName; }
 
   /// getName for the Input class returns the FileName
+  /// getOriginalFileName returns the name before any --remap-inputs was
+  /// applied.
+  const std::string &getOriginalFileName() const { return OriginalFileName; }
+
+  bool wasRemapped() const { return !OriginalFileName.empty(); }
+
+  /// getName for the Input class returns the FileName
   const std::string getName() const { return Name; }
 
   const sys::fs::Path &getResolvedPath() const { return *ResolvedPath; }
@@ -181,6 +188,7 @@ protected:
   std::string FileName;                      // Filename as what is passed to
                                              //   the linker
   std::string Name;                          // Resolved Name or
+  std::string OriginalFileName;              // FileName before --remap-inputs
                                              // Member Name or the SONAME.
   std::optional<sys::fs::Path> ResolvedPath; // Resolved path.
   Attribute Attr;                            // Attribute

--- a/include/eld/LayoutMap/LayoutInfo.h
+++ b/include/eld/LayoutMap/LayoutInfo.h
@@ -176,6 +176,7 @@ public:
   // Linker Script support
   struct ScriptInputT {
     std::string Include;
+    std::string RemappedFrom;
     std::string Parent;
     bool Found = false;
     uint32_t Depth = 0;
@@ -285,7 +286,8 @@ public:
 
   std::string getPath(const std::string &Filename) const;
 
-  void recordLinkerScript(std::string File, bool Found = true);
+  void recordLinkerScript(std::string File, bool Found = true,
+                          llvm::StringRef RemappedFrom = "");
 
   void recordLinkerScriptRule();
 

--- a/lib/Input/Input.cpp
+++ b/lib/Input/Input.cpp
@@ -91,6 +91,18 @@ bool Input::resolvePath(const LinkerConfig &PConfig) {
     return true;
   if (PConfig.options().hasMappingFile() && !isInternal())
     return resolvePathMappingFile(PConfig);
+  // Apply --remap-inputs remappings (in order, first match wins).
+  for (const auto &Entry : PConfig.options().getRemapInputs()) {
+    WildcardPattern Pat(Entry.Pattern);
+    if (Pat.matched(FileName)) {
+      if (PConfig.getPrinter()->isVerbose())
+        PConfig.raise(Diag::verbose_remap_input)
+            << FileName << Entry.Replacement;
+      OriginalFileName = FileName;
+      FileName = Entry.Replacement;
+      break;
+    }
+  }
   auto &PSearchDirs = PConfig.directories();
   switch (Type) {
   default:

--- a/lib/LayoutMap/LayoutInfo.cpp
+++ b/lib/LayoutMap/LayoutInfo.cpp
@@ -12,6 +12,8 @@
 #include "eld/Fragment/Fragment.h"
 #include "eld/Fragment/FragmentRef.h"
 #include "eld/Fragment/RegionFragment.h"
+#include "eld/Input/ArchiveFile.h"
+#include "eld/Input/ArchiveMemberInput.h"
 #include "eld/Input/Input.h"
 #include "eld/Input/ObjectFile.h"
 #include "eld/Plugin/PluginOp.h"
@@ -269,12 +271,28 @@ std::string LayoutInfo::getStringFromLoadSequence(InputSequenceT Ist) {
 
   Input *Input = Ist.Input;
   std::string Files = "";
+  std::string RemapComment = "";
+  auto appendRemapComment = [&](llvm::StringRef Comment) {
+    if (RemapComment.empty())
+      RemapComment = " # ";
+    else
+      RemapComment += ", ";
+    RemapComment += Comment.str();
+  };
   InputFile::InputFileKind K;
 
   if (Input != nullptr) {
     Files = Input->decoratedPath();
     if (ThisConfig.options().hasMappingFile())
       Files += "(" + Input->getName() + ")";
+    if (Input->wasRemapped())
+      appendRemapComment("remapped from " + Input->getOriginalFileName());
+    if (const auto *AMI = llvm::dyn_cast<ArchiveMemberInput>(Input)) {
+      const eld::Input *ArchInput = AMI->getArchiveFile()->getInput();
+      if (ArchInput && ArchInput->wasRemapped())
+        appendRemapComment("archive remapped from " +
+                           ArchInput->getOriginalFileName());
+    }
     K = Input->getInputFile()->getKind();
   }
 
@@ -309,7 +327,7 @@ std::string LayoutInfo::getStringFromLoadSequence(InputSequenceT Ist) {
     default:
       ASSERT(0, "Unhandled Input File Kind");
     }
-    return Pref + Files + FileType;
+    return Pref + Files + FileType + RemapComment;
   }
 
   std::string InputFileStr = Pref + Files + ArchFlag;
@@ -319,7 +337,7 @@ std::string LayoutInfo::getStringFromLoadSequence(InputSequenceT Ist) {
     if (!FeatureStr.empty())
       InputFileStr += "[" + FeatureStr + "]";
   }
-  return InputFileStr;
+  return InputFileStr + RemapComment;
 }
 
 void LayoutInfo::recordInputActions(InputKindPrefix Prefix, Input *Input,
@@ -341,11 +359,12 @@ void LayoutInfo::recordGC(const ELFSection *Section) {
     LinkStats.NumZeroSizedSectionsGarbageCollected++;
 }
 
-void LayoutInfo::recordLinkerScript(std::string LinkerScriptFile,
-                                       bool Found) {
+void LayoutInfo::recordLinkerScript(std::string LinkerScriptFile, bool Found,
+                                    llvm::StringRef RemappedFrom) {
   ScriptInputT Script;
   LinkStats.NumLinkerScripts++;
   Script.Include = LinkerScriptFile;
+  Script.RemappedFrom = RemappedFrom.str();
   Script.Depth = LinkerScriptStack.size();
   if (LinkerScriptStack.size() > 0)
     Script.Parent = LinkerScriptStack.top();

--- a/lib/LayoutMap/TextLayoutPrinter.cpp
+++ b/lib/LayoutMap/TextLayoutPrinter.cpp
@@ -1078,6 +1078,8 @@ void TextLayoutPrinter::printScriptIncludes(bool UseColor) {
                          LinkerScriptName + ")";
     if (!Script.Found)
       LinkerScriptName += "(NOTFOUND)";
+    if (!Script.RemappedFrom.empty())
+      LinkerScriptName += " # remapped from " + Script.RemappedFrom;
     outputStream() << Indent << LinkerScriptName;
     outputStream() << "\n";
   }

--- a/lib/LayoutMap/YamlLayoutPrinter.cpp
+++ b/lib/LayoutMap/YamlLayoutPrinter.cpp
@@ -205,6 +205,8 @@ eld::YamlLayoutPrinter::buildYaml(eld::Module &Module,
                          LinkerScriptName + ")";
     if (!Script.Found)
       LinkerScriptName += "(NOTFOUND)";
+    if (!Script.RemappedFrom.empty())
+      LinkerScriptName += " # remapped from " + Script.RemappedFrom;
     Result.LinkerScriptsUsed.push_back(Indent + LinkerScriptName);
   }
   Result.BuildType = Module.getConfig().codeGenType();

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -26,6 +26,7 @@
 #include "eld/LayoutMap/TextLayoutPrinter.h"
 #include "eld/LayoutMap/YamlLayoutPrinter.h"
 #include "eld/Object/ArchiveMemberReport.h"
+#include "eld/Support/FileSystem.h"
 #include "eld/Support/MappingFileReader.h"
 #include "eld/Support/MsgHandling.h"
 #include "eld/Support/OutputTarWriter.h"
@@ -44,7 +45,6 @@
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"
-#include <fstream>
 #include <thread>
 
 using namespace llvm;
@@ -874,6 +874,65 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
   for (auto *Arg : Args.filtered(T::extern_list))
     Config.options().getExternList().emplace(Arg->getValue());
 
+  // Helper lambda to parse and add a single "pattern=filename" remap entry.
+  auto addRemapEntry = [&](llvm::StringRef Value) -> bool {
+    auto EqPos = Value.find('=');
+    if (EqPos == llvm::StringRef::npos) {
+      Config.raise(Diag::err_remap_inputs_bad_format) << Value.str();
+      return false;
+    }
+    GeneralOptions::RemapEntry Entry;
+    Entry.Pattern = Value.substr(0, EqPos).str();
+    Entry.Replacement = Value.substr(EqPos + 1).str();
+    Config.options().getRemapInputs().push_back(std::move(Entry));
+    return true;
+  };
+
+  // --remap-inputs=pattern=filename
+  for (auto *Arg : Args.filtered(T::remap_inputs))
+    if (!addRemapEntry(Arg->getValue()))
+      return false;
+
+  // --remap-inputs-file=file
+  for (auto *Arg : Args.filtered(T::remap_inputs_file)) {
+    std::string FilePath = Arg->getValue();
+    std::vector<std::string> Lines;
+    if (std::error_code EC = eld::sys::fs::loadFileContents(FilePath, Lines)) {
+      Config.raise(Diag::err_remap_inputs_file_not_found)
+          << FilePath << EC.message();
+      return false;
+    }
+    for (const std::string &Line : Lines) {
+      llvm::StringRef LineRef(Line);
+      // Strip comments (# to end of line).
+      auto HashPos = LineRef.find('#');
+      if (HashPos != llvm::StringRef::npos)
+        LineRef = LineRef.substr(0, HashPos);
+      LineRef = LineRef.trim();
+      if (LineRef.empty())
+        continue;
+      // Allow whitespace or = as separator between pattern and filename.
+      llvm::StringRef Pattern, Replacement;
+      auto EqPos = LineRef.find('=');
+      auto SpPos = LineRef.find_first_of(" \t");
+      if (EqPos != llvm::StringRef::npos &&
+          (SpPos == llvm::StringRef::npos || EqPos < SpPos)) {
+        Pattern = LineRef.substr(0, EqPos).trim();
+        Replacement = LineRef.substr(EqPos + 1).trim();
+      } else if (SpPos != llvm::StringRef::npos) {
+        Pattern = LineRef.substr(0, SpPos).trim();
+        Replacement = LineRef.substr(SpPos).trim();
+      } else {
+        Config.raise(Diag::err_remap_inputs_bad_format) << Line;
+        return false;
+      }
+      GeneralOptions::RemapEntry Entry;
+      Entry.Pattern = Pattern.str();
+      Entry.Replacement = Replacement.str();
+      Config.options().getRemapInputs().push_back(std::move(Entry));
+    }
+  }
+
   // --exclude-lto-filelist
   std::vector<std::string> ltoExcludes;
   std::vector<std::string> ltoincludes;
@@ -1619,6 +1678,13 @@ bool GnuLdDriver::processReproduceOption(
     case T::dynamic_list:
     case T::extern_list:
     case T::version_script:
+      os << arg->getSpelling() << ' ' << outputTar->rewritePath(arg->getValue())
+         << ' ';
+      break;
+    case T::remap_inputs:
+      os << arg->getSpelling() << ' ' << arg->getValue() << ' ';
+      break;
+    case T::remap_inputs_file:
       os << arg->getSpelling() << ' ' << outputTar->rewritePath(arg->getValue())
          << ' ';
       break;

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -208,7 +208,11 @@ bool ObjectLinker::readLinkerScript(InputFile *Input) {
   // Record the linker script in the Map file.
   LayoutInfo *layoutInfo = ThisModule->getLayoutInfo();
   if (layoutInfo)
-    layoutInfo->recordLinkerScript(Input->getInput()->getFileName());
+    layoutInfo->recordLinkerScript(
+        Input->getInput()->getFileName(), /*Found=*/true,
+        Input->getInput()->wasRemapped()
+            ? llvm::StringRef(Input->getInput()->getOriginalFileName())
+            : llvm::StringRef());
 
   ThisModule->getScript().addToHash(Input->getInput()->decoratedPath());
 
@@ -1463,7 +1467,11 @@ bool ObjectLinker::parseListFile(std::string Filename, uint32_t Type) {
   SymbolListInput->setInputFile(SymbolListInputFile);
   // Record the dynamic list script in the Map file.
   if (layoutInfo)
-    layoutInfo->recordLinkerScript(SymbolListInput->decoratedPath());
+    layoutInfo->recordLinkerScript(
+        SymbolListInput->decoratedPath(), /*Found=*/true,
+        SymbolListInput->wasRemapped()
+            ? llvm::StringRef(SymbolListInput->getOriginalFileName())
+            : llvm::StringRef());
   // Read the dynamic List file
   ScriptFile SymbolListReader(
       (ScriptFile::Kind)Type, *ThisModule,

--- a/lib/ScriptParser/ScriptParser.cpp
+++ b/lib/ScriptParser/ScriptParser.cpp
@@ -1371,12 +1371,27 @@ bool ScriptParser::readInclude(llvm::StringRef Tok) {
     return false;
   bool IsOptionalInclude = Tok == "INCLUDE_OPTIONAL";
   llvm::StringRef FileName = unquote(next());
+  // Apply --remap-inputs to the INCLUDE filename before searching.
+  std::string RemappedFileName = FileName.str();
+  for (const auto &Entry : ThisConfig.options().getRemapInputs()) {
+    WildcardPattern Pat(Entry.Pattern);
+    if (Pat.matched(RemappedFileName)) {
+      if (ThisConfig.getPrinter()->isVerbose())
+        ThisConfig.raise(Diag::verbose_remap_input)
+            << RemappedFileName << Entry.Replacement;
+      RemappedFileName = Entry.Replacement;
+      break;
+    }
+  }
   LayoutInfo *layoutInfo = ThisScriptFile.module().getLayoutInfo();
   bool Result = true;
+  llvm::StringRef RemappedFrom;
   std::string ResolvedFileName = ThisScriptFile.findIncludeFile(
-      FileName.str(), Result, /*state=*/!IsOptionalInclude);
+      RemappedFileName, Result, /*state=*/!IsOptionalInclude);
+  if (RemappedFileName != FileName)
+    RemappedFrom = FileName;
   if (layoutInfo)
-    layoutInfo->recordLinkerScript(ResolvedFileName, Result);
+    layoutInfo->recordLinkerScript(ResolvedFileName, Result, RemappedFrom);
   if (!Result && IsOptionalInclude)
     return true;
   ThisScriptFile.module().getScript().addToHash(ResolvedFileName);

--- a/lib/Support/FileSystem.cpp
+++ b/lib/Support/FileSystem.cpp
@@ -17,6 +17,7 @@
 std::error_code
 eld::sys::fs::loadFileContents(llvm::StringRef FilePath,
                                std::vector<std::string> &Lines) {
+  Lines.clear();
   // Map in file list file.
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> MB =
       llvm::MemoryBuffer::getFileOrSTDIN(FilePath);
@@ -27,9 +28,10 @@ eld::sys::fs::loadFileContents(llvm::StringRef FilePath,
     // Split off each line in the file.
     std::pair<llvm::StringRef, llvm::StringRef> LineAndRest =
         Buffer.split('\n');
-    std::string Line =
-        std::string(LineAndRest.first.data(), LineAndRest.first.size());
-    Lines.push_back(Line);
+    llvm::StringRef Line = LineAndRest.first;
+    // Normalize Windows line endings for line-based parsers.
+    Line = Line.rtrim('\r');
+    Lines.push_back(Line.str());
     Buffer = LineAndRest.second;
   }
   return std::error_code();

--- a/test/Common/standalone/RemapInputs/Inputs/bar.c
+++ b/test/Common/standalone/RemapInputs/Inputs/bar.c
@@ -1,0 +1,1 @@
+int foo(void) { return 99; }

--- a/test/Common/standalone/RemapInputs/Inputs/foo.c
+++ b/test/Common/standalone/RemapInputs/Inputs/foo.c
@@ -1,0 +1,1 @@
+int foo(void) { return 42; }

--- a/test/Common/standalone/RemapInputs/Inputs/main.c
+++ b/test/Common/standalone/RemapInputs/Inputs/main.c
@@ -1,0 +1,2 @@
+int foo(void);
+int main(void) { return foo(); }

--- a/test/Common/standalone/RemapInputs/Inputs/script.t
+++ b/test/Common/standalone/RemapInputs/Inputs/script.t
@@ -1,0 +1,5 @@
+SECTIONS {
+  .text : { *(.text*) }
+  .data : { *(.data*) }
+  .bss  : { *(.bss*)  }
+}

--- a/test/Common/standalone/RemapInputs/RemapInputs.test
+++ b/test/Common/standalone/RemapInputs/RemapInputs.test
@@ -1,0 +1,102 @@
+#---RemapInputs.test--------------------- Executable---------------------#
+#BEGIN_COMMENT
+# Tests for --remap-inputs and --remap-inputs-file.
+# Covers: exact rename, wildcard rename, file-based remapping (= and
+# whitespace separators, comments, blank lines), multiple remaps (first
+# match wins), archive remapping, linker-script INPUT() remapping, verbose
+# output, and error cases.
+#END_COMMENT
+
+# Build the two object files used throughout.
+RUN: %clang %clangopts -c %p/Inputs/main.c -o %t1.main.o
+RUN: %clang %clangopts -c %p/Inputs/foo.c  -o %t1.foo.o
+RUN: %clang %clangopts -c %p/Inputs/bar.c  -o %t1.bar.o
+
+#--- Test 1: basic exact-name remap via --remap-inputs ----------------------
+# Remap foo.o -> bar.o so the link uses bar.o (which defines foo() = 99).
+RUN: %link %linkopts -o %t1.exact.out \
+RUN:   --remap-inputs=%t1.foo.o=%t1.bar.o \
+RUN:   %t1.main.o %t1.foo.o -T %p/Inputs/script.t
+RUN: %readelf -s %t1.exact.out | %filecheck %s --check-prefix=LINKED
+
+#--- Test 2: wildcard remap via --remap-inputs ------------------------------
+# Pattern matches any path ending in foo.o.
+RUN: %link %linkopts -o %t1.wildcard.out \
+RUN:   "--remap-inputs=*foo.o=%t1.bar.o" \
+RUN:   %t1.main.o %t1.foo.o -T %p/Inputs/script.t
+RUN: %readelf -s %t1.wildcard.out | %filecheck %s --check-prefix=LINKED
+
+#--- Test 3: --remap-inputs-file with = separator ---------------------------
+RUN: echo "%t1.foo.o=%t1.bar.o" > %t1.remap_eq.txt
+RUN: %link %linkopts -o %t1.remapfile_eq.out \
+RUN:   --remap-inputs-file=%t1.remap_eq.txt \
+RUN:   %t1.main.o %t1.foo.o -T %p/Inputs/script.t
+RUN: %readelf -s %t1.remapfile_eq.out | %filecheck %s --check-prefix=LINKED
+
+#--- Test 4: --remap-inputs-file with whitespace separator ------------------
+RUN: echo "%t1.foo.o %t1.bar.o" > %t1.remap_ws.txt
+RUN: %link %linkopts -o %t1.remapfile_ws.out \
+RUN:   --remap-inputs-file=%t1.remap_ws.txt \
+RUN:   %t1.main.o %t1.foo.o -T %p/Inputs/script.t
+RUN: %readelf -s %t1.remapfile_ws.out | %filecheck %s --check-prefix=LINKED
+
+#--- Test 5: --remap-inputs-file with comments and blank lines --------------
+RUN: printf "# this is a comment\n\n%t1.foo.o=%t1.bar.o\n# another comment\n" > %t1.remap_comments.txt
+RUN: %link %linkopts -o %t1.remapfile_comments.out \
+RUN:   --remap-inputs-file=%t1.remap_comments.txt \
+RUN:   %t1.main.o %t1.foo.o -T %p/Inputs/script.t
+RUN: %readelf -s %t1.remapfile_comments.out | %filecheck %s --check-prefix=LINKED
+
+#--- Test 6: multiple remaps - first match wins -----------------------------
+# First rule maps foo.o -> bar.o; second rule (never reached) maps foo.o -> main.o.
+RUN: %link %linkopts -o %t1.firstmatch.out \
+RUN:   --remap-inputs=%t1.foo.o=%t1.bar.o \
+RUN:   --remap-inputs=%t1.foo.o=%t1.main.o \
+RUN:   %t1.main.o %t1.foo.o -T %p/Inputs/script.t
+RUN: %readelf -s %t1.firstmatch.out | %filecheck %s --check-prefix=LINKED
+
+#--- Test 7: remap of archive member ----------------------------------------
+RUN: %ar cr %aropts %t1.libfoo.a %t1.foo.o
+RUN: %ar cr %aropts %t1.libbar.a %t1.bar.o
+RUN: %link %linkopts -o %t1.archive.out \
+RUN:   --remap-inputs=%t1.libfoo.a=%t1.libbar.a \
+RUN:   %t1.main.o %t1.libfoo.a -T %p/Inputs/script.t
+RUN: %readelf -s %t1.archive.out | %filecheck %s --check-prefix=LINKED
+
+#--- Test 8: remap applied to INPUT() in linker script ----------------------
+RUN: echo "INPUT(%t1.foo.o)" > %t1.input_script.t
+RUN: %link %linkopts -o %t1.lscinput.out \
+RUN:   --remap-inputs=%t1.foo.o=%t1.bar.o \
+RUN:   %t1.main.o -T %t1.input_script.t -T %p/Inputs/script.t
+RUN: %readelf -s %t1.lscinput.out | %filecheck %s --check-prefix=LINKED
+
+#--- Test 9: verbose output reports the remapping ---------------------------
+RUN: %link %linkopts -o %t1.verbose.out \
+RUN:   --remap-inputs=%t1.foo.o=%t1.bar.o \
+RUN:   %t1.main.o %t1.foo.o -T %p/Inputs/script.t --verbose 2>&1 \
+RUN:   | %filecheck %s --check-prefix=VERBOSE
+
+#--- Test 10: no remap - original file is used (sanity check) ---------------
+RUN: %link %linkopts -o %t1.noremap.out \
+RUN:   %t1.main.o %t1.foo.o -T %p/Inputs/script.t
+RUN: %readelf -s %t1.noremap.out | %filecheck %s --check-prefix=NOREMAP
+
+#--- Test 11: error - bad format (no = in --remap-inputs value) -------------
+RUN: %not %link %linkopts -o %t1.err.out \
+RUN:   --remap-inputs=justpattern \
+RUN:   %t1.main.o %t1.foo.o 2>&1 | %filecheck %s --check-prefix=ERR_FMT
+
+#--- Test 12: error - --remap-inputs-file with nonexistent file -------------
+RUN: %not %link %linkopts -o %t1.err2.out \
+RUN:   --remap-inputs-file=%t1.nonexistent_remap.txt \
+RUN:   %t1.main.o %t1.foo.o 2>&1 | %filecheck %s --check-prefix=ERR_FILE
+
+LINKED: foo
+
+NOREMAP: foo
+
+VERBOSE: Verbose: Remapping input file {{.*}}foo.o to {{.*}}bar.o
+
+ERR_FMT: Error: invalid --remap-inputs value justpattern: expected pattern=filename
+
+ERR_FILE: Error: cannot open --remap-inputs-file {{.*}}nonexistent_remap.txt

--- a/test/Common/standalone/linkerscript/RemapInputs/Inputs/bar.c
+++ b/test/Common/standalone/linkerscript/RemapInputs/Inputs/bar.c
@@ -1,0 +1,1 @@
+int foo(void) { return 2; }

--- a/test/Common/standalone/linkerscript/RemapInputs/Inputs/baz.c
+++ b/test/Common/standalone/linkerscript/RemapInputs/Inputs/baz.c
@@ -1,0 +1,1 @@
+int foo(void) { return 99; }

--- a/test/Common/standalone/linkerscript/RemapInputs/Inputs/foo.c
+++ b/test/Common/standalone/linkerscript/RemapInputs/Inputs/foo.c
@@ -1,0 +1,1 @@
+int foo(void) { return 1; }

--- a/test/Common/standalone/linkerscript/RemapInputs/Inputs/inner.t
+++ b/test/Common/standalone/linkerscript/RemapInputs/Inputs/inner.t
@@ -1,0 +1,5 @@
+SECTIONS {
+  .text : { *(.text*) }
+  .data : { *(.data*) }
+  .bss  : { *(.bss*)  }
+}

--- a/test/Common/standalone/linkerscript/RemapInputs/Inputs/main.c
+++ b/test/Common/standalone/linkerscript/RemapInputs/Inputs/main.c
@@ -1,0 +1,2 @@
+int foo(void);
+int main(void) { return foo(); }

--- a/test/Common/standalone/linkerscript/RemapInputs/Inputs/outer.t
+++ b/test/Common/standalone/linkerscript/RemapInputs/Inputs/outer.t
@@ -1,0 +1,1 @@
+INCLUDE inner.t

--- a/test/Common/standalone/linkerscript/RemapInputs/Inputs/replacement.t
+++ b/test/Common/standalone/linkerscript/RemapInputs/Inputs/replacement.t
@@ -1,0 +1,5 @@
+SECTIONS {
+  .text : { *(.text*) }
+  .data : { *(.data*) }
+  .bss  : { *(.bss*)  }
+}

--- a/test/Common/standalone/linkerscript/RemapInputs/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/RemapInputs/Inputs/script.t
@@ -1,0 +1,5 @@
+SECTIONS {
+  .text : { *(.text*) }
+  .data : { *(.data*) }
+  .bss  : { *(.bss*)  }
+}

--- a/test/Common/standalone/linkerscript/RemapInputs/Inputs/script_archive.t
+++ b/test/Common/standalone/linkerscript/RemapInputs/Inputs/script_archive.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  .text_from_bar_archive : { *libbar.a(*) }
+  .text_rest : { *(.text*) }
+  .data : { *(.data*) }
+  .bss  : { *(.bss*)  }
+}

--- a/test/Common/standalone/linkerscript/RemapInputs/Inputs/script_exclude.t
+++ b/test/Common/standalone/linkerscript/RemapInputs/Inputs/script_exclude.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  .text_nobar : { EXCLUDE_FILE(*bar.o) *(.text*) }
+  .text_bar   : { *(.text*) }
+  .data : { *(.data*) }
+  .bss  : { *(.bss*)  }
+}

--- a/test/Common/standalone/linkerscript/RemapInputs/Inputs/script_exclude_archive.t
+++ b/test/Common/standalone/linkerscript/RemapInputs/Inputs/script_exclude_archive.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  .text_nobar : { EXCLUDE_FILE(*libbar.a) *(.text*) }
+  .text_bar   : { *(.text*) }
+  .data : { *(.data*) }
+  .bss  : { *(.bss*)  }
+}

--- a/test/Common/standalone/linkerscript/RemapInputs/Inputs/script_filepat.t
+++ b/test/Common/standalone/linkerscript/RemapInputs/Inputs/script_filepat.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  .text_bar  : { *bar.o(.text*) }
+  .text_rest : { *(.text*) }
+  .data      : { *(.data*) }
+  .bss       : { *(.bss*)  }
+}

--- a/test/Common/standalone/linkerscript/RemapInputs/RemapInputs.test
+++ b/test/Common/standalone/linkerscript/RemapInputs/RemapInputs.test
@@ -1,0 +1,120 @@
+#---RemapInputs.test--------------------- Executable,LS ---------------------#
+#BEGIN_COMMENT
+# Tests for --remap-inputs interactions with linker scripts:
+#  - File input patterns (*foo.o) match the remapped name
+#  - EXCLUDE_FILE patterns match the remapped name
+#  - Archive patterns match the remapped archive name
+#  - EXCLUDE_FILE for archives matches the remapped archive name
+#  - INCLUDE <file> in a linker script is remapped before file search and map
+#    output annotates it as remapped
+#  - INPUT() command in a linker script is remapped
+#  - Map file annotates remapped inputs with "# remapped from ..."
+#END_COMMENT
+
+RUN: %clang %clangopts -c %p/Inputs/main.c -o %t1.main.o
+RUN: %clang %clangopts -c %p/Inputs/foo.c  -o %t1.foo.o
+RUN: %clang %clangopts -c %p/Inputs/bar.c  -o %t1.bar.o
+RUN: %clang %clangopts -c %p/Inputs/baz.c  -o %t1.baz.o
+RUN: %ar cr %aropts %t1.libfoo.a %t1.foo.o
+RUN: %ar cr %aropts %t1.libbar.a %t1.bar.o
+
+#--- Test 1: file input pattern matches remapped name -----------------------
+# Remap foo.o -> bar.o; script routes *bar.o(.text*) to .text_bar.
+# Without remap, foo.o sections would go to .text_rest.
+# With remap, they go to .text_bar (because the file is now bar.o).
+RUN: %link -MapStyle txt %linkopts -o %t1.filepat.out \
+RUN:   --remap-inputs=%t1.foo.o=%t1.bar.o \
+RUN:   %t1.main.o %t1.foo.o \
+RUN:   -T %p/Inputs/script_filepat.t -Map %t1.filepat.map.txt
+RUN: %filecheck %s --check-prefix=FILEPAT < %t1.filepat.map.txt
+
+#--- Test 2: EXCLUDE_FILE matches remapped name -----------------------------
+# Remap foo.o -> bar.o; script excludes *bar.o from .text_nobar.
+# Without remap, foo.o would go to .text_nobar.
+# With remap, foo.o (now bar.o) is excluded from .text_nobar and goes to .text_bar.
+RUN: %link -MapStyle txt %linkopts -o %t1.exclude.out \
+RUN:   --remap-inputs=%t1.foo.o=%t1.bar.o \
+RUN:   %t1.main.o %t1.foo.o \
+RUN:   -T %p/Inputs/script_exclude.t -Map %t1.exclude.map.txt
+RUN: %filecheck %s --check-prefix=EXCLUDE < %t1.exclude.map.txt
+
+#--- Test 3: archive pattern matches remapped archive name ------------------
+# Remap libfoo.a -> libbar.a; script routes *libbar.a(*) to .text_from_bar_archive.
+# Without remap, libfoo.a members would go to .text_rest.
+# With remap, they go to .text_from_bar_archive.
+RUN: %link -MapStyle txt %linkopts -o %t1.archive.out \
+RUN:   --remap-inputs=%t1.libfoo.a=%t1.libbar.a \
+RUN:   %t1.main.o %t1.libfoo.a \
+RUN:   -T %p/Inputs/script_archive.t -Map %t1.archive.map.txt
+RUN: %filecheck %s --check-prefix=ARCHIVE < %t1.archive.map.txt
+
+#--- Test 4: EXCLUDE_FILE for archive matches remapped archive name ---------
+# Remap libfoo.a -> libbar.a; script excludes *libbar.a from .text_nobar.
+# Without remap, libfoo.a members would go to .text_nobar.
+# With remap, they are excluded from .text_nobar and go to .text_bar.
+RUN: %link -MapStyle txt %linkopts -o %t1.excl_arch.out \
+RUN:   --remap-inputs=%t1.libfoo.a=%t1.libbar.a \
+RUN:   %t1.main.o %t1.libfoo.a \
+RUN:   -T %p/Inputs/script_exclude_archive.t -Map %t1.excl_arch.map.txt
+RUN: %filecheck %s --check-prefix=EXCL_ARCH < %t1.excl_arch.map.txt
+
+#--- Test 5: INCLUDE in linker script is remapped ---------------------------
+# outer.t does INCLUDE inner.t; remap inner.t -> replacement.t.
+# replacement.t has the same SECTIONS as inner.t so the link succeeds.
+RUN: %link %linkopts -o %t1.include.out \
+RUN:   --remap-inputs=inner.t=%p/Inputs/replacement.t \
+RUN:   %t1.main.o %t1.foo.o \
+RUN:   -T %p/Inputs/outer.t -MapStyle txt -Map %t1.include.map.txt
+RUN: %readelf -s %t1.include.out | %filecheck %s --check-prefix=INCLUDE_REMAP
+RUN: %filecheck %s --check-prefix=INCLUDE_MAP < %t1.include.map.txt
+
+#--- Test 6: INPUT() in linker script is remapped ---------------------------
+# Script uses INPUT(foo.o); remap foo.o -> bar.o.
+RUN: echo "INPUT(%t1.foo.o)" > %t1.input_cmd.t
+RUN: %link %linkopts -o %t1.inputcmd.out \
+RUN:   --remap-inputs=%t1.foo.o=%t1.bar.o \
+RUN:   %t1.main.o -T %t1.input_cmd.t -T %p/Inputs/script.t
+RUN: %readelf -s %t1.inputcmd.out | %filecheck %s --check-prefix=INPUT_CMD
+
+#--- Test 7: map file annotates remapped inputs -----------------------------
+RUN: %link -MapStyle txt %linkopts -o %t1.mapannot.out \
+RUN:   --remap-inputs=%t1.foo.o=%t1.bar.o \
+RUN:   %t1.main.o %t1.foo.o \
+RUN:   -T %p/Inputs/script.t -Map %t1.mapannot.map.txt
+RUN: %filecheck %s --check-prefix=MAPANNOT < %t1.mapannot.map.txt
+
+#--- Test 8: wildcard remap + file pattern in script -----------------------
+# Remap *foo.o -> bar.o (wildcard); script routes *bar.o(.text*) to .text_bar.
+RUN: %link -MapStyle txt %linkopts -o %t1.wildpat.out \
+RUN:   "--remap-inputs=*foo.o=%t1.bar.o" \
+RUN:   %t1.main.o %t1.foo.o \
+RUN:   -T %p/Inputs/script_filepat.t -Map %t1.wildpat.map.txt
+RUN: %filecheck %s --check-prefix=FILEPAT < %t1.wildpat.map.txt
+
+# .text_bar
+# {{.*}}bar.o
+FILEPAT: .text_bar
+FILEPAT: {{.*}}bar.o
+
+EXCLUDE: .text_nobar
+EXCLUDE: EXCLUDE_FILE ( *bar.o )
+EXCLUDE: main.o
+EXCLUDE: .text_bar
+EXCLUDE: bar.o
+
+ARCHIVE: .text_from_bar_archive
+ARCHIVE: {{.*}}libbar.a
+
+EXCL_ARCH: .text_nobar
+EXCL_ARCH: EXCLUDE_FILE ( *libbar.a )
+EXCL_ARCH: main.o
+EXCL_ARCH: .text_bar
+EXCL_ARCH: libbar.a
+
+INCLUDE_REMAP: foo
+INCLUDE_MAP: # remapped from inner.t
+
+INPUT_CMD: foo
+
+MAPANNOT: # remapped from
+MAPANNOT: {{.*}}foo.o


### PR DESCRIPTION
Add GNU ld-compatible --remap-inputs and --remap-inputs-file options that allow input file names to be redirected before the linker opens them.

GNU ld doc : https://sourceware.org/binutils/docs/ld/Options.html