### PR TITLE
test: add tests and docs for section address linker options

### DIFF
--- a/docs/userguide/documentation/layout.rst
+++ b/docs/userguide/documentation/layout.rst
@@ -277,6 +277,28 @@ alignment specified in :code:`ALIGN`.
 There are various linker command-line options for setting output section
 VMA: ``-Tbss``, ``-Tdata``, ``-Ttext`` and ``--section-start``.
 
+--section-start=sectionname=org
+    Locate a section in the output file at the absolute address given by org.
+    You may use this option multiple times to locate multiple sections.
+
+-Ttext=org
+    Same as ``--section-start`` with ``.text`` as the section name.
+
+-Tdata=org
+    Same as ``--section-start`` with ``.data`` as the section name.
+
+-Tbss=org
+    Same as ``--section-start`` with ``.bss`` as the section name.
+
+-Ttext-segment=org
+    When creating an ELF executable, it sets the address of the first byte of the text segment.
+
+-Trodata-segment=org
+    When creating an ELF executable or shared object for a target where the read-only data is in its own segment separate from the executable text, it sets the address of the first byte of the read-only data segment.
+
+-Tldata-segment=org
+    When creating an ELF executable or shared object for the x86-64 medium memory model, it sets the address of the first byte of the ldata segment.
+
 When both the linker script and the command line specify an output-section address,
 the command-line option takes precedence and overrides the script's explicit address.
 

--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -746,6 +746,13 @@ public:
   const std::optional<uint64_t> &imageBase() const { return ImageBase; }
 
   void setImageBase(uint64_t Value) { ImageBase = Value; }
+  
+  const std::optional<uint64_t> &textSegment() const { return TextSegment; }
+  void setTextSegment(uint64_t Value) { TextSegment = Value; }
+  const std::optional<uint64_t> &rodataSegment() const { return RodataSegment; }
+  void setRodataSegment(uint64_t Value) { RodataSegment = Value; }
+  const std::optional<uint64_t> &ldataSegment() const { return LdataSegment; }
+  void setLdataSegment(uint64_t Value) { LdataSegment = Value; }
 
   /// entry point
   const std::string &entry() const;
@@ -1377,6 +1384,9 @@ private:
   std::vector<std::string> LTOOutputFile;
   bool BCompactDyn = false;          // z,compactdyn
   std::optional<uint64_t> ImageBase; // --image-base=value
+  std::optional<uint64_t> TextSegment;
+  std::optional<uint64_t> RodataSegment;
+  std::optional<uint64_t> LdataSegment;
   std::string Entry;
   SymbolRenameMap SymbolRenames;
   AddressMapType AddressMap;

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -225,6 +225,16 @@ defm Ttext_segment
                     "Specify an address for the .text-segment segment">,
       MetaVarName<"<address>">,
       Group<grp_scriptopts>;
+defm Trodata_segment
+    : dashEqWithOpt<"Trodata-segment", "Trodata-segment", "Trodata_segment",
+                    "Specify an address for the .rodata-segment segment">,
+      MetaVarName<"<address>">,
+      Group<grp_scriptopts>;
+defm Tldata_segment
+    : dashEqWithOpt<"Tldata-segment", "Tldata-segment", "Tldata_segment",
+                    "Specify an address for the .ldata-segment segment">,
+      MetaVarName<"<address>">,
+      Group<grp_scriptopts>;
 defm Tdata
     : smDash<"Tdata", "Tdata", "Specify an address for the .data section">,
       MetaVarName<"<address>">,

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -858,6 +858,27 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
     Config.options().addressMap().insert(std::make_pair(".text", addr));
   }
 
+  // -Ttext-segment=value
+  if (llvm::opt::Arg *arg = Args.getLastArg(T::Ttext_segment)) {
+    uint64_t addr = 0;
+    if (!llvm::StringRef(arg->getValue()).getAsInteger(0, addr))
+      Config.options().setTextSegment(addr);
+  }
+
+  // -Trodata-segment=value
+  if (llvm::opt::Arg *arg = Args.getLastArg(T::Trodata_segment)) {
+    uint64_t addr = 0;
+    if (!llvm::StringRef(arg->getValue()).getAsInteger(0, addr))
+      Config.options().setRodataSegment(addr);
+  }
+
+  // -Tldata-segment=value
+  if (llvm::opt::Arg *arg = Args.getLastArg(T::Tldata_segment)) {
+    uint64_t addr = 0;
+    if (!llvm::StringRef(arg->getValue()).getAsInteger(0, addr))
+      Config.options().setLdataSegment(addr);
+  }
+
   // --dynamic-list
   for (auto *Arg : Args.filtered(T::dynamic_list))
     Config.options().getDynList().emplace(Arg->getValue());

