### PR TITLE
Fix build errors seen when using the -fno-permissive compiler flag

### DIFF
--- a/include/eld/Config/LinkerConfig.h
+++ b/include/eld/Config/LinkerConfig.h
@@ -254,13 +254,13 @@ public:
   void raiseDiagEntry(std::unique_ptr<plugin::DiagnosticEntry> DiagEntry) const;
 
   /// search directory
-  const SearchDirs &directories() const { return SearchDirs; }
+  const SearchDirs &directories() const { return searchDirs; }
 
-  SearchDirs &directories() { return SearchDirs; }
+  SearchDirs &directories() { return searchDirs; }
 
-  void setSysRoot(std::string SysRoot) { SearchDirs.setSysRoot(SysRoot); }
+  void setSysRoot(std::string SysRoot) { searchDirs.setSysRoot(SysRoot); }
 
-  const SearchDirs &searchDirs() const { return SearchDirs; }
+  const SearchDirs &getSearchDirs() const { return searchDirs; }
 
   /// ---------------------Wall functionality---------------------------
   bool hasShowAllWarnings() const {
@@ -445,7 +445,7 @@ private:
   bool GlobalThreadingEnabled = false;
   uint32_t EnableThreads = LinkerConfig::EnableThreadsOpt::AllThreads;
   DiagnosticEngine *DiagEngine;
-  SearchDirs SearchDirs;
+  SearchDirs searchDirs;
   WarnOptions WarnOpt;
   std::optional<bool> UseOldStyleTrampolineNames;
   MappingFileInfo MappingFile;

--- a/include/eld/Core/LinkerScript.h
+++ b/include/eld/Core/LinkerScript.h
@@ -303,11 +303,11 @@ public:
   llvm::ArrayRef<OverlayDesc *> getOverlayDescs() const { return OverlayDescs; }
 
   // ------------------ MEMORY Support --------------------------
-  MemoryCmd *getMemoryCommand() const { return MemoryCmd; }
+  MemoryCmd *getMemoryCommand() const { return memoryCmd; }
 
-  bool hasMemoryCommand() const { return MemoryCmd != nullptr; }
+  bool hasMemoryCommand() const { return memoryCmd != nullptr; }
 
-  void setMemoryCommand(MemoryCmd *Cmd) { MemoryCmd = Cmd; }
+  void setMemoryCommand(MemoryCmd *Cmd) { memoryCmd = Cmd; }
 
   bool insertMemoryDescriptor(llvm::StringRef DescName) {
     return !MemoryDescriptors.insert(DescName).second;
@@ -417,7 +417,7 @@ private:
   std::vector<SymbolContainer *> ThisSymbolContainers;
   DiagnosticEngine *Diag = nullptr;
   // Support MEMORY commmand
-  MemoryCmd *MemoryCmd = nullptr;
+  MemoryCmd *memoryCmd = nullptr;
   std::unordered_map<const plugin::LinkerWrapper *,
                      std::unordered_set<const RuleContainer *>>
       MPendingRuleInsertions;

--- a/include/eld/Core/Module.h
+++ b/include/eld/Core/Module.h
@@ -279,9 +279,9 @@ public:
 
   bool linkFail() const { return Failure; }
 
-  Linker *getLinker() const { return Linker; }
+  Linker *getLinker() const { return L; }
 
-  void setLinker(Linker *L) { Linker = L; }
+  void setLinker(Linker *linker) { L = linker; }
 
   bool createInternalInputs();
 
@@ -658,8 +658,6 @@ private:
   // Read one plugin config file
   bool readOnePluginConfig(llvm::StringRef Cfg, bool IsDefaultConfig);
 
-
-
 private:
   LinkerScript &UserLinkerScript;
   ObjectList InputObjectList;
@@ -687,7 +685,7 @@ private:
   llvm::StringSet<> NeededSymbols;
   NoCrossRefSet NonRefSections;
   LDSymbol *DotSymbol = nullptr;
-  Linker *Linker = nullptr;
+  Linker *L = nullptr;
   LayoutInfo *ThisLayoutInfo = nullptr;
   bool Failure = false;
   bool UsesLto = false;

--- a/include/eld/Diagnostics/DiagnosticEngine.h
+++ b/include/eld/Diagnostics/DiagnosticEngine.h
@@ -168,7 +168,7 @@ public:
     void reset() {
       NumArgs = 0;
       ID.reset();
-      Severity = None;
+      severity = None;
       File = nullptr;
       Plugin = nullptr;
       ThreadID = std::thread::id();
@@ -180,7 +180,7 @@ public:
     uint8_t ArgumentKinds[MaxArguments];
     int8_t NumArgs = 0;
     std::optional<DiagIDType> ID;
-    Severity Severity = Severity::None;
+    Severity severity = Severity::None;
     Input *File = nullptr;
     const eld::Plugin *Plugin = nullptr;
     std::thread::id ThreadID;

--- a/include/eld/Input/ELFObjectFile.h
+++ b/include/eld/Input/ELFObjectFile.h
@@ -41,9 +41,9 @@ public:
 
   ELFSection *getLLVMBCSection() const { return LLVMBCSection; }
 
-  TimingSection *getTimingSection() const { return TimingSection; }
+  TimingSection *getTimingSection() const { return timingSection; }
 
-  void setTimingSection(TimingSection *T) { TimingSection = T; }
+  void setTimingSection(TimingSection *T) { timingSection = T; }
 
   void setDynamicSections(ELFSection &GOT, ELFSection &GOTPLT, ELFSection &PLT,
                           ELFSection &RelDyn, ELFSection &RelPLT);
@@ -136,7 +136,7 @@ public:
 
 private:
   eld::ELFSection *LLVMBCSection = nullptr;
-  eld::TimingSection *TimingSection = nullptr;
+  eld::TimingSection *timingSection = nullptr;
   bool IsResultFromLTO = false;
   std::unique_ptr<llvm::DWARFContext> DWARFContext;
   std::vector<std::unique_ptr<llvm::MemoryBuffer>> DebugSections;

--- a/include/eld/LayoutMap/LayoutInfo.h
+++ b/include/eld/LayoutMap/LayoutInfo.h
@@ -135,7 +135,7 @@ public:
 
   struct InputSequenceT {
     InputKindPrefix Prefix;
-    Input *Input;
+    Input *Inp;
     std::string ArchFlag;
   };
 

--- a/include/eld/Object/ObjectLinker.h
+++ b/include/eld/Object/ObjectLinker.h
@@ -226,23 +226,23 @@ public:
   // -----  readers and writers  ----- //
   ELFRelocObjParser *getRelocObjParser() const { return RelocObjParser; }
 
-  ELFExecObjParser *getELFExecObjParser() const { return ELFExecObjParser; }
+  ELFExecObjParser *getELFExecObjParser() const { return execObjParser; }
 
-  BinaryFileParser *getBinaryFileParser() const { return BinaryFileParser; }
+  BinaryFileParser *getBinaryFileParser() const { return binaryFileParser; }
 
   ELFDynObjParser *getNewDynObjReader() const { return DynObjReader; }
 
-  ArchiveParser *getArchiveParser() const { return ArchiveParser; }
+  ArchiveParser *getArchiveParser() const { return archiveParser; }
 
-  GroupReader *getGroupReader() const { return GroupReader; }
+  GroupReader *getGroupReader() const { return groupReader; }
 
-  LibReader *getLibReader() const { return LibReader; }
+  LibReader *getLibReader() const { return libReader; }
 
-  ScriptReader *getScriptReader() const { return ScriptReader; }
+  ScriptReader *getScriptReader() const { return scriptReader; }
 
   BitcodeReader *getBitcodeReader() const { return MPBitcodeReader; }
 
-  ObjectReader *getSymDefReader() const { return SymDefReader; }
+  ObjectReader *getSymDefReader() const { return symDefReader; }
 
   ELFObjectWriter *getWriter() const { return ObjWriter; }
 
@@ -513,15 +513,15 @@ private:
   // -----  readers and writers  ----- //
   ELFRelocObjParser *RelocObjParser = nullptr;
   ELFDynObjParser *DynObjReader = nullptr;
-  ArchiveParser *ArchiveParser = nullptr;
-  ELFExecObjParser *ELFExecObjParser = nullptr;
-  BinaryFileParser *BinaryFileParser = nullptr;
-  GroupReader *GroupReader = nullptr;
-  LibReader *LibReader = nullptr;
-  ScriptReader *ScriptReader = nullptr;
+  ArchiveParser *archiveParser = nullptr;
+  ELFExecObjParser *execObjParser = nullptr;
+  BinaryFileParser *binaryFileParser = nullptr;
+  GroupReader *groupReader = nullptr;
+  LibReader *libReader = nullptr;
+  ScriptReader *scriptReader = nullptr;
   ELFObjectWriter *ObjWriter = nullptr;
   BitcodeReader *MPBitcodeReader = nullptr;
-  ObjectReader *SymDefReader = nullptr;
+  ObjectReader *symDefReader = nullptr;
   llvm::StringSet<> MDynlistExports;
 
   // Is this the second phase of normalize for LTO

--- a/include/eld/Script/PluginCmd.h
+++ b/include/eld/Script/PluginCmd.h
@@ -28,7 +28,7 @@ public:
 
   eld::Expected<void> activate(Module &CurModule) override;
 
-  Plugin *getPlugin() const { return Plugin; }
+  Plugin *getPlugin() const { return plugin; }
 
   static bool classof(const ScriptCommand *LinkerScriptCommand) {
     return LinkerScriptCommand->getKind() == ScriptCommand::PLUGIN;
@@ -50,7 +50,7 @@ private:
   std::string Name;
   std::string R;
   std::string Options;
-  eld::Plugin *Plugin = nullptr;
+  eld::Plugin *plugin = nullptr;
   bool PluginHasOutputSection = false;
 };
 

--- a/include/eld/Script/VersionScript.h
+++ b/include/eld/Script/VersionScript.h
@@ -42,9 +42,9 @@ public:
                          eld::StrToken *Language)
       : ScriptFileKind(K), ThisSymbol(P), VersionScriptLanguage(Language) {}
 
-  void setBlock(VersionScriptBlock *B) { VersionScriptBlock = B; }
+  void setBlock(VersionScriptBlock *B) { Block = B; }
 
-  VersionScriptBlock *getBlock() const { return VersionScriptBlock; }
+  VersionScriptBlock *getBlock() const { return Block; }
 
   ScriptSymbol *getSymbolPattern() const { return ThisSymbol; }
 
@@ -75,7 +75,7 @@ protected:
   VersionSymbolKind ScriptFileKind;
   ScriptSymbol *ThisSymbol = nullptr;
   eld::StrToken *VersionScriptLanguage = nullptr;
-  eld::VersionScriptBlock *VersionScriptBlock = nullptr;
+  eld::VersionScriptBlock *Block = nullptr;
 };
 
 class VersionScriptBlock {
@@ -87,7 +87,7 @@ public:
 
 public:
   VersionScriptBlock(BlockKind K, class VersionScriptNode *N)
-      : ScriptFileKind(K), VersionScriptNode(N) {}
+      : ScriptFileKind(K), Node(N) {}
 
   void addSymbol(eld::ScriptSymbol *S, eld::StrToken *Language);
 
@@ -95,9 +95,9 @@ public:
 
   bool isGlobal() const { return ScriptFileKind == Global; }
 
-  void setNode(VersionScriptNode *N) { VersionScriptNode = N; }
+  void setNode(VersionScriptNode *N) { Node = N; }
 
-  VersionScriptNode *getNode() const { return VersionScriptNode; }
+  VersionScriptNode *getNode() const { return Node; }
 
   const std::vector<VersionSymbol *> &getSymbols() const { return ThisSymbols; }
 
@@ -112,7 +112,7 @@ public:
 protected:
   std::vector<VersionSymbol *> ThisSymbols;
   VersionScriptBlock::BlockKind ScriptFileKind = Global;
-  VersionScriptNode *VersionScriptNode = nullptr;
+  VersionScriptNode *Node = nullptr;
 };
 
 class LocalVersionScriptBlock : public VersionScriptBlock {

--- a/include/eld/Target/ARMEXIDXSection.h
+++ b/include/eld/Target/ARMEXIDXSection.h
@@ -17,7 +17,7 @@ class RegionFragment;
 
 struct EXIDXEntry {
   uint32_t InputOffset = -1;
-  Fragment *Fragment = nullptr;
+  Fragment *Frag = nullptr;
 };
 
 class ARMEXIDXSection : public ELFSection {

--- a/lib/Config/LinkerConfig.cpp
+++ b/lib/Config/LinkerConfig.cpp
@@ -30,12 +30,12 @@ using namespace eld;
 //===----------------------------------------------------------------------===//
 LinkerConfig::LinkerConfig(DiagnosticEngine *DiagEngine)
     : GenOptions(DiagEngine), Targets(), CodeGen(Unknown), CodePos(Unset),
-      DiagEngine(DiagEngine), SearchDirs(DiagEngine) {}
+      DiagEngine(DiagEngine), searchDirs(DiagEngine) {}
 
 LinkerConfig::LinkerConfig(DiagnosticEngine *DiagEngine,
                            const std::string &PTripleString)
     : GenOptions(DiagEngine), Targets(PTripleString), CodeGen(Unknown),
-      CodePos(Unset), DiagEngine(DiagEngine), SearchDirs(DiagEngine) {}
+      CodePos(Unset), DiagEngine(DiagEngine), searchDirs(DiagEngine) {}
 
 LinkerConfig::~LinkerConfig() {}
 

--- a/lib/Core/Module.cpp
+++ b/lib/Core/Module.cpp
@@ -47,9 +47,9 @@ using namespace eld;
 Module::Module(LinkerScript &CurScript, LinkerConfig &Config,
                LayoutInfo *LayoutInfo)
     : UserLinkerScript(CurScript), ThisConfig(Config), DotSymbol(nullptr),
-      Linker(nullptr), ThisLayoutInfo(LayoutInfo), Failure(false),
-      UsesLto(false), Saver(BAlloc), PM(CurScript, *Config.getDiagEngine(),
-                                        Config.options().printTimingStats()),
+      L(nullptr), ThisLayoutInfo(LayoutInfo), Failure(false), UsesLto(false),
+      Saver(BAlloc), PM(CurScript, *Config.getDiagEngine(),
+                        Config.options().printTimingStats()),
       SymbolNamePool(Config, PM) {
   State = LinkState::Initializing;
   initThreading();
@@ -90,8 +90,8 @@ ELFSection *Module::getSection(const std::string &Name) const {
 }
 
 eld::IRBuilder *Module::getIRBuilder() const {
-  ASSERT(Linker->getIRBuilder(), "Value must be non-null!");
-  return Linker->getIRBuilder();
+  ASSERT(L->getIRBuilder(), "Value must be non-null!");
+  return L->getIRBuilder();
 }
 
 /// createSection - create an output section.
@@ -251,7 +251,7 @@ bool Module::createInternalInputs() {
     InternalFiles[IType] = IF;
   }
 
-  if (Linker->getBackend())
+  if (L->getBackend())
     getBackend().createInternalInputs();
 
   // Add implicit dot symbol
@@ -619,8 +619,8 @@ Module::createPluginFragmentWithCustomName(std::string Name, size_t SectType,
 }
 
 GNULDBackend &Module::getBackend() const {
-  ASSERT(Linker->getBackend(), "The value must be non-null.");
-  return *Linker->getBackend();
+  ASSERT(L->getBackend(), "The value must be non-null.");
+  return *L->getBackend();
 }
 
 void Module::replaceFragment(FragmentRef *F, const uint8_t *Data, size_t Sz) {
@@ -887,7 +887,7 @@ Module::createCommonELFSection(const std::string &SectionName, uint32_t Align,
 }
 
 bool Module::isPostLTOPhase() const {
-  return Linker->getObjLinker()->isPostLTOPhase();
+  return L->getObjLinker()->isPostLTOPhase();
 }
 
 void Module::setFragmentPaddingValue(Fragment *F, uint64_t V) {
@@ -901,6 +901,4 @@ Module::getFragmentPaddingValue(const Fragment *F) const {
   return FragmentPaddingValues.at(F);
 }
 
-bool Module::isBackendInitialized() const {
-  return Linker->getBackend() != nullptr;
-}
+bool Module::isBackendInitialized() const { return L->getBackend() != nullptr; }

--- a/lib/Input/InputAction.cpp
+++ b/lib/Input/InputAction.cpp
@@ -241,15 +241,15 @@ DefSymAction::DefSymAction(std::string PAssignment, DiagnosticPrinter *Printer)
 bool DefSymAction::activate(InputBuilder &PBuilder) {
   std::string FileName =
       (llvm::Twine("Expression(Defsym)") + llvm::Twine(MAssignment)).str();
-  Input *Input = PBuilder.createInputNode(FileName, true /*isSpecial*/);
-  Input->setInputType(Input::Script);
-  Input->setResolvedPath(FileName);
+  Input *Inp = PBuilder.createInputNode(FileName, true /*isSpecial*/);
+  Inp->setInputType(Input::Script);
+  Inp->setResolvedPath(FileName);
   auto pos = MAssignment.find("=");
   if (pos != std::string::npos)
     MAssignment =
         MAssignment.substr(0, pos) + " = " + MAssignment.substr(pos + 1);
   MAssignment.append(";");
-  PBuilder.setMemory(*Input, &MAssignment[0], MAssignment.size());
+  PBuilder.setMemory(*Inp, &MAssignment[0], MAssignment.size());
   return true;
 }
 

--- a/lib/LayoutMap/LayoutInfo.cpp
+++ b/lib/LayoutMap/LayoutInfo.cpp
@@ -269,7 +269,7 @@ std::string LayoutInfo::getStringFromLoadSequence(InputSequenceT Ist) {
     return "END LIB";
   }
 
-  Input *Input = Ist.Input;
+  Input *Input = Ist.Inp;
   std::string Files = "";
   std::string RemapComment = "";
   auto appendRemapComment = [&](llvm::StringRef Comment) {
@@ -341,10 +341,10 @@ std::string LayoutInfo::getStringFromLoadSequence(InputSequenceT Ist) {
 }
 
 void LayoutInfo::recordInputActions(InputKindPrefix Prefix, Input *Input,
-                                       std::string FileType) {
+                                    std::string FileType) {
   InputSequenceT IS;
   IS.Prefix = Prefix;
-  IS.Input = Input;
+  IS.Inp = Input;
   IS.ArchFlag = FileType;
   InputActions.push_back(IS);
 }
@@ -392,9 +392,7 @@ void LayoutInfo::recordRetainedSections() {
   LinkStats.NumRetainedSections++;
 }
 
-void LayoutInfo::recordNoLinkerScriptRuleMatch() {
-  LinkStats.NumNoRuleMatch++;
-}
+void LayoutInfo::recordNoLinkerScriptRuleMatch() { LinkStats.NumNoRuleMatch++; }
 
 void LayoutInfo::recordPlugin() { LinkStats.NumPlugins++; }
 

--- a/lib/LayoutMap/TextLayoutPrinter.cpp
+++ b/lib/LayoutMap/TextLayoutPrinter.cpp
@@ -1117,18 +1117,18 @@ void TextLayoutPrinter::printBuildStatistics(Module &CurModule, bool UseColor) {
   outputStream() << "\nBuild Statistics";
   outputStream() << "\n# <file> <start time> <duration>\n";
   for (auto &I : ThisLayoutInfo->getInputActions()) {
-    if (I.Input == nullptr || I.Input->getInputFile() == nullptr)
+    if (I.Inp == nullptr || I.Inp->getInputFile() == nullptr)
       continue;
-    if (!I.Input->getInputFile()->isObjectFile())
+    if (!I.Inp->getInputFile()->isObjectFile())
       continue;
-    ELFObjectFile *EObj =
-        llvm::dyn_cast<ELFObjectFile>(I.Input->getInputFile());
+    ELFObjectFile *EObj = llvm::dyn_cast<ELFObjectFile>(I.Inp->getInputFile());
     if (EObj->getTimingSection()) {
       for (const Fragment *TF : EObj->getTimingSection()->getFragmentList()) {
-        const TimingSlice *TS =
+        const TimingSlice *timingSection =
             llvm::dyn_cast<TimingFragment>(TF)->getTimingSlice();
-        outputStream() << TS->getModuleName() << " " << TS->getDate() << " "
-                       << TS->getDurationSeconds() << "\n";
+        outputStream() << timingSection->getModuleName() << " "
+                       << timingSection->getDate() << " "
+                       << timingSection->getDurationSeconds() << "\n";
       }
     }
   }

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -137,14 +137,14 @@ bool ObjectLinker::initialize() {
   // initialize the readers and writers
   RelocObjParser = createRelocObjParser();
   DynObjReader = createDynObjReader();
-  ArchiveParser = createArchiveParser();
-  ELFExecObjParser = createELFExecObjParser();
-  BinaryFileParser = createBinaryFileParser();
+  archiveParser = createArchiveParser();
+  execObjParser = createELFExecObjParser();
+  binaryFileParser = createBinaryFileParser();
   // SymDef Reader.
-  SymDefReader = createSymDefReader();
-  GroupReader = make<eld::GroupReader>(*ThisModule, this);
-  LibReader = make<eld::LibReader>(*ThisModule, this);
-  ScriptReader = make<eld::ScriptReader>();
+  symDefReader = createSymDefReader();
+  groupReader = make<eld::GroupReader>(*ThisModule, this);
+  libReader = make<eld::LibReader>(*ThisModule, this);
+  scriptReader = make<eld::ScriptReader>();
   ObjWriter = createWriter();
 
   // initialize Relocator

--- a/lib/Script/Plugin.cpp
+++ b/lib/Script/Plugin.cpp
@@ -487,10 +487,10 @@ void Plugin::recordFragmentRemove(RuleContainer *R, Fragment *F) {
 eld::Expected<std::pair<void *, std::string>>
 Plugin::loadLibrary(const std::string &LibraryName) {
   const eld::sys::fs::Path *Library =
-      ThisModule.getConfig().searchDirs().findLibrary(
+      ThisModule.getConfig().getSearchDirs().findLibrary(
           "plugin loadLibrary", LibraryName, ThisModule.getConfig());
   if (!Library) {
-    Library = ThisModule.getConfig().searchDirs().findLibrary(
+    Library = ThisModule.getConfig().getSearchDirs().findLibrary(
         "plugin loadLibrary", DynamicLibrary::getLibraryName(LibraryName),
         ThisModule.getConfig());
     if (!Library)

--- a/lib/Script/PluginCmd.cpp
+++ b/lib/Script/PluginCmd.cpp
@@ -19,7 +19,7 @@ eld::Expected<void> PluginCmd::activate(Module &CurModule) {
       CurModule.getConfig().options().printTimingStats("Plugin") ||
       CurModule.getConfig().options().printTimingStats(Name.c_str()) ||
       CurModule.getConfig().options().allUserPluginStatsRequested();
-  Plugin =
+  plugin =
       CurModule.getScript().addPlugin(T, Name, R, Options, PrintTimingStats,
                                       /*IsDefaultPlugin=*/false, CurModule);
   return eld::Expected<void>();

--- a/lib/Script/VersionScript.cpp
+++ b/lib/Script/VersionScript.cpp
@@ -134,9 +134,9 @@ void LocalVersionScriptBlock::dump(
 }
 
 // -----------------------VersionScriptSymbol -------------------------------
-bool VersionSymbol::isGlobal() const { return VersionScriptBlock->isGlobal(); }
+bool VersionSymbol::isGlobal() const { return Block->isGlobal(); }
 
-bool VersionSymbol::isLocal() const { return VersionScriptBlock->isLocal(); }
+bool VersionSymbol::isLocal() const { return Block->isLocal(); }
 
 void VersionSymbol::dump(
     llvm::raw_ostream &Ostream,

--- a/lib/Target/ARM/ARMLDBackend.cpp
+++ b/lib/Target/ARM/ARMLDBackend.cpp
@@ -1240,7 +1240,7 @@ bool ARMGNULDBackend::handleRelocation(ELFSection *Section,
   if (auto *EXIDX = llvm::dyn_cast<ARMEXIDXSection>(Section)) {
     EXIDXEntry Entry = EXIDX->getEntry(Offset);
     Relocation *R = eld::IRBuilder::addRelocation(
-        getRelocator(), *Entry.Fragment, Type, Sym, Offset - Entry.InputOffset);
+        getRelocator(), *Entry.Frag, Type, Sym, Offset - Entry.InputOffset);
     EXIDX->addRelocation(R);
     return true;
   }

--- a/test/Hexagon/Plugin/MoveChunksFromOutputSection/MoveChunksFromOutputSection.cpp
+++ b/test/Hexagon/Plugin/MoveChunksFromOutputSection/MoveChunksFromOutputSection.cpp
@@ -12,8 +12,8 @@ using namespace eld::plugin;
 
 class InputChunk {
 public:
-  InputChunk(Chunk S) : Chunk(S) {}
-  Chunk Chunk;
+  InputChunk(Chunk S) : C(S) {}
+  Chunk C;
 };
 
 class DLL_A_EXPORT OSIter : public OutputSectionIteratorPlugin {


### PR DESCRIPTION
This commit fixes the build errors seen when using the -fno-permissive compiler flag. All the errors were due to the name collisions among type and variables. I have used the naming convention discussed here for resolving the naming conflicts: https://github.com/qualcomm/eld/discussions/718

Resolves #1107