### PR TITLE
Add support for 'extern "C++"' in version scripts

### DIFF
--- a/include/eld/Script/ScriptSymbol.h
+++ b/include/eld/Script/ScriptSymbol.h
@@ -35,6 +35,8 @@ public:
 
   bool matched(const ResolveInfo &Sym) const;
 
+  bool matched(const ResolveInfo &Sym, llvm::StringRef demangledName) const;
+
   void addResolveInfoToContainer(const ResolveInfo *Info) const;
 
 private:

--- a/include/eld/Script/VersionScript.h
+++ b/include/eld/Script/VersionScript.h
@@ -8,6 +8,7 @@
 #define ELD_SCRIPT_VERSIONSCRIPT_H
 
 #include "eld/Script/ScriptSymbol.h"
+#include "llvm/ADT/DenseMap.h"
 #include <string>
 namespace eld {
 class StrToken;
@@ -16,6 +17,10 @@ class VersionScriptBlock;
 class VersionScriptNode;
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
 class NamePool;
+
+/// Map from ResolveInfo to its demangled name. Used for extern "C++" matching.
+/// The map is lazily populated during version script matching.
+using DemangledNamesMap = llvm::DenseMap<const ResolveInfo *, std::string>;
 #endif
 
 /*
@@ -55,6 +60,9 @@ public:
   void dump(llvm::raw_ostream &Ostream,
             std::function<std::string(const Input *)> GetDecoratedPath) const;
 
+  /// Returns true if this is an extern "C++" symbol pattern.
+  bool isExternCpp() const;
+
   /// Returns true if the symbol R matches the version symbol.
   ///
   /// A symbol R matches the version symbol when both the conditions are
@@ -67,8 +75,12 @@ public:
   /// is present in the link. In this case, the symbol version name
   /// does not need to match the version node. It is sufficient that
   /// the symbol non-versioned name matches the version symbol pattern.
+  ///
+  /// For extern "C++" symbols, the pattern is matched against the demangled
+  /// name of the symbol. The DemangledNames map is lazily populated.
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
-  bool matched(const ResolveInfo &R, const NamePool &NP) const;
+  bool matched(const ResolveInfo &R, const NamePool &NP,
+               DemangledNamesMap &DemangledNames) const;
 #endif
 
 protected:

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -55,6 +55,7 @@
 #include "eld/Script/ScriptFile.h"
 #include "eld/Script/ScriptReader.h"
 #include "eld/Script/ScriptSymbol.h"
+#include "eld/Script/VersionScript.h"
 #include "eld/Support/Memory.h"
 #include "eld/Support/MsgHandling.h"
 #include "eld/Support/RegisterTimer.h"
@@ -407,13 +408,16 @@ bool ObjectLinker::parseVersionScript() {
   }
   auto &SymbolScopes = getTargetBackend().symbolScopes();
   auto &NP = ThisModule->getNamePool();
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  DemangledNamesMap DemangledNames;
+#endif
   for (auto &G : NP.getGlobals()) {
     ResolveInfo *R = G.getValue();
     for (auto &VersionScriptNode : ThisModule->getVersionScriptNodes()) {
       if (VersionScriptNode->getGlobalBlock()) {
         for (auto *Sym : VersionScriptNode->getGlobalBlock()->getSymbols()) {
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
-          bool isMatched = Sym->matched(*R, NP);
+          bool isMatched = Sym->matched(*R, NP, DemangledNames);
 #else
           bool isMatched = Sym->getSymbolPattern()->matched(*R);
 #endif
@@ -438,7 +442,7 @@ bool ObjectLinker::parseVersionScript() {
       if (VersionScriptNode->getLocalBlock()) {
         for (auto *Sym : VersionScriptNode->getLocalBlock()->getSymbols()) {
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
-          bool isMatched = Sym->matched(*R, NP);
+          bool isMatched = Sym->matched(*R, NP, DemangledNames);
 #else
           bool isMatched = Sym->getSymbolPattern()->matched(*R);
 #endif

--- a/lib/Script/ScriptSymbol.cpp
+++ b/lib/Script/ScriptSymbol.cpp
@@ -50,3 +50,14 @@ bool ScriptSymbol::matched(const ResolveInfo &Sym) const {
   }
   return false;
 }
+
+bool ScriptSymbol::matched(const ResolveInfo &RI,
+                           llvm::StringRef demangledName) const {
+  uint64_t Hash = llvm::hash_combine(demangledName);
+  if ((hasHash() && hashValue() == Hash) ||
+      WildcardPattern::matched(demangledName)) {
+    addResolveInfoToContainer(&RI);
+    return true;
+  }
+  return false;
+}

--- a/lib/Script/VersionScript.cpp
+++ b/lib/Script/VersionScript.cpp
@@ -6,9 +6,11 @@
 
 #include "eld/Script/VersionScript.h"
 #include "eld/Script/ScriptSymbol.h"
+#include "eld/Script/StrToken.h"
 #include "eld/Script/SymbolContainer.h"
 #include "eld/Support/Memory.h"
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
+#include "eld/Support/StringRefUtils.h"
 #include "eld/SymbolResolver/NamePool.h"
 #endif
 
@@ -138,6 +140,13 @@ bool VersionSymbol::isGlobal() const { return Block->isGlobal(); }
 
 bool VersionSymbol::isLocal() const { return Block->isLocal(); }
 
+bool VersionSymbol::isExternCpp() const {
+  if (ScriptFileKind != Extern || !VersionScriptLanguage)
+    return false;
+  llvm::StringRef Lang = VersionScriptLanguage->name();
+  return Lang == "\"C++\"";
+}
+
 void VersionSymbol::dump(
     llvm::raw_ostream &Ostream,
     std::function<std::string(const Input *)> GetDecoratedPath) const {
@@ -150,7 +159,8 @@ void VersionSymbol::dump(
 }
 
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
-bool VersionSymbol::matched(const ResolveInfo &R, const NamePool &NP) const {
+bool VersionSymbol::matched(const ResolveInfo &R, const NamePool &NP,
+                            DemangledNamesMap &DemangledNames) const {
   auto *VB = getBlock();
   VersionScriptNode *VN = VB->getNode();
   if (!VN->isAnonymous()) {
@@ -170,7 +180,20 @@ bool VersionSymbol::matched(const ResolveInfo &R, const NamePool &NP) const {
         return false;
     }
   }
+
   ScriptSymbol *symbolPattern = getSymbolPattern();
+
+  if (isExternCpp()) {
+    auto It = DemangledNames.find(&R);
+    if (It == DemangledNames.end()) {
+      std::string Demangled =
+          eld::string::getDemangledName(R.getNonVersionedName());
+      It = DemangledNames.insert({&R, std::move(Demangled)}).first;
+    }
+    const std::string &demangledName = It->second;
+    return symbolPattern->matched(R, demangledName);
+  }
+
   return symbolPattern->matched(R);
 }
 #endif

--- a/test/Common/standalone/VersionScriptExternCpp/Inputs/1.cpp
+++ b/test/Common/standalone/VersionScriptExternCpp/Inputs/1.cpp
@@ -1,0 +1,39 @@
+// C++ source file with various symbol types for testing extern "C++" in version
+// scripts. The mangled names will be matched against demangled patterns in the
+// version script.
+
+namespace ns {
+
+class MyClass {
+public:
+  // Demangled: ns::MyClass::foo()
+  int foo() { return 1; }
+
+  // Demangled: ns::MyClass::bar(int)
+  int bar(int x) { return x + 1; }
+
+  // Demangled: ns::MyClass::baz(int, float)
+  int baz(int x, float y) { return x + y; }
+
+  // Demangled: ns::MyClass::staticMethod(double)
+  static int staticMethod(double x) { return 42; }
+};
+
+// Demangled: ns::freeFunc()
+int freeFunc() { return 100; }
+
+// Demangled: ns::freeFuncChar(char)
+int freeFuncChar(char x) { return (int)x * 2; }
+
+} // namespace ns
+
+// Demangled: globalCppFunc()
+int globalFunc() { return 200; }
+
+// Entry point
+extern "C" int _start() {
+  ns::MyClass obj;
+  return obj.foo() + obj.bar(1) + obj.baz(1, 2) +
+         ns::MyClass::staticMethod(1.0) + ns::freeFunc() +
+         ns::freeFuncChar('a') + globalFunc();
+}

--- a/test/Common/standalone/VersionScriptExternCpp/Inputs/vs.global.t
+++ b/test/Common/standalone/VersionScriptExternCpp/Inputs/vs.global.t
@@ -1,0 +1,11 @@
+{
+  global:
+    extern "C++" {
+      "ns::MyClass::foo()";
+      "ns::MyClass::staticMethod(double)";
+      "ns::freeFuncChar*";
+      globalFunc*;
+    };
+  local:
+    *;
+};

--- a/test/Common/standalone/VersionScriptExternCpp/Inputs/vs.global.version.t
+++ b/test/Common/standalone/VersionScriptExternCpp/Inputs/vs.global.version.t
@@ -1,0 +1,11 @@
+V1 {
+  global:
+    extern "C++" {
+      "ns::MyClass::foo()";
+      "ns::MyClass::staticMethod(double)";
+      "ns::freeFuncChar*";
+      globalFunc*;
+    };
+  local:
+    *;
+};

--- a/test/Common/standalone/VersionScriptExternCpp/Inputs/vs.local.t
+++ b/test/Common/standalone/VersionScriptExternCpp/Inputs/vs.local.t
@@ -1,0 +1,9 @@
+{
+  local:
+    extern "C++" {
+      "ns::MyClass::foo()";
+      "ns::MyClass::staticMethod(double)";
+      "ns::freeFuncChar*";
+      globalFunc*;
+    };
+};

--- a/test/Common/standalone/VersionScriptExternCpp/VersionScriptExternCpp.test
+++ b/test/Common/standalone/VersionScriptExternCpp/VersionScriptExternCpp.test
@@ -1,0 +1,50 @@
+REQUIRES: symbol_versioning
+#---VersionScriptExternCpp.test------------- VersionScript --------#
+#BEGIN_COMMENT
+# Tests for extern "C++" blocks in version scripts.
+# The extern "C++" directive allows matching C++ symbols by their
+# demangled names rather than their mangled names.
+#END_COMMENT
+#START_TEST
+
+RUN: %clang %clangopts -o %t1.1.o -c %p/Inputs/1.cpp -fPIC
+RUN: %link %linkopts -o %t1.lib1.so %t1.1.o -shared --version-script %p/Inputs/vs.global.t
+RUN: %readelf --dyn-syms %t1.lib1.so | %filecheck %s --check-prefix=GLOBAL
+
+RUN: %link %linkopts -o %t1.lib2.so %t1.1.o -shared --version-script %p/Inputs/vs.local.t
+RUN: %readelf --dyn-syms %t1.lib2.so | %filecheck %s --check-prefix=LOCAL
+
+RUN: %link %linkopts -o %t1.lib3.so %t1.1.o -shared --version-script %p/Inputs/vs.global.version.t
+RUN: %readelf --dyn-syms %t1.lib3.so | %filecheck %s --check-prefix=VERSION
+
+#END_TEST
+
+GLOBAL-DAG: {{.*}}freeFuncChar{{.*}}
+GLOBAL-DAG: {{.*}}globalFunc{{.*}}
+GLOBAL-DAG: {{.*}}staticMethod{{.*}}
+GLOBAL-DAG: {{.*}}foo{{.*}}
+GLOBAL-NOT: {{.*}}bar{{.*}}
+GLOBAL-NOT: {{.*}}baz{{.*}}
+GLOBAL-NOT: {{.*}}freeFunc{{.*}}
+GLOBAL-NOT: {{.*}}globalFunc{{.*}}
+GLOBAL-NOT: _start
+
+LOCAL-DAG: {{.*}}bar{{.*}}
+LOCAL-DAG: {{.*}}baz{{.*}}
+LOCAL-DAG: {{.*}}freeFunc{{.*}}
+LOCAL-DAG: _start
+LOCAL-NOT: {{.*}}globalFunc{{.*}}
+LOCAL-NOT: {{.*}}freeFuncChar{{.*}}
+LOCAL-NOT: {{.*}}globalFunc{{.*}}
+LOCAL-NOT: {{.*}}staticMethod{{.*}}
+LOCAL-NOT: {{.*}}foo{{.*}}
+
+VERSION-DAG: {{.*}}freeFuncChar{{.*}}@@V1
+VERSION-DAG: {{.*}}globalFunc{{.*}}@@V1
+VERSION-DAG: {{.*}}staticMethod{{.*}}@@V1
+VERSION-DAG: {{.*}}foo{{.*}}@@V1
+VERSION-NOT: {{.*}}bar{{.*}}
+VERSION-NOT: {{.*}}baz{{.*}}
+VERSION-NOT: {{.*}}freeFunc{{.*}}
+VERSION-NOT: {{.*}}globalFunc{{.*}}
+VERSION-NOT: _start


### PR DESCRIPTION
This commit adds support for C++ linkage (`extern "C++"`) in the version scripts. Before this change, we were correctly parsing the `extern "C++"` directive but were not changing the logic of symbol matching with version patterns to use C++ linkage names.

Resolves #1117