### PR TITLE
[linker-script] ScriptParser: support ASCIZ escapes and reject hex es…

### DIFF
--- a/docs/userguide/documentation/linker_script.rst
+++ b/docs/userguide/documentation/linker_script.rst
@@ -1092,8 +1092,9 @@ ELD supports the following output section data commands:
      - Emit eight bytes (64 bits) as a signed value.
    * - ``ASCIZ "string"``
      - Emit a null-terminated ASCII string. The string literal (enclosed in
-       double quotes) is written byte-for-byte followed by a NUL byte
-       (``\0``). The size contributed is ``strlen(string) + 1``.
+       double quotes) supports a small set of escape sequences and is then
+       written followed by a NUL byte (``\0``). The size contributed is
+       ``strlen(unescaped_string) + 1``.
 
 .. note::
 
@@ -1104,6 +1105,16 @@ ELD supports the following output section data commands:
 
    ``ASCIZ`` accepts only a quoted string literal, not an arbitrary
    expression.
+
+   Supported ``ASCIZ`` escape sequences are:
+
+   - ``\n`` (line feed)
+   - ``\r`` (carriage return)
+   - ``\t`` (horizontal tab)
+   - Octal escapes with up to 3 octal digits (for example ``\0``, ``\12``,
+     ``\101``)
+
+   Hex escapes (for example ``\x41``) are not supported.
 
 .. note::
 

--- a/include/eld/ScriptParser/ScriptParser.h
+++ b/include/eld/ScriptParser/ScriptParser.h
@@ -20,6 +20,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/MemoryBufferRef.h"
 #include <optional>
+#include <string>
 
 namespace eld {
 class Expression;
@@ -177,6 +178,7 @@ private:
   void readRegionAlias();
 
   bool readOutputSectionData(llvm::StringRef Tok);
+  std::optional<std::string> parseASCIZString(llvm::StringRef Str);
 
   std::optional<WildcardPattern::SortPolicy> readSortPolicy();
 

--- a/lib/ScriptParser/ScriptParser.cpp
+++ b/lib/ScriptParser/ScriptParser.cpp
@@ -35,6 +35,7 @@
 #include "eld/Script/StrToken.h"
 #include "eld/Script/WildcardPattern.h"
 #include "eld/ScriptParser/ScriptLexer.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/BinaryFormat/ELF.h"
@@ -1225,7 +1226,10 @@ bool ScriptParser::readOutputSectionData(llvm::StringRef Tok) {
       setError("ASCIZ expects a quoted string literal");
       return true;
     }
-    std::string Str = unquote(StrTok).str();
+    std::optional<std::string> OptStr = parseASCIZString(unquote(StrTok));
+    if (!OptStr.has_value())
+      return true;
+    std::string Str = std::move(OptStr.value());
     ThisScriptFile.addASCIZ(std::move(Str));
     return true;
   }
