### PR TITLE
Add non-blocking cpp-linter PR workflow with downloadable reports

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,23 @@
+---
+# ELD clang-tidy policy following LLVM-style checks and tooling behavior.
+# Keep this practical: strong bug-finding checks on by default, avoid naming/style
+# checks that generate high-noise during initial adoption.
+
+Checks: >
+  -*,
+  clang-analyzer-*,
+  bugprone-*,
+  performance-*,
+  modernize-use-nullptr,
+  modernize-use-override,
+  llvm-header-guard,
+  llvm-include-order,
+  llvm-namespace-comment,
+  -readability-identifier-naming,
+  -readability-magic-numbers
+
+WarningsAsErrors: ''
+HeaderFilterRegex: '.*'
+FormatStyle: file
+UseColor: true
+...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ on:
       - '.github/workflows/update-build-dashboard-data.yml'
       - '.github/workflows/scripts/record_builds.py'
       - '.github/workflows/BuildStatusDataRecorder/action.yaml'
-      - '.github/workflows/zephyr-nightly.yml'
+      - '.github/workflows/clang-format-pr.yml'
+      - '.github/workflows/cpp-linter-pr.yml'
 
 permissions:
   contents: write

--- a/.github/workflows/cpp-linter-pr.yml
+++ b/.github/workflows/cpp-linter-pr.yml
@@ -1,0 +1,222 @@
+name: Cpp Linter PR Check
+
+on:
+  # Temporarily disable PR-triggered runs.
+  # pull_request:
+  # Run on push for now.
+  push:
+  workflow_dispatch:
+
+permissions:
+  # Required for checkout and metadata reads.
+  contents: read
+  # Allows cpp-linter action to publish check-run results.
+  checks: write
+  # Needed for sticky PR comments with report links.
+  pull-requests: write
+
+env:
+  # Knob for future strict mode. Keep false for now to avoid failing PRs.
+  CPP_LINTER_ENFORCE: "false"
+  # Build directory for external LLVM ELD build (compile_commands.json lives here).
+  CPP_LINTER_BUILD_DIR: "llvm-build-ext-clang-pr"
+  CPP_LINTER_CCACHE_DIR: ".ccache-external-llvm"
+
+jobs:
+  cpp-linter:
+    # Keep the check non-blocking while surfacing actionable diagnostics.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Collect changed C/C++ files
+        id: changed-files
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Build a deterministic file list used by all later steps.
+          BASE_REF="${{ github.base_ref }}"
+          git fetch origin "${BASE_REF}" --depth=1
+          git diff --name-only --diff-filter=ACMRT "origin/${BASE_REF}...HEAD" \
+            | grep -E '\.(c|cc|cpp|cxx|h|hh|hpp|hxx|inc|def)$' > .cpp-linter-files.txt || true
+          COUNT="$(wc -l < .cpp-linter-files.txt | tr -d ' ')"
+          echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
+          if [[ "${COUNT}" -eq 0 ]]; then
+            echo "has_files=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_files=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Changed files count: ${COUNT}"
+
+      - name: Install latest clang-tidy from LLVM apt repo
+        id: toolchain
+        if: steps.changed-files.outputs.has_files == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Install toolchain from LLVM apt so clang-tidy/clang-format stay current.
+          sudo apt-get update
+          sudo apt-get install -y wget gpg lsb-release ccache cmake ninja-build
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+            | gpg --dearmor \
+            | sudo tee /usr/share/keyrings/llvm-archive-keyring.gpg >/dev/null
+          UBUNTU_CODENAME="$(lsb_release -cs)"
+          echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME} main" \
+            | sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null
+          sudo apt-get update
+          sudo apt-get install -y clang clang-tidy llvm llvm-dev
+          clang-tidy --version
+          clang-format --version
+          # cpp-linter action expects a clang major version string.
+          CLANG_MAJOR="$(clang-tidy --version | sed -n 's/.*version \([0-9][0-9]*\).*/\1/p' | head -n1)"
+          echo "clang_major=${CLANG_MAJOR}" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare external LLVM release layout
+        id: llvm-layout
+        if: steps.changed-files.outputs.has_files == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Create a lightweight external LLVM prefix expected by configure_external_llvm.sh.
+          ROOT="${GITHUB_WORKSPACE}"
+          EXT_LLVM_DIR="${ROOT}/external-llvm-release"
+          mkdir -p "${EXT_LLVM_DIR}/bin" "${EXT_LLVM_DIR}/lib/cmake"
+          LLVM_PREFIX="$(llvm-config --prefix)"
+          LLVM_CMAKE_DIR="$(llvm-config --cmakedir)"
+          ln -sf "$(command -v clang)" "${EXT_LLVM_DIR}/bin/clang"
+          ln -sf "$(command -v clang++)" "${EXT_LLVM_DIR}/bin/clang++"
+          ln -sf "${LLVM_PREFIX}/bin/llvm-tblgen" "${EXT_LLVM_DIR}/bin/llvm-tblgen"
+          ln -sfn "${LLVM_CMAKE_DIR}" "${EXT_LLVM_DIR}/lib/cmake/llvm"
+          echo "ext_llvm_dir=${EXT_LLVM_DIR}" >> "$GITHUB_OUTPUT"
+
+      - name: Configure and build ELD with external LLVM
+        if: steps.changed-files.outputs.has_files == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Produce compile_commands.json for clang-tidy-driven checks.
+          mkdir -p "${CPP_LINTER_BUILD_DIR}" "${CPP_LINTER_CCACHE_DIR}"
+          ./configure_external_llvm.sh \
+            "${{ steps.llvm-layout.outputs.ext_llvm_dir }}" \
+            "${CPP_LINTER_BUILD_DIR}" \
+            --target ld.eld \
+            --ccache-dir "${CPP_LINTER_CCACHE_DIR}"
+
+      - name: Run C/C++ linter (non-blocking)
+        id: cpp-lint
+        uses: cpp-linter/cpp-linter-action@v2
+        if: steps.changed-files.outputs.has_files == 'true'
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          version: "${{ steps.toolchain.outputs.clang_major }}"
+          # Respect repository .clang-format.
+          style: "file"
+          # Use project defaults for clang-tidy checks.
+          tidy-checks: ""
+          # Limit scope/noise to touched files only.
+          files-changed-only: true
+          # Keep PR clean; report via artifact/link instead.
+          thread-comments: false
+          step-summary: false
+          file-annotations: false
+
+      - name: Run helper linter (non-blocking detailed diagnostics)
+        id: helper-lint
+        if: steps.changed-files.outputs.has_files == 'true'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Helper script collects richer clang-tidy diagnostics into a log artifact.
+          source ./etc/bash/eld_cpp_linter_helpers.sh
+          eld_cpp_linter_check \
+            --base-branch "${{ github.base_ref }}" \
+            --build-directory "${CPP_LINTER_BUILD_DIR}" \
+            > cpp-linter-helper.log 2>&1 || true
+
+      - name: Write cpp-linter report
+        if: always()
+        shell: bash
+        run: |
+          # Single downloadable report for reviewers and authors.
+          {
+            echo "Cpp Linter PR Report"
+            echo "===================="
+            echo "Date (UTC): $(date -u '+%Y-%m-%d %H:%M:%S')"
+            echo "Base branch: ${{ github.base_ref }}"
+            echo "clang-tidy version:"
+            clang-tidy --version || true
+            echo
+            echo "Build directory: ${CPP_LINTER_BUILD_DIR}"
+            echo "ccache directory: ${CPP_LINTER_CCACHE_DIR}"
+            echo
+            echo "Changed C/C++ files:"
+            if [[ -s .cpp-linter-files.txt ]]; then
+              sed 's/^/  - /' .cpp-linter-files.txt
+            else
+              echo "  (none)"
+            fi
+            echo
+            echo "cpp-linter action outputs:"
+            echo "  checks-failed: ${{ steps.cpp-lint.outputs.checks-failed }}"
+            echo "  tidy-checks-failed: ${{ steps.cpp-lint.outputs.tidy-checks-failed }}"
+            echo "  format-checks-failed: ${{ steps.cpp-lint.outputs.format-checks-failed }}"
+            echo
+            echo "What to fix:"
+            echo "  1. Download the 'cpp-linter-report' artifact from this workflow run."
+            echo "  2. For local reproduction/fixes, use:"
+            echo "       source etc/bash/eld_cpp_linter_helpers.sh"
+            echo "       eld_cpp_linter_check --base-branch '${{ github.base_ref }}' --build-directory '<build-dir>'"
+            echo "       eld_cpp_linter_fix   --base-branch '${{ github.base_ref }}' --build-directory '<build-dir>'"
+            echo
+            echo "Helper linter detailed log:"
+            if [[ -f cpp-linter-helper.log ]]; then
+              sed 's/^/  /' cpp-linter-helper.log
+            else
+              echo "  (helper log not generated)"
+            fi
+            echo
+            echo "PR enforcement knob:"
+            echo "  CPP_LINTER_ENFORCE=${CPP_LINTER_ENFORCE}"
+          } > cpp-linter-report.txt
+
+      - name: Upload cpp-linter report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          # Stable artifact name referenced by PR comment and docs.
+          name: cpp-linter-report
+          path: |
+            cpp-linter-report.txt
+            cpp-linter-helper.log
+            .cpp-linter-files.txt
+          if-no-files-found: error
+
+      - name: Report non-blocking lint warnings
+        if: ${{ steps.cpp-lint.outputs.checks-failed != '' && steps.cpp-lint.outputs.checks-failed != '0' }}
+        run: |
+          # Keep job green for now, but visibly flag that follow-up is required.
+          echo "::warning::cpp-linter reported ${{ steps.cpp-lint.outputs.checks-failed }} warning(s). See workflow artifacts: cpp-linter-report."
+
+      - name: Post PR comment with report link
+        if: ${{ steps.cpp-lint.outputs.checks-failed != '' && steps.cpp-lint.outputs.checks-failed != '0' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          # Sticky comment updates in-place across pushes.
+          header: cpp-linter-report
+          message: |
+            cpp-linter found **${{ steps.cpp-lint.outputs.checks-failed }}** warning(s).
+            Download the **cpp-linter-report** artifact from this workflow run:
+            https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Optional strict mode (currently disabled)
+        if: ${{ env.CPP_LINTER_ENFORCE == 'true' && steps.cpp-lint.outputs.checks-failed != '' && steps.cpp-lint.outputs.checks-failed != '0' }}
+        run: |
+          # Switch this on later to enforce lint cleanliness.
+          echo "cpp-linter strict mode enabled and checks failed."
+          exit 1

--- a/README.md
+++ b/README.md
@@ -253,6 +253,81 @@ eld_clang_format_fix <base-branch>
 Pull requests run `.github/workflows/clang-format-pr.yml`, which fails if any
 changed C/C++ source file is not formatted with `clang-format --style=file`.
 
+## Clang-tidy and cpp-linter
+
+ELD PRs also run clang-tidy-based lint checks via:
+`.github/workflows/cpp-linter-pr.yml`
+
+Current behavior:
+- Runs on changed C/C++ files in the PR.
+- Uses external-LLVM build setup to generate `compile_commands.json`.
+- Runs non-blocking for now (does not fail the PR by default).
+- Uploads downloadable logs/artifacts (including detailed diagnostics).
+
+### Local helper functions
+
+Use the helper script at:
+`etc/bash/eld_cpp_linter_helpers.sh`
+
+To enable the functions in your shell:
+
+```bash
+source </path/to/eld>/etc/bash/eld_cpp_linter_helpers.sh
+```
+
+For usage/help:
+
+```bash
+eld_cpp_linter_check --help
+```
+
+Common usage:
+
+```bash
+# Check changed files against base branch
+eld_cpp_linter_check --base-branch main --build-directory <build-dir>
+
+# Apply clang-tidy fixes on changed files
+eld_cpp_linter_fix --base-branch main --build-directory <build-dir>
+
+# Check or fix a single file
+eld_cpp_linter_check --build-directory <build-dir> --file path/to/file.cpp
+eld_cpp_linter_fix   --build-directory <build-dir> --file path/to/file.cpp
+```
+
+### How to skip files from clang-tidy checks
+
+1. Skip in PR workflow input list (temporary CI-level skip):
+
+```bash
+git diff --name-only --diff-filter=ACMRT "origin/${BASE_REF}...HEAD" \
+  | grep -E '\.(c|cc|cpp|cxx|h|hh|hpp|hxx|inc|def)$' \
+  | grep -Ev '^(path/to/file1\.cpp|path/to/legacy/.*)$' \
+  > .cpp-linter-files.txt || true
+```
+
+2. Run helpers on a specific file only (local scope control):
+
+```bash
+eld_cpp_linter_check --build-directory <build-dir> --file path/to/file.cpp
+```
+
+3. Add source-level suppressions where justified:
+- `// NOLINT(<check-name>)`
+- `// NOLINTBEGIN(<check-name>)` / `// NOLINTEND(<check-name>)`
+
+4. Use repo-level `.clang-tidy` policy filters, if maintained, for broad path/check tuning.
+
+### Where to find clang-tidy check names
+
+- Official clang-tidy checks list:
+  `https://clang.llvm.org/extra/clang-tidy/checks/list.html`
+- Checks supported by your installed clang-tidy version:
+
+```bash
+clang-tidy -list-checks -checks='*'
+```
+
 ## ELD Build Status
 
 Live status of workflows building with ELD

--- a/configure_external_llvm.sh
+++ b/configure_external_llvm.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage:
-  ./configure_external_llvm.sh <LLVM_RELEASE_DIR> <ELD_BUILD_DIR>
+  ./configure_external_llvm.sh <LLVM_RELEASE_DIR> <ELD_BUILD_DIR> [options]
 
 Arguments:
   LLVM_RELEASE_DIR   Path to an installed LLVM "release" directory containing:
@@ -15,9 +15,22 @@ Arguments:
                      - lib/cmake/llvm (or lib64/cmake/llvm)
   ELD_BUILD_DIR      Build directory to configure/build ELD into (created if needed)
 
+Options:
+  --target <ninja-target>
+      Build this ninja target after configure. Default: ld.eld
+  --no-build
+      Configure only; do not run ninja.
+  --ccache-dir <path>
+      Use this ccache directory (restored/reused across runs).
+      Default: ${ELD_BUILD_DIR}/.ccache
+  --no-ccache
+      Disable ccache even if installed.
+
 Examples:
   ./configure_external_llvm.sh /path/to/llvm.rel.latest ./llvm-build-ext-clang
   ./configure_external_llvm.sh /opt/llvm-22.0.0 /tmp/eld-build
+  ./configure_external_llvm.sh /opt/llvm-22.0.0 /tmp/eld-build --target all
+  ./configure_external_llvm.sh /opt/llvm-22.0.0 /tmp/eld-build --no-build
 EOF
 }
 
@@ -26,8 +39,8 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   exit 0
 fi
 
-if [[ $# -ne 2 ]]; then
-  echo "error: expected 2 arguments, got $#." >&2
+if [[ $# -lt 2 ]]; then
+  echo "error: expected at least 2 arguments, got $#." >&2
   echo "" >&2
   usage >&2
   exit 2
@@ -35,6 +48,40 @@ fi
 
 LLVM_RELEASE_DIR="$1"
 BUILD_DIR_ARG="$2"
+shift 2
+
+BUILD_AFTER_CONFIG=1
+NINJA_TARGET="ld.eld"
+USE_CCACHE=1
+CCACHE_DIR_ARG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)
+      [[ $# -ge 2 ]] || { echo "error: missing value for --target" >&2; exit 2; }
+      NINJA_TARGET="$2"
+      shift 2
+      ;;
+    --no-build)
+      BUILD_AFTER_CONFIG=0
+      shift
+      ;;
+    --ccache-dir)
+      [[ $# -ge 2 ]] || { echo "error: missing value for --ccache-dir" >&2; exit 2; }
+      CCACHE_DIR_ARG="$2"
+      shift 2
+      ;;
+    --no-ccache)
+      USE_CCACHE=0
+      shift
+      ;;
+    *)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
 
 if [[ ! -d "${LLVM_RELEASE_DIR}" ]]; then
   echo "error: LLVM release directory does not exist: ${LLVM_RELEASE_DIR}" >&2
@@ -44,6 +91,7 @@ fi
 # Canonicalize input paths
 EXTERNAL_LLVM_ROOT="$(cd "${LLVM_RELEASE_DIR}" && pwd)"
 BUILD_DIR="$(mkdir -p "${BUILD_DIR_ARG}" && cd "${BUILD_DIR_ARG}" && pwd)"
+CCACHE_DIR="${CCACHE_DIR_ARG:-${BUILD_DIR}/.ccache}"
 
 EXTERNAL_LLVM_CMAKE="${EXTERNAL_LLVM_ROOT}/lib/cmake/llvm"
 if [[ ! -d "${EXTERNAL_LLVM_CMAKE}" ]]; then
@@ -82,7 +130,25 @@ echo "Source directory: ${SOURCE_DIR}"
 echo "Build directory: ${BUILD_DIR}"
 echo "External LLVM: ${EXTERNAL_LLVM_ROOT}"
 echo "LLVM CMake dir: ${EXTERNAL_LLVM_CMAKE}"
+echo "Build target: ${NINJA_TARGET}"
+echo "Build after configure: $([[ ${BUILD_AFTER_CONFIG} -eq 1 ]] && echo yes || echo no)"
 echo ""
+
+CCACHE_CMAKE_ARGS=()
+if [[ ${USE_CCACHE} -eq 1 ]] && command -v ccache >/dev/null 2>&1; then
+  mkdir -p "${CCACHE_DIR}"
+  echo "ccache: enabled"
+  echo "ccache directory: ${CCACHE_DIR}"
+  ccache --show-stats --dir="${CCACHE_DIR}" || true
+  CCACHE_CMAKE_ARGS+=(
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+    -DLLVM_CCACHE_BUILD:BOOL=ON
+    -DLLVM_CCACHE_DIR:STRING="${CCACHE_DIR}"
+  )
+else
+  echo "ccache: disabled"
+fi
 
 # Create build directory (already created during canonicalization)
 cd "${BUILD_DIR}"
@@ -101,14 +167,21 @@ cmake -G Ninja \
   -DCMAKE_INSTALL_PREFIX="${BUILD_DIR}/install" \
   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
   -DLLVM_ENABLE_SPHINX=ON \
+  "${CCACHE_CMAKE_ARGS[@]}" \
   "${SOURCE_DIR}"
 
 echo ""
 echo "=== Configuration complete ==="
-echo "To build, run:"
-echo "  cd ${BUILD_DIR}"
-echo "  ninja"
-echo ""
-echo "To build specific targets:"
-echo "  ninja ld.eld"
-echo ""
+if [[ ${BUILD_AFTER_CONFIG} -eq 1 ]]; then
+  echo "Building target: ${NINJA_TARGET}"
+  ninja "${NINJA_TARGET}"
+  if [[ ${USE_CCACHE} -eq 1 ]] && command -v ccache >/dev/null 2>&1; then
+    echo ""
+    echo "ccache stats after build:"
+    ccache --show-stats --dir="${CCACHE_DIR}" || true
+  fi
+else
+  echo "To build, run:"
+  echo "  cd ${BUILD_DIR}"
+  echo "  ninja ${NINJA_TARGET}"
+fi

--- a/etc/bash/eld_cpp_linter_helpers.sh
+++ b/etc/bash/eld_cpp_linter_helpers.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+
+# Helpers for checking/fixing cpp-linter style issues on PR-changed files.
+# Usage:
+#   source etc/bash/eld_cpp_linter_helpers.sh
+#   eld_cpp_linter_check [base-branch]
+#   eld_cpp_linter_fix [base-branch]
+
+eld_cpp_linter_usage() {
+  cat <<'EOF'
+Usage:
+  eld_cpp_linter_check [--base-branch <branch>] [--build-directory <path>] [--file <path>]
+  eld_cpp_linter_fix [--base-branch <branch>] [--build-directory <path>] [--file <path>]
+
+Behavior:
+  - --base-branch defaults to $BASE_BRANCH, or "main" if unset.
+  - --build-directory is optional and should contain compile_commands.json.
+  - --file limits check/fix to one explicit file.
+  - Operates on files changed in: origin/<base-branch>...HEAD
+  - Targets C/C++ sources: .c .cc .cpp .cxx .h .hh .hpp .hxx .inc .def
+  - This helper only runs clang-tidy checks/fixes (not clang-format checks).
+EOF
+}
+
+_eld_cpp_linter_changed_files() {
+  local base_branch="$1"
+  git fetch origin "$base_branch" >/dev/null 2>&1
+  git diff --name-only --diff-filter=ACMRT "origin/${base_branch}...HEAD" |
+    grep -E '\.(c|cc|cpp|cxx|h|hh|hpp|hxx|inc|def)$' || true
+}
+
+_eld_cpp_linter_compile_db_dir() {
+  local root="$1"
+  local requested="${2:-}"
+  if [[ -n "$requested" ]]; then
+    if [[ -f "$requested/compile_commands.json" ]]; then
+      echo "$requested"
+      return 0
+    fi
+    if [[ -f "$root/$requested/compile_commands.json" ]]; then
+      echo "$root/$requested"
+      return 0
+    fi
+    return 1
+  fi
+  local d
+  for d in "." "build" "llvm-build-ext-clang-debug"; do
+    if [[ -f "$root/$d/compile_commands.json" ]]; then
+      echo "$root/$d"
+      return 0
+    fi
+  done
+  return 1
+}
+
+_eld_cpp_linter_is_cpp_file() {
+  local f="$1"
+  [[ "$f" =~ \.(c|cc|cpp|cxx|h|hh|hpp|hxx|inc|def)$ ]]
+}
+
+_eld_cpp_linter_print_failure_details() {
+  local tidy_out="$1"
+  echo "    clang-tidy diagnostics:"
+  sed 's/^/      /' "$tidy_out"
+}
+
+eld_cpp_linter_check() {
+  local base_branch="${BASE_BRANCH:-main}"
+  local requested_build_dir=""
+  local requested_file=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        eld_cpp_linter_usage
+        return 0
+        ;;
+      --base-branch)
+        [[ $# -ge 2 ]] || { echo "Missing value for --base-branch"; return 1; }
+        base_branch="$2"
+        shift 2
+        ;;
+      --build-directory)
+        [[ $# -ge 2 ]] || { echo "Missing value for --build-directory"; return 1; }
+        requested_build_dir="$2"
+        shift 2
+        ;;
+      --file)
+        [[ $# -ge 2 ]] || { echo "Missing value for --file"; return 1; }
+        requested_file="$2"
+        shift 2
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        eld_cpp_linter_usage
+        return 1
+        ;;
+    esac
+  done
+  local green=$'\033[0;32m'
+  local red=$'\033[0;31m'
+  local yellow=$'\033[0;33m'
+  local reset=$'\033[0m'
+  local failed=0
+  local root
+  local file_path
+  root="$(git rev-parse --show-toplevel)" || return 1
+  cd "$root" || return 1
+
+  if [[ -n "$requested_file" ]]; then
+    file_path="$requested_file"
+    if [[ ! -f "$file_path" && -f "$root/$file_path" ]]; then
+      file_path="$root/$file_path"
+    fi
+    if [[ ! -f "$file_path" ]]; then
+      echo "Requested file not found: $requested_file"
+      return 1
+    fi
+    if ! _eld_cpp_linter_is_cpp_file "$file_path"; then
+      echo "Requested file is not a supported C/C++ source/header: $requested_file"
+      return 1
+    fi
+    files=("$file_path")
+  else
+    mapfile -t files < <(_eld_cpp_linter_changed_files "$base_branch")
+  fi
+  if [[ ${#files[@]} -eq 0 ]]; then
+    echo "No changed C/C++ files to lint."
+    return 0
+  fi
+
+  echo "Checking ${#files[@]} changed C/C++ file(s):"
+  local f
+  for f in "${files[@]}"; do
+    echo "  - $f"
+  done
+
+  local tidy_bin=""
+  command -v clang-tidy >/dev/null 2>&1 && tidy_bin="clang-tidy"
+
+  local compile_db_dir=""
+  if ! compile_db_dir="$(_eld_cpp_linter_compile_db_dir "$root" "$requested_build_dir")"; then
+    if [[ -n "$requested_build_dir" ]]; then
+      printf "%b[FAILED]%b build-dir does not contain compile_commands.json: %s\n" "$red" "$reset" "$requested_build_dir"
+      return 1
+    fi
+    compile_db_dir=""
+  fi
+  if [[ -z "$tidy_bin" || -z "$compile_db_dir" ]]; then
+    printf "%b[INFO]%b clang-tidy check skipped (missing clang-tidy or compile_commands.json).\n" "$yellow" "$reset"
+  fi
+
+  local tidy_out tidy_rc
+  for f in "${files[@]}"; do
+    [[ -f "$f" ]] || continue
+
+    if [[ -n "$tidy_bin" && -n "$compile_db_dir" ]]; then
+      tidy_out="$(mktemp)"
+      tidy_rc=0
+      "$tidy_bin" -p "$compile_db_dir" "$f" >"$tidy_out" 2>&1 || tidy_rc=$?
+      if grep -Eq "no compile command|Error while processing" "$tidy_out"; then
+        printf "%b[SKIPPED]%b clang-tidy  %s\n" "$yellow" "$reset" "$f"
+      elif grep -Eq '(^|[^A-Za-z])warning:|(^|[^A-Za-z])error:' "$tidy_out"; then
+        printf "%b[FAILED]%b clang-tidy  %s\n" "$red" "$reset" "$f"
+        _eld_cpp_linter_print_failure_details "$tidy_out"
+        failed=1
+      elif [[ $tidy_rc -ne 0 ]]; then
+        printf "%b[FAILED]%b clang-tidy  %s (exit %d)\n" "$red" "$reset" "$f" "$tidy_rc"
+        _eld_cpp_linter_print_failure_details "$tidy_out"
+        failed=1
+      else
+        printf "%b[PASSED]%b clang-tidy  %s\n" "$green" "$reset" "$f"
+      fi
+      rm -f "$tidy_out"
+    fi
+  done
+
+  if [[ $failed -eq 0 ]]; then
+    printf "%bcpp-linter check PASSED%b\n" "$green" "$reset"
+  else
+    printf "%bcpp-linter check FAILED%b\n" "$red" "$reset"
+  fi
+  return "$failed"
+}
+
+eld_cpp_linter_fix() {
+  local base_branch="${BASE_BRANCH:-main}"
+  local requested_build_dir=""
+  local requested_file=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        eld_cpp_linter_usage
+        return 0
+        ;;
+      --base-branch)
+        [[ $# -ge 2 ]] || { echo "Missing value for --base-branch"; return 1; }
+        base_branch="$2"
+        shift 2
+        ;;
+      --build-directory)
+        [[ $# -ge 2 ]] || { echo "Missing value for --build-directory"; return 1; }
+        requested_build_dir="$2"
+        shift 2
+        ;;
+      --file)
+        [[ $# -ge 2 ]] || { echo "Missing value for --file"; return 1; }
+        requested_file="$2"
+        shift 2
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        eld_cpp_linter_usage
+        return 1
+        ;;
+    esac
+  done
+  local green=$'\033[0;32m'
+  local red=$'\033[0;31m'
+  local yellow=$'\033[0;33m'
+  local reset=$'\033[0m'
+  local failed=0
+  local root
+  local file_path
+  root="$(git rev-parse --show-toplevel)" || return 1
+  cd "$root" || return 1
+
+  if [[ -n "$requested_file" ]]; then
+    file_path="$requested_file"
+    if [[ ! -f "$file_path" && -f "$root/$file_path" ]]; then
+      file_path="$root/$file_path"
+    fi
+    if [[ ! -f "$file_path" ]]; then
+      echo "Requested file not found: $requested_file"
+      return 1
+    fi
+    if ! _eld_cpp_linter_is_cpp_file "$file_path"; then
+      echo "Requested file is not a supported C/C++ source/header: $requested_file"
+      return 1
+    fi
+    files=("$file_path")
+  else
+    mapfile -t files < <(_eld_cpp_linter_changed_files "$base_branch")
+  fi
+  if [[ ${#files[@]} -eq 0 ]]; then
+    echo "No changed C/C++ files to fix."
+    return 0
+  fi
+
+  echo "Fixing ${#files[@]} changed C/C++ file(s):"
+  local f
+  for f in "${files[@]}"; do
+    echo "  - $f"
+  done
+
+  local tidy_bin=""
+  command -v clang-tidy >/dev/null 2>&1 && tidy_bin="clang-tidy"
+
+  local compile_db_dir=""
+  if ! compile_db_dir="$(_eld_cpp_linter_compile_db_dir "$root" "$requested_build_dir")"; then
+    if [[ -n "$requested_build_dir" ]]; then
+      printf "%b[FAILED]%b build-dir does not contain compile_commands.json: %s\n" "$red" "$reset" "$requested_build_dir"
+      return 1
+    fi
+    compile_db_dir=""
+  fi
+
+  if [[ -z "$tidy_bin" || -z "$compile_db_dir" ]]; then
+    printf "%b[INFO]%b clang-tidy -fix skipped (missing clang-tidy or compile_commands.json).\n" "$yellow" "$reset"
+  else
+    local tidy_out tidy_rc
+    for f in "${files[@]}"; do
+      [[ -f "$f" ]] || continue
+      tidy_out="$(mktemp)"
+      tidy_rc=0
+      "$tidy_bin" -p "$compile_db_dir" -fix -fix-errors "$f" >"$tidy_out" 2>&1 ||
+          tidy_rc=$?
+      if grep -Eq "no compile command|Error while processing" "$tidy_out"; then
+        printf "%b[SKIPPED]%b   clang-tidy  %s\n" "$yellow" "$reset" "$f"
+      elif [[ $tidy_rc -eq 0 ]]; then
+        printf "%b[FIXED]%b     clang-tidy  %s\n" "$green" "$reset" "$f"
+      else
+        printf "%b[FAILED]%b    clang-tidy  %s (exit %d)\n" "$red" "$reset" "$f" "$tidy_rc"
+        _eld_cpp_linter_print_failure_details "$tidy_out"
+        failed=1
+      fi
+      rm -f "$tidy_out"
+    done
+  fi
+
+  if [[ $failed -eq 0 ]]; then
+    printf "%bcpp-linter fix PASSED%b\n" "$green" "$reset"
+  else
+    printf "%bcpp-linter fix FAILED%b\n" "$red" "$reset"
+  fi
+  return "$failed"
+}


### PR DESCRIPTION
- Add cpp-linker-pr.yml with changed-files-only cpp-linter checks

- Install latest clang-tidy from LLVM apt repo and use detected major

- Upload cpp-linter report artifact with failures and fix guidance

- Add strict-mode knob (disabled by default) for future enforcement

- Add eld_cpp_linter_helpers.sh with check/fix helpers, --build-directory and --file support