### PR TITLE
Fix ELFObjectWriter::emitRelocation function

### DIFF
--- a/include/eld/Writers/ELFObjectWriter.h
+++ b/include/eld/Writers/ELFObjectWriter.h
@@ -102,12 +102,12 @@ private:
   // Emit SHT_REL/SHT_RELA relocations
   template <typename ELFT>
   void emitRelocation(typename ELFT::Rel &PRel, Relocation::Type CurType,
-                      uint32_t CurSymIdx, uint32_t CurOffset) const;
+                      uint32_t CurSymIdx, uint64_t CurOffset) const;
 
   template <typename ELFT>
   void emitRelocation(typename ELFT::Rela &PRel, Relocation::Type CurType,
-                      uint32_t CurSymIdx, uint32_t CurOffset,
-                      int32_t CurAddend) const;
+                      uint32_t CurSymIdx, uint64_t CurOffset,
+                      int64_t CurAddend) const;
 
 private:
   Module &ThisModule;

--- a/lib/Writers/ELFObjectWriter.cpp
+++ b/lib/Writers/ELFObjectWriter.cpp
@@ -843,20 +843,27 @@ bool ELFObjectWriter::shouldEmitReloc(const Relocation *R) const {
                                               /*IgnoreUnknown=*/true);
 }
 
-/// emitRelocation - write data to the ELF32_Rel entry
+/// emitRelocation - write data to the ELFX_Rel entry
+/// Please note that it is okay to use 64-bit types for
+/// ELFX_Rel because 64-bit signed type can represent
+/// all the values of 32-bit signed type and the conversion
+/// between 32-bit and 64-bit is well-defined as long as the
+/// value fits in the 32-bit signed range. Similar reasoning
+/// is also valid for the conversion between 32-bit and 64-bit
+/// unsigned values.
 template <typename ELFT>
 void ELFObjectWriter::emitRelocation(typename ELFT::Rel &pRel,
                                      Relocation::Type pType, uint32_t pSymIdx,
-                                     uint32_t pOffset) const {
+                                     uint64_t pOffset) const {
   pRel.r_offset = pOffset;
   pRel.setSymbolAndType(pSymIdx, pType, false);
 }
 
-/// emitRelocation - write data to the ELF32_Rela entry
+/// emitRelocation - write data to the ELFX_Rela entry
 template <typename ELFT>
 void ELFObjectWriter::emitRelocation(typename ELFT::Rela &pRel,
                                      Relocation::Type pType, uint32_t pSymIdx,
-                                     uint32_t pOffset, int32_t pAddend) const {
+                                     uint64_t pOffset, int64_t pAddend) const {
   pRel.r_offset = pOffset;
   pRel.r_addend = pAddend;
   pRel.setSymbolAndType(pSymIdx, pType, false);
@@ -894,13 +901,13 @@ template uint64_t
 ELFObjectWriter::getLastStartOffset<llvm::object::ELF64LE>() const;
 template void ELFObjectWriter::emitRelocation<llvm::object::ELF32LE>(
     llvm::object::ELF32LE::Rel &pRel, Relocation::Type pType, uint32_t pSymIdx,
-    uint32_t pOffset) const;
+    uint64_t pOffset) const;
 template void ELFObjectWriter::emitRelocation<llvm::object::ELF64LE>(
     llvm::object::ELF64LE::Rel &pRel, Relocation::Type pType, uint32_t pSymIdx,
-    uint32_t pOffset) const;
+    uint64_t pOffset) const;
 template void ELFObjectWriter::emitRelocation<llvm::object::ELF32LE>(
     llvm::object::ELF32LE::Rela &pRela, Relocation::Type pType,
-    uint32_t pSymIdx, uint32_t pOffset, int32_t Addend) const;
+    uint32_t pSymIdx, uint64_t pOffset, int64_t Addend) const;
 template void ELFObjectWriter::emitRelocation<llvm::object::ELF64LE>(
     llvm::object::ELF64LE::Rela &pRela, Relocation::Type pType,
-    uint32_t pSymIdx, uint32_t pOffset, int32_t Addend) const;
+    uint32_t pSymIdx, uint64_t pOffset, int64_t Addend) const;

--- a/test/AArch64/standalone/Relocations/PAuthReloc.s
+++ b/test/AArch64/standalone/Relocations/PAuthReloc.s
@@ -5,13 +5,13 @@
 #START_TEST
 # RUN: rm -rf %t && split-file %s %t && cd %t
 
-# RUN: %llvm-mc -filetype=obj -triple=aarch64 a.s -o a.o
-# RUN: %link %linkopts -shared a.o -o a.so
-# RUN: %llvm-mc -filetype=obj -triple=aarch64 main.s -o main.o
+# RUN: %llvm-mc -filetype=obj -triple=aarch64 a.s -o %t/a.o
+# RUN: %link %linkopts -shared %t/a.o -o %t/a.so
+# RUN: %llvm-mc -filetype=obj -triple=aarch64 main.s -o %t/main.o
 
 # Test PAuth relocations with PIE