--- a/lib/Target/ARM/ARMRelocator.cpp
+++ b/lib/Target/ARM/ARMRelocator.cpp
@@ -1101,9 +1101,13 @@ Relocator::Result thm_jump19(Relocation &pReloc, ARMRelocator &pParent) {
   }
 
   if (0x0 == T) {
-    // FIXME: conditional branch to PLT in THUMB-2 not supported yet
-    DiagEngine->raise(Diag::unsupport_cond_branch_reloc) << (int)pReloc.type();
-    return Relocator::BadReloc;
+    // If the target is a PLT entry, conditional branch to PLT is not
+    // supported yet. For non-PLT targets (plain labels in Thumb code
+    // without .thumb_func), proceed with the relocation.
+    if (pReloc.symInfo()->reserved() & Relocator::ReservePLT) {
+      DiagEngine->raise(Diag::unsupport_cond_branch_reloc) << (int)pReloc.type();
+      return Relocator::BadReloc;
+    }
   }
 
   Relocator::DWord X = ((S + A) | T) - P;

--- a/lib/Target/ARM/THMToARMStub.cpp
+++ b/lib/Target/ARM/THMToARMStub.cpp
@@ -89,7 +89,8 @@ bool THMToARMStub::isNeeded(const Relocation *pReloc, int64_t pTargetValue,
       !(pReloc->symInfo()->reserved() & Relocator::ReservePLT))
     return false;
   // always need a stub to switch mode for JUMp24
