### PR TITLE
Fix windows test failures

### DIFF
--- a/test/UnitTests/lit.cfg
+++ b/test/UnitTests/lit.cfg
@@ -2,6 +2,7 @@
 
 import os
 import platform
+from pathlib import Path
 import re
 import subprocess
 
@@ -25,7 +26,7 @@ config.suffixes = []
 # test_exec_root: The root path where tests should be run.
 eld_obj_root = getattr(config, 'eld_obj_root', None)
 if eld_obj_root is not None:
-    config.test_exec_root = os.path.join(eld_obj_root, 'test/Unittests/')
+    config.test_exec_root = os.fspath(Path(eld_obj_root) / 'test' / 'Unittests')
 
 # Set llvm_{src,obj}_root for use by others.
 config.llvm_src_root = getattr(config, 'llvm_src_root', None)
@@ -37,7 +38,9 @@ if eld_obj_root is not None:
     if not llvm_tools_dir:
         lit_config.fatal('No LLVM tools dir set!')
     path = os.path.pathsep.join((llvm_tools_dir, config.environment['PATH']))
-    path = os.path.pathsep.join((os.path.join(getattr(config, 'llvm_src_root', None),'test','Scripts'),path))
+    path = os.path.pathsep.join(
+        (os.fspath(Path(getattr(config, 'llvm_src_root', None)) / 'test' / 'Scripts'), path)
+    )
 
     config.environment['PATH'] = path
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2,6 +2,7 @@
 
 import os
 import platform
+from pathlib import Path
 import re
 import subprocess
 import sys
@@ -11,7 +12,9 @@ import lit.util
 
 from lit.llvm import llvm_config
 
-sys.path.insert(0, os.path.dirname(__file__))
+test_source_root = Path(__file__).resolve().parent
+
+sys.path.insert(0, os.fspath(test_source_root))
 import eld_test_formats
 
 # Configuration file for the 'lit' test runner.
@@ -55,12 +58,12 @@ config.suffixes = ['.test', '.s', '.ll', '.sh', '.yaml']
 config.excludes = ['Inputs']
 
 # test_source_root: The root path where tests are located.
-config.test_source_root = os.path.dirname(__file__)
+config.test_source_root = os.fspath(test_source_root)
 
 # test_exec_root: The root path where tests should be run.
 eld_obj_root = getattr(config, 'eld_obj_root', None)
 if eld_obj_root is not None:
-    config.test_exec_root = os.path.join(eld_obj_root, 'test')
+    config.test_exec_root = os.fspath(Path(eld_obj_root) / 'test')
 
 # Set llvm_{src,obj}_root for use by others.
 config.llvm_src_root = getattr(config, 'llvm_src_root', None)
@@ -72,7 +75,9 @@ if eld_obj_root is not None:
     if not llvm_tools_dir:
         lit_config.fatal('No LLVM tools dir set!')
     path = os.path.pathsep.join((llvm_tools_dir, config.environment['PATH']))
-    path = os.path.pathsep.join((os.path.join(getattr(config, 'llvm_src_root', None),'test','Scripts'),path))
+    path = os.path.pathsep.join(
+        (os.fspath(Path(getattr(config, 'llvm_src_root', None)) / 'test' / 'Scripts'), path)
+    )
 
     config.environment['PATH'] = path
 
@@ -91,14 +96,15 @@ eld_src_root = getattr(config, 'eld_src_root', None)
 test_templates_dir = ""
 if eld_src_root is not None:
     # YAML Map Parser
-    path = os.path.join(eld_src_root, 'utils/YAMLMapParser')
-    yamlmapparser = os.path.join(path, 'YAMLMapParser.py')
-    yamlmapparser = yamlmapparser.replace("\\","/")
-    test_templates_dir = os.path.join(eld_src_root, 'templates/')
-    xarch_mem_trace = os.path.join(
-        eld_src_root, 'utils/archive_member_report/archive_member_trace.py'
-    )
-    xarch_mem_trace = xarch_mem_trace.replace("\\", "/")
+    path = Path(eld_src_root) / 'utils' / 'YAMLMapParser'
+    yamlmapparser = (path / 'YAMLMapParser.py').as_posix()
+    test_templates_dir = (Path(eld_src_root) / 'templates').as_posix()
+    xarch_mem_trace = (
+        Path(eld_src_root)
+        / 'utils'
+        / 'archive_member_report'
+        / 'archive_member_trace.py'
+    ).as_posix()
 
 # When running under valgrind, we mangle '-vg' onto the end of the triple so we
 # can check it with XFAIL and XTARGET.
@@ -309,7 +315,7 @@ if config.test_target == 'X86':
     config.march = ''
     datalayout = 'e-m:e-i64:64-f80:128-n8:16:32:64-S128'
     clang = 'clang -target x86_64-linux-gnu'
-    clangxx = 'clang++'
+    clangxx = 'clang++ -target x86_64-linux-gnu'
     readelf = 'llvm-readelf'
     link = 'ld.eld'
     config.emulation = '-m elf_x86_64'
@@ -504,7 +510,9 @@ else:
     muslclang = None
 
 # Set target-wise path where tests should be run.
-config.test_exec_root = os.path.join(config.test_exec_root, config.eld_targets_to_build)
+config.test_exec_root = os.fspath(
+    Path(config.test_exec_root) / config.eld_targets_to_build
+)
 
 lit_config.note('----------------------------------------------------------')
 lit_config.note('Configuring for Target : {}'.format(config.eld_targets_to_build))
@@ -563,18 +571,17 @@ else:
 # We need to detect this at runtime by checking which path exists
 def find_config_dir(base_path):
     """Find the configuration directory for multi-config generators."""
-    import os
     # Try common configuration names
     for config_name in ['Release', 'Debug', 'RelWithDebInfo', 'MinSizeRel']:
-        if os.path.exists(os.path.join(base_path, config_name)):
-            return "/" + config_name
+        if (Path(base_path) / config_name).exists():
+            return os.sep + config_name
     # No config subdirectory found (single-config generator)
     return ""
 
 # Determine config directory by checking if Release/Debug subdirectories exist
 config_dir = ""
 if config.llvm_obj_root:
-    test_path = os.path.join(config.llvm_obj_root, "bin", "tests")
+    test_path = os.fspath(Path(config.llvm_obj_root) / 'bin' / 'tests')
     config_dir = find_config_dir(test_path)
 
 config.substitutions.append( ("%config", config_dir))


### PR DESCRIPTION
Update path joins in lit config to use pathlib to support both
linux and windows path join using same syntax.
Update target flags for x86 in lit.cfg.

Fixes #1100