### PR TITLE
test: add tests and docs for section address linker options

### DIFF
--- a/docs/userguide/documentation/layout.rst
+++ b/docs/userguide/documentation/layout.rst
@@ -277,6 +277,28 @@ alignment specified in :code:`ALIGN`.
 There are various linker command-line options for setting output section
 VMA: ``-Tbss``, ``-Tdata``, ``-Ttext`` and ``--section-start``.
 
+--section-start=sectionname=org
+    Locate a section in the output file at the absolute address given by org.
+    You may use this option multiple times to locate multiple sections.
+
+-Ttext=org
+    Same as ``--section-start`` with ``.text`` as the section name.
+
+-Tdata=org
+    Same as ``--section-start`` with ``.data`` as the section name.
+
+-Tbss=org
+    Same as ``--section-start`` with ``.bss`` as the section name.
+
+-Ttext-segment=org
+    When creating an ELF executable, it sets the address of the first byte of the text segment.
+
+-Trodata-segment=org
+    When creating an ELF executable or shared object for a target where the read-only data is in its own segment separate from the executable text, it sets the address of the first byte of the read-only data segment.
+
+-Tldata-segment=org
+    When creating an ELF executable or shared object for the x86-64 medium memory model, it sets the address of the first byte of the ldata segment.
+
 When both the linker script and the command line specify an output-section address,
 the command-line option takes precedence and overrides the script's explicit address.
 

--- a/docs/userguide/documentation/layout.rst
+++ b/docs/userguide/documentation/layout.rst
@@ -278,7 +278,7 @@ There are various linker command-line options for setting output section
 VMA: ``-Tbss``, ``-Tdata``, ``-Ttext`` and ``--section-start``.
 
 --section-start=sectionname=org
-    Locate a section in the output file at the absolute address given by org.
+    --section-start assigns the specified address to the output section in the output file at the absolute address given by org.
     You may use this option multiple times to locate multiple sections.
 
 -Ttext=org

--- a/docs/userguide/documentation/layout.rst
+++ b/docs/userguide/documentation/layout.rst
@@ -279,16 +279,20 @@ VMA: ``-Tbss``, ``-Tdata``, ``-Ttext`` and ``--section-start``.
 
 --section-start=sectionname=org
     Assigns the absolute address org to the named output section.
-    You may use this option multiple times to place multiple sections at specific addresses.
+    This option can be used multiple times to set addresses for different sections.
+    If the same section name is specified more than once, the last address is used.
 
 -Ttext=org
     Same as ``--section-start`` with ``.text`` as the section name.
+    If the output does not contain a ``.text`` section, this has no effect.
 
 -Tdata=org
     Same as ``--section-start`` with ``.data`` as the section name.
+    If the output does not contain a ``.data`` section, this has no effect.
 
 -Tbss=org
     Same as ``--section-start`` with ``.bss`` as the section name.
+    If the output does not contain a ``.bss`` section, this has no effect.
 
 -Ttext-segment=org
     When creating an ELF executable, it sets the address of the first byte of the text segment.

--- a/docs/userguide/documentation/layout.rst
+++ b/docs/userguide/documentation/layout.rst
@@ -278,8 +278,8 @@ There are various linker command-line options for setting output section
 VMA: ``-Tbss``, ``-Tdata``, ``-Ttext`` and ``--section-start``.
 
 --section-start=sectionname=org
-    --section-start assigns the specified address to the output section in the output file at the absolute address given by org.
-    You may use this option multiple times to locate multiple sections.
+    Assigns the absolute address org to the named output section.
+    You may use this option multiple times to place multiple sections at specific addresses.
 
 -Ttext=org
     Same as ``--section-start`` with ``.text`` as the section name.

--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -746,6 +746,13 @@ public:
   const std::optional<uint64_t> &imageBase() const { return ImageBase; }
 
   void setImageBase(uint64_t Value) { ImageBase = Value; }
+  
+  const std::optional<uint64_t> &textSegment() const { return TextSegment; }
+  void setTextSegment(uint64_t Value) { TextSegment = Value; }
+  const std::optional<uint64_t> &rodataSegment() const { return RodataSegment; }
+  void setRodataSegment(uint64_t Value) { RodataSegment = Value; }
+  const std::optional<uint64_t> &ldataSegment() const { return LdataSegment; }
+  void setLdataSegment(uint64_t Value) { LdataSegment = Value; }
 
   /// entry point
   const std::string &entry() const;
