### PR TITLE
Fix incorrect version assignment to undefined symbols

### DIFF
--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -5535,7 +5535,7 @@ void GNULDBackend::assignOutputVersionIDs() {
   // foo@@VER, assign the version index based on version node names.
   for (std::size_t i = 1, e = DynamicSymbols.size(); i < e; ++i) {
     ResolveInfo *R = DynamicSymbols[i];
-    if (llvm::isa<ELFDynObjectFile>(R->resolvedOrigin()))
+    if (llvm::isa<ELFDynObjectFile>(R->resolvedOrigin()) || R->isUndef())
       continue;
     std::string FullName = R->getName().str();
     bool isDefaultVersionSymbol = false;

--- a/test/Common/standalone/SymbolVersioning/VersionOfUndefSymbol/Inputs/1.c
+++ b/test/Common/standalone/SymbolVersioning/VersionOfUndefSymbol/Inputs/1.c
@@ -1,0 +1,3 @@
+int foo();
+
+int bar() { return foo(); }

--- a/test/Common/standalone/SymbolVersioning/VersionOfUndefSymbol/Inputs/vs.t
+++ b/test/Common/standalone/SymbolVersioning/VersionOfUndefSymbol/Inputs/vs.t
@@ -1,0 +1,5 @@
+V1 {
+  global:
+    foo;
+    bar;
+};

--- a/test/Common/standalone/SymbolVersioning/VersionOfUndefSymbol/VersionOfUndefSymbol.test
+++ b/test/Common/standalone/SymbolVersioning/VersionOfUndefSymbol/VersionOfUndefSymbol.test
@@ -1,0 +1,14 @@
+REQUIRES: symbol_versioning
+#---BuildingSharedLibsWithSymbolVersioning.test---------------------------------------#
+#BEGIN_COMMENT
+# This test verifies that linker properly creates shared libraries with
+# symbol versioning information.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -fPIC
+RUN: %link %linkopts -o %t1.lib1.so %t1.1.o -shared --version-script %p/Inputs/vs.t
+RUN: %readelf --dyn-syms --version-info %t1.lib1.so | %filecheck %s
+#END_TEST
+
+CHECK-DAG: UND foo{{$}}
+CHECK-DAG: {{[0-9]+}} bar@@V1


### PR DESCRIPTION
This commit fixes the incorrect version assignment from version script to undefined symbols. The version script must only be used to assign version nodes to defined symbols.

Resolves #1090