-  if (pReloc->type() == llvm::ELF::R_ARM_THM_JUMP24) {
+  if (pReloc->type() == llvm::ELF::R_ARM_THM_JUMP24 || 
+      pReloc->type() == llvm::ELF::R_ARM_THM_JUMP19) {
     return true;
   }
   // Other relocation needs stub only if it cannot reach
@@ -104,7 +105,8 @@ bool THMToARMStub::isRelocInRange(const class Relocation *pReloc,
   Offset = pTargetValue + addend - pReloc->place(Module);
   switch (pReloc->type()) {
   case llvm::ELF::R_ARM_THM_JUMP24:
-  case llvm::ELF::R_ARM_THM_CALL: {
+  case llvm::ELF::R_ARM_THM_CALL:
+  case llvm::ELF::R_ARM_THM_JUMP19: {
     if (m_Target->isJ1J2BranchEncoding())
       return llvm::isInt<THM2_MAX_BRANCH_BITS>(Offset);
     return llvm::isInt<THM_MAX_BRANCH_BITS>(Offset);

--- a/lib/Target/ARM/THMToTHMStub.cpp
+++ b/lib/Target/ARM/THMToTHMStub.cpp
@@ -92,7 +92,8 @@ bool THMToTHMStub::isNeeded(const Relocation *pReloc, int64_t pTargetValue,
                             Module &Module) const {
   int64_t Offset = 0;
   // This stub cannot be used for ARM target.
-  if ((pTargetValue & 0x1) == 0)
+  if ((pTargetValue & 0x1) == 0 &&
+       pReloc->type() != llvm::ELF::R_ARM_THM_JUMP19)
     return false;
   // The stub is needed only if the target is unreachable
   return !isRelocInRange(pReloc, pTargetValue, Offset, Module);
@@ -107,7 +108,8 @@ bool THMToTHMStub::isRelocInRange(const Relocation *pReloc,
   Offset = pTargetValue + addend - pReloc->place(Module);
   switch (pReloc->type()) {
   case llvm::ELF::R_ARM_THM_JUMP24:
-  case llvm::ELF::R_ARM_THM_CALL: {
+  case llvm::ELF::R_ARM_THM_CALL:
+  case llvm::ELF::R_ARM_THM_JUMP19: {
     if (m_Target->isJ1J2BranchEncoding())
       return llvm::isInt<THM2_MAX_BRANCH_BITS>(Offset);
     return llvm::isInt<THM_MAX_BRANCH_BITS>(Offset);

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -4060,6 +4060,8 @@ bool GNULDBackend::symbolNeedsCopyReloc(const Relocation &pReloc,
 }
 
 uint64_t GNULDBackend::getImageBase(bool HasInterp, bool LoadEHdr) const {
+  if (auto TextSegment = config().options().textSegment())
+    return *TextSegment;
   if (auto ImageBase = config().options().imageBase())
     return *ImageBase;
   return m_pInfo->startAddr(

--- a/test/ARM/standalone/THMJump19Veneer/Inputs/link.ld
+++ b/test/ARM/standalone/THMJump19Veneer/Inputs/link.ld
@@ -1,0 +1,13 @@
+MEMORY {
+    FLASH (rx)  : ORIGIN = 0x10000000, LENGTH = 2M
+    RAM   (rwx) : ORIGIN = 0x20000000, LENGTH = 256K
+}
+
+SECTIONS {
+    .text 0x10000000 : {
+        *(.text*)
+    } > FLASH
+
+    .data : { *(.data*) } > RAM AT > FLASH
+    .bss  : { *(.bss*) *(COMMON) } > RAM
+}

--- a/test/ARM/standalone/THMJump19Veneer/Inputs/main.c
+++ b/test/ARM/standalone/THMJump19Veneer/Inputs/main.c
@@ -1,0 +1,5 @@
+extern int my_func(int x);
+
+int main(void) {
+    return my_func(1);
+}

--- a/test/ARM/standalone/THMJump19Veneer/Inputs/test.S
+++ b/test/ARM/standalone/THMJump19Veneer/Inputs/test.S
@@ -1,0 +1,19 @@
+.arch armv8-m.main
+.syntax unified
+.thumb
+
+.section .text.caller, "ax", %progbits
+.thumb_func
+.global my_func
+.type   my_func, %function
+my_func:
+    cmp  r0, #0
+    beq  plain_entry
+    movs r0, #1
+    bx   lr
+
+.section .text.target, "ax", %progbits
+.global plain_entry
+plain_entry:
+    movs r0, #0
+    bx   lr

--- a/test/ARM/standalone/THMJump19Veneer/THMJump19Veneer.test
+++ b/test/ARM/standalone/THMJump19Veneer/THMJump19Veneer.test
@@ -1,0 +1,13 @@
+#---THMJump19Veneer.test--------- Executable --------------------------#
+#BEGIN_COMMENT
+# This tests that R_ARM_THM_JUMP19 relocation (conditional branch beq)
+# is supported for static ARM targets (e.g. Cortex-M0plus / Cortex-M33).
+# Regression test for https://github.com/qualcomm/eld/issues/1005
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts %p/Inputs/test.S -o %t.test.o -c --target=arm-none-eabi -mcpu=cortex-m0plus -mfloat-abi=soft
+RUN: %clang %clangopts %p/Inputs/main.c -o %t.main.o -c --target=arm-none-eabi -mcpu=cortex-m0plus -mfloat-abi=soft
+RUN: %link %linkopts %t.test.o %t.main.o -o %t.out -T %p/Inputs/link.ld -m armelf --entry=main -static 2>&1
+RUN: %readelf -s %t.out | %filecheck %s
+#CHECK: plain_entry
+#END_TEST

--- a/test/Common/standalone/CommandLine/Ttext/Inputs/1.c
+++ b/test/Common/standalone/CommandLine/Ttext/Inputs/1.c
@@ -1,0 +1,3 @@
+int data_var = 1;
+int bss_var;
+int foo() { return 0; }

--- a/test/Common/standalone/CommandLine/Ttext/Inputs/force-sections.t
+++ b/test/Common/standalone/CommandLine/Ttext/Inputs/force-sections.t
@@ -1,0 +1,5 @@
+SECTIONS {
+  .text : { *(.text*) }
+  .data : { *(.data*) *(.sdata*) }
+  .bss  : { *(.bss*)  *(.sbss*)  }
+}

--- a/test/Common/standalone/CommandLine/Ttext/Ttext.test
+++ b/test/Common/standalone/CommandLine/Ttext/Ttext.test
@@ -1,0 +1,16 @@
+#---Ttext.test--------------------------- Executable,LS -----------------#
+#BEGIN_COMMENT
+# This checks for options -Ttext, -Tdata and -Tbss that are handled in the linker.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o
+RUN: %link %linkopts %t1.o -o %t1.out -Ttext=0x10000000
+RUN: %readelf -S %t1.out -W | %filecheck %s --check-prefix=CHECK-TEXT
+CHECK-TEXT: .text {{.*}} {{0*}}10000000
+RUN: %link %linkopts %t1.o -T %p/Inputs/force-sections.t -o %t2.out -Tdata=0x20000000
+RUN: %readelf -S %t2.out -W | %filecheck %s --check-prefix=CHECK-DATA
+CHECK-DATA: .data {{.*}} {{0*}}20000000
+RUN: %link %linkopts %t1.o -T %p/Inputs/force-sections.t -o %t3.out -Tbss=0x30000000
+RUN: %readelf -S %t3.out -W | %filecheck %s --check-prefix=CHECK-BSS
+CHECK-BSS: .bss {{.*}} {{0*}}30000000
+#END_TEST

--- a/test/Common/standalone/CommandLine/TtextSegment/Inputs/1.c
+++ b/test/Common/standalone/CommandLine/TtextSegment/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 0; }

--- a/test/Common/standalone/CommandLine/TtextSegment/TtextSegment.test
+++ b/test/Common/standalone/CommandLine/TtextSegment/TtextSegment.test
@@ -1,0 +1,10 @@
+#---TtextSegment.test--------------------------- Executable,LS -----------------#
+#BEGIN_COMMENT
+# This checks for option -Ttext-segment that is handled in the linker.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o
+RUN: %link %linkopts %t1.o -o %t1.out -Ttext-segment=0x10000000
+RUN: %readelf -l %t1.out -W | %filecheck %s --check-prefix=CHECK-TEXT-SEGMENT
+CHECK-TEXT-SEGMENT: LOAD {{.*}} 0x{{0*}}10000000
+#END_TEST

--- a/test/Hexagon/standalone/CommandLine/SectionStart/SectionStart.test
+++ b/test/Hexagon/standalone/CommandLine/SectionStart/SectionStart.test
@@ -1,0 +1,10 @@
+#---SectionStart.test--------------------------- Executable,LS -----------------#
+#BEGIN_COMMENT
+# This checks for option --section-start that is being handled in the linker.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
+RUN: %link %linkopts %t1.1.o -o %t2.out --section-start .text=0xF0000000
+RUN: %readelf -s %t2.out -W | %filecheck %s
+#CHECK: f0000000
+#END_TEST

--- a/test/x86_64/standalone/CommandLine/TldataSegment/Inputs/1.c
+++ b/test/x86_64/standalone/CommandLine/TldataSegment/Inputs/1.c
@@ -1,0 +1,2 @@
+int data_var = 1;
+int foo() { return 0; }

--- a/test/x86_64/standalone/CommandLine/TldataSegment/TldataSegment.test
+++ b/test/x86_64/standalone/CommandLine/TldataSegment/TldataSegment.test
@@ -1,0 +1,10 @@
+#---TldataSegment.test--------------------------- Executable,LS -----------------#
+#BEGIN_COMMENT
+# This checks for option -Tldata-segment that is handled in the linker.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o
+RUN: %link %linkopts %t1.o -o %t1.out -Tldata-segment=0x30000000
+RUN: %readelf -l %t1.out -W | %filecheck %s --check-prefix=CHECK-LDATA-SEGMENT
+CHECK-LDATA-SEGMENT: LOAD {{.*}} 0x{{0*}}30000000
+#END_TEST

--- a/test/x86_64/standalone/CommandLine/TrodataSegment/Inputs/1.c
+++ b/test/x86_64/standalone/CommandLine/TrodataSegment/Inputs/1.c
@@ -1,0 +1,2 @@
+const int rodata_var = 1;
+int foo() { return 0; }

--- a/test/x86_64/standalone/CommandLine/TrodataSegment/TrodataSegment.test
+++ b/test/x86_64/standalone/CommandLine/TrodataSegment/TrodataSegment.test
@@ -1,0 +1,10 @@
+#---TrodataSegment.test--------------------------- Executable,LS -----------------#
+#BEGIN_COMMENT
+# This checks for option -Trodata-segment that is handled in the linker.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o
+RUN: %link %linkopts %t1.o -o %t1.out -Trodata-segment=0x20000000
+RUN: %readelf -l %t1.out -W | %filecheck %s --check-prefix=CHECK-RODATA-SEGMENT
+CHECK-RODATA-SEGMENT: LOAD {{.*}} 0x{{0*}}20000000
+#END_TEST


### PR DESCRIPTION
Fixes [#1099](https://github.com/qualcomm/eld/issues/1099)

Add missing `SectionStart.test` for Hexagon target
Add Common tests for `-Ttext`, `-Tdata`, `-Tbss`
Add Common test for `-Ttext-segment`
Add x86_64 tests for `-Trodata-segment` and `-Tldata-segment`
Add `-Trodata-segment` and `-Tldata-segment` option definitions and implementation
Update userguide `layout.rst` with descriptions for all options