### PR TITLE
Add meta tags in dashboard html.

### DIFF
--- a/dash/dash.html
+++ b/dash/dash.html
@@ -1,7 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Build Status</title>
+<title>ELD Linker Dashboard</title>
+<meta name="description" content="ELD Linker Dashboard for live build status, workflows, and build health tracking.">
+<meta name="keywords" content="eld dashboard, linker dashboard, eld build status, eld build dashboard, eld workflows, eld dash, deepmap dash, eld linker dashboard, eld status dashboard, eld live dashboard">
+<meta name="robots" content="index,follow">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="Footer" content="DeepDash by Deepmap">
 <link rel="stylesheet" type="text/css" href="builds-summary-style.css">
@@ -24,7 +27,7 @@
 </head>
 
 <body style="overflow: hidden;">
-  <h1 id='page-title'>Build Status</h1>
+  <h1 id='page-title'>ELD Build Status Dashboard</h1>
   <br>
   <div id="filters-div">
     <input id="datePicker" name="datePicker">


### PR DESCRIPTION
Add meta tags in dashboard for search engines.
These tags allow for better indexing and match when searching eld linker and dashboard related queries.

Closes #1125