### PR TITLE
test: add test for anonymous version definition diagnostic

### DIFF
--- a/test/Common/standalone/VersionScriptAnonymousMixed/Inputs/1.c
+++ b/test/Common/standalone/VersionScriptAnonymousMixed/Inputs/1.c
@@ -1,0 +1,2 @@
+void foo() {}
+void bar() {}

--- a/test/Common/standalone/VersionScriptAnonymousMixed/Inputs/vs_anon_first
+++ b/test/Common/standalone/VersionScriptAnonymousMixed/Inputs/vs_anon_first
@@ -1,0 +1,6 @@
+{
+  global: bar;
+};
+VER_1.0 {
+  global: foo;
+};

--- a/test/Common/standalone/VersionScriptAnonymousMixed/Inputs/vs_mixed
+++ b/test/Common/standalone/VersionScriptAnonymousMixed/Inputs/vs_mixed
@@ -1,0 +1,6 @@
+VER_1.0 {
+  global: foo;
+};
+{
+  global: bar;
+};

--- a/test/Common/standalone/VersionScriptAnonymousMixed/VersionScriptAnonymousMixed.test
+++ b/test/Common/standalone/VersionScriptAnonymousMixed/VersionScriptAnonymousMixed.test
@@ -1,0 +1,13 @@
+#---VersionScriptAnonymousMixed.test--------------------- SharedLibrary,VS------------------#
+#BEGIN_COMMENT
+# Test that an error is emitted when an anonymous version definition
+# is used in combination with other named version definitions
+# in a version script.
+#END_COMMENT
+
+RUN: %clang %clangopts -c -fpic %p/Inputs/1.c -o %t1.o
+RUN: %not %link %linkopts -shared -o %t1.so %t1.o --version-script=%p/Inputs/vs_mixed 2>&1 | %filecheck %s --check-prefix=NAMED
+RUN: %not %link %linkopts -shared -o %t1.so %t1.o --version-script=%p/Inputs/vs_anon_first 2>&1 | %filecheck %s --check-prefix=ANON
+
+NAMED: Error: {{.*}}: anonymous version definition is used in combination with other version definitions
+ANON: Error: {{.*}}: EOF expected, but got VER_1.0


### PR DESCRIPTION
Fixes #1124 

Adds a lit test covering the error diagnostic emitted when an anonymous 
version definition is used in combination with other named version 
definitions in a version script.

Problem : 
The diagnostic `anonymous version definition is used in combination with 
other version definitions` (emitted in `ScriptParser::readVersionScriptCommand()`) 
had no test coverage.

Solution : 
Added a new lit test at `test/Common/standalone/VersionScriptAnonymousMixed/` 
with the following files:

- `Inputs/1.c` — minimal C source file to produce an object file for linking
- `Inputs/vs_mixed` — version script mixing a named and anonymous version node to trigger the diagnostic
- `VersionScriptAnonymousMixed.test` — compiles `1.c` into an object file, 
  links it as a shared library with `vs_mixed` via `--version-script=`, 
  expects the link to fail (`%not`), and verifies the error message using 
  `FileCheck`

Testing : 
Tested on AArch64, ARM, RISCV, RISCV64, Hexagon, x86 - > all pass.