### PR TITLE
Fix: Emit error for non-power-of-2 SUBALIGN value

### DIFF
--- a/include/eld/Diagnostics/DiagLDScript.inc
+++ b/include/eld/Diagnostics/DiagLDScript.inc
@@ -130,6 +130,8 @@ DIAG(warn_non_power_of_2_value_to_align_builtin, DiagnosticEngine::Warning,
 DIAG(
     warn_subalign_less_than_section_alignment, DiagnosticEngine::Warning,
     "SUBALIGN(0x%0) is less than the section alignment (0x%1) for section '%2'")
+DIAG(error_subalign_not_power_of_two, DiagnosticEngine::Error,
+     "%0: SUBALIGN value 0x%1 is not a power of 2 for output section '%2'")
 DIAG(error_non_power_of_2_value_to_align_output_section,
      DiagnosticEngine::Error,
      "%0: non-power-of-2 value 0x%1 passed to ALIGN in '%2' output section "

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -1370,7 +1370,13 @@ void ObjectLinker::applySubAlign() {
     prolog.subAlign().eval();
     prolog.subAlign().commit();
     subAlign = prolog.subAlign().result();
-
+    // Validate SUBALIGN is power of 2
+    if (subAlign != 0 && !llvm::isPowerOf2_64(subAlign)) {
+      ThisConfig.raise(Diag::error_subalign_not_power_of_two)
+          << prolog.subAlign().getContext() << utility::toHex(subAlign)
+          << O->name();
+      continue;
+    }
     for (RuleContainer *R : *O) {
       ELFSection *inSect = R->getSection();
       for (Fragment *F : inSect->getFragmentList()) {
@@ -1380,7 +1386,8 @@ void ObjectLinker::applySubAlign() {
         }
         if (owningSect && seen.insert(owningSect).second) {
           // Warn if SUBALIGN is reducing the section alignment
-          if (ThisConfig.showLinkerScriptWarnings() && F->alignment() > subAlign) {
+          if (ThisConfig.showLinkerScriptWarnings() &&
+              F->alignment() > subAlign) {
             ThisConfig.raise(Diag::warn_subalign_less_than_section_alignment)
                 << utility::toHex(subAlign) << utility::toHex(F->alignment())
                 << owningSect->getLocation(0, ThisConfig.options());

--- a/test/Common/standalone/SubAlignNonPowerOf2/Inputs/1.c
+++ b/test/Common/standalone/SubAlignNonPowerOf2/Inputs/1.c
@@ -1,0 +1,3 @@
+__thread int a;
+__thread int b = 11;
+int foo() { return 11; }

--- a/test/Common/standalone/SubAlignNonPowerOf2/Inputs/script.t
+++ b/test/Common/standalone/SubAlignNonPowerOf2/Inputs/script.t
@@ -1,0 +1,9 @@
+PHDRS {
+  A PT_LOAD;
+  T PT_TLS;
+}
+
+SECTIONS {
+  .tdata : ALIGN(0x200) { *(.tdata*) } :A :T
+  .tbss : SUBALIGN(0x401) { *(.tbss*) } :A :T
+}

--- a/test/Common/standalone/SubAlignNonPowerOf2/SubAlignNonPowerOf2.test
+++ b/test/Common/standalone/SubAlignNonPowerOf2/SubAlignNonPowerOf2.test
@@ -1,0 +1,10 @@
+#---SubAlignNonPowerOf2.test--------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# Test that ELD emits an error when SUBALIGN value is not a power of 2
+# instead of crashing with an assertion failure. (issue #310)
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangg0opts -o %t1.1.o %p/Inputs/1.c -c
+RUN: %not %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t 2>&1 | %filecheck %s
+#CHECK: SUBALIGN value 0x401 is not a power of 2 for output section '.tbss'
+#END_TEST


### PR DESCRIPTION
## Problem
Fixes #310

ELD crashes with an internal assertion failure when `SUBALIGN` is given  a non-power-of-2 value in a linker script: This gives the user no actionable information about what went wrong.

## Fix
Added validation in `applySubAlign()` to check if the SUBALIGN value is  a power of 2 before use. If not, a clear error message is emitted: This matches LLD behavior which emits an error for the same case:

## Testing
Added a lit test `SubAlignNonPowerOf2` that verifies ELD emits a clear error message instead of crashing when a non-power-of-2 value is passed  to SUBALIGN.