### PR TITLE
Fix: Emit diagnostic when LMA is unaligned

### DIFF
--- a/include/eld/Diagnostics/DiagLDScript.inc
+++ b/include/eld/Diagnostics/DiagLDScript.inc
@@ -144,3 +144,5 @@ DIAG(internal_error_null_expression, DiagnosticEngine::InternalError,
      "Trying to evaluate null expression")
 DIAG(warn_address_not_aligned, DiagnosticEngine::Warning,
      "address (0x%0) of section %1 is not a multiple of alignment (%2)")
+DIAG(warn_lma_not_aligned, DiagnosticEngine::Warning,
+     "LMA (0x%0) of section %1 is not a multiple of alignment (%2)")

--- a/include/eld/Diagnostics/DiagLDScript.inc
+++ b/include/eld/Diagnostics/DiagLDScript.inc
@@ -142,3 +142,5 @@ DIAG(internal_error_null_expression, DiagnosticEngine::InternalError,
      "Trying to evaluate null expression")
 DIAG(warn_address_not_aligned, DiagnosticEngine::Warning,
      "address (0x%0) of section %1 is not a multiple of alignment (%2)")
+DIAG(warn_lma_not_aligned, DiagnosticEngine::Warning,
+     "LMA (0x%0) of section %1 is not a multiple of alignment (%2)")

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -3576,9 +3576,14 @@ bool GNULDBackend::postLayout() {
   // in the output file.
   std::vector<SectionOffset> lmas;
   for (ELFSection *sec : outputSections) {
-    if (sec->size() > 0 && (sec->isAlloc() && !sec->isTLS()) &&
-        !sec->isNoBits()) {
-      lmas.push_back({sec, sec->pAddr()});
+    if (sec->size() > 0 && (sec->isAlloc() && !sec->isTLS())) {
+      if (sec->pAddr() % sec->getAddrAlign() != 0 &&
+          config().showLinkerScriptWarnings())
+        config().raise(Diag::warn_lma_not_aligned)
+            << utility::toHex(static_cast<uint64_t>(sec->pAddr()))
+            << sec->name() << sec->getAddrAlign();
+      if (!sec->isNoBits())
+        lmas.push_back({sec, sec->pAddr()});
     }
   }
   checkOverlap("load address", lmas, false);

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -3363,9 +3363,14 @@ bool GNULDBackend::postLayout() {
   // in the output file.
   std::vector<SectionOffset> lmas;
   for (ELFSection *sec : outputSections) {
-    if (sec->size() > 0 && (sec->isAlloc() && !sec->isTLS()) &&
-        !sec->isNoBits()) {
-      lmas.push_back({sec, sec->pAddr()});
+    if (sec->size() > 0 && (sec->isAlloc() && !sec->isTLS())) {
+      if (sec->pAddr() % sec->getAddrAlign() != 0 &&
+          config().showLinkerScriptWarnings())
+        config().raise(Diag::warn_lma_not_aligned)
+            << utility::toHex(static_cast<uint64_t>(sec->pAddr()))
+            << sec->name() << sec->getAddrAlign();
+      if (!sec->isNoBits())
+        lmas.push_back({sec, sec->pAddr()});
     }
   }
   checkOverlap("load address", lmas, false);

--- a/test/Common/standalone/linkerscript/LMAUnaligned/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/LMAUnaligned/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 0; }

--- a/test/Common/standalone/linkerscript/LMAUnaligned/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/LMAUnaligned/Inputs/script.t
@@ -1,0 +1,3 @@
+SECTIONS {
+  .foo (0x208) : AT(0x201) { *(.text.foo) }
+}

--- a/test/Common/standalone/linkerscript/LMAUnaligned/LMAUnaligned.test
+++ b/test/Common/standalone/linkerscript/LMAUnaligned/LMAUnaligned.test
@@ -1,0 +1,10 @@
+#---LMAUnaligned.test--------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# Test that ELD emits a warning diagnostic when the LMA specified via AT()
+# is not a multiple of the section alignment.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangg0opts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t -Wlinker-script 2>&1 | %filecheck %s
+#CHECK: Warning: LMA (0x201) of section .foo is not a multiple of alignment
+#END_TEST


### PR DESCRIPTION
Currently eld does not warn when a section's load memory address (LMA) is not a multiple of its alignment, like when AT() specifies an unaligned address.Added a warning in GNULDBackend::postLayout() to catch when the LMA isn’t properly aligned , mirroring the existing VMA-alignment check added in e09c562f.

Fixes #444