### PR TITLE
[RISCV] Add GNU IFunc functionality support in RISCV static links

### DIFF
--- a/docs/DeveloperDocs/IFunc.md
+++ b/docs/DeveloperDocs/IFunc.md
@@ -35,24 +35,24 @@ calls the corresponding resolver function to fill the GOTPLT slot.
 For the case of static executables, libc plays the role of runtime and takes on a task that is typically
 unusual for a libc -- resolve symbols and patch the binary at runtime with the resolution information.
 
-eld emits `R_AARCH64_IRELATIVE` relocations in `.rela.plt` section, and `__rela_iplt_start` and
+eld emits `R_<TARGET>_IRELATIVE` relocations in `.rela.plt` section, and `__rela_iplt_start` and
 `__rela_iplt_end` symbols that store the start and end addresses of `.rela.plt` section.
 
-The tiny-loader in the libc process the `R_AARCH64_IRELATIVE` relocations by
+The tiny-loader in the libc process the `R_<TARGET>_IRELATIVE` relocations by
 iterating over the [`__rela_iplt_start`, `__rela_iplt_end`) range.
 
 ```
 Relocation section '.rela.plt' at offset 0x190 contains 6 entries:
     Offset             Info             Type               Symbol's Value
-0000000000490000  0000000000000408 R_AARCH64_IRELATIVE               4358c0
-0000000000490008  0000000000000408 R_AARCH64_IRELATIVE               40db20
+0000000000490000  0000000000000408 R_<TARGET>_IRELATIVE               4358c0
+0000000000490008  0000000000000408 R_<TARGET>_IRELATIVE               40db20
 ```
 
 The symbol value of `IRELATIVE` relocations contains the IFunc resolver address, and
 the relocation offset points to the GOTPLT slot for the IFunc symbol. For each relocation,
 the tiny-loader in the libc calls the IFunc resolver and stores the result in the GOTPLT slot.
 
-Note that there is no lazy binding here.
+**Note that there is no lazy binding here.**
 
 ### Direct reference to an IFunc symbol
 
@@ -60,11 +60,11 @@ Direct references to an IFunc symbol are resolved to the PLT slot of the IFunc s
 
 ```
 // global variable!
-// R_AARCH64_ABS64
+// Absolute relocation, for example, `R_AARCH64_ABS64`, `R_RISCV64_64`.
 int (*foo_gp)(int) = foo;
 ```
 
-eld will resolve `R_AARCH64_ABS64` relocation to the address of PLT[foo].
+eld will resolve the absolute relocation to the address of PLT[foo].
 
 ### GOT references to an IFunc symbol
 
@@ -130,7 +130,8 @@ into the following categories:
 - Control flow relocations
 - GOT-related instruction relocations
 - Absolute / PC-relative address-forming relocations
-- Absolute / PC-relative load/store relocations.
+- Absolute / PC-relative load/store relocations
+- General address forming relocations
 - General computation relocation
 
 The relocations which are not supported by GNU for IFunc symbols are annotated with
@@ -144,27 +145,32 @@ Resolves to PLT[IFuncSymbol]. Sets HasDirectReference[IFuncSymbol] to true.
 
 - R_AARCH64_ABS{16, 32, 64}
 
-Not handled currently.
+- R_RISCV_{32, 64}
 
-[!IMPORTANT]
-They should be resolved to PLT[IFuncSymbol] as well!
+
+The below relocations are not handled currently by eld.
+They should be resolved to PLT[IFuncSymbol] as well.
 
 - R_AARCH64_PREL{16, 32, 64} (NotSupportedInGNULDForIFunc)
 - R_AARCH64_PLT32 (UNSUPPORTED)
 
 #### GOT-related data relocations
 
-- GOTREL{32, 64} (UNSUPPORTED)
-- GOTPCREL32 (UNSUPPORTED)
+- R_AARCH64_GOTREL{32, 64} (UNSUPPORTED)
+- R_AARCH64_GOTPCREL32 (UNSUPPORTED)
 
 #### Control flow relocations
 
 Resolves to PLT[IFuncSymbol].
 
-- TSTBR14
-- CONDBR19
-- JUMP26
-- CALL26
+- R_AARCH64_TSTBR14
+- R_AARCH64_CONDBR19
+- R_AARCH64_JUMP26
+- R_AARCH64_CALL26
+
+- R_RISCV_CALL
+- R_RISCV_CALL_PLT
+- R_RISCV_JAL
 
 #### GOT-related instruction relocations
 
@@ -178,22 +184,30 @@ IFuncSymbol; otherwise uses GOT[IFuncSymbol].
 - AUTH-ABI GOT relocations (UNSUPPORTED)
 - R_AARCH64_MOVW_GOTOFF_G{0,1}{_NC} (UNSUPPORTED)
 
+- R_RISCV_GOT_HI20
+
 #### Absolute / PC-relative address-forming relocations
+
+Resolves to PLT[IFuncSymbol]. Sets HasDirectReference[IFuncSymbol] to true.
 
 - R_AARCH64_ADR_PREL_LO21 (NotSupportedInGNULDForIFunc)
 - R_AARCH64_ADR_PREL_PG_HI21{_NC}
 
-Resolves to PLT[IFuncSymbol]. Sets HasDirectReference[IFuncSymbol] to true.
+- R_RISCV_HI20
+- R_RISCV_PCREL_HI20
+- R_RISCV_LO12_I
+- R_RISCV_LO12_S
+
+The below relocations are resolved to the IFunc symbol:
 
 - R_AARCH64_MOVW_UABS_G{0,1,2,3}{_NC} (NotSupportedInGNULDForIFunc)
 - R_AARCH64_SABS_G{0,1,2,3} (NotSupportedInGNULDForIFunc)
 - MOVW_PREL_G{0, 1, 2, 3}{_NC} (UNSUPPORTED)
 
-Resolves to IFuncSymbol.
-
 [!IMPORTANT]
 FIXME: We should perhaps resolve these relocations to the PLT[IFuncSymbol]
 instead of the IFuncSymbol for ensuring pointer equality.
+
 
 #### Absolute / PC-relative load/store relocations
 
@@ -206,6 +220,16 @@ at a function address.
 
 [!IMPORTANT]
 FIXME: It should be an error to use these relocations with IFunc symbols.
+
+#### General address-forming relocations
+
+These are the relocations that can be used to form both
+GOT and non-GOT addresses.
+
+The behavior of these relocations depend upon the corresponding Hi-relocation pair.
+
+- R_RISCV_PCREL_LO12_I
+- R_RISCV_PCREL_LO12_S
 
 #### General computation relocation
 

--- a/docs/DeveloperDocs/IFunc.md
+++ b/docs/DeveloperDocs/IFunc.md
@@ -1,10 +1,11 @@
-# GNU IFunc support with AArch64
+# GNU IFunc support
 
 GNU IFunc functionality enables a developer to provide multiple implementations
-of a function and a resolver function that selects which implementation to use at runtime.
+for a function and a resolver function that selects at runtime which implementation to use.
 It is typically used for selecting the most optimized implementation for a given CPU / runtime.
 The resolver function is called once at the start of the application runtime and then the
-selected implementation is fixed.
+selected implementation is fixed. Resolver function is always called eagerly (at program start)
+instead of lazily (when first needed).
 
 Example:
 
@@ -25,34 +26,35 @@ int bar(int u) {
 }
 ```
 
-## Static linking
+# Static linking
 
 eld generates a PLT slot for each ifunc symbol. Each PLT slot has a corresponding
 GOTPLT slot. This model is very similar to how preemptible dynamic symbols are handled.
 However, instead of doing symbol resolution at runtime to fill the GOTPLT slot, the runtime
 calls the corresponding resolver function to fill the GOTPLT slot.
 
-For the case of static executables, libc plays the role of runtime and takes on a task that is typically
-unusual for a libc -- resolve symbols and patch the binary at runtime with the resolution information.
+For the case of static executables, libc plays the role of runtime and takes on a task
+that is typically unusual for a libc -- resolve symbols and patch the binary at runtime
+with the resolution information.
 
-eld emits `R_AARCH64_IRELATIVE` relocations in `.rela.plt` section, and `__rela_iplt_start` and
+eld emits `R_<TARGET>_IRELATIVE` relocations in `.rela.plt` section, and `__rela_iplt_start` and
 `__rela_iplt_end` symbols that store the start and end addresses of `.rela.plt` section.
 
-The tiny-loader in the libc process the `R_AARCH64_IRELATIVE` relocations by
+The tiny-loader in the libc process the `R_<TARGET>_IRELATIVE` relocations by
 iterating over the [`__rela_iplt_start`, `__rela_iplt_end`) range.
 
 ```
 Relocation section '.rela.plt' at offset 0x190 contains 6 entries:
     Offset             Info             Type               Symbol's Value
-0000000000490000  0000000000000408 R_AARCH64_IRELATIVE               4358c0
-0000000000490008  0000000000000408 R_AARCH64_IRELATIVE               40db20
+0000000000490000  0000000000000408 R_<TARGET>_IRELATIVE               4358c0
+0000000000490008  0000000000000408 R_<TARGET>_IRELATIVE               40db20
 ```
 
 The symbol value of `IRELATIVE` relocations contains the IFunc resolver address, and
 the relocation offset points to the GOTPLT slot for the IFunc symbol. For each relocation,
 the tiny-loader in the libc calls the IFunc resolver and stores the result in the GOTPLT slot.
 
-Note that there is no lazy binding here.
+**Note that there is no lazy binding here.**
 
 ### Direct reference to an IFunc symbol
 
@@ -60,20 +62,19 @@ Direct references to an IFunc symbol are resolved to the PLT slot of the IFunc s
 
 ```
 // global variable!