@@ -1377,6 +1384,9 @@ private:
   std::vector<std::string> LTOOutputFile;
   bool BCompactDyn = false;          // z,compactdyn
   std::optional<uint64_t> ImageBase; // --image-base=value
+  std::optional<uint64_t> TextSegment;
+  std::optional<uint64_t> RodataSegment;
+  std::optional<uint64_t> LdataSegment;
   std::string Entry;
   SymbolRenameMap SymbolRenames;
   AddressMapType AddressMap;

--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -747,12 +747,12 @@ public:
 
   void setImageBase(uint64_t Value) { ImageBase = Value; }
   
-  const std::optional<uint64_t> &textSegment() const { return TextSegment; }
-  void setTextSegment(uint64_t Value) { TextSegment = Value; }
-  const std::optional<uint64_t> &rodataSegment() const { return RodataSegment; }
-  void setRodataSegment(uint64_t Value) { RodataSegment = Value; }
-  const std::optional<uint64_t> &ldataSegment() const { return LdataSegment; }
-  void setLdataSegment(uint64_t Value) { LdataSegment = Value; }
+const std::optional<uint64_t> &getTextSegmentAddress() const { return TextSegment; }
+void setTextSegmentAddress(uint64_t Value) { TextSegment = Value; }
+const std::optional<uint64_t> &getRodataSegmentAddress() const { return RodataSegment; }
+void setRodataSegmentAddress(uint64_t Value) { RodataSegment = Value; }
+const std::optional<uint64_t> &getLdataSegmentAddress() const { return LdataSegment; }
+void setLdataSegmentAddress(uint64_t Value) { LdataSegment = Value; }
 
   /// entry point
   const std::string &entry() const;

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -225,6 +225,16 @@ defm Ttext_segment
                     "Specify an address for the .text-segment segment">,
       MetaVarName<"<address>">,
       Group<grp_scriptopts>;
+defm Trodata_segment
+    : dashEqWithOpt<"Trodata-segment", "Trodata-segment", "Trodata_segment",
+                    "Specify an address for the .rodata-segment segment">,
+      MetaVarName<"<address>">,
+      Group<grp_scriptopts>;
+defm Tldata_segment
+    : dashEqWithOpt<"Tldata-segment", "Tldata-segment", "Tldata_segment",
+                    "Specify an address for the .ldata-segment segment">,
+      MetaVarName<"<address>">,
+      Group<grp_scriptopts>;
 defm Tdata
     : smDash<"Tdata", "Tdata", "Specify an address for the .data section">,
       MetaVarName<"<address>">,

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -227,12 +227,12 @@ defm Ttext_segment
       Group<grp_scriptopts>;
 defm Trodata_segment
     : dashEqWithOpt<"Trodata-segment", "Trodata-segment", "Trodata_segment",
-                    "Specify an address for the .rodata-segment segment">,
+                    "Set address of rodata segment">,
       MetaVarName<"<address>">,
       Group<grp_scriptopts>;
 defm Tldata_segment
     : dashEqWithOpt<"Tldata-segment", "Tldata-segment", "Tldata_segment",
-                    "Specify an address for the .ldata-segment segment">,
+                    "Set address of ldata segment">,
       MetaVarName<"<address>">,
       Group<grp_scriptopts>;
 defm Tdata

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -858,6 +858,27 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
     Config.options().addressMap().insert(std::make_pair(".text", addr));
   }
 
