### PR TITLE
Fix: avoid creating unnecessary .got.plt section

### DIFF
--- a/lib/Target/AArch64/AArch64LDBackend.cpp
+++ b/lib/Target/AArch64/AArch64LDBackend.cpp
@@ -721,8 +721,9 @@ AArch64GOT *AArch64LDBackend::createGOT(GOT::GOTType T,
                         config().options().traceSymbol(*R)) ||
                        m_Module.getPrinter()->traceDynamicLinking()))
     config().raise(Diag::create_got_entry) << R->name();
-  // If we are creating a GOT, always create a .got.plt.
-  if (!getGOTPLT()->hasFragments()) {
+  // Only create .got.plt when dynamic linking is involved
+  if (!getGOTPLT()->hasFragments() &&
+   (config().isCodeDynamic() || T == GOT::GOTPLT0)) {
     // TODO: This should be GOT0, not GOTPLT0.
     LDSymbol *Dynamic = m_Module.getNamePool().findSymbol("_DYNAMIC");
     AArch64GOTPLT0::Create(getGOTPLT(),

--- a/lib/Target/AArch64/AArch64LDBackend.cpp
+++ b/lib/Target/AArch64/AArch64LDBackend.cpp
@@ -722,8 +722,9 @@ AArch64GOT *AArch64LDBackend::createGOT(GOT::GOTType T,
                        m_Module.getPrinter()->traceDynamicLinking()))
     config().raise(Diag::create_got_entry)
         << GOT::getGOTTypeAsStr(T) << R->name();
-  // If we are creating a GOT, always create a .got.plt.
-  if (!getGOTPLT()->hasFragments()) {
+  // Only create .got.plt when dynamic linking is involved
+  if (!getGOTPLT()->hasFragments() &&
+      (config().isCodeDynamic() || T == GOT::GOTPLT0)) {
     // TODO: This should be GOT0, not GOTPLT0.
     LDSymbol *Dynamic = m_Module.getNamePool().findSymbol("_DYNAMIC");
     AArch64GOTPLT0::Create(getGOTPLT(),

--- a/lib/Target/ARM/ARMLDBackend.cpp
+++ b/lib/Target/ARM/ARMLDBackend.cpp
@@ -149,7 +149,7 @@ void ARMGNULDBackend::initTargetSymbols() {
   if (m_Module.getScript().linkerScriptHasSectionsCommand())
     return;
 
-  const NamePool& NP = m_Module.getNamePool();
+  const NamePool &NP = m_Module.getNamePool();
   SymbolName = "__exidx_start";
   const ResolveInfo *EXIDXStartInfo = NP.findInfo(SymbolName);
   if (EXIDXStartInfo && EXIDXStartInfo->isUndef()) {
@@ -218,8 +218,7 @@ void ARMGNULDBackend::doPreLayout() {
   if (isMicroController() &&
       ((config().codeGenType() == LinkerConfig::DynObj) ||
        (config().options().isPIE()))) {
-    config().raise(Diag::not_supported) << "SharedLibrary/PIE"
-                                        << "Cortex-M";
+    config().raise(Diag::not_supported) << "SharedLibrary/PIE" << "Cortex-M";
     m_Module.setFailure(true);
     return;
   }
@@ -517,7 +516,7 @@ bool ARMGNULDBackend::readSection(InputFile &pInput, ELFSection *S) {
       LayoutInfo *layoutInfo = getModule().getLayoutInfo();
       if (layoutInfo)
         layoutInfo->recordFragment(m_pARMAttributeSection->getInputFile(),
-                                m_pARMAttributeSection, AttributeFragment);
+                                   m_pARMAttributeSection, AttributeFragment);
     }
     AttributeFragment->updateAttributes(
         Region, m_Module, llvm::dyn_cast<ObjectFile>(&pInput), config());
@@ -1047,7 +1046,7 @@ ARMGOT *ARMGNULDBackend::createGOT(GOT::GOTType T, ELFObjectFile *Obj,
                         config().options().traceSymbol(*R)) ||
                        m_Module.getPrinter()->traceDynamicLinking()))
     config().raise(Diag::create_got_entry) << R->name();
-  // If we are creating a GOT, always create a .got.plt.
+  // Only create .got.plt when dynamic linking is involved
   if (!getGOTPLT()->hasFragments()) {
     // TODO: This should be GOT0, not GOTPLT0.
     LDSymbol *Dynamic = m_Module.getNamePool().findSymbol("_DYNAMIC");
@@ -1192,7 +1191,7 @@ void ARMGNULDBackend::finishAssignOutputSections() {
   LayoutInfo *layoutInfo = getModule().getLayoutInfo();
   if (layoutInfo)
     layoutInfo->recordFragment(m_pRegionTableSection->getInputFile(),
-                            m_pRegionTableSection, m_pRegionTableFragment);
+                               m_pRegionTableSection, m_pRegionTableFragment);
 }
 
 // Update the RegionTable with updated information from the Backend.

--- a/lib/Target/ARM/ARMLDBackend.cpp
+++ b/lib/Target/ARM/ARMLDBackend.cpp
@@ -142,7 +142,7 @@ void ARMGNULDBackend::initTargetSymbols() {
   if (m_Module.getScript().linkerScriptHasSectionsCommand())
     return;
 
-  const NamePool& NP = m_Module.getNamePool();
+  const NamePool &NP = m_Module.getNamePool();
   SymbolName = "__exidx_start";
   const ResolveInfo *EXIDXStartInfo = NP.findInfo(SymbolName);
   if (EXIDXStartInfo && EXIDXStartInfo->isUndef()) {
@@ -211,8 +211,7 @@ void ARMGNULDBackend::doPreLayout() {
   if (isMicroController() &&
       ((config().codeGenType() == LinkerConfig::DynObj) ||
        (config().options().isPIE()))) {
-    config().raise(Diag::not_supported) << "SharedLibrary/PIE"
-                                        << "Cortex-M";
+    config().raise(Diag::not_supported) << "SharedLibrary/PIE" << "Cortex-M";
     m_Module.setFailure(true);
     return;
   }
@@ -510,7 +509,7 @@ bool ARMGNULDBackend::readSection(InputFile &pInput, ELFSection *S) {
       LayoutInfo *layoutInfo = getModule().getLayoutInfo();
       if (layoutInfo)
         layoutInfo->recordFragment(m_pARMAttributeSection->getInputFile(),
-                                m_pARMAttributeSection, AttributeFragment);
+                                   m_pARMAttributeSection, AttributeFragment);
     }
     AttributeFragment->updateAttributes(
         Region, m_Module, llvm::dyn_cast<ObjectFile>(&pInput), config());
@@ -1069,8 +1068,9 @@ ARMGOT *ARMGNULDBackend::createGOT(GOT::GOTType T, ELFObjectFile *Obj,
                        m_Module.getPrinter()->traceDynamicLinking()))
     config().raise(Diag::create_got_entry)
         << GOT::getGOTTypeAsStr(T) << R->name();
-  // If we are creating a GOT, always create a .got.plt.
-  if (!getGOTPLT()->hasFragments()) {
+  // Only create .got.plt when dynamic linking is involved
+  if (!getGOTPLT()->hasFragments() &&
+      (config().isCodeDynamic() || T == GOT::GOTPLT0)) {
     // TODO: This should be GOT0, not GOTPLT0.
     LDSymbol *Dynamic = m_Module.getNamePool().findSymbol("_DYNAMIC");
     ARMGOTPLT0::Create(getGOTPLT(), Dynamic ? Dynamic->resolveInfo() : nullptr);
@@ -1187,6 +1187,10 @@ ARMPLT *ARMGNULDBackend::findEntryInPLT(ResolveInfo *I) const {
     return nullptr;
   return Entry->second;
 }
+
+
+// Update the RegionTable with updated information from the Backend.
+
 
 bool ARMGNULDBackend::canRewriteToBLX() const {
   // We always rewrite the instruction to BLX except for cases if

--- a/lib/Target/Hexagon/HexagonLDBackend.cpp
+++ b/lib/Target/Hexagon/HexagonLDBackend.cpp
@@ -251,8 +251,8 @@ void HexagonLDBackend::createAttributeSection() {
   AttributeFragment = make<HexagonAttributeFragment>(AttributeSection);
   AttributeSection->addFragment(AttributeFragment);
   if (auto *layoutInfo = getModule().getLayoutInfo())
-    layoutInfo->recordFragment(AttributeSection->getInputFile(), AttributeSection,
-                            AttributeFragment);
+    layoutInfo->recordFragment(AttributeSection->getInputFile(),
+                               AttributeSection, AttributeFragment);
 }
 
 void HexagonLDBackend::initTargetSections(ObjectBuilder &pBuilder) {
@@ -948,7 +948,7 @@ HexagonGOT *HexagonLDBackend::createGOT(GOT::GOTType T, ELFObjectFile *Obj,
                         config().options().traceSymbol(*R)) ||
                        m_Module.getPrinter()->traceDynamicLinking()))
     config().raise(Diag::create_got_entry) << R->name();
-  // If we are creating a GOT, always create a .got.plt.
+  // Only create .got.plt when dynamic linking is involved
   if (!getGOTPLT()->hasFragments()) {
     LDSymbol *Dynamic = m_Module.getNamePool().findSymbol("_DYNAMIC");
     HexagonGOTPLT0::Create(getGOTPLT(),

--- a/lib/Target/Hexagon/HexagonLDBackend.cpp
+++ b/lib/Target/Hexagon/HexagonLDBackend.cpp
@@ -250,8 +250,8 @@ void HexagonLDBackend::createAttributeSection() {
   AttributeFragment = make<HexagonAttributeFragment>(AttributeSection);
   AttributeSection->addFragment(AttributeFragment);
   if (auto *layoutInfo = getModule().getLayoutInfo())
-    layoutInfo->recordFragment(AttributeSection->getInputFile(), AttributeSection,
-                            AttributeFragment);
+    layoutInfo->recordFragment(AttributeSection->getInputFile(),
+                               AttributeSection, AttributeFragment);
 }
 
 void HexagonLDBackend::initTargetSections(ObjectBuilder &pBuilder) {
@@ -948,8 +948,9 @@ HexagonGOT *HexagonLDBackend::createGOT(GOT::GOTType T, ELFObjectFile *Obj,
                        m_Module.getPrinter()->traceDynamicLinking()))
     config().raise(Diag::create_got_entry)
         << GOT::getGOTTypeAsStr(T) << R->name();
-  // If we are creating a GOT, always create a .got.plt.
-  if (!getGOTPLT()->hasFragments()) {
+  // Only create .got.plt when dynamic linking is involved
+  if (!getGOTPLT()->hasFragments() &&
+      (config().isCodeDynamic() || T == GOT::GOTPLT0)) {
     LDSymbol *Dynamic = m_Module.getNamePool().findSymbol("_DYNAMIC");
     HexagonGOTPLT0::Create(getGOTPLT(),
                            Dynamic ? Dynamic->resolveInfo() : nullptr);

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -1547,8 +1547,9 @@ RISCVGOT *RISCVLDBackend::createGOT(GOT::GOTType T, ELFObjectFile *Obj,
                         config().options().traceSymbol(*R)) ||
                        m_Module.getPrinter()->traceDynamicLinking()))
     config().raise(Diag::create_got_entry) << R->name();
-  // If we are creating a GOT, always create a .got.plt.
-  if (!getGOTPLT()->hasFragments()) {
+  // Only create .got.plt when dynamic linking is involved
+  if (!getGOTPLT()->hasFragments() && 
+      (config().isCodeDynamic() || T == GOT::GOTPLT0)) {
     LDSymbol *Dynamic = m_Module.getNamePool().findSymbol("_DYNAMIC");
     // TODO: This should be GOT0, not GOTPLT0.
     RISCVGOT::CreateGOT0(getGOT(), Dynamic ? Dynamic->resolveInfo() : nullptr,

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -2250,8 +2250,9 @@ RISCVGOT *RISCVLDBackend::createGOT(GOT::GOTType T, ELFObjectFile *Obj,
                        m_Module.getPrinter()->traceDynamicLinking()))
     config().raise(Diag::create_got_entry)
         << GOT::getGOTTypeAsStr(T) << R->name();
-  // If we are creating a GOT, always create a .got.plt.
-  if (!getGOTPLT()->hasFragments()) {
+  // Only create .got.plt when dynamic linking is involved
+  if (!getGOTPLT()->hasFragments() &&
+      (config().isCodeDynamic() || T == GOT::GOTPLT0)) {
     LDSymbol *Dynamic = m_Module.getNamePool().findSymbol("_DYNAMIC");
     // TODO: This should be GOT0, not GOTPLT0.
     RISCVGOT::CreateGOT0(getGOT(), Dynamic ? Dynamic->resolveInfo() : nullptr,

--- a/lib/Target/X86/x86_64LDBackend.cpp
+++ b/lib/Target/X86/x86_64LDBackend.cpp
@@ -193,8 +193,9 @@ x86_64GOT *x86_64LDBackend::createGOT(GOT::GOTType T, ELFObjectFile *Obj,
                         config().options().traceSymbol(*R)) ||
                        m_Module.getPrinter()->traceDynamicLinking()))
     config().raise(Diag::create_got_entry) << R->name();
-  // If we are creating a GOT, always create a .got.plt.
-  if (!getGOTPLT()->hasFragments()) {
+  // Only create .got.plt when dynamic linking is involved
+  if (!getGOTPLT()->hasFragments() && 
+      (config().isCodeDynamic() || T == GOT::GOTPLT0)) {
     // GOTPLT0 will populate its first 8 bytes with .dynamic address.
     x86_64GOTPLT0::Create(getGOTPLT(), &m_Module);
   }

--- a/lib/Target/X86/x86_64LDBackend.cpp
+++ b/lib/Target/X86/x86_64LDBackend.cpp
@@ -194,8 +194,9 @@ x86_64GOT *x86_64LDBackend::createGOT(GOT::GOTType T, ELFObjectFile *Obj,
                        m_Module.getPrinter()->traceDynamicLinking()))
     config().raise(Diag::create_got_entry)
         << GOT::getGOTTypeAsStr(T) << R->name();
-  // If we are creating a GOT, always create a .got.plt.
-  if (!getGOTPLT()->hasFragments()) {
+  // Only create .got.plt when dynamic linking is involved
+  if (!getGOTPLT()->hasFragments() &&
+      (config().isCodeDynamic() || T == GOT::GOTPLT0)) {
     // GOTPLT0 will populate its first 8 bytes with .dynamic address.
     x86_64GOTPLT0::Create(getGOTPLT(), &m_Module);
   }

--- a/test/Common/standalone/UnnecessaryGOTPLT/Inputs/1.c
+++ b/test/Common/standalone/UnnecessaryGOTPLT/Inputs/1.c
@@ -1,0 +1,2 @@
+int u = 1;
+int foo() { return u; }

--- a/test/Common/standalone/UnnecessaryGOTPLT/UnnecessaryGOTPLT.test
+++ b/test/Common/standalone/UnnecessaryGOTPLT/UnnecessaryGOTPLT.test
@@ -1,0 +1,12 @@
+#---UnnecessaryGOTPLT.test--------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# Test that ELD does not create unnecessary .got.plt section when only
+# .got section is required for a static executable. (issue #1030)
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -fPIC
+RUN: %link %linkopts -o %t1.1.out %t1.1.o
+RUN: %readelf -S %t1.1.out | %filecheck %s
+#CHECK: .got
+#CHECK-NOT: .got.plt
+#END_TEST

--- a/test/Common/standalone/UnnecessaryGOTPLT/UnnecessaryGOTPLT.test
+++ b/test/Common/standalone/UnnecessaryGOTPLT/UnnecessaryGOTPLT.test
@@ -1,0 +1,23 @@
+#---UnnecessaryGOTPLT.test--------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# Test that ELD does not create unnecessary .got.plt section when only
+# Also verify that .got.plt IS created when dynamic linking is involved.
+#END_COMMENT
+#START_TEST
+
+# Test 1: Static executable - should have .got but NOT .got.plt
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -fPIC
+RUN: %link %linkopts -o %t1.1.out %t1.1.o
+RUN: %readelf -S %t1.1.out | %filecheck %s --check-prefix=STATIC
+
+# Test 2: Shared library - should have both .got AND .got.plt
+RUN: %clang %clangopts -o %t1.2.o %p/Inputs/1.c -c -fPIC
+RUN: %link %linkopts -shared -o %t1.2.out %t1.2.o
+RUN: %readelf -S %t1.2.out | %filecheck %s --check-prefix=DYNAMIC
+
+STATIC: .got
+STATIC-NOT: .got.plt
+
+DYNAMIC: .got
+DYNAMIC: .got.plt
+#END_TEST


### PR DESCRIPTION
## Description

### Problem
Fixes #1030

ELD unnecessarily creates `.got.plt` section when only `.got`  section is required for a static executable.

### Fix
The `.got.plt` section is only needed when dynamic linking is involved. Added `isCodeDynamic()` check before creating `GOTPLT0`  entry in `createGOT()` across all targets:
- AArch64
- ARM
- RISCV
- Hexagon
- x86_64

### Testing
Added test `UnnecessaryGOTPLT` that verifies `.got.plt` is not  created for static executables that only require `.got`.

cc @quic-seaswara @parth-07
