### PR TITLE
test: remove unnecessary target exclusions from RevisionInfo

### DIFF
--- a/test/Common/standalone/Map/RevisionInfo/RevisionInfo.s
+++ b/test/Common/standalone/Map/RevisionInfo/RevisionInfo.s
@@ -1,4 +1,3 @@
-// UNSUPPORTED: arm, aarch64, riscv32, riscv64
 #---RevisionInfo.s----------------------- Executable ---------------------------#
 
 // START_COMMENT


### PR DESCRIPTION
## Summary

Remove the unnecessary `UNSUPPORTED` line from
`test/Common/standalone/Map/RevisionInfo/RevisionInfo.s`.

This test only assembles a simple `nop` and checks linker/LLVM revision
information in the generated map file, so it does not need to be excluded for
`arm`, `aarch64`, `riscv32`, or `riscv64`.

## Testing

Attempted targeted test runs with:
- `python D:\obj\tools\eld\test\llvm-lit-arm-default -a D:\llvm-project\eld\test\Common\standalone\Map\RevisionInfo\RevisionInfo.s`
- `python D:\obj\tools\eld\test\llvm-lit-aarch64-default -a D:\llvm-project\eld\test\Common\standalone\Map\RevisionInfo\RevisionInfo.s`
- `python D:\obj\tools\eld\test\llvm-lit-riscv64-default -a D:\llvm-project\eld\test\Common\standalone\Map\RevisionInfo\RevisionInfo.s`

In this local Windows environment, lit fails before test execution due to a
test harness path issue in `/bin/bash` when invoking the generated `.script`
file, so the local runs are inconclusive.