+  // -Ttext-segment=value
+  if (llvm::opt::Arg *arg = Args.getLastArg(T::Ttext_segment)) {
+    uint64_t addr = 0;
+    if (!llvm::StringRef(arg->getValue()).getAsInteger(0, addr))
+      Config.options().setTextSegment(addr);
+  }
+
+  // -Trodata-segment=value
+  if (llvm::opt::Arg *arg = Args.getLastArg(T::Trodata_segment)) {
+    uint64_t addr = 0;
+    if (!llvm::StringRef(arg->getValue()).getAsInteger(0, addr))
+      Config.options().setRodataSegment(addr);
+  }
+
+  // -Tldata-segment=value
+  if (llvm::opt::Arg *arg = Args.getLastArg(T::Tldata_segment)) {
+    uint64_t addr = 0;
+    if (!llvm::StringRef(arg->getValue()).getAsInteger(0, addr))
+      Config.options().setLdataSegment(addr);
+  }
+
   // --dynamic-list
   for (auto *Arg : Args.filtered(T::dynamic_list))
     Config.options().getDynList().emplace(Arg->getValue());

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -862,21 +862,21 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
   if (llvm::opt::Arg *arg = Args.getLastArg(T::Ttext_segment)) {
     uint64_t addr = 0;
     if (!llvm::StringRef(arg->getValue()).getAsInteger(0, addr))
-      Config.options().setTextSegment(addr);
+      Config.options().setTextSegmentAddress(addr);
   }
 
   // -Trodata-segment=value
   if (llvm::opt::Arg *arg = Args.getLastArg(T::Trodata_segment)) {
     uint64_t addr = 0;
     if (!llvm::StringRef(arg->getValue()).getAsInteger(0, addr))
-      Config.options().setRodataSegment(addr);
+      Config.options().setRodataSegmentAddress(addr);
   }
 
   // -Tldata-segment=value
   if (llvm::opt::Arg *arg = Args.getLastArg(T::Tldata_segment)) {
     uint64_t addr = 0;
     if (!llvm::StringRef(arg->getValue()).getAsInteger(0, addr))
-      Config.options().setLdataSegment(addr);
+      Config.options().setLdataSegmentAddress(addr);
   }
 
   // --dynamic-list

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -4060,6 +4060,8 @@ bool GNULDBackend::symbolNeedsCopyReloc(const Relocation &pReloc,
 }
 
 uint64_t GNULDBackend::getImageBase(bool HasInterp, bool LoadEHdr) const {
+  if (auto TextSegment = config().options().textSegment())
+    return *TextSegment;
   if (auto ImageBase = config().options().imageBase())
     return *ImageBase;
   return m_pInfo->startAddr(

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -4060,7 +4060,7 @@ bool GNULDBackend::symbolNeedsCopyReloc(const Relocation &pReloc,
 }
 
 uint64_t GNULDBackend::getImageBase(bool HasInterp, bool LoadEHdr) const {
-  if (auto TextSegment = config().options().textSegment())
+  if (auto TextSegment = config().options().getTextSegmentAddress())
     return *TextSegment;
   if (auto ImageBase = config().options().imageBase())
     return *ImageBase;

--- a/test/Common/standalone/CommandLine/Ttext/Inputs/1.c
+++ b/test/Common/standalone/CommandLine/Ttext/Inputs/1.c
@@ -1,0 +1,3 @@
+int data_var = 1;
+int bss_var;
+int foo() { return 0; }

--- a/test/Common/standalone/CommandLine/Ttext/Inputs/force-sections.t
+++ b/test/Common/standalone/CommandLine/Ttext/Inputs/force-sections.t
@@ -1,0 +1,5 @@
+SECTIONS {
+  .text : { *(.text*) }
+  .data : { *(.data*) *(.sdata*) }
+  .bss  : { *(.bss*)  *(.sbss*)  }
+}

--- a/test/Common/standalone/CommandLine/Ttext/Ttext.test
+++ b/test/Common/standalone/CommandLine/Ttext/Ttext.test
@@ -1,0 +1,16 @@
+#---Ttext.test--------------------------- Executable,LS -----------------#
+#BEGIN_COMMENT
+# This checks for options -Ttext, -Tdata and -Tbss that are handled in the linker.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o
+RUN: %link %linkopts %t1.o -o %t1.out -Ttext=0x10000000
+RUN: %readelf -S %t1.out -W | %filecheck %s --check-prefix=CHECK-TEXT
+CHECK-TEXT: .text {{.*}} {{0*}}10000000
+RUN: %link %linkopts %t1.o -T %p/Inputs/force-sections.t -o %t2.out -Tdata=0x20000000
+RUN: %readelf -S %t2.out -W | %filecheck %s --check-prefix=CHECK-DATA
+CHECK-DATA: .data {{.*}} {{0*}}20000000
+RUN: %link %linkopts %t1.o -T %p/Inputs/force-sections.t -o %t3.out -Tbss=0x30000000
+RUN: %readelf -S %t3.out -W | %filecheck %s --check-prefix=CHECK-BSS
+CHECK-BSS: .bss {{.*}} {{0*}}30000000
+#END_TEST

--- a/test/Common/standalone/CommandLine/TtextSegment/Inputs/1.c
+++ b/test/Common/standalone/CommandLine/TtextSegment/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 0; }

--- a/test/Common/standalone/CommandLine/TtextSegment/TtextSegment.test
+++ b/test/Common/standalone/CommandLine/TtextSegment/TtextSegment.test
@@ -1,0 +1,10 @@
+#---TtextSegment.test--------------------------- Executable,LS -----------------#
+#BEGIN_COMMENT
+# This checks for option -Ttext-segment that is handled in the linker.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o
+RUN: %link %linkopts %t1.o -o %t1.out -Ttext-segment=0x10000000
+RUN: %readelf -l %t1.out -W | %filecheck %s --check-prefix=CHECK-TEXT-SEGMENT
+CHECK-TEXT-SEGMENT: LOAD {{.*}} 0x{{0*}}10000000
+#END_TEST

--- a/test/Hexagon/standalone/CommandLine/SectionStart/SectionStart.test
+++ b/test/Hexagon/standalone/CommandLine/SectionStart/SectionStart.test
@@ -1,0 +1,10 @@
+#---SectionStart.test--------------------------- Executable,LS -----------------#
+#BEGIN_COMMENT
+# This checks for option --section-start that is being handled in the linker.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
+RUN: %link %linkopts %t1.1.o -o %t2.out --section-start .text=0xF0000000
+RUN: %readelf -s %t2.out -W | %filecheck %s
+#CHECK: f0000000
+#END_TEST

--- a/test/x86_64/standalone/CommandLine/TldataSegment/Inputs/1.c
+++ b/test/x86_64/standalone/CommandLine/TldataSegment/Inputs/1.c
@@ -1,0 +1,2 @@
+int data_var = 1;
+int foo() { return 0; }

--- a/test/x86_64/standalone/CommandLine/TldataSegment/TldataSegment.test
+++ b/test/x86_64/standalone/CommandLine/TldataSegment/TldataSegment.test
@@ -1,0 +1,10 @@
+#---TldataSegment.test--------------------------- Executable,LS -----------------#
+#BEGIN_COMMENT
+# This checks for option -Tldata-segment that is handled in the linker.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o
+RUN: %link %linkopts %t1.o -o %t1.out -Tldata-segment=0x30000000
+RUN: %readelf -l %t1.out -W | %filecheck %s --check-prefix=CHECK-LDATA-SEGMENT
+CHECK-LDATA-SEGMENT: LOAD {{.*}} 0x{{0*}}30000000
+#END_TEST

--- a/test/x86_64/standalone/CommandLine/TrodataSegment/Inputs/1.c
+++ b/test/x86_64/standalone/CommandLine/TrodataSegment/Inputs/1.c
@@ -1,0 +1,2 @@
+const int rodata_var = 1;
+int foo() { return 0; }

--- a/test/x86_64/standalone/CommandLine/TrodataSegment/TrodataSegment.test
+++ b/test/x86_64/standalone/CommandLine/TrodataSegment/TrodataSegment.test
@@ -1,0 +1,10 @@
+#---TrodataSegment.test--------------------------- Executable,LS -----------------#
+#BEGIN_COMMENT
+# This checks for option -Trodata-segment that is handled in the linker.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o
+RUN: %link %linkopts %t1.o -o %t1.out -Trodata-segment=0x20000000
+RUN: %readelf -l %t1.out -W | %filecheck %s --check-prefix=CHECK-RODATA-SEGMENT
+CHECK-RODATA-SEGMENT: LOAD {{.*}} 0x{{0*}}20000000
+#END_TEST


### PR DESCRIPTION
Fixes [#1099](https://github.com/qualcomm/eld/issues/1099)

Add missing `SectionStart.test` for Hexagon target
Add Common tests for `-Ttext`, `-Tdata`, `-Tbss`
Add Common test for `-Ttext-segment`
Add x86_64 tests for `-Trodata-segment` and `-Tldata-segment`
Update userguide `layout.rst` with descriptions for all options

Modifications to support this fix:
Add `-Trodata-segment` and `-Tldata-segment` option definitions and implementation
Implement `-Ttext-segment` option (required for tests to pass)

Note: When both `-Ttext-segment` and a linker script address assignment are
specified, the linker script takes precedence. This matches `GNU ld` behavior
and has been confirmed by the maintainer.