-// R_AARCH64_ABS64
+// Absolute relocation, for example, `R_AARCH64_ABS64`, `R_RISCV_64`.
 int (*foo_gp)(int) = foo;
 ```
 
-eld will resolve `R_AARCH64_ABS64` relocation to the address of PLT[foo].
+eld will resolve the absolute relocation to the address of PLT[foo].
 
-### GOT references to an IFunc symbol
+## GOT references to an IFunc symbol
 
 GOT references to an IFunc symbol are resolved to the GOTPLT slot of the IFunc symbol
-when there is no direct references to the IFunc symbol. When there is a direct reference
+when there are no direct references to the IFunc symbol. When there is a direct reference
 to the IFunc symbol, then the GOT references to the IFunc symbols gets resolved to the
-GOT slot of the IFunc symbol.
-
-Let's see why:
+GOT slot of the IFunc symbol. It is to ensure pointer equality. Let's understand this
+in detail:
 
 Case 1: PIC code and no direct reference
 
@@ -120,7 +121,7 @@ the PLT[foo], and resolve all GOT references of `foo` to the GOT[foo] instead of
 With this design, `foo_lp` will store the address of PLT[foo], the same as `foo_gp`. Hence,
 no pointer inequality issue.
 
-### IFunc behaviour across all relocations
+## IFunc behaviour across all relocations
 
 To describe IFunc behavior for all relocations, we categorize the relocations
 into the following categories:
@@ -128,45 +129,63 @@ into the following categories:
 - Absolute / PC-relative data relocations
 - GOT-related data relocations
 - Control flow relocations
-- GOT-related instruction relocations
-- Absolute / PC-relative address-forming relocations
-- Absolute / PC-relative load/store relocations.
-- General computation relocation
+- Regular GOT-related instruction relocations
+- Regular absolute / PC-relative address-forming relocations
+- Address forming relocations used to compute both GOT and non-GOT addresses.
+- Absolute / PC-relative load/store relocations
+
+*Regular* in the relocation category name here means that the relocations are
+non-TLS non-call relocations.
 
 The relocations which are not supported by GNU for IFunc symbols are annotated with
 NotSupportedInGNULDForIFunc. The GNU toolchain that is used for verifying this is:
-aarch64-none-linux-gnu-gcc (Arm GNU Toolchain 15.2.Rel1 (Build arm-15.86)) 15.2.1 20251203
+aarch64-none-linux-gnu-gcc (Arm GNU Toolchain 15.2.Rel1 (Build arm-15.86)) 15.2.1 20251203,
+and riscv64-unknown-linux-ld (GNU ld (GNU Binutils) 2.43.1).
 
 
-#### Absolute / PC-relative data relocations
+### Absolute / PC-relative data relocations
 
 Resolves to PLT[IFuncSymbol]. Sets HasDirectReference[IFuncSymbol] to true.
 
 - R_AARCH64_ABS{16, 32, 64}
 
-Not handled currently.
+- R_RISCV_{32, 64}
 
-[!IMPORTANT]
-They should be resolved to PLT[IFuncSymbol] as well!
+
+The below relocations are currently unsupported by eld.
+For IFunc symbols, these should be resolved to the PLT[IFuncSymbol]
+as well.
 
 - R_AARCH64_PREL{16, 32, 64} (NotSupportedInGNULDForIFunc)
-- R_AARCH64_PLT32 (UNSUPPORTED)
+- R_AARCH64_PLT32
+- R_RISCV_PLT32
 
-#### GOT-related data relocations
+### GOT-related data relocations
 
-- GOTREL{32, 64} (UNSUPPORTED)
-- GOTPCREL32 (UNSUPPORTED)
+The below relocations are currently unsupported by eld.
 
-#### Control flow relocations
+- R_AARCH64_GOTREL{32, 64}
+- R_AARCH64_GOTPCREL32
+
+- R_RISCV_GOT32_PCREL
+
+### Control flow relocations
 
 Resolves to PLT[IFuncSymbol].
 
-- TSTBR14
-- CONDBR19
-- JUMP26
-- CALL26
+- R_AARCH64_TSTBR14
+- R_AARCH64_CONDBR19
+- R_AARCH64_JUMP26
+- R_AARCH64_CALL26
 
-#### GOT-related instruction relocations
+- R_RISCV_CALL
+- R_RISCV_CALL_PLT
+- R_RISCV_JAL
+- R_RISCV_BRANCH
+- R_RISCV_RVC_BRANCH
+- R_RISCV_RVC_JUMP
+
+### Regular GOT-related instruction relocations
 
 Resolves-to / uses GOTPLT[IFuncSymbol] if there is no direct reference to
 IFuncSymbol; otherwise uses GOT[IFuncSymbol].
@@ -178,24 +197,47 @@ IFuncSymbol; otherwise uses GOT[IFuncSymbol].
 - AUTH-ABI GOT relocations (UNSUPPORTED)
 - R_AARCH64_MOVW_GOTOFF_G{0,1}{_NC} (UNSUPPORTED)
 
-#### Absolute / PC-relative address-forming relocations
+- R_RISCV_GOT_HI20
 
-- R_AARCH64_ADR_PREL_LO21 (NotSupportedInGNULDForIFunc)
-- R_AARCH64_ADR_PREL_PG_HI21{_NC}
+### Regular absolute / PC-relative address-forming relocations
 
 Resolves to PLT[IFuncSymbol]. Sets HasDirectReference[IFuncSymbol] to true.
 
+- R_AARCH64_ADR_PREL_LO21 (NotSupportedInGNULDForIFunc)
+- R_AARCH64_ADR_PREL_PG_HI21{_NC}
+- R_AARCH64_ADD_ABS_LO12_NC
+
+- R_RISCV_HI20
+- R_RISCV_PCREL_HI20
+- R_RISCV_LO12_I
+- R_RISCV_LO12_S
+
+The below relocations are resolved to the IFunc symbol:
+
 - R_AARCH64_MOVW_UABS_G{0,1,2,3}{_NC} (NotSupportedInGNULDForIFunc)
 - R_AARCH64_SABS_G{0,1,2,3} (NotSupportedInGNULDForIFunc)
-- MOVW_PREL_G{0, 1, 2, 3}{_NC} (UNSUPPORTED)
 
-Resolves to IFuncSymbol.
+> [!IMPORTANT]
+> FIXME: We should perhaps resolve these relocations to the PLT[IFuncSymbol]
+> instead of the IFuncSymbol for ensuring pointer equality.
 
-[!IMPORTANT]
-FIXME: We should perhaps resolve these relocations to the PLT[IFuncSymbol]
-instead of the IFuncSymbol for ensuring pointer equality.
+The below relocations are currenty unsupported in eld:
 
-#### Absolute / PC-relative load/store relocations
+- MOVW_PREL_G{0, 1, 2, 3}{_NC}
+
+### Address forming relocations used to compute both GOT and non-GOT addresses
+
+These are the relocations that can be used to form both
+GOT and non-GOT addresses.
+
+The behavior of these relocations depend upon the corresponding Hi-relocation pair.
+
+- R_RISCV_PCREL_LO12_I
+- R_RISCV_PCREL_LO12_S
+
+- There is no relevant AArch64 relocation here.
+
+### Absolute / PC-relative load/store relocations
 
 - LD_PREL_LO19 (NotSupportedInGNULDForIFunc)
 - LDST{8, 16, 32, 64, 128}_ABS_LO12_NC (NotSupportedInGNULDForIFunc)
@@ -204,11 +246,6 @@ These relocations does not make sense with IFunc symbols. Loading value
 at a function address is an invalid behavior, and so is storing a value
 at a function address.
 
-[!IMPORTANT]
-FIXME: It should be an error to use these relocations with IFunc symbols.
+> [!IMPORTANT]
+> FIXME: It should be an error to use these relocations with IFunc symbols.
 
-#### General computation relocation
-
-- R_AARCH64_ADD_ABS_LO12_NC
-
-Resolves to PLT[IFuncSymbol]. Set HasDirectReference[IFuncSymbol].

--- a/include/eld/Diagnostics/DiagDynamicLink.inc
+++ b/include/eld/Diagnostics/DiagDynamicLink.inc
@@ -11,8 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-DIAG(create_got_entry, DiagnosticEngine::Note,
-     "Created GOT Entry for Symbol %0")
+DIAG(create_got_entry, DiagnosticEngine::Note, "Created %0 Entry for Symbol %1")
 DIAG(create_plt_entry, DiagnosticEngine::Note,
      "Created PLT Entry for Symbol %0")
 DIAG(error_discarded_dynamic_section_required, DiagnosticEngine::Error,

--- a/include/eld/Fragment/GOT.h
+++ b/include/eld/Fragment/GOT.h
@@ -9,6 +9,7 @@
 
 #include "eld/Fragment/Fragment.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/DataTypes.h"
 #include <string>
 #include <vector>
@@ -68,6 +69,8 @@ public:
 
   // -- GOT Type
   GOTType getType() const { return GotType; }
+
+  static llvm::StringRef getGOTTypeAsStr(GOTType T);
 
 protected:
   ResolveInfo *ThisSymInfo;

--- a/lib/Fragment/GOT.cpp
+++ b/lib/Fragment/GOT.cpp
@@ -9,6 +9,7 @@
 #include "eld/Core/Module.h"
 #include "eld/SymbolResolver/ResolveInfo.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/Support/ErrorHandling.h"
 
 using namespace eld;
 
@@ -33,4 +34,26 @@ const std::string GOT::name() const {
   if (!ThisSymInfo)
     return "";
   return (llvm::Twine("GOT entry for ") + ThisSymInfo->name()).str();
+}
+
+llvm::StringRef GOT::getGOTTypeAsStr(GOTType T) {
+  switch (T) {
+  case GOTType::Regular:
+    return "GOT";
+  case GOTType::GOTPLT0:
+    return "GOTPLT0";
+  case GOTType::GOTPLTN:
+    return "GOTPLT";
+  case GOTType::TLS_DESC:
+    return "TLS_DESC";
+  case GOTType::TLS_GD:
+    return "TLS_GD";
+  case GOTType::TLS_LD:
+    return "TLS_LD";
+  case GOTType::TLS_IE:
+    return "TLS_IE";
+  case GOTType::TLS_LE:
+    return "TLS_LE";
+  }
+  llvm_unreachable("Invalid GOTType!");
 }

--- a/lib/Target/AArch64/AArch64LDBackend.cpp
+++ b/lib/Target/AArch64/AArch64LDBackend.cpp
@@ -720,7 +720,8 @@ AArch64GOT *AArch64LDBackend::createGOT(GOT::GOTType T,
   if (R != nullptr && ((config().options().isSymbolTracingRequested() &&
                         config().options().traceSymbol(*R)) ||
                        m_Module.getPrinter()->traceDynamicLinking()))
-    config().raise(Diag::create_got_entry) << R->name();
+    config().raise(Diag::create_got_entry)
+        << GOT::getGOTTypeAsStr(T) << R->name();
   // If we are creating a GOT, always create a .got.plt.
   if (!getGOTPLT()->hasFragments()) {
     // TODO: This should be GOT0, not GOTPLT0.

--- a/lib/Target/ARM/ARMLDBackend.cpp
+++ b/lib/Target/ARM/ARMLDBackend.cpp
@@ -1046,7 +1046,8 @@ ARMGOT *ARMGNULDBackend::createGOT(GOT::GOTType T, ELFObjectFile *Obj,
   if (R != nullptr && ((config().options().isSymbolTracingRequested() &&
                         config().options().traceSymbol(*R)) ||
                        m_Module.getPrinter()->traceDynamicLinking()))
-    config().raise(Diag::create_got_entry) << R->name();
+    config().raise(Diag::create_got_entry)
+        << GOT::getGOTTypeAsStr(T) << R->name();
   // If we are creating a GOT, always create a .got.plt.
   if (!getGOTPLT()->hasFragments()) {
     // TODO: This should be GOT0, not GOTPLT0.

--- a/lib/Target/Hexagon/HexagonLDBackend.cpp
+++ b/lib/Target/Hexagon/HexagonLDBackend.cpp
@@ -946,7 +946,8 @@ HexagonGOT *HexagonLDBackend::createGOT(GOT::GOTType T, ELFObjectFile *Obj,
   if (R != nullptr && ((config().options().isSymbolTracingRequested() &&
                         config().options().traceSymbol(*R)) ||
                        m_Module.getPrinter()->traceDynamicLinking()))
-    config().raise(Diag::create_got_entry) << R->name();
+    config().raise(Diag::create_got_entry)
+        << GOT::getGOTTypeAsStr(T) << R->name();
   // If we are creating a GOT, always create a .got.plt.
   if (!getGOTPLT()->hasFragments()) {
     LDSymbol *Dynamic = m_Module.getNamePool().findSymbol("_DYNAMIC");

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -1111,6 +1111,16 @@ void RISCVLDBackend::mayBeRelax(int relaxation_pass, bool &pFinished) {
 
 /// finalizeSymbol - finalize the symbol value
 bool RISCVLDBackend::finalizeTargetSymbols() {
+  if (m_pIRelativeStart && m_pIRelativeEnd) {
+    m_pIRelativeStart->setValue(
+        getRelaPLT()->getOutputSection()->getSection()->addr());
+    m_pIRelativeEnd->setValue(
+        getRelaPLT()->getOutputSection()->getSection()->addr() +
+        getRelaPLT()->getOutputSection()->getSection()->size());
+    addSectionInfo(m_pIRelativeStart, getRelaPLT());
+    addSectionInfo(m_pIRelativeEnd, getRelaPLT());
+  }
+
   for (auto &I : m_LabeledSymbols)
     m_Module.getLinker()->getObjLinker()->finalizeSymbolValue(I);
 
@@ -1529,6 +1539,44 @@ void RISCVLDBackend::defineGOTSymbol(Fragment &pFrag) {
     config().raise(Diag::target_specific_symbol) << SymbolName;
 }
 
+void RISCVLDBackend::defineIRelativeRange(ResolveInfo &pSym) {
+  if (m_Module.getScript().linkerScriptHasSectionsCommand())
+    return;
+
+  auto SymbolName = "__rela_iplt_start";
+  if (!m_pIRelativeStart && !m_pIRelativeEnd) {
+    m_pIRelativeStart =
+        m_Module.getIRBuilder()
+            ->addSymbol<IRBuilder::Force, IRBuilder::Resolve>(
+                m_Module.getInternalInput(Module::Script), SymbolName,
+                ResolveInfo::Type::NoType, ResolveInfo::Define,
+                ResolveInfo::Binding::Local,
+                0,   // size
+                0x0, // value
+                FragmentRef::null(), ResolveInfo::Visibility::Default);
+    if (m_Module.getConfig().options().isSymbolTracingRequested() &&
+        m_Module.getConfig().options().traceSymbol(SymbolName)) {
+      config().raise(Diag::target_specific_symbol) << SymbolName;
+    }
+    m_pIRelativeStart->setShouldIgnore(false);
+    SymbolName = "__rela_iplt_end";
+    m_pIRelativeEnd =
+        m_Module.getIRBuilder()
+            ->addSymbol<IRBuilder::Force, IRBuilder::Resolve>(
+                m_Module.getInternalInput(Module::Script), SymbolName,
+                ResolveInfo::Type::NoType, ResolveInfo::Define,
+                ResolveInfo::Binding::Local,
+                pSym.size(), // size
+                0x0,         // value
+                FragmentRef::null(), ResolveInfo::Visibility::Default);
+    if (m_Module.getConfig().options().isSymbolTracingRequested() &&
+        m_Module.getConfig().options().traceSymbol(SymbolName)) {
+      config().raise(Diag::target_specific_symbol) << SymbolName;
+    }
+    m_pIRelativeEnd->setShouldIgnore(false);
+  }
+}
+
 bool RISCVLDBackend::finalizeScanRelocations() {
   Fragment *frag = nullptr;
   if (auto *GOT = getGOT())
@@ -1536,6 +1584,32 @@ bool RISCVLDBackend::finalizeScanRelocations() {
       frag = *GOT->getFragmentList().begin();
   if (frag)
     defineGOTSymbol(*frag);
+
+  if (!config().isCodeStatic())
+    return true;
+
+  ELFObjectFile *Obj = getDynamicSectionHeadersInputFile();
+  ASSERT(Obj, "Must not be null!");
+
+  bool is32Bits = config().targets().is32Bits();
+
+  for (auto &[symInfo, plt] : m_PLTMap) {
+    if (!symInfo->isIFunc() || !symInfo->hasIFuncDirectRef() ||
+        !symInfo->hasIFuncNeedsGOT())
+      continue;
+
+    RISCVGOT *G = RISCVGOT::Create(Obj->getGOT(), symInfo, is32Bits);
+
+    FragmentRef *PLTFragRef = make<FragmentRef>(*plt, 0);
+    Relocation *r = Relocation::Create(
+        is32Bits ? llvm::ELF::R_RISCV_32 : llvm::ELF::R_RISCV_64,
+        is32Bits ? 32 : 64, make<FragmentRef>(*G, 0), 0);
+    Obj->getGOT()->addRelocation(r);
+    r->modifyRelocationFragmentRef(PLTFragRef);
+
+    recordGOT(symInfo, G);
+    symInfo->setReserved(symInfo->reserved() | Relocator::ReserveGOT);
+  }
   return true;
 }
 
@@ -1625,7 +1699,8 @@ RISCVGOT *RISCVLDBackend::findEntryInGOT(ResolveInfo *I) const {
 }
 
 // Create PLT entry.
-RISCVPLT *RISCVLDBackend::createPLT(ELFObjectFile *Obj, ResolveInfo *R) {
+RISCVPLT *RISCVLDBackend::createPLT(ELFObjectFile *Obj, ResolveInfo *R,
+                                    bool isIRelative) {
   bool is32Bits = config().targets().is32Bits();
   if ((config().options().isSymbolTracingRequested() &&
        config().options().traceSymbol(*R)) ||
@@ -1672,10 +1747,11 @@ RISCVPLT *RISCVLDBackend::createPLT(ELFObjectFile *Obj, ResolveInfo *R) {
           make<FragmentRef>(**getPLT()->getFragmentList().begin()));
       Obj->getGOTPLT()->addRelocation(r0);
     }
+    Relocation::Type relocType = (isIRelative ? llvm::ELF::R_RISCV_IRELATIVE
+                                              : llvm::ELF::R_RISCV_JUMP_SLOT);
     // Create a dynamic relocation for the GOTPLT slot.
-    Relocation *dynRel =
-        Relocation::Create(llvm::ELF::R_RISCV_JUMP_SLOT, is32Bits ? 32 : 64,
-                           make<FragmentRef>(*G));
+    Relocation *dynRel = Relocation::Create(relocType, is32Bits ? 32 : 64,
+                                            make<FragmentRef>(*G));
     dynRel->setSymInfo(R);
     Obj->getRelaPLT()->addRelocation(dynRel);
   }

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -1546,7 +1546,8 @@ RISCVGOT *RISCVLDBackend::createGOT(GOT::GOTType T, ELFObjectFile *Obj,
   if (R != nullptr && ((config().options().isSymbolTracingRequested() &&
                         config().options().traceSymbol(*R)) ||
                        m_Module.getPrinter()->traceDynamicLinking()))
-    config().raise(Diag::create_got_entry) << R->name();
+    config().raise(Diag::create_got_entry)
+        << GOT::getGOTTypeAsStr(T) << R->name();
   // If we are creating a GOT, always create a .got.plt.
   if (!getGOTPLT()->hasFragments()) {
     LDSymbol *Dynamic = m_Module.getNamePool().findSymbol("_DYNAMIC");

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -1111,6 +1111,16 @@ void RISCVLDBackend::mayBeRelax(int relaxation_pass, bool &pFinished) {
 
 /// finalizeSymbol - finalize the symbol value
 bool RISCVLDBackend::finalizeTargetSymbols() {
+  if (m_pIRelativeStart && m_pIRelativeEnd) {
+    m_pIRelativeStart->setValue(
+        getRelaPLT()->getOutputSection()->getSection()->addr());
+    m_pIRelativeEnd->setValue(
+        getRelaPLT()->getOutputSection()->getSection()->addr() +
+        getRelaPLT()->getOutputSection()->getSection()->size());
+    addSectionInfo(m_pIRelativeStart, getRelaPLT());
+    addSectionInfo(m_pIRelativeEnd, getRelaPLT());
+  }
+
   for (auto &I : m_LabeledSymbols)
     m_Module.getLinker()->getObjLinker()->finalizeSymbolValue(I);
 
@@ -1529,6 +1539,44 @@ void RISCVLDBackend::defineGOTSymbol(Fragment &pFrag) {
     config().raise(Diag::target_specific_symbol) << SymbolName;
 }
 
+void RISCVLDBackend::defineIRelativeRange(ResolveInfo &pSym) {
+  if (m_Module.getScript().linkerScriptHasSectionsCommand())
+    return;
+
+  if (!m_pIRelativeStart && !m_pIRelativeEnd) {
+    auto SymbolName = "__rela_iplt_start";
+    m_pIRelativeStart =
+        m_Module.getIRBuilder()
+            ->addSymbol<IRBuilder::Force, IRBuilder::Resolve>(
+                m_Module.getInternalInput(Module::Script), SymbolName,
+                ResolveInfo::Type::NoType, ResolveInfo::Define,
+                ResolveInfo::Binding::Local,
+                0,   // size
+                0x0, // value
+                FragmentRef::null(), ResolveInfo::Visibility::Default);
+    if (m_Module.getConfig().options().isSymbolTracingRequested() &&
+        m_Module.getConfig().options().traceSymbol(SymbolName)) {
+      config().raise(Diag::target_specific_symbol) << SymbolName;
+    }
+    m_pIRelativeStart->setShouldIgnore(false);
+    SymbolName = "__rela_iplt_end";
+    m_pIRelativeEnd =
+        m_Module.getIRBuilder()
+            ->addSymbol<IRBuilder::Force, IRBuilder::Resolve>(
+                m_Module.getInternalInput(Module::Script), SymbolName,
+                ResolveInfo::Type::NoType, ResolveInfo::Define,
+                ResolveInfo::Binding::Local,
+                0x0, // size
+                0x0, // value
+                FragmentRef::null(), ResolveInfo::Visibility::Default);
+    if (m_Module.getConfig().options().isSymbolTracingRequested() &&
+        m_Module.getConfig().options().traceSymbol(SymbolName)) {
+      config().raise(Diag::target_specific_symbol) << SymbolName;
+    }
+    m_pIRelativeEnd->setShouldIgnore(false);
+  }
+}
+
 bool RISCVLDBackend::finalizeScanRelocations() {
   Fragment *frag = nullptr;
   if (auto *GOT = getGOT())
@@ -1536,6 +1584,31 @@ bool RISCVLDBackend::finalizeScanRelocations() {
       frag = *GOT->getFragmentList().begin();
   if (frag)
     defineGOTSymbol(*frag);
+
+  if (!config().isCodeStatic())
+    return true;
+
+  bool is32Bits = config().targets().is32Bits();
+
+  for (auto &[symInfo, plt] : m_PLTMap) {
+    if (!symInfo->isIFunc() || !symInfo->hasIFuncDirectRef() ||
+        !symInfo->hasIFuncNeedsGOT())
+      continue;
+
+    ELFObjectFile *PLTSlotObjFile =
+        llvm::cast<ELFObjectFile>(plt->getOwningSection()->getInputFile());
+    RISCVGOT *G = createGOT(GOT::GOTType::Regular, PLTSlotObjFile, symInfo);
+
+    FragmentRef *PLTFragRef = make<FragmentRef>(*plt, 0);
+    Relocation *r = Relocation::Create(
+        is32Bits ? llvm::ELF::R_RISCV_32 : llvm::ELF::R_RISCV_64,
+        is32Bits ? 32 : 64, make<FragmentRef>(*G, 0), 0);
+    PLTSlotObjFile->getGOT()->addRelocation(r);
+    r->modifyRelocationFragmentRef(PLTFragRef);
+
+    recordGOT(symInfo, G);
+    symInfo->setReserved(symInfo->reserved() | Relocator::ReserveGOT);
+  }
   return true;
 }
 
@@ -1626,7 +1699,8 @@ RISCVGOT *RISCVLDBackend::findEntryInGOT(ResolveInfo *I) const {
 }
 
 // Create PLT entry.
-RISCVPLT *RISCVLDBackend::createPLT(ELFObjectFile *Obj, ResolveInfo *R) {
+RISCVPLT *RISCVLDBackend::createPLT(ELFObjectFile *Obj, ResolveInfo *R,
+                                    bool isIRelative) {
   bool is32Bits = config().targets().is32Bits();
   if ((config().options().isSymbolTracingRequested() &&
        config().options().traceSymbol(*R)) ||
@@ -1673,10 +1747,11 @@ RISCVPLT *RISCVLDBackend::createPLT(ELFObjectFile *Obj, ResolveInfo *R) {
           make<FragmentRef>(**getPLT()->getFragmentList().begin()));
       Obj->getGOTPLT()->addRelocation(r0);
     }
+    Relocation::Type relocType = (isIRelative ? llvm::ELF::R_RISCV_IRELATIVE
+                                              : llvm::ELF::R_RISCV_JUMP_SLOT);
     // Create a dynamic relocation for the GOTPLT slot.
-    Relocation *dynRel =
-        Relocation::Create(llvm::ELF::R_RISCV_JUMP_SLOT, is32Bits ? 32 : 64,
-                           make<FragmentRef>(*G));
+    Relocation *dynRel = Relocation::Create(relocType, is32Bits ? 32 : 64,
+                                            make<FragmentRef>(*G));
     dynRel->setSymInfo(R);
     Obj->getRelaPLT()->addRelocation(dynRel);
   }

--- a/lib/Target/RISCV/RISCVLDBackend.h
+++ b/lib/Target/RISCV/RISCVLDBackend.h
@@ -113,9 +113,14 @@ public:
   shouldProcessSectionForGC(const ELFSection &pSec) const override;
 
   // ---------------------  PLT Support ---------------------------
-  RISCVPLT *createPLT(ELFObjectFile *Obj, ResolveInfo *sym);
+  RISCVPLT *createPLT(ELFObjectFile *Obj, ResolveInfo *sym,
+                      bool isIRelative = false);
 
   void recordPLT(ResolveInfo *, RISCVPLT *);
+
+  /// defineIRelativeRange - define __rela_iplt_start/__rela_iplt_end symbols
+  /// for IFunc support in static linking
+  void defineIRelativeRange(ResolveInfo &pSym);
 
   RISCVPLT *findEntryInPLT(ResolveInfo *) const;
 
@@ -137,6 +142,8 @@ public:
     if (X->type() == llvm::ELF::R_RISCV_JUMP_SLOT)
       return DynRelocType::JMP_SLOT;
     if (X->type() == llvm::ELF::R_RISCV_RELATIVE)
+      return DynRelocType::RELATIVE;
+    if (X->type() == llvm::ELF::R_RISCV_IRELATIVE)
       return DynRelocType::RELATIVE;
     if (X->type() == llvm::ELF::R_RISCV_TLS_DTPMOD32 ||
         X->type() == llvm::ELF::R_RISCV_TLS_DTPMOD64) {
@@ -293,6 +300,9 @@ private:
   RISCVELFDynamic *m_pDynamic = nullptr;
   /// RISCV Attribute Fragment
   RISCVAttributeFragment *AttributeFragment = nullptr;
+
+  LDSymbol *m_pIRelativeStart = nullptr;
+  LDSymbol *m_pIRelativeEnd = nullptr;
 
   llvm::DenseMap<ResolveInfo *, RISCVGOT *> m_GOTMap;
   llvm::DenseMap<ResolveInfo *, RISCVGOT *> m_GOTPLTMap;

--- a/lib/Target/RISCV/RISCVRelocator.cpp
+++ b/lib/Target/RISCV/RISCVRelocator.cpp
@@ -614,6 +614,10 @@ void RISCVRelocator::scanGlobalReloc(InputFile &pInputFile, Relocation &pReloc,
   ELFObjectFile *Obj = llvm::dyn_cast<ELFObjectFile>(&pInputFile);
   // rsym - The relocation target symbol
   ResolveInfo *rsym = pReloc.symInfo();
+
+  if (rsym && rsym->isIFunc() && config().isCodeStatic())
+    return handleScanForNonPreemptibleIFunc(pReloc, Obj);
+
   RISCVLDBackend &ld_backend = getTarget();
   switch (pReloc.type()) {
   case llvm::ELF::R_RISCV_32:
@@ -989,10 +993,14 @@ RISCVRelocator::Result applyRelLO(Relocation &pReloc, RISCVLDBackend &Backend,
   if (HIReloc->type() == llvm::ELF::R_RISCV_GOT_HI20 ||
       HIReloc->type() == llvm::ELF::R_RISCV_TLS_GD_HI20 ||
       HIReloc->type() == llvm::ELF::R_RISCV_TLS_GOT_HI20) {
-    RISCVGOT *GOT = Backend.findEntryInGOT(pReloc.symInfo());
-    if (!GOT)
+    GOT *GOTEntry = Backend.findEntryInGOT(pReloc.symInfo());
+    if (!GOTEntry && pReloc.symInfo()->isIFunc()) {
+      auto PLTEntry = Backend.findEntryInPLT(pReloc.symInfo());
+      GOTEntry = PLTEntry->getGOT();
+    }
+    if (!GOTEntry)
       return RISCVRelocator::BadReloc;
-    Value = GOT->getAddr(DiagEngine);
+    Value = GOTEntry->getAddr(DiagEngine);
   } else
     Value = Backend.getSymbolValuePLT(*HIReloc);
 
@@ -1017,7 +1025,8 @@ RISCVRelocator::Result applyRelLO(Relocation &pReloc, RISCVLDBackend &Backend,
 RISCVRelocator::Result applyGOT(Relocation &pReloc, RISCVLDBackend &Backend,
                                 RISCVRelocator &Parent,
                                 RelocationDescription &pRelocDesc) {
-  if (!(pReloc.symInfo()->reserved() & Relocator::ReserveGOT)) {
+  ResolveInfo *RI = pReloc.symInfo();
+  if (!(RI->reserved() & Relocator::ReserveGOT) && !RI->isIFunc()) {
     return Relocator::BadReloc;
   }
 
@@ -1030,8 +1039,14 @@ RISCVRelocator::Result applyGOT(Relocation &pReloc, RISCVLDBackend &Backend,
   if (!BaseReloc)
     return RISCVRelocator::BadReloc;
 
-  int64_t S = Backend.findEntryInGOT(BaseReloc->symInfo())
-                  ->getAddr(Backend.config().getDiagEngine());
+  GOT *GOTEntry = Backend.findEntryInGOT(BaseReloc->symInfo());
+  if (!GOTEntry && BaseReloc->symInfo()->isIFunc()) {
+    auto PLTEntry = Backend.findEntryInPLT(BaseReloc->symInfo());
+    GOTEntry = PLTEntry->getGOT();
+  }
+  if (!GOTEntry)
+    return RISCVRelocator::BadReloc;
+  int64_t S = GOTEntry->getAddr(Backend.config().getDiagEngine());
   int64_t A = BaseReloc->addend();
   int64_t P = BaseReloc->place(Backend.getModule());
   int64_t Result = S + A - P;
@@ -1131,5 +1146,80 @@ RISCVRelocator::Result applyVendor(Relocation &pReloc, RISCVLDBackend &,
 }
 
 } // anonymous namespace
+
+void RISCVRelocator::handleScanForNonPreemptibleIFunc(Relocation &R,
+                                                      ELFObjectFile *Obj) {
+  std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
+  ResolveInfo *RI = R.symInfo();
+  Relocator::Type RType = R.type();
+
+  bool isValidRelocForIFunc = isGOTBasedInstrRelocation(RType) ||
+                              isAbsDataRelocation(RType) ||
+                              isControlFlowRelocation(RType) ||
+                              isAbsOrPCRELAddressInstrRelocation(RType) ||
+                              RType == llvm::ELF::R_RISCV_PCREL_LO12_I ||
+                              RType == llvm::ELF::R_RISCV_PCREL_LO12_S;
+
+  if (!isValidRelocForIFunc) {
+    config().raise(Diag::warn_invalid_reloc_for_ifunc)
+        << getName(RType)
+        << RI->getDecoratedName(config().options().shouldDemangle());
+  }
+
+  if (isGOTBasedInstrRelocation(RType))
+    RI->setIFuncNeedsGOT();
+  if (isAbsDataRelocation(RType) || isAbsOrPCRELAddressInstrRelocation(RType))
+    RI->setIFuncDirectRef();
+
+  if (RI->reserved() & Relocator::ReservePLT)
+    return;
+
+  m_Target.createPLT(Obj, RI, /*isIRelative=*/true);
+  m_Target.defineIRelativeRange(*RI);
+  RI->setReserved(RI->reserved() | Relocator::ReservePLT);
+}
+
+bool RISCVRelocator::isGOTBasedInstrRelocation(
+    Relocation::Type relocType) const {
+  switch (relocType) {
+  case llvm::ELF::R_RISCV_GOT_HI20:
+    return true;
+  default:
+    return false;
+  }
+}
+
+bool RISCVRelocator::isAbsDataRelocation(Relocation::Type relocType) const {
+  switch (relocType) {
+  case llvm::ELF::R_RISCV_32:
+  case llvm::ELF::R_RISCV_64:
+    return true;
+  default:
+    return false;
+  }
+}
+
+bool RISCVRelocator::isAbsOrPCRELAddressInstrRelocation(
+    Relocation::Type relocType) const {
+  switch (relocType) {
+  case llvm::ELF::R_RISCV_HI20:
+  case llvm::ELF::R_RISCV_PCREL_HI20:
+  case llvm::ELF::R_RISCV_LO12_S:
+  case llvm::ELF::R_RISCV_LO12_I:
+    return true;
+  }
+  return false;
+}
+
+bool RISCVRelocator::isControlFlowRelocation(Relocation::Type relocType) const {
+  switch (relocType) {
+  case llvm::ELF::R_RISCV_CALL:
+  case llvm::ELF::R_RISCV_CALL_PLT:
+  case llvm::ELF::R_RISCV_JAL:
+    return true;
+  default:
+    return false;
+  }
+}
 
 } // namespace eld

--- a/lib/Target/RISCV/RISCVRelocator.cpp
+++ b/lib/Target/RISCV/RISCVRelocator.cpp
@@ -607,6 +607,10 @@ void RISCVRelocator::scanGlobalReloc(InputFile &pInputFile, Relocation &pReloc,
   ELFObjectFile *Obj = llvm::dyn_cast<ELFObjectFile>(&pInputFile);
   // rsym - The relocation target symbol
   ResolveInfo *rsym = pReloc.symInfo();
+
+  if (rsym && rsym->isIFunc() && config().isCodeStatic())
+    return handleScanForNonPreemptibleIFunc(pReloc, Obj);
+
   RISCVLDBackend &ld_backend = getTarget();
   switch (pReloc.type()) {
   case llvm::ELF::R_RISCV_32:
@@ -986,10 +990,15 @@ RISCVRelocator::Result applyRelLO(Relocation &pReloc, RISCVLDBackend &Backend,
   if (HIReloc->type() == llvm::ELF::R_RISCV_GOT_HI20 ||
       HIReloc->type() == llvm::ELF::R_RISCV_TLS_GD_HI20 ||
       HIReloc->type() == llvm::ELF::R_RISCV_TLS_GOT_HI20) {
-    RISCVGOT *GOT = Backend.findEntryInGOT(pReloc.symInfo());
-    if (!GOT)
+    GOT *GOTEntry = Backend.findEntryInGOT(pReloc.symInfo());
+    if (!GOTEntry && pReloc.symInfo()->isIFunc()) {
+      auto PLTEntry = Backend.findEntryInPLT(pReloc.symInfo());
+      ASSERT(PLTEntry, "IFunc symbols must always have a PLT entry!");
+      GOTEntry = PLTEntry->getGOT();
+    }
+    if (!GOTEntry)
       return RISCVRelocator::BadReloc;
-    Value = GOT->getAddr(DiagEngine);
+    Value = GOTEntry->getAddr(DiagEngine);
   } else
     Value = Backend.getSymbolValuePLT(*HIReloc);
 
@@ -1014,7 +1023,8 @@ RISCVRelocator::Result applyRelLO(Relocation &pReloc, RISCVLDBackend &Backend,
 RISCVRelocator::Result applyGOT(Relocation &pReloc, RISCVLDBackend &Backend,
                                 RISCVRelocator &Parent,
                                 RelocationDescription &pRelocDesc) {
-  if (!(pReloc.symInfo()->reserved() & Relocator::ReserveGOT)) {
+  ResolveInfo *RI = pReloc.symInfo();
+  if (!(RI->reserved() & Relocator::ReserveGOT) && !RI->isIFunc()) {
     return Relocator::BadReloc;
   }
 
@@ -1027,8 +1037,15 @@ RISCVRelocator::Result applyGOT(Relocation &pReloc, RISCVLDBackend &Backend,
   if (!BaseReloc)
     return RISCVRelocator::BadReloc;
 
-  int64_t S = Backend.findEntryInGOT(BaseReloc->symInfo())
-                  ->getAddr(Backend.config().getDiagEngine());
+  GOT *GOTEntry = Backend.findEntryInGOT(BaseReloc->symInfo());
+  if (!GOTEntry && BaseReloc->symInfo()->isIFunc()) {
+    auto PLTEntry = Backend.findEntryInPLT(BaseReloc->symInfo());
+    ASSERT(PLTEntry, "IFunc symbol must always have a PLT entry!");
+    GOTEntry = PLTEntry->getGOT();
+  }
+  if (!GOTEntry)
+    return RISCVRelocator::BadReloc;
+  int64_t S = GOTEntry->getAddr(Backend.config().getDiagEngine());
   int64_t A = BaseReloc->addend();
   int64_t P = BaseReloc->place(Backend.getModule());
   int64_t Result = S + A - P;
@@ -1129,4 +1146,87 @@ RISCVRelocator::Result applyVendor(Relocation &pReloc, RISCVLDBackend &,
 
 } // anonymous namespace
 
+void RISCVRelocator::handleScanForNonPreemptibleIFunc(Relocation &R,
+                                                      ELFObjectFile *Obj) {
+  std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
+  ResolveInfo *RI = R.symInfo();
+  Relocator::Type relocType = R.type();
+
+  bool isValidRelocForIFunc = isRegularAddressInstrRelocation(relocType) ||
+                              isAbsDataRelocation(relocType) ||
+                              isControlFlowRelocation(relocType);
+
+  if (!isValidRelocForIFunc) {
+    config().raise(Diag::warn_invalid_reloc_for_ifunc)
+        << getName(relocType)
+        << RI->getDecoratedName(config().options().shouldDemangle());
+  }
+
+  if (isRegularGOTInstrRelocation(relocType))
+    RI->setIFuncNeedsGOT();
+  if (isAbsDataRelocation(relocType) ||
+      isAbsOrPCRELAddressInstrRelocation(relocType))
+    RI->setIFuncDirectRef();
+
+  if (RI->reserved() & Relocator::ReservePLT)
+    return;
+
+  m_Target.createPLT(Obj, RI, /*isIRelative=*/true);
+  m_Target.defineIRelativeRange(*RI);
+  RI->setReserved(RI->reserved() | Relocator::ReservePLT);
+}
+
+bool RISCVRelocator::isRegularGOTInstrRelocation(
+    Relocation::Type relocType) const {
+  switch (relocType) {
+  case llvm::ELF::R_RISCV_GOT_HI20:
+    return true;
+  default:
+    return false;
+  }
+}
+
+bool RISCVRelocator::isAbsDataRelocation(Relocation::Type relocType) const {
+  switch (relocType) {
+  case llvm::ELF::R_RISCV_32:
+  case llvm::ELF::R_RISCV_64:
+    return true;
+  default:
+    return false;
+  }
+}
+
+bool RISCVRelocator::isAbsOrPCRELAddressInstrRelocation(
+    Relocation::Type relocType) const {
+  switch (relocType) {
+  case llvm::ELF::R_RISCV_HI20:
+  case llvm::ELF::R_RISCV_PCREL_HI20:
+  case llvm::ELF::R_RISCV_LO12_S:
+  case llvm::ELF::R_RISCV_LO12_I:
+    return true;
+  }
+  return false;
+}
+
+bool RISCVRelocator::isRegularAddressInstrRelocation(
+    Relocation::Type relocType) const {
+  return isRegularGOTInstrRelocation(relocType) ||
+         isAbsOrPCRELAddressInstrRelocation(relocType) ||
+         relocType == llvm::ELF::R_RISCV_PCREL_LO12_I ||
+         relocType == llvm::ELF::R_RISCV_PCREL_LO12_S;
+}
+
+bool RISCVRelocator::isControlFlowRelocation(Relocation::Type relocType) const {
+  switch (relocType) {
+  case llvm::ELF::R_RISCV_CALL:
+  case llvm::ELF::R_RISCV_CALL_PLT:
+  case llvm::ELF::R_RISCV_JAL:
+  case llvm::ELF::R_RISCV_BRANCH:
+  case llvm::ELF::R_RISCV_RVC_BRANCH:
+  case llvm::ELF::R_RISCV_RVC_JUMP:
+    return true;
+  default:
+    return false;
+  }
+}
 } // namespace eld

--- a/lib/Target/RISCV/RISCVRelocator.h
+++ b/lib/Target/RISCV/RISCVRelocator.h
@@ -64,6 +64,25 @@ private:
 
   RISCVGOT *getTLSModuleID(ResolveInfo *rsym);
 
+  void handleScanForNonPreemptibleIFunc(Relocation &R, ELFObjectFile *Obj);
+
+  /// Returns true if the relocation computation uses GOT entry of the symbol.
+  bool isGOTBasedInstrRelocation(Relocation::Type relocType) const;
+
+  /// Returns true if the relocation is an absolute relocation designed for
+  /// data section of the program.
+  bool isAbsDataRelocation(Relocation::Type relocType) const;
+
+  /// Returns true if the relocation is used to compute an absolute
+  /// or PC-relative address.
+  ///
+  /// This function returns false for PCREL_LO12_I and PCREL_LO12_S because
+  /// these relocations may be used to construct a GOT address depending upon
+  /// the corresponding Hi-relocation.
+  bool isAbsOrPCRELAddressInstrRelocation(Relocation::Type relocType) const;
+
+  bool isControlFlowRelocation(Relocation::Type relocType) const;
+
 public:
   RISCVLDBackend &m_Target;
 

--- a/lib/Target/RISCV/RISCVRelocator.h
+++ b/lib/Target/RISCV/RISCVRelocator.h
@@ -64,6 +64,30 @@ private:
 
   RISCVGOT *getTLSModuleID(ResolveInfo *rsym);
 
+  void handleScanForNonPreemptibleIFunc(Relocation &R, ELFObjectFile *Obj);
+
+  /// Returns true if the relocation is a non-TLS instruction relocation whose
+  /// computation uses GOT entry of the symbol.
+  bool isRegularGOTInstrRelocation(Relocation::Type relocType) const;
+
+  /// Returns true if the relocation is an absolute or PCREl relocation designed
+  /// for data section of the program.
+  bool isAbsDataRelocation(Relocation::Type relocType) const;
+
+  /// Returns true if the relocation is used for computing an absolute
+  /// or a PC-relative address.
+  ///
+  /// This function returns false for PCREL_LO12_I and PCREL_LO12_S because
+  /// these relocations may be used to construct a GOT address depending upon
+  /// the corresponding Hi-relocation.
+  bool isAbsOrPCRELAddressInstrRelocation(Relocation::Type relocType) const;
+
+  /// Returns true if the relocation is a non-TLS non-call instruction
+  /// relocation used for computing address.
+  bool isRegularAddressInstrRelocation(Relocation::Type relocType) const;
+
+  bool isControlFlowRelocation(Relocation::Type relocType) const;
+
 public:
   RISCVLDBackend &m_Target;
 

--- a/lib/Target/X86/x86_64LDBackend.cpp
+++ b/lib/Target/X86/x86_64LDBackend.cpp
@@ -192,7 +192,8 @@ x86_64GOT *x86_64LDBackend::createGOT(GOT::GOTType T, ELFObjectFile *Obj,
   if (R != nullptr && ((config().options().isSymbolTracingRequested() &&
                         config().options().traceSymbol(*R)) ||
                        m_Module.getPrinter()->traceDynamicLinking()))
-    config().raise(Diag::create_got_entry) << R->name();
+    config().raise(Diag::create_got_entry)
+        << GOT::getGOTTypeAsStr(T) << R->name();
   // If we are creating a GOT, always create a .got.plt.
   if (!getGOTPLT()->hasFragments()) {
     // GOTPLT0 will populate its first 8 bytes with .dynamic address.

--- a/test/Common/RunTests/HelloWorldCXX/HelloWorldCXX.test
+++ b/test/Common/RunTests/HelloWorldCXX/HelloWorldCXX.test
@@ -1,5 +1,4 @@
 REQUIRES: run_cxx_test
-XFAIL: riscv32, riscv64
 UNSUPPORTED: x86
 #---HelloWorldCXX.test--------------------- Executable------------------#
 #BEGIN_COMMENT

--- a/test/Common/standalone/TraceSymbols/TraceSymbolGOTPLT.test
+++ b/test/Common/standalone/TraceSymbols/TraceSymbolGOTPLT.test
@@ -12,6 +12,6 @@ CHECK: Note: Symbol `foo' from Input file `{{.*}}.o' with info `(ELF)(NOTYPE)(UN
 CHECK-NEXT: Note: Symbol `foo' from Input file `{{.*}}.so' with info `(ELF)(FUNCTION)(DEFINE)[Global]{DEFAULT}{DYN}' being added to Namepool
 CHECK-NEXT: Note: Symbol `foo' from Input file `{{.*}}.so' with info `(ELF)(FUNCTION)(DEFINE)[Global]{DEFAULT}{DYN}' being resolved from Namepool
 CHECK-NEXT: Note: Created PLT Entry for Symbol foo
-CHECK-NEXT: Note: Created GOT Entry for Symbol foo
+CHECK-NEXT: Note: Created GOTPLT Entry for Symbol foo
 
 

--- a/test/Hexagon/standalone/TraceDynamicLinking/TraceDynamicLinking.test
+++ b/test/Hexagon/standalone/TraceDynamicLinking/TraceDynamicLinking.test
@@ -8,6 +8,6 @@ RUN: %clang %clangopts  -ffunction-sections -c %p/Inputs/2.c -o %t2.o -fPIC
 RUN: %link %linkopts -shared %t1.o  -o %t3.so
 RUN: %link %linkopts -o %t.out %t2.o -dy %t3.so --trace="dynamic-linking" 2>&1 | %filecheck %s
 CHECK: Note: Created PLT Entry for Symbol foo
-CHECK-NEXT: Note: Created GOT Entry for Symbol foo
+CHECK-NEXT: Note: Created GOTPLT Entry for Symbol foo
 
 

--- a/test/RISCV/RunTests/IFunc/StaticIFunc/Inputs/abs.c
+++ b/test/RISCV/RunTests/IFunc/StaticIFunc/Inputs/abs.c
@@ -1,0 +1,5 @@
+int foo();
+
+int (*foo_gp)() = foo;
+
+int (*get_foo_from_outside())() { return foo_gp; }

--- a/test/RISCV/RunTests/IFunc/StaticIFunc/Inputs/auipc-addi.s
+++ b/test/RISCV/RunTests/IFunc/StaticIFunc/Inputs/auipc-addi.s
@@ -1,0 +1,11 @@
+  .section .text,"ax",%progbits
+  .global get_foo_from_outside
+  .type get_foo_from_outside, @function
+
+get_foo_from_outside:
+.Lpcrel_hi0:
+  auipc a0, %pcrel_hi(foo)
+  addi a0, a0, %pcrel_lo(.Lpcrel_hi0)
+  ret
+
+  .size get_foo_from_outside, .-get_foo_from_outside

--- a/test/RISCV/RunTests/IFunc/StaticIFunc/Inputs/auipc-got.s
+++ b/test/RISCV/RunTests/IFunc/StaticIFunc/Inputs/auipc-got.s
@@ -1,0 +1,9 @@
+  .section .text,"ax",@progbits
+  .global get_foo_from_outside
+  .type get_foo_from_outside, @function
+
+get_foo_from_outside:
+  la a0, foo
+  ret
+
+  .size get_foo_from_outside, .-get_foo_from_outside

--- a/test/RISCV/RunTests/IFunc/StaticIFunc/Inputs/branch.s
+++ b/test/RISCV/RunTests/IFunc/StaticIFunc/Inputs/branch.s
@@ -1,0 +1,6 @@
+  .section ".text","ax",%progbits
+  .global call_foo_from_outside
+call_foo_from_outside:
+  addi t0, x0, 0x1
+  bne x0, t0, foo
+  ret

--- a/test/RISCV/RunTests/IFunc/StaticIFunc/Inputs/jal.s
+++ b/test/RISCV/RunTests/IFunc/StaticIFunc/Inputs/jal.s
@@ -1,0 +1,5 @@
+  .section ".text","ax",%progbits
+  .global call_foo_from_outside
+call_foo_from_outside:
+  jal x0, foo
+  ret

--- a/test/RISCV/RunTests/IFunc/StaticIFunc/Inputs/main-call.c
+++ b/test/RISCV/RunTests/IFunc/StaticIFunc/Inputs/main-call.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+int foo_impl() { return 11; }
+
+int (*foo_resolver())() { return foo_impl; }
+
+__attribute__((ifunc("foo_resolver"))) int foo();
+
+int call_foo_from_outside();
+
+int main() {
+  int (*foo_lp)() = foo;
+  int foo_value_from_outside = call_foo_from_outside();
+  printf("%d %d %d\n", foo(), foo_lp(), foo_value_from_outside);
+  printf("%p %p\n", &foo, foo_lp);
+  return 0;
+}

--- a/test/RISCV/RunTests/IFunc/StaticIFunc/Inputs/main.c
+++ b/test/RISCV/RunTests/IFunc/StaticIFunc/Inputs/main.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+int foo_impl() { return 11; }
+
+int (*foo_resolver())() { return foo_impl; }
+
+__attribute__((ifunc("foo_resolver"))) int foo();
+
+int (*get_foo_from_outside())();
+
+int main() {
+  int (*foo_lp)() = foo;
+  int (*foo_outside)() = get_foo_from_outside();
+  printf("%d %d %d\n", foo(), foo_lp(), foo_outside());
+  printf("%p %p %p\n", &foo, foo_lp, foo_outside);
+  return 0;
+}

--- a/test/RISCV/RunTests/IFunc/StaticIFunc/Inputs/rvc-jump.s
+++ b/test/RISCV/RunTests/IFunc/StaticIFunc/Inputs/rvc-jump.s
@@ -1,0 +1,6 @@
+  .option rvc
+  .section ".text","ax",%progbits
+  .global call_foo_from_outside
+call_foo_from_outside:
+  c.j foo
+  nop

--- a/test/RISCV/RunTests/IFunc/StaticIFunc/StaticIFunc.test
+++ b/test/RISCV/RunTests/IFunc/StaticIFunc/StaticIFunc.test
@@ -1,0 +1,69 @@
+REQUIRES: run_test
+#---IFunc.test---------------------------------- Executable --------------------#
+#BEGIN_COMMENT
+# This test checks that the IFunc functionality works correctly for static RISCV executables.
+#END_COMMENT
+#START_TEST
+RUN: %run_cc -target %linuxtarget -o %t1.main.nopic.o %p/Inputs/main.c -c
+RUN: %run_cc -target %linuxtarget -o %t1.main.pic.o %p/Inputs/main.c -c -fPIC
+
+RUN: %run_cc -target %linuxtarget -o %t1.auipc-addi.o %p/Inputs/auipc-addi.s -c
+RUN: %run_cc -o %t1.nopic.auipc-addi.out %t1.main.nopic.o %t1.auipc-addi.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run_cc -o %t1.pic.auipc-addi.out %t1.main.pic.o %t1.auipc-addi.o \
+RUN:   -static -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_GOT
+RUN: %run %t1.nopic.auipc-addi.out | %filecheck %s
+RUN: %run %t1.pic.auipc-addi.out | %filecheck %s
+
+RUN: %run_cc -target %linuxtarget -o %t1.auipc-got.o %p/Inputs/auipc-got.s -c -fPIC
+RUN: %run_cc -o %t1.nopic.auipc-got.out %t1.main.nopic.o %t1.auipc-got.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_GOT
+RUN: %run_cc -o %t1.pic.auipc-got.out %t1.main.pic.o %t1.auipc-got.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run %t1.nopic.auipc-got.out | %filecheck %s
+RUN: %run %t1.pic.auipc-got.out | %filecheck %s
+
+RUN: %run_cc -target %linuxtarget -o %t1.abs.o %p/Inputs/abs.c -c -static
+RUN: %run_cc -o %t1.nopic.abs.out %t1.main.nopic.o %t1.abs.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run_cc -o %t1.pic.abs.out %t1.main.pic.o %t1.abs.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_GOT
+RUN: %run %t1.nopic.abs.out | %filecheck %s
+RUN: %run %t1.pic.abs.out | %filecheck %s
+
+RUN: %run_cc -target %linuxtarget -o %t1.main-call.nopic.o %p/Inputs/main-call.c -c
+RUN: %run_cc -target %linuxtarget -o %t1.main-call.pic.o %p/Inputs/main-call.c -c
+RUN: %run_cc -target %linuxtarget -o %t1.jal.o %p/Inputs/jal.s -c -static
+RUN: %run_cc -o %t1.nopic.jal.out %t1.main-call.nopic.o %t1.jal.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run_cc -o %t1.pic.jal.out %t1.main-call.pic.o %t1.jal.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run %t1.nopic.jal.out | %filecheck %s --check-prefix=CALL_FROM_OUTSIDE
+RUN: %run %t1.pic.jal.out | %filecheck %s --check-prefix=CALL_FROM_OUTSIDE
+
+RUN: %run_cc -target %linuxtarget -o %t1.branch.o %p/Inputs/branch.s -c -static
+RUN: %run_cc -o %t1.nopic.branch.out %t1.main-call.nopic.o %t1.branch.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run_cc -o %t1.pic.branch.out %t1.main-call.pic.o %t1.branch.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run %t1.nopic.branch.out | %filecheck %s --check-prefix=CALL_FROM_OUTSIDE
+RUN: %run %t1.pic.branch.out | %filecheck %s --check-prefix=CALL_FROM_OUTSIDE
+
+RUN: %run_cc -target %linuxtarget -o %t1.rvc-jump.o %p/Inputs/rvc-jump.s -c -static
+RUN: %run_cc -o %t1.nopic.rvc-jump.out %t1.main-call.nopic.o %t1.rvc-jump.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run_cc -o %t1.pic.rvc-jump.out %t1.main-call.pic.o %t1.rvc-jump.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run %t1.nopic.rvc-jump.out | %filecheck %s --check-prefix=CALL_FROM_OUTSIDE
+RUN: %run %t1.pic.rvc-jump.out | %filecheck %s --check-prefix=CALL_FROM_OUTSIDE
+#END_TEST
+
+CHECK: 11 11 11
+CHECK: [[FOO_ADDR:0x[0-9a-fA-F]+]] [[FOO_ADDR]] [[FOO_ADDR]]
+
+CALL_FROM_OUTSIDE: 11 11 11
+CALL_FROM_OUTSIDE: [[FOO_ADDR:0x[0-9a-fA-F]+]] [[FOO_ADDR]]
+
+CHECK_GOT: Created GOT Entry for Symbol foo{{$}}
+
+CHECK_NO_GOT-NOT: Created GOT Entry for Symbol foo{{$}}

--- a/test/RISCV/standalone/IFunc/IFunc-32.test
+++ b/test/RISCV/standalone/IFunc/IFunc-32.test
@@ -1,0 +1,68 @@
+UNSUPPORTED: riscv64
+#---IFunc.test---------------------------------- Executable --------------------#
+#BEGIN_COMMENT
+# This test checks the IFunc functionality in RISCV.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -target %linuxtarget -o %t1.main.nopic.o %p/Inputs/main-nopic.s -c
+RUN: %clang %clangopts -target %linuxtarget -o %t1.main.pic.o %p/Inputs/main-pic-32.s -c
+RUN: SECTION_ADDR_LINK_OPTS="--section-start .text=0x10000 --section-start .data=0x20000 \
+RUN:   --section-start .got=0x30000 --section-start .plt=0x40000"
+
+RUN: %clang %clangopts -target %linuxtarget -o %t1.auipc-addi.o %p/Inputs/auipc-addi.s -c
+RUN: %link %linkopts -o %t1.nopic.auipc-addi.out %t1.main.nopic.o %t1.auipc-addi.o --no-relax -static ${SECTION_ADDR_LINK_OPTS}
+RUN: %link %linkopts -o %t1.pic.auipc-addi.out %t1.main.pic.o %t1.auipc-addi.o --no-relax -static ${SECTION_ADDR_LINK_OPTS}
+RUN: %readelf -Ss %t1.nopic.auipc-addi.out | %filecheck %s --check-prefix=READELF
+RUN: ( %objdump -dr %t1.nopic.auipc-addi.out --disassemble-symbols=main,get_foo_from_outside && %readelf -S %t1.nopic.auipc-addi.out ) | %filecheck %s --check-prefix=LUI_AND_AUIPC
+RUN: ( %objdump -dr %t1.pic.auipc-addi.out && %readelf -x .got %t1.pic.auipc-addi.out ) | %filecheck %s --check-prefix=AUIPC_GOT_AND_AUIPC
+
+RUN: %clang %clangopts -target %linuxtarget -o %t1.auipc-got.o %p/Inputs/auipc-got-32.s -c
+RUN: %link %linkopts -o %t1.nopic.auipc-got.out %t1.main.nopic.o %t1.auipc-got.o --no-relax -static ${SECTION_ADDR_LINK_OPTS}
+RUN: %link %linkopts -o %t1.pic.auipc-got.out %t1.main.pic.o %t1.auipc-got.o --no-relax -static ${SECTION_ADDR_LINK_OPTS}
+RUN: ( %objdump -dr %t1.nopic.auipc-got.out --disassemble-symbols=main,get_foo_from_outside && %readelf -S -x .got %t1.nopic.auipc-got.out ) | %filecheck %s --check-prefix=LUI_AND_AUIPC_GOT
+RUN: %objdump -dr %t1.pic.auipc-got.out | %filecheck %s --check-prefix=AUIPC_GOT
+#END_TEST
+
+READELF: [[#SECTION_INDEX:]]] .rela.plt
+READELF: NOTYPE LOCAL DEFAULT [[#SECTION_INDEX]] __rela_iplt_start
+READELF: NOTYPE LOCAL DEFAULT [[#SECTION_INDEX]] __rela_iplt_end
+
+LUI_AND_AUIPC: <main>:
+LUI_AND_AUIPC: lui a0, 0x40
+LUI_AND_AUIPC: addi a0, a0, 0x20
+LUI_AND_AUIPC: <get_foo_from_outside>:
+LUI_AND_AUIPC: 10020: {{.*}} auipc a0, 0x30
+LUI_AND_AUIPC: mv a0, a0
+LUI_AND_AUIPC: .plt {{.*}} {{0+}}40000
+
+AUIPC_GOT_AND_AUIPC: <main>:
+# 0x1000e + 0x20000 - 0xa = 0x30004 (.got)
+AUIPC_GOT_AND_AUIPC: 1000e: {{.*}} auipc a0, 0x20
+AUIPC_GOT_AND_AUIPC: lw a0, -0xa
+AUIPC_GOT_AND_AUIPC: <get_foo_from_outside>:
+# 0x10092 + 0x30000 - 0x72 = 0x40020
+AUIPC_GOT_AND_AUIPC: 10020: {{.*}} auipc a0, 0x30
+AUIPC_GOT_AND_AUIPC: 10024: {{.*}} mv a0, a0
+AUIPC_GOT_AND_AUIPC: '.got':
+AUIPC_GOT_AND_AUIPC: 20000400
+
+LUI_AND_AUIPC_GOT: <main>:
+LUI_AND_AUIPC_GOT: lui a0, 0x40
+LUI_AND_AUIPC_GOT: addi a0, a0, 0x20
+LUI_AND_AUIPC_GOT: <get_foo_from_outside>:
+# 0x10020 + 0x20000 - 0x1c = 0x30004 (.got)
+LUI_AND_AUIPC_GOT: 10020: {{.*}} auipc a0, 0x20
+LUI_AND_AUIPC_GOT: 10024: {{.*}} lw a0, -0x1c
+LUI_AND_AUIPC_GOT-DAG: .plt {{.*}} {{0+}}4000
+LUI_AND_AUIPC_GOT-DAG: .got {{.*}} {{0+}}3000
+LUI_AND_AUIPC_GOT: '.got':
+LUI_AND_AUIPC_GOT: 20000400
+
+AUIPC_GOT: <main>:
+# 0x1000e + 0x20000 - 0x2 = 0x3000c (.got.plt)
+AUIPC_GOT: 1000e: {{.*}} auipc a0, 0x20
+AUIPC_GOT: {{.*}} lw a0, -0x2
+AUIPC_GOT: <get_foo_from_outside>:
+# 0x10020 + 0x20000 - 0x14 = 0x3000c (.got.plt)
+AUIPC_GOT: 10020: {{.*}} auipc a0, 0x20
+AUIPC_GOT: 10024: {{.*}} lw a0, -0x14

--- a/test/RISCV/standalone/IFunc/IFunc.test
+++ b/test/RISCV/standalone/IFunc/IFunc.test
@@ -1,0 +1,69 @@
+UNSUPPORTED: riscv32
+#---IFunc.test---------------------------------- Executable --------------------#
+#BEGIN_COMMENT
+# This test checks the IFunc functionality in RISCV.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -target %linuxtarget -o %t1.main.nopic.o %p/Inputs/main-nopic.s -c
+RUN: %clang %clangopts -target %linuxtarget -o %t1.main.pic.o %p/Inputs/main-pic.s -c
+RUN: SECTION_ADDR_LINK_OPTS="--section-start .text=0x10000 --section-start .data=0x20000 \
+RUN:   --section-start .got=0x30000 --section-start .plt=0x40000"
+
+RUN: %clang %clangopts -target %linuxtarget -o %t1.auipc-addi.o %p/Inputs/auipc-addi.s -c
+RUN: %link %linkopts -o %t1.nopic.auipc-addi.out %t1.main.nopic.o %t1.auipc-addi.o --no-relax -static ${SECTION_ADDR_LINK_OPTS}
+RUN: %link %linkopts -o %t1.pic.auipc-addi.out %t1.main.pic.o %t1.auipc-addi.o --no-relax -static ${SECTION_ADDR_LINK_OPTS}
+RUN: %readelf -Ss %t1.nopic.auipc-addi.out | %filecheck %s --check-prefix=READELF
+RUN: ( %objdump -dr %t1.nopic.auipc-addi.out --disassemble-symbols=main,get_foo_from_outside && %readelf -S %t1.nopic.auipc-addi.out ) | %filecheck %s --check-prefix=LUI_AND_AUIPC
+RUN: ( %objdump -dr %t1.pic.auipc-addi.out && %readelf -x .got %t1.pic.auipc-addi.out ) | %filecheck %s --check-prefix=AUIPC_GOT_AND_AUIPC
+
+RUN: %clang %clangopts -target %linuxtarget -o %t1.auipc-got.o %p/Inputs/auipc-got.s -c
+RUN: %link %linkopts -o %t1.nopic.auipc-got.out %t1.main.nopic.o %t1.auipc-got.o --no-relax -static ${SECTION_ADDR_LINK_OPTS}
+RUN: %link %linkopts -o %t1.pic.auipc-got.out %t1.main.pic.o %t1.auipc-got.o --no-relax -static ${SECTION_ADDR_LINK_OPTS}
+RUN: ( %objdump -dr %t1.nopic.auipc-got.out --disassemble-symbols=main,get_foo_from_outside && %readelf -S -x .got %t1.nopic.auipc-got.out ) | %filecheck %s --check-prefix=LUI_AND_AUIPC_GOT
+RUN: %objdump -dr %t1.pic.auipc-got.out | %filecheck %s --check-prefix=AUIPC_GOT
+#END_TEST
+
+READELF: [[#SECTION_INDEX:]]] .rela.plt
+READELF: NOTYPE LOCAL DEFAULT [[#SECTION_INDEX]] __rela_iplt_start
+READELF: NOTYPE LOCAL DEFAULT [[#SECTION_INDEX]] __rela_iplt_end
+
+LUI_AND_AUIPC: <main>:
+LUI_AND_AUIPC: lui a0, 0x40
+LUI_AND_AUIPC: addi a0, a0, 0x20
+LUI_AND_AUIPC: <get_foo_from_outside>:
+# 10020 + 0x30000 = 0x40020 (.plt)
+LUI_AND_AUIPC: 10020: {{.*}} auipc a0, 0x30
+LUI_AND_AUIPC: mv a0, a0
+LUI_AND_AUIPC: .plt {{.*}} {{0+}}40000
+
+AUIPC_GOT_AND_AUIPC: <main>:
+# 0x1000e + 0x20000 - 0x6 = 0x30008 (.got)
+AUIPC_GOT_AND_AUIPC: 1000e: {{.*}} auipc a0, 0x20
+AUIPC_GOT_AND_AUIPC: ld a0, -0x6
+AUIPC_GOT_AND_AUIPC: <get_foo_from_outside>:
+# 0x10020 + 0x30000 = 0x40020 (.plt)
+AUIPC_GOT_AND_AUIPC: 10020: {{.*}} auipc a0, 0x30
+AUIPC_GOT_AND_AUIPC: 10024: {{.*}} mv a0, a0
+AUIPC_GOT_AND_AUIPC: '.got':
+AUIPC_GOT_AND_AUIPC: 20000400 {{0+}}
+
+LUI_AND_AUIPC_GOT: <main>:
+LUI_AND_AUIPC_GOT: lui a0, 0x40
+LUI_AND_AUIPC_GOT: addi a0, a0, 0x20
+LUI_AND_AUIPC_GOT: <get_foo_from_outside>:
+# 0x10020 + 0x20000 - 0x18 = 0x30008 (.got)
+LUI_AND_AUIPC_GOT: 10020: {{.*}} auipc a0, 0x20
+LUI_AND_AUIPC_GOT: 10024: {{.*}} ld a0, -0x18
+LUI_AND_AUIPC_GOT-DAG: .plt {{.*}} {{0+}}4000
+LUI_AND_AUIPC_GOT-DAG: .got {{.*}} {{0+}}3000
+LUI_AND_AUIPC_GOT: '.got':
+LUI_AND_AUIPC_GOT: 20000400 {{0+}}
+
+AUIPC_GOT: <main>:
+# 0x1000e + 0x20000 + 0xa = 0x30018 (.got.plt)
+AUIPC_GOT: 1000e: {{.*}} auipc a0, 0x20
+AUIPC_GOT: 10012: {{.*}} ld a0, 0xa
+AUIPC_GOT: <get_foo_from_outside>:
+# 0x10020 + 0x20000 - 0x8 = 0x30018 (.got.plt)
+AUIPC_GOT: 10020: {{.*}} auipc a0, 0x20
+AUIPC_GOT: 10024: {{.*}} ld a0, -0x8

--- a/test/RISCV/standalone/IFunc/IFunc.test
+++ b/test/RISCV/standalone/IFunc/IFunc.test
@@ -1,0 +1,67 @@
+UNSUPPORTED: riscv32
+#---IFunc.test---------------------------------- Executable --------------------#
+#BEGIN_COMMENT
+# This test checks the IFunc functionality in RISCV.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -target %linuxtarget -o %t1.main.nopic.o %p/Inputs/main-nopic.s -c
+RUN: %clang %clangopts -target %linuxtarget -o %t1.main.pic.o %p/Inputs/main-pic.s -c -fPIC
+RUN: SECTION_ADDR_LINK_OPTS="--section-start .text=0x10000 --section-start .data=0x20000 \
+RUN:   --section-start .got=0x30000 --section-start .plt=0x40000"
+
+RUN: %clang %clangopts -target %linuxtarget -o %t1.auipc-addi.o %p/Inputs/auipc-addi.s -c
+RUN: %link %linkopts -o %t1.nopic.auipc-addi.out %t1.main.nopic.o %t1.auipc-addi.o --no-relax -static ${SECTION_ADDR_LINK_OPTS}
+RUN: %link %linkopts -o %t1.pic.auipc-addi.out %t1.main.pic.o %t1.auipc-addi.o --no-relax -static ${SECTION_ADDR_LINK_OPTS}
+RUN: %readelf -Ss %t1.nopic.auipc-addi.out | %filecheck %s --check-prefix=READELF
+RUN: ( %objdump -dr %t1.nopic.auipc-addi.out --disassemble-symbols=main,get_foo_from_outside && %readelf -S %t1.nopic.auipc-addi.out ) | %filecheck %s --check-prefix=LUI_AND_AUIPC
+RUN: ( %objdump -dr %t1.pic.auipc-addi.out && %readelf -x .got %t1.pic.auipc-addi.out ) | %filecheck %s --check-prefix=AUIPC_GOT_AND_AUIPC
+
+RUN: %clang %clangopts -target %linuxtarget -o %t1.auipc-got.o %p/Inputs/auipc-got.s -c -fPIC
+RUN: %link %linkopts -o %t1.nopic.auipc-got.out %t1.main.nopic.o %t1.auipc-got.o --no-relax -static ${SECTION_ADDR_LINK_OPTS}
+RUN: %link %linkopts -o %t1.pic.auipc-got.out %t1.main.pic.o %t1.auipc-got.o --no-relax -static ${SECTION_ADDR_LINK_OPTS}
+RUN: ( %objdump -dr %t1.nopic.auipc-got.out --disassemble-symbols=main,get_foo_from_outside && %readelf -S -x .got %t1.nopic.auipc-got.out ) | %filecheck %s --check-prefix=LUI_AND_AUIPC_GOT
+RUN: %objdump -dr %t1.pic.auipc-got.out | %filecheck %s --check-prefix=AUIPC_GOT
+#END_TEST
+
+READELF: [[#SECTION_INDEX:]]] .rela.plt
+READELF: 0 NOTYPE LOCAL DEFAULT [[#SECTION_INDEX]] __rela_iplt_start
+READELF: 0 NOTYPE LOCAL DEFAULT [[#SECTION_INDEX]] __rela_iplt_end
+
+LUI_AND_AUIPC: <main>:
+LUI_AND_AUIPC: lui a0, 0x40
+LUI_AND_AUIPC: addi a0, a0, 0x20
+LUI_AND_AUIPC: <get_foo_from_outside>:
+# 10020 + 0x30000 = 0x40020 (.plt)
+LUI_AND_AUIPC: 10020: {{.*}} auipc a0, 0x30
+LUI_AND_AUIPC: .plt {{.*}} {{0+}}40000
+
+AUIPC_GOT_AND_AUIPC: <main>:
+# 0x1000e + 0x20000 - 0x6 = 0x30008 (.got)
+AUIPC_GOT_AND_AUIPC: 1000e: {{.*}} auipc a0, 0x20
+AUIPC_GOT_AND_AUIPC: ld a0, -0x6
+AUIPC_GOT_AND_AUIPC: <get_foo_from_outside>:
+# 0x10020 + 0x30000 = 0x40020 (.plt)
+AUIPC_GOT_AND_AUIPC: 10020: {{.*}} auipc a0, 0x30
+AUIPC_GOT_AND_AUIPC: '.got':
+AUIPC_GOT_AND_AUIPC: 20000400 {{0+}}
+
+LUI_AND_AUIPC_GOT: <main>:
+LUI_AND_AUIPC_GOT: lui a0, 0x40
+LUI_AND_AUIPC_GOT: addi a0, a0, 0x20
+LUI_AND_AUIPC_GOT: <get_foo_from_outside>:
+# 0x10020 + 0x20000 - 0x18 = 0x30008 (.got)
+LUI_AND_AUIPC_GOT: 10020: {{.*}} auipc a0, 0x20
+LUI_AND_AUIPC_GOT: 10024: {{.*}} ld a0, -0x18
+LUI_AND_AUIPC_GOT-DAG: .plt {{.*}} {{0+}}4000
+LUI_AND_AUIPC_GOT-DAG: .got {{.*}} {{0+}}3000
+LUI_AND_AUIPC_GOT: '.got':
+LUI_AND_AUIPC_GOT: 20000400 {{0+}}
+
+AUIPC_GOT: <main>:
+# 0x1000e + 0x20000 + 0xa = 0x30018 (.got.plt)
+AUIPC_GOT: 1000e: {{.*}} auipc a0, 0x20
+AUIPC_GOT: 10012: {{.*}} ld a0, 0xa
+AUIPC_GOT: <get_foo_from_outside>:
+# 0x10020 + 0x20000 - 0x8 = 0x30018 (.got.plt)
+AUIPC_GOT: 10020: {{.*}} auipc a0, 0x20
+AUIPC_GOT: 10024: {{.*}} ld a0, -0x8

--- a/test/RISCV/standalone/IFunc/IFuncInvalidReloc.test
+++ b/test/RISCV/standalone/IFunc/IFuncInvalidReloc.test
@@ -1,0 +1,16 @@
+#---IFuncInvalidReloc.test---------------------------------- Executable --------------------#
+#BEGIN_COMMENT
+# This test checks the warning emitted when invalid relocations are used
+# with IFunc symbols.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -target %linuxtarget -o %t1.main.nopic.o %p/Inputs/main.c -c -fno-pic
+RUN: %clang %clangopts -target %linuxtarget -o %t1.add32.o %p/Inputs/add32.s -c
+RUN: %link %linkopts -o %t1.nopic.add32.out %t1.main.nopic.o %t1.add32.o 2>&1 \
+RUN:   | %filecheck %s --check-prefix=ADD32
+RUN: %clang %clangopts -target %linuxtarget -o %t1.32pcrel.o %p/Inputs/32pcrel.s -c
+RUN: %link %linkopts -o %t1.nopic.32pcrel.out %t1.main.nopic.o %t1.32pcrel.o 2>&1 \
+RUN:   | %filecheck %s --check-prefix=32_PCREL
+
+ADD32: Warning: Invalid relocation R_RISCV_ADD32 used for STT_GNU_IFUNC symbol 'foo'
+32_PCREL: Warning: Invalid relocation R_RISCV_32_PCREL used for STT_GNU_IFUNC symbol 'foo'

--- a/test/RISCV/standalone/IFunc/Inputs/32pcrel.s
+++ b/test/RISCV/standalone/IFunc/Inputs/32pcrel.s
@@ -1,0 +1,16 @@
+.section .data,"aw",%progbits
+foo_gp:
+  .word 0x0
+  .reloc ., R_RISCV_32_PCREL, foo
+
+  .section .text,"ax",%progbits
+  .global get_foo_from_outside
+  .type get_foo_from_outside, @function
+
+get_foo_from_outside:
+.Lpcrel_hi0:
+  auipc a0, %pcrel_hi(foo_gp)
+  addi a0, a0, %pcrel_lo(.Lpcrel_hi0)
+  ret
+
+  .size get_foo_from_outside, .-get_foo_from_outside

--- a/test/RISCV/standalone/IFunc/Inputs/add32.s
+++ b/test/RISCV/standalone/IFunc/Inputs/add32.s
@@ -1,0 +1,16 @@
+.section .data,"aw",%progbits
+foo_gp:
+  .word 0x0
+  .reloc ., R_RISCV_ADD32, foo
+
+  .section .text,"ax",%progbits
+  .global get_foo_from_outside
+  .type get_foo_from_outside, @function
+
+get_foo_from_outside:
+.Lpcrel_hi0:
+  auipc a0, %pcrel_hi(foo_gp)
+  addi a0, a0, %pcrel_lo(.Lpcrel_hi0)
+  ret
+
+  .size get_foo_from_outside, .-get_foo_from_outside

--- a/test/RISCV/standalone/IFunc/Inputs/auipc-addi.s
+++ b/test/RISCV/standalone/IFunc/Inputs/auipc-addi.s
@@ -1,0 +1,11 @@
+  .section .text,"ax",%progbits
+  .global get_foo_from_outside
+  .type get_foo_from_outside, @function
+
+get_foo_from_outside:
+.Lpcrel_hi0:
+  auipc a0, %pcrel_hi(foo)
+  addi a0, a0, %pcrel_lo(.Lpcrel_hi0)
+  ret
+
+  .size get_foo_from_outside, .-get_foo_from_outside

--- a/test/RISCV/standalone/IFunc/Inputs/auipc-got-32.s
+++ b/test/RISCV/standalone/IFunc/Inputs/auipc-got-32.s
@@ -1,0 +1,11 @@
+  .section .text,"ax",@progbits
+  .global get_foo_from_outside
+  .type get_foo_from_outside, @function
+
+get_foo_from_outside:
+.Lgot_hi0:
+  auipc a0, %got_pcrel_hi(foo)
+  lw a0, %pcrel_lo(.Lgot_hi0)(a0)
+  ret
+
+  .size get_foo_from_outside, .-get_foo_from_outside

--- a/test/RISCV/standalone/IFunc/Inputs/auipc-got.s
+++ b/test/RISCV/standalone/IFunc/Inputs/auipc-got.s
@@ -1,0 +1,11 @@
+  .section .text,"ax",@progbits
+  .global get_foo_from_outside
+  .type get_foo_from_outside, @function
+
+get_foo_from_outside:
+.Lgot_hi0:
+  auipc a0, %got_pcrel_hi(foo)
+  ld a0, %pcrel_lo(.Lgot_hi0)(a0)
+  ret
+
+  .size get_foo_from_outside, .-get_foo_from_outside

--- a/test/RISCV/standalone/IFunc/Inputs/auipc-got.s
+++ b/test/RISCV/standalone/IFunc/Inputs/auipc-got.s
@@ -1,0 +1,9 @@
+  .section .text,"ax",@progbits
+  .global get_foo_from_outside
+  .type get_foo_from_outside, @function
+
+get_foo_from_outside:
+  la a0, foo
+  ret
+
+  .size get_foo_from_outside, .-get_foo_from_outside

--- a/test/RISCV/standalone/IFunc/Inputs/main-nopic.s
+++ b/test/RISCV/standalone/IFunc/Inputs/main-nopic.s
@@ -1,0 +1,33 @@
+  .section .text,"ax",%progbits
+  .global foo_impl
+  .type foo_impl, @function
+
+foo_impl:
+  addi a0, x0, 0x11
+  ret
+
+  .size foo_impl, . - foo_impl
+
+  .global foo_resolver
+  .type foo_resolver, @function
+
+foo_resolver:
+  lui a0, %hi(foo_impl)
+  addi a0, a0, %lo(foo_impl)
+  ret
+
+  .size foo_resolver, . - foo_resolver
+
+  .global foo
+  .type foo, @gnu_indirect_function
+  .set foo, foo_resolver
+
+  .global main
+  .type main, @function
+main:
+  lui a0, %hi(foo)
+  addi a0, a0, %lo(foo)
+  call foo
+  ret
+
+  .size main, . - main

--- a/test/RISCV/standalone/IFunc/Inputs/main-pic-32.s
+++ b/test/RISCV/standalone/IFunc/Inputs/main-pic-32.s
@@ -1,0 +1,34 @@
+  .section .text,"ax",%progbits
+  .global foo_impl
+  .type foo_impl, @function
+
+foo_impl:
+  addi a0, x0, 0x11
+  ret
+
+  .size foo_impl, . - foo_impl
+
+  .global foo_resolver
+  .type foo_resolver, @function
+
+foo_resolver:
+  lui a0, %hi(foo_impl)
+  addi a0, a0, %lo(foo_impl)
+  ret
+
+  .size foo_resolver, . - foo_resolver
+
+  .global foo
+  .type foo, @gnu_indirect_function
+  .set foo, foo_resolver
+
+  .global main
+  .type main, @function
+main:
+.Ltmp1:
+  auipc a0, %got_pcrel_hi(foo)
+  lw a0, %pcrel_lo(.Ltmp1)(a0)
+  call foo
+  ret
+
+  .size main, . - main

--- a/test/RISCV/standalone/IFunc/Inputs/main-pic.s
+++ b/test/RISCV/standalone/IFunc/Inputs/main-pic.s
@@ -1,0 +1,34 @@
+  .section .text,"ax",%progbits
+  .global foo_impl
+  .type foo_impl, @function
+
+foo_impl:
+  addi a0, x0, 0x11
+  ret
+
+  .size foo_impl, . - foo_impl
+
+  .global foo_resolver
+  .type foo_resolver, @function
+
+foo_resolver:
+  lui a0, %hi(foo_impl)
+  addi a0, a0, %lo(foo_impl)
+  ret
+
+  .size foo_resolver, . - foo_resolver
+
+  .global foo
+  .type foo, @gnu_indirect_function
+  .set foo, foo_resolver
+
+  .global main
+  .type main, @function
+main:
+.Ltmp1:
+  auipc a0, %got_pcrel_hi(foo)
+  ld a0, %pcrel_lo(.Ltmp1)(a0)
+  call foo
+  ret
+
+  .size main, . - main

--- a/test/RISCV/standalone/IFunc/Inputs/main-pic.s
+++ b/test/RISCV/standalone/IFunc/Inputs/main-pic.s
@@ -1,0 +1,32 @@
+  .section .text,"ax",%progbits
+  .global foo_impl
+  .type foo_impl, @function
+
+foo_impl:
+  addi a0, x0, 0x11
+  ret
+
+  .size foo_impl, . - foo_impl
+
+  .global foo_resolver
+  .type foo_resolver, @function
+
+foo_resolver:
+  lui a0, %hi(foo_impl)
+  addi a0, a0, %lo(foo_impl)
+  ret
+
+  .size foo_resolver, . - foo_resolver
+
+  .global main
+  .type main, @function
+main:
+  la a0, foo
+  call foo
+  ret
+
+  .size main, . - main
+
+  .global foo
+  .type foo, @gnu_indirect_function
+  .set foo, foo_resolver

--- a/test/RISCV/standalone/IFunc/Inputs/main.c
+++ b/test/RISCV/standalone/IFunc/Inputs/main.c
@@ -1,0 +1,13 @@
+int foo_impl() { return 1; }
+
+int (*foo_resolver())() { return foo_impl; }
+
+__attribute__((ifunc("foo_resolver"))) int foo();
+
+int (*get_foo_from_outside())();
+
+int main() {
+  int (*foo_lp)() = foo;
+  int (*foo_outside)() = get_foo_from_outside();
+  return foo == foo_lp && foo_lp == foo_outside;
+}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -401,6 +401,7 @@ if config.test_target == 'AArch64':
         if re.match(r'.*-android', config.target_triple):
             config.available_features.add("ndk-build")
 
+linuxtarget = ''
 if config.test_target == 'RISCV64':
     if not config.target_triple:
         config.target_triple = "riscv64-unknown-none-elf"
@@ -430,6 +431,7 @@ if config.test_target == 'RISCV64':
     nm = 'llvm-nm'
     objdump = 'llvm-objdump'
     dwarfdump = 'llvm-dwarfdump'
+    linuxtarget = "riscv64-linux-gnu"
 
 if config.test_target == 'RISCV':
     if not config.target_triple:
@@ -459,6 +461,7 @@ if config.test_target == 'RISCV':
     nm = 'llvm-nm'
     objdump = 'llvm-objdump'
     dwarfdump = 'llvm-dwarfdump'
+    linuxtarget = 'riscv32-linux-gnu'
 
 cnot = which(cnot)
 clangxx = which(clangxx)
@@ -661,3 +664,4 @@ config.substitutions.append( ("%emulation","".join(config.emulation)) )
 config.substitutions.append( ("%run","".join(run)) )
 if muslclang is not None:
     config.substitutions.append( ("%musl-clang","".join(muslclang)) )
+config.substitutions.append( ("%linuxtarget", linuxtarget))

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -409,6 +409,7 @@ if config.test_target == 'AArch64':
         if re.match(r'.*-android', config.target_triple):
             config.available_features.add("ndk-build")
 
+linuxtarget = ''
 if config.test_target == 'RISCV64':
     if not config.target_triple:
         config.target_triple = "riscv64-unknown-none-elf"
@@ -438,6 +439,7 @@ if config.test_target == 'RISCV64':
     nm = 'llvm-nm'
     objdump = 'llvm-objdump'
     dwarfdump = 'llvm-dwarfdump'
+    linuxtarget = "riscv64-linux-gnu"
 
 if config.test_target == 'RISCV':
     if not config.target_triple:
@@ -467,6 +469,7 @@ if config.test_target == 'RISCV':
     nm = 'llvm-nm'
     objdump = 'llvm-objdump'
     dwarfdump = 'llvm-dwarfdump'
+    linuxtarget = 'riscv32-linux-gnu'
 
 cnot = which(cnot)
 clangxx = which(clangxx)
@@ -713,3 +716,4 @@ config.substitutions.append( ("%sysroot", sysroot) )
 config.substitutions.append( ("%run","".join(run)) )
 if muslclang is not None:
     config.substitutions.append( ("%musl-clang","".join(muslclang)) )
+config.substitutions.append( ("%linuxtarget", linuxtarget))


### PR DESCRIPTION
This commit adds GNU IFunc functionality support in RISCV static links.

GNU IFunc functionality allows a developer to provide multiple
implementations for a function and resolver fucntion that is called at
runtime to decide which implementation should be used.

GNU IFunc functionality is handled similarly to preemptible-functions in
dynamic linking. Each GNU IFunc function has a PLT slot and a GOTPLT
slot. A call/branch instruction to an IFunc function, jumps to the PLT
slot of the function. However, unlike general pre-emptible functions,
the runtime resolves ifunc functions eagerly (at startup) by iterating
over the R_RISCV_IRELATIVE relocations and calling the resolver function
for each relocation.

A GNU IFunc function additionally has a GOT slot as well if there is a
direct reference to the if IFunc function. It is required to ensure
pointer equality in cases when we have both GOT and direct
references to an ifunc symbol. For example:

Case 1) No direct reference
```
.L0
  auipc a0, %got_pcrel_hi(foo)
  ld a0, %pcrel_lo(.L0)(a0)
  jalr ra, x0
```
In this case, 'auicpc + ld' will directly resolve to GOTPLT[foo] to
avoid paying the PLT-indirection penalty.

Case 2) With direct reference
```
; A direct reference!
foo_gp:
  .quad foo

; A GOT-reference, same as before
.L0
  auipc a0, %got_pcrel_hi(foo)
  ld a0, %pcrel_lo(.L0)(a0)
  jalr ra, x0
```
In this case, if the GOT-reference resolves to GOTPLT[foo], then there
will be pointer inequality issue. Both foo_gp and a0 here stores the
address of foo, but they have different values. foo_gp has the address
of PLT[foo] and a0 has the address stored in GOTPLT[foo].

To resolve this, 'auipc + ld' is resolved to GOT[foo] and the GOT[foo]
stores the address of PLT[foo]. With this, both foo_gp and a0 have PLT[foo]
address now. Hence, the pointer inequality issue is resolved.

The developer documentation docs/DeveloperDocs/IFunc.md provides more
information about for this feature and implementation and details the
behavior of different relocations for this feature.

Additionally, this patch changes enables HelloWorldCXX test for riscv
and hence the test is no longer marked XFAIL for riscv.

Resolves #1137
