### PR TITLE
Improve checking of invalid symbol versions

### DIFF
--- a/include/eld/Diagnostics/DiagSymbolVersioning.inc
+++ b/include/eld/Diagnostics/DiagSymbolVersioning.inc
@@ -20,6 +20,8 @@ DIAG(trace_clear_export_due_to_local_scope, DiagnosticEngine::Trace,
      "Clearing export for symbol '%0' due to local scope")
 DIAG(error_missing_version_node, DiagnosticEngine::Error,
      "%0: symbol %1 has undefined version %2")
+DIAG(error_versioned_undef_symbol, DiagnosticEngine::Error,
+     "%0: undefined symbol '%1' cannot have version")
 DIAG(trace_assign_output_version_ids, DiagnosticEngine::Trace,
      "Assigning version IDs to output symbols")
 DIAG(trace_adding_verneed_entry, DiagnosticEngine::Trace,

--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -1079,6 +1079,12 @@ private:
   /// Assigns the version IDs to the dynamic symbols.
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
   void assignOutputVersionIDs();
+
+  /// Validates that dynamic symbols have valid versions. It reports an error
+  /// if: 1) A defined non-shared library dynamic symbol has a version not
+  /// present in version script. 2) An undefined dynamic symbol has a version.
+  bool validateVersionedSymbols();
+
   void setSymbolVersionID(const ResolveInfo *R, uint16_t VerID) {
     OutputVersionIDs[R] = VerID;
   }

--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -1090,6 +1090,12 @@ private:
   /// Assigns the version IDs to the dynamic symbols.
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
   void assignOutputVersionIDs();
+
+  /// Validates that dynamic symbols have valid versions. It reports an error
+  /// if: 1) A defined non-shared library dynamic symbol has a version not
+  /// present in version script. 2) An undefined dynamic symbol has a version.
+  bool validateVersionedSymbols();
+
   void setSymbolVersionID(const ResolveInfo *R, uint16_t VerID) {
     OutputVersionIDs[R] = VerID;
   }

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -24,6 +24,7 @@
 #include "eld/Fragment/EhFrameFragment.h"
 #include "eld/Fragment/FillFragment.h"
 #include "eld/Fragment/GNUHashFragment.h"
+#include "llvm/ADT/StringSet.h"
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
 #include "eld/Fragment/GNUVerDefFragment.h"
 #include "eld/Fragment/GNUVerNeedFragment.h"
@@ -853,8 +854,10 @@ void GNULDBackend::sizeDynNamePools() {
     }
   }
 
-  // Versioning assignment and fragment creation only when enabled.
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  if (!validateVersionedSymbols())
+    return;
+
   if (!shouldEmitVersioningSections())
     return;
 
@@ -5545,12 +5548,8 @@ void GNULDBackend::assignOutputVersionIDs() {
     if (!VernSymbol) {
       llvm::StringRef VerName = R->getVersionName();
       auto it = VerNameToID.find(VerName.str());
-      if (it == VerNameToID.end() && !VerName.empty()) {
-        InputFile *origin = R->resolvedOrigin();
-        config().raise(Diag::error_missing_version_node)
-            << origin->getInput()->decoratedPath() << R->name() << VerName;
-        continue;
-      }
+      ASSERT(it != VerNameToID.end(), "We should not reach here if the link "
+                                      "contains symbols with invalid versions");
       VernID = it->second;
     } else {
       VersionScriptNode *VSN = VernSymbol->getBlock()->getNode();
@@ -5598,5 +5597,42 @@ void GNULDBackend::assignOutputVersionIDs() {
       config().raise(Diag::trace_symbol_to_output_version_id)
           << R->name() << VernAuxID;
   }
+}
+
+bool GNULDBackend::validateVersionedSymbols() {
+  if (DynamicSymbols.empty())
+    return true;
+
+  const auto &VSNodes = m_Module.getVersionScriptNodes();
+  llvm::StringSet<> DefinedVersions;
+
+  for (const auto *VSNode : VSNodes) {
+    ASSERT(VSNode, "VSNode must not be null!");
+    if (!VSNode->isAnonymous())
+      DefinedVersions.insert(VSNode->getName());
+  }
+  bool hasError = false;
+  for (std::size_t i = 1, e = DynamicSymbols.size(); i < e; ++i) {
+    ResolveInfo *R = DynamicSymbols[i];
+    if (llvm::isa<ELFDynObjectFile>(R->resolvedOrigin()))
+      continue;
+
+    llvm::StringRef VerName = R->getVersionName();
+    if (VerName.empty())
+      continue;
+
+    InputFile *origin = R->resolvedOrigin();
+
+    if (R->isUndef()) {
+      config().raise(Diag::error_versioned_undef_symbol)
+          << origin->getInput()->decoratedPath() << R->name() << VerName;
+      hasError = true;
+    } else if (!DefinedVersions.contains(VerName)) {
+      config().raise(Diag::error_missing_version_node)
+          << origin->getInput()->decoratedPath() << R->name() << VerName;
+      hasError = true;
+    }
+  }
+  return !hasError;
 }
 #endif

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -24,6 +24,7 @@
 #include "eld/Fragment/EhFrameFragment.h"
 #include "eld/Fragment/FillFragment.h"
 #include "eld/Fragment/GNUHashFragment.h"
+#include "llvm/ADT/StringSet.h"
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
 #include "eld/Fragment/GNUVerDefFragment.h"
 #include "eld/Fragment/GNUVerNeedFragment.h"
@@ -852,8 +853,10 @@ void GNULDBackend::sizeDynNamePools() {
     }
   }
 
