### PR TITLE
Add LLVM clang-format policy checks and helper script

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+# Synced from llvm-project/llvm/.clang-format (LLVM community style baseline).
+BasedOnStyle: LLVM
+LineEnding: LF
+---
+# Don't format .td files
+Language: TableGen
+DisableFormat: true
+SortIncludes: false
+---

--- a/.github/workflows/clang-format-pr.yml
+++ b/.github/workflows/clang-format-pr.yml
@@ -1,0 +1,76 @@
+name: Clang Format Check
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install clang-format
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y wget gpg lsb-release
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+            | gpg --dearmor \
+            | sudo tee /usr/share/keyrings/llvm-archive-keyring.gpg >/dev/null
+          UBUNTU_CODENAME="$(lsb_release -cs)"
+          echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME} main" \
+            | sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null
+          sudo apt-get update
+          sudo apt-get install -y clang-format
+          clang-format --version
+
+      - name: Check formatting of changed files
+        shell: bash
+        run: |
+          set -euo pipefail
+          GREEN=$'\033[0;32m'
+          RED=$'\033[0;31m'
+          RESET=$'\033[0m'
+          CLANG_FORMAT_BIN=clang-format
+
+          BASE_REF="${{ github.base_ref }}"
+          git fetch origin "${BASE_REF}" --depth=1
+          "$CLANG_FORMAT_BIN" --version
+
+          mapfile -t FILES < <(
+            git diff --name-only --diff-filter=ACMRT "origin/${BASE_REF}...HEAD" \
+            | grep -E '\.(c|cc|cpp|cxx|h|hh|hpp|hxx|inc|def)$' || true
+          )
+
+          if [[ ${#FILES[@]} -eq 0 ]]; then
+            echo "No C/C++ source files changed."
+            exit 0
+          fi
+
+          echo "Checking ${#FILES[@]} changed C/C++ file(s)..."
+          FAIL=0
+          for f in "${FILES[@]}"; do
+            if [[ ! -f "$f" ]]; then
+              continue
+            fi
+            if "$CLANG_FORMAT_BIN" --style=file "$f" | diff -u "$f" - >/dev/null; then
+              printf "%b[PASSED]%b %s\n" "$GREEN" "$RESET" "$f"
+            else
+              printf "%b[FAILED]%b %s\n" "$RED" "$RESET" "$f"
+              FAIL=1
+            fi
+          done
+
+          if [[ $FAIL -ne 0 ]]; then
+            printf "%bclang-format check FAILED%b\n" "$RED" "$RESET"
+            echo "Run clang-format --style=file -i on the listed files."
+            exit 1
+          fi
+
+          printf "%bclang-format check PASSED%b\n" "$GREEN" "$RESET"

--- a/.licenseignore
+++ b/.licenseignore
@@ -5,3 +5,4 @@ test/**/*
 **/lit.site.cfg.in
 **/lit.local.cfg
 **/*.test
+**/*.sh

--- a/README.md
+++ b/README.md
@@ -210,6 +210,49 @@ To run the DCO checks locally use the following command:
 repolinter lint </path/to/eld>
 ```
 
+## Clang-format
+
+ELD uses LLVM clang-format style via the repository `.clang-format` file.
+
+### Bash functions
+
+Use the helper script at:
+`etc/bash/eld_clang_format_helpers.sh`
+
+To enable the functions in your shell, add this to your `~/.bashrc`
+(or `~/.bash_aliases`) and reload:
+
+```bash
+source </path/to/eld>/etc/bash/eld_clang_format_helpers.sh
+```
+
+For usage, run:
+
+```bash
+eld_clang_format_check --help
+```
+
+### Check formatting locally
+
+```bash
+clang-format --version
+eld_clang_format_check <base-branch>
+```
+
+`eld_clang_format_check` prints per-file colored status and returns non-zero on
+failure.
+
+### Format changed files locally
+
+```bash
+eld_clang_format_fix <base-branch>
+```
+
+### CI enforcement
+
+Pull requests run `.github/workflows/clang-format-pr.yml`, which fails if any
+changed C/C++ source file is not formatted with `clang-format --style=file`.
+
 ## ELD Build Status
 
 Live status of workflows building with ELD

--- a/etc/bash/eld_clang_format_helpers.sh
+++ b/etc/bash/eld_clang_format_helpers.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# Helpers for checking/fixing clang-format on PR-changed files.
+# Usage:
+#   source etc/bash/eld_clang_format_helpers.sh
+#   eld_clang_format_check [base-branch]
+#   eld_clang_format_fix [base-branch]
+
+eld_clang_format_usage() {
+  cat <<'EOF'
+Usage:
+  eld_clang_format_check [base-branch]
+  eld_clang_format_fix [base-branch]
+
+Behavior:
+  - base-branch defaults to $BASE_BRANCH, or "main" if unset.
+  - Operates on files changed in: origin/<base-branch>...HEAD
+  - Checks/formats C/C++ sources: .c .cc .cpp .cxx .h .hh .hpp .hxx .inc .def
+EOF
+}
+
+eld_clang_format_check() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    eld_clang_format_usage
+    return 0
+  fi
+  local base_branch="${1:-${BASE_BRANCH:-main}}"
+  local failed=0
+  local green=$'\033[0;32m'
+  local red=$'\033[0;31m'
+  local reset=$'\033[0m'
+  git fetch origin "$base_branch" || return 1
+  while IFS= read -r f; do
+    [ -f "$f" ] || continue
+    if ! clang-format --style=file "$f" | diff -u "$f" - >/dev/null; then
+      printf "%b[FAILED]%b %s\n" "$red" "$reset" "$f"
+      failed=1
+    else
+      printf "%b[PASSED]%b %s\n" "$green" "$reset" "$f"
+    fi
+  done < <(
+    git diff --name-only --diff-filter=ACMRT "origin/${base_branch}...HEAD" |
+      grep -E '\.(c|cc|cpp|cxx|h|hh|hpp|hxx|inc|def)$' || true
+  )
+  if [[ $failed -eq 0 ]]; then
+    printf "%bclang-format check PASSED%b\n" "$green" "$reset"
+  else
+    printf "%bclang-format check FAILED%b\n" "$red" "$reset"
+  fi
+  return "$failed"
+}
+
+eld_clang_format_fix() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    eld_clang_format_usage
+    return 0
+  fi
+  local base_branch="${1:-${BASE_BRANCH:-main}}"
+  local green=$'\033[0;32m'
+  local red=$'\033[0;31m'
+  local reset=$'\033[0m'
+  local failed=0
+  git fetch origin "$base_branch" || return 1
+  while IFS= read -r f; do
+    [ -f "$f" ] || continue
+    if clang-format --style=file -i "$f"; then
+      printf "%b[FORMATTED]%b %s\n" "$green" "$reset" "$f"
+    else
+      printf "%b[FAILED]%b %s\n" "$red" "$reset" "$f"
+      failed=1
+    fi
+  done < <(
+    git diff --name-only --diff-filter=ACMRT "origin/${base_branch}...HEAD" |
+      grep -E '\.(c|cc|cpp|cxx|h|hh|hpp|hxx|inc|def)$' || true
+  )
+  return "$failed"
+}


### PR DESCRIPTION
- Add repository .clang-format based on LLVM style

- Add PR workflow to enforce clang-format on changed C/C++ files

- Add etc/bash/eld_clang_format_helpers.sh with check/fix helpers