-# RUN: %link %linkopts -z notext main.o -pie a.so -o main
-# RUN: %readelf --elf-output-style LLVM -r main 2>&1 | %filecheck %s --check-prefix=UNPACKED
+# RUN: %link %linkopts -z notext main.o -pie a.so -o %t/main
+# RUN: %readelf --elf-output-style LLVM -r %t/main 2>&1 | %filecheck %s --check-prefix=UNPACKED
 
 # UNPACKED:          Section ({{.+}}) .rela.dyn {
 # UNPACKED-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
@@ -20,8 +20,8 @@
 # UNPACKED-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
 # UNPACKED-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0xFFFFFFFFFFFFF{{[0-9A-F]+}}
 # UNPACKED-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0x12345{{[0-9A-F]+}}
-# UNPACKED-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0x34567{{[0-9A-F]+}}
-# UNPACKED-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0xFFFFFFFFCBA98{{[0-9A-F]+}}
+# UNPACKED-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0x1234567{{[0-9A-F]+}}
+# UNPACKED-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0xFFFFFFEDCBA{{[0-9A-F]+}}
 # UNPACKED-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
 # UNPACKED-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
 # UNPACKED-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
@@ -101,8 +101,8 @@
 # NOPIE-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
 # NOPIE-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0xFFFFFFFFFFFFF{{[0-9A-F]+}}
 # NOPIE-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0x12345{{[0-9A-F]+}}
-# NOPIE-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0x34567{{[0-9A-F]+}}
-# NOPIE-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0xFFFFFFFFCBA98{{[0-9A-F]+}}
+# NOPIE-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0x1234567{{[0-9A-F]+}}
+# NOPIE-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0xFFFFFFEDCBA{{[0-9A-F]+}}
 # NOPIE-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
 # NOPIE-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
 # NOPIE-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
@@ -111,7 +111,7 @@
 # NOPIE-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_ABS64 foo 0x1111
 
 # Test PAuth relocations with static executable (PIE)
-# RUN: %link %linkopts -z notext -static main.o -pie a.o -o main.static
+# RUN: %link %linkopts -z notext -static main.o -pie %t/a.o -o %t/main.static
 # RUN: %readelf --elf-output-style LLVM -r main.static 2>&1 | %filecheck %s --check-prefix=STATIC
 
 # STATIC:      Section ({{.+}}) .rela.dyn {
@@ -122,8 +122,8 @@
 # STATIC-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
 # STATIC-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0xFFFFFFFFFFFFF{{[0-9A-F]+}}
 # STATIC-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0x12345{{[0-9A-F]+}}
-# STATIC-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0x34567{{[0-9A-F]+}}
-# STATIC-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0xFFFFFFFFCBA98{{[0-9A-F]+}}
+# STATIC-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0x1234567{{[0-9A-F]+}}
+# STATIC-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - 0xFFFFFFEDCBA98{{[0-9A-F]+}}
 # STATIC-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
 # STATIC-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
 # STATIC-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
@@ -131,8 +131,8 @@
 # STATIC-DAG:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
 
 # Test PAuth relocations with static executable (without PIE)
-# RUN: %link %linkopts -z notext -static main.o -no-pie a.o -o main.static.nopie
-# RUN: %readelf --elf-output-style LLVM -r main.static.nopie 2>&1 | %filecheck %s --check-prefix=STATIC_NOPIE
+# RUN: %link %linkopts -z notext -static %t/main.o -no-pie a.o -o %t/main.static.nopie
+# RUN: %readelf --elf-output-style LLVM -r %t/main.static.nopie 2>&1 | %filecheck %s --check-prefix=STATIC_NOPIE
 
 # STATIC_NOPIE-COUNT-14:       {{0x[0-9A-F]+}} R_AARCH64_AUTH_RELATIVE - {{0x[0-9A-F]+}}
 

--- a/test/Common/standalone/64BitRela/64BitRela.test
+++ b/test/Common/standalone/64BitRela/64BitRela.test
@@ -1,0 +1,13 @@
+UNSUPPORTED: 32BitsArch
+#---64BitRela.test--------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# This test checks that the linker generates correct RELA relocations
+# when the addend is greater than INT32_MAX.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangg0opts -o %t1.1.o %p/Inputs/1.c -c -fPIC
+RUN: %link %linkg0opts -o %t1.lib1.so %t1.1.o -shared --section-start=.data=0x80000000
+RUN: %readelf -r %t1.lib1.so | %filecheck %s
+#END_TEST
+
+CHECK: R_{{.*}}_RELATIVE 80000000

--- a/test/Common/standalone/64BitRela/Inputs/1.c
+++ b/test/Common/standalone/64BitRela/Inputs/1.c
@@ -1,0 +1,4 @@
+static int u = 11;
+int *v = &u;
+
+int foo() { return 1; }


### PR DESCRIPTION
This commit fixes the parameter types of ELFObjectWriter::emitRelocation function to use 64-bit values for r_offset and r_addend fields.