### PR TITLE
[Zephyr] Delete ULEB patch application

### DIFF
--- a/.github/workflows/zephyr-nightly.yml
+++ b/.github/workflows/zephyr-nightly.yml
@@ -116,12 +116,6 @@ jobs:
           wget -q --tries=3 --retry-on-http-error=429,500,502,503,504 --waitretry=5 https://github.com/zephyrproject-rtos/zephyr/pull/103778.patch -O eld-support.patch
           git apply eld-support.patch
 
-      - name: Download and apply ULEB128 fix for kobject list
-        run: |
-          cd zephyr
-          wget -q --tries=3 --retry-on-http-error=429,500,502,503,504 --waitretry=5 https://github.com/quic-areg/zephyr/commit/17f605dd6a9fed6bb93e148a822f9bf7e0dae8f0.patch -O uleb128-fix.patch
-          git apply uleb128-fix.patch
-
       - name: West setup
         run: |
           cd zephyr


### PR DESCRIPTION
The patch was merged upstream and is no longer needed here.