-  // Versioning assignment and fragment creation only when enabled.
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  if (!validateVersionedSymbols())
+    return;
+
   if (!shouldEmitVersioningSections())
     return;
 
@@ -5368,12 +5371,8 @@ void GNULDBackend::assignOutputVersionIDs() {
     if (!VernSymbol) {
       llvm::StringRef VerName = R->getVersionName();
       auto it = VerNameToID.find(VerName.str());
-      if (it == VerNameToID.end() && !VerName.empty()) {
-        InputFile *origin = R->resolvedOrigin();
-        config().raise(Diag::error_missing_version_node)
-            << origin->getInput()->decoratedPath() << R->name() << VerName;
-        continue;
-      }
+      ASSERT(it != VerNameToID.end(), "We should not reach here if the link "
+                                      "contains symbols with invalid versions");
       VernID = it->second;
     } else {
       VersionScriptNode *VSN = VernSymbol->getBlock()->getNode();
@@ -5421,5 +5420,43 @@ void GNULDBackend::assignOutputVersionIDs() {
       config().raise(Diag::trace_symbol_to_output_version_id)
           << R->name() << VernAuxID;
   }
+}
+
+bool GNULDBackend::validateVersionedSymbols() {
+  if (DynamicSymbols.empty())
+    return true;
+
+  const auto &VSNodes = m_Module.getVersionScriptNodes();
+  llvm::StringSet<> DefinedVersions;
+
+  for (const auto *VSNode : VSNodes) {
+    ASSERT(VSNode, "VSNode must not be null!");
+    if (!VSNode->isAnonymous())
+      DefinedVersions.insert(VSNode->getName());
+  }
+  bool hasError = false;
+  for (std::size_t i = 1, e = DynamicSymbols.size(); i < e; ++i) {
+    ResolveInfo *R = DynamicSymbols[i];
+    if (llvm::isa<ELFDynObjectFile>(R->resolvedOrigin()))
+      continue;
+
+    llvm::StringRef VerName = R->getVersionName();
+    if (VerName.empty())
+      continue;
+
+    InputFile *origin = R->resolvedOrigin();
+
+    if (R->isUndef()) {
+      config().raise(Diag::error_versioned_undef_symbol)
+          << origin->getInput()->decoratedPath() << R->name();
+      hasError = true;
+    } else if (!DefinedVersions.contains(VerName)) {
+      config().raise(Diag::error_missing_version_node)
+          << origin->getInput()->decoratedPath() << R->getNonVersionedName()
+          << VerName;
+      hasError = true;
+    }
+  }
+  return !hasError;
 }
 #endif

--- a/test/Common/standalone/SymbolVersioning/BuildingSharedLibsWithSymbolVersioning/BuildingSharedLibsWithSymbolVersioningErrors.test
+++ b/test/Common/standalone/SymbolVersioning/BuildingSharedLibsWithSymbolVersioning/BuildingSharedLibsWithSymbolVersioningErrors.test
@@ -9,5 +9,5 @@ RUN: %clang %clangopts -o %t1.2.o %p/Inputs/2.c -c -fPIC
 RUN: %not %link %linkopts -o %t1.lib1.so %t1.2.o -shared --version-script %p/Inputs/vs.5.t 2>&1 | %filecheck %s --check-prefix=ERRORS1
 #END_TEST
 
-ERRORS1: Error: {{.*}}2.o: symbol foo@V1 has undefined version V1
-ERRORS1: Error: {{.*}}2.o: symbol bar@V1 has undefined version V1
+ERRORS1: Error: {{.*}}2.o: symbol foo has undefined version V1
+ERRORS1: Error: {{.*}}2.o: symbol bar has undefined version V1

--- a/test/Common/standalone/SymbolVersioning/UndefSymbolWithSymbolVersion/Inputs/1.c
+++ b/test/Common/standalone/SymbolVersioning/UndefSymbolWithSymbolVersion/Inputs/1.c
@@ -1,0 +1,4 @@
+extern int real_foo(void);
+__asm__(".symver real_foo, foo@SOME_VERSION");
+
+int bar(void) { return real_foo(); }

--- a/test/Common/standalone/SymbolVersioning/UndefSymbolWithSymbolVersion/Inputs/vs.t
+++ b/test/Common/standalone/SymbolVersioning/UndefSymbolWithSymbolVersion/Inputs/vs.t
@@ -1,0 +1,4 @@
+SOME_VERSION {
+  global:
+    foo;
+};

--- a/test/Common/standalone/SymbolVersioning/UndefSymbolWithSymbolVersion/UndefSymbolWithSymbolVersion.test
+++ b/test/Common/standalone/SymbolVersioning/UndefSymbolWithSymbolVersion/UndefSymbolWithSymbolVersion.test
@@ -1,0 +1,14 @@
+REQUIRES: symbol_versioning
+#---UndefSymbolWithSymbolVersion.test--------- SymbolVersioning ----------------#
+#BEGIN_COMMENT
+# This test verifies that the linker errors when building a shared library
+# with an undefined symbol that has a version.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -fPIC
+RUN: %not %link %linkopts -o %t1.1.so %t1.1.o -shared 2>&1 | %filecheck %s
+RUN: %not %link %linkopts -o %t1.1.so %t1.1.o -shared --version-script %p/Inputs/vs.t \
+RUN:   2>&1 | %filecheck %s
+#END_TEST
+
+CHECK: {{.*}}1.o: undefined symbol 'foo@SOME_VERSION' cannot have version

--- a/test/Common/standalone/SymbolVersioning/UnknownSymbolVersion/Inputs/1.c
+++ b/test/Common/standalone/SymbolVersioning/UnknownSymbolVersion/Inputs/1.c
@@ -1,0 +1,2 @@
+int real_foo(void) { return 1; }
+__asm__(".symver real_foo, foo@DOES_NOT_EXIST");

--- a/test/Common/standalone/SymbolVersioning/UnknownSymbolVersion/Inputs/2.c
+++ b/test/Common/standalone/SymbolVersioning/UnknownSymbolVersion/Inputs/2.c
@@ -1,0 +1,1 @@
+int bar() { return 1; }

--- a/test/Common/standalone/SymbolVersioning/UnknownSymbolVersion/UnknownSymbolVersion.test
+++ b/test/Common/standalone/SymbolVersioning/UnknownSymbolVersion/UnknownSymbolVersion.test
@@ -1,0 +1,16 @@
+REQUIRES: symbol_versioning
+#---UnknownSymbolVersion.test--------------- Executable, SharedLibrary ----------------#
+#BEGIN_COMMENT
+# This test verifies that the linker errors out when a defined symbol has an
+# invalid symbol version and the link does not contain version script and
+# shared libraries with symbol versioning.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -fPIC
+RUN: %not %link %linkopts -o %t1.1.so %t1.1.o -shared 2>&1 | %filecheck %s
+RUN: %clang %clangopts -o %t1.2.o %p/Inputs/2.c -c -fPIC
+RUN: %link %linkopts -o %t1.lib2.so %t1.2.o -shared
+RUN: %not %link %linkopts -dy -o %t1.1.out %t1.1.o %t1.lib2.so -E 2>&1 | %filecheck %s
+#END_TEST
+
+CHECK: {{.*}}1.o: symbol foo@DOES_NOT_EXIST has undefined version DOES_NOT_EXIST

--- a/test/Common/standalone/SymbolVersioning/UnknownSymbolVersion/UnknownSymbolVersion.test
+++ b/test/Common/standalone/SymbolVersioning/UnknownSymbolVersion/UnknownSymbolVersion.test
@@ -1,0 +1,16 @@
+REQUIRES: symbol_versioning
+#---UnknownSymbolVersion.test--------------- Executable, SharedLibrary ----------------#
+#BEGIN_COMMENT
+# This test verifies that the linker errors out when a defined symbol has an
+# invalid symbol version and the link does not contain version script and
+# shared libraries with symbol versioning.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -fPIC
+RUN: %not %link %linkopts -o %t1.1.so %t1.1.o -shared 2>&1 | %filecheck %s
+RUN: %clang %clangopts -o %t1.2.o %p/Inputs/2.c -c -fPIC
+RUN: %link %linkopts -o %t1.lib2.so %t1.2.o -shared
+RUN: %not %link %linkopts -dy -o %t1.1.out %t1.1.o %t1.lib2.so -E 2>&1 | %filecheck %s
+#END_TEST
+
+CHECK: {{.*}}1.o: symbol foo has undefined version DOES_NOT_EXIST


### PR DESCRIPTION
This commit improves checking of invalid symbol versions. In particular, we now report errors when:
- A defined symbol contains an unknown version.
- An undefined symbol contains a version. Please note that there is no valid case where an undefined symbol can have a symbol version.

Resolves #1094