@@ -1245,6 +1249,74 @@ bool ScriptParser::readOutputSectionData(llvm::StringRef Tok) {
   expect(")");
   ThisScriptFile.addOutputSectData(OptDataKind.value(), Exp);
   return true;
+}
+
+std::optional<std::string> ScriptParser::parseASCIZString(llvm::StringRef Str) {
+  std::string Parsed;
+  Parsed.reserve(Str.size());
+  auto IsOctalDigit = [](char C) { return llvm::isDigit(C) && C < '8'; };
+
+  size_t I = 0;
+  while (I < Str.size()) {
+    char C = Str[I++];
+    if (C != '\\') {
+      Parsed.push_back(C);
+      continue;
+    }
+
+    if (I >= Str.size()) {
+      Parsed.push_back('\\');
+      continue;
+    }
+
+    char Esc = Str[I++];
+    switch (Esc) {
+    case 'n':
+      Parsed.push_back('\n');
+      break;
+    case 'r':
+      Parsed.push_back('\r');
+      break;
+    case 't':
+      Parsed.push_back('\t');
+      break;
+    case 'x':
+    case 'X':
+      setError("ASCIZ does not support hex escape sequences");
+      return std::nullopt;
+    default:
+      if (IsOctalDigit(Esc)) {
+        std::string OctalDigits(1, Esc);
+        // Consume at most 3 octal digits, matching C-style escape parsing.
+        while (OctalDigits.size() < 3 && I < Str.size() &&
+               IsOctalDigit(Str[I])) {
+          OctalDigits.push_back(Str[I]);
+          ++I;
+        }
+        if (I < Str.size() && IsOctalDigit(Str[I])) {
+          setWarn("ASCIZ octal escape supports at most 3 digits");
+        }
+
+        uint32_t OctalValue = 0;
+        if (llvm::StringRef(OctalDigits)
+                .getAsInteger(/*Radix=*/8, OctalValue)) {
+          setError("ASCIZ has invalid octal escape sequence");
+          return std::nullopt;
+        }
+        if (OctalValue > 0xFFu) {
+          setError("ASCIZ octal escape value is out of range");
+          return std::nullopt;
+        }
+        Parsed.push_back(static_cast<char>(OctalValue));
+        break;
+      }
+      // Keep unknown escapes unchanged for compatibility.
+      Parsed.push_back('\\');
+      Parsed.push_back(Esc);
+      break;
+    }
+  }
+  return Parsed;
 }
 
 std::optional<WildcardPattern::SortPolicy> ScriptParser::readSortPolicy() {

--- a/test/Common/LinkerScriptParsing/Errors/Sections/OutputSectionData/ASCIZHexEscapeNotSupported/ASCIZHexEscapeNotSupported.test
+++ b/test/Common/LinkerScriptParsing/Errors/Sections/OutputSectionData/ASCIZHexEscapeNotSupported/ASCIZHexEscapeNotSupported.test
@@ -1,0 +1,8 @@
+UNSUPPORTED: old_lsparser
+#---ASCIZHexEscapeNotSupported.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+# This test checks that ASCIZ rejects hex escapes.
+#END_COMMENT
+RUN: %not %lsparserverifier %lsparserverifier_opts %p/Inputs/script.t 2>&1 | %filecheck %s
+
+CHECK: Error: {{.*}}script.t:3: ASCIZ does not support hex escape sequences

--- a/test/Common/LinkerScriptParsing/Errors/Sections/OutputSectionData/ASCIZHexEscapeNotSupported/Inputs/script.t
+++ b/test/Common/LinkerScriptParsing/Errors/Sections/OutputSectionData/ASCIZHexEscapeNotSupported/Inputs/script.t
@@ -1,0 +1,5 @@
+SECTIONS {
+  .rodata : {
+    ASCIZ "A\x42"
+  }
+}

--- a/test/Common/LinkerScriptParsing/SECTIONS/OutputSectionData/ASCIZEscapes.test
+++ b/test/Common/LinkerScriptParsing/SECTIONS/OutputSectionData/ASCIZEscapes.test
@@ -1,0 +1,5 @@
+#---ASCIZEscapes.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+# This test verifies that ASCIZ accepts supported escape sequences.
+#END_COMMENT
+RUN: %lsparserverifier %lsparserverifier_opts %p/Inputs/asciz-escapes.t

--- a/test/Common/LinkerScriptParsing/SECTIONS/OutputSectionData/Inputs/asciz-escapes.t
+++ b/test/Common/LinkerScriptParsing/SECTIONS/OutputSectionData/Inputs/asciz-escapes.t
@@ -1,0 +1,5 @@
+SECTIONS {
+  .rodata : {
+    ASCIZ "A\nB\rC\tD\101\0E"
+  }
+}

--- a/test/Common/standalone/ExplicitOutputSectionData/ASCIZEscapes.test
+++ b/test/Common/standalone/ExplicitOutputSectionData/ASCIZEscapes.test
@@ -1,0 +1,11 @@
+#---ASCIZEscapes.test--------------------- Executable---------------------#
+#BEGIN_COMMENT
+# This test checks ASCIZ escape handling for \n, \r, \t and octal escapes.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.o -c %p/Inputs/1.c
+RUN: %link -MapStyle txt %linkopts -o %t1.elf %t1.o -T %p/Inputs/asciiz-escapes.t
+RUN: %objdump -s %t1.elf --section .rodata | %filecheck %s
+#END_TEST
+
+CHECK: {{[0-9a-f]+}} 410a420d 43094441 004500

--- a/test/Common/standalone/ExplicitOutputSectionData/ASCIZHexEscapeNotSupported.test
+++ b/test/Common/standalone/ExplicitOutputSectionData/ASCIZHexEscapeNotSupported.test
@@ -1,0 +1,8 @@
+#---ASCIZHexEscapeNotSupported.test--------------------- Executable---------------------#
+#BEGIN_COMMENT
+# This test checks that ASCIZ rejects hex escapes.
+#END_COMMENT
+RUN: %clang %clangopts -o %t1.o -c %p/Inputs/1.c
+RUN: %not %link %linkopts -o %t1.elf %t1.o -T %p/Inputs/asciiz-invalid-hex-escape.t 2>&1 | %filecheck %s
+
+CHECK: Error: {{.*}}asciiz-invalid-hex-escape.t:4: ASCIZ does not support hex escape sequences

--- a/test/Common/standalone/ExplicitOutputSectionData/ASCIZOctalEscapeTooLong.test
+++ b/test/Common/standalone/ExplicitOutputSectionData/ASCIZOctalEscapeTooLong.test
@@ -1,0 +1,9 @@
+#---ASCIZOctalEscapeTooLong.test--------------------- Executable---------------------#
+#BEGIN_COMMENT
+# This test checks that ASCIZ emits a warning for octal escapes longer
+# than 3 digits when -Wlinker-script is enabled.
+#END_COMMENT
+RUN: %clang %clangopts -o %t1.o -c %p/Inputs/1.c
+RUN: %link %linkopts -Wlinker-script -o %t1.elf %t1.o -T %p/Inputs/asciiz-invalid-octal-too-long.t 2>&1 | %filecheck %s --check-prefix=WARN
+
+WARN: Warning: {{.*}}asciiz-invalid-octal-too-long.t:4: ASCIZ octal escape supports at most 3 digits

--- a/test/Common/standalone/ExplicitOutputSectionData/Inputs/asciiz-escapes.t
+++ b/test/Common/standalone/ExplicitOutputSectionData/Inputs/asciiz-escapes.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  .text : { *(.text*) }
+  .rodata : {
+    ASCIZ "A\nB\rC\tD\101\0E"
+  }
+}

--- a/test/Common/standalone/ExplicitOutputSectionData/Inputs/asciiz-invalid-hex-escape.t
+++ b/test/Common/standalone/ExplicitOutputSectionData/Inputs/asciiz-invalid-hex-escape.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  .text : { *(.text*) }
+  .rodata : {
+    ASCIZ "A\x41"
+  }
+}

--- a/test/Common/standalone/ExplicitOutputSectionData/Inputs/asciiz-invalid-octal-too-long.t
+++ b/test/Common/standalone/ExplicitOutputSectionData/Inputs/asciiz-invalid-octal-too-long.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  .text : { *(.text*) }
+  .rodata : {
+    ASCIZ "A\1234"
+  }
+}


### PR DESCRIPTION
Add ASCIZ string parsing for linker script output section data.

Supported escapes: \n, \r, \t, and 1-3 digit octal escapes (up to 0xFF).

Reject hex escapes (\x/\X) with a clear parser error as unsupported.

Resolves #1073