### PR TITLE
Fix ELFObjectWriter::emitRelocation function

### DIFF
--- a/include/eld/Writers/ELFObjectWriter.h
+++ b/include/eld/Writers/ELFObjectWriter.h
@@ -102,12 +102,12 @@ private:
   // Emit SHT_REL/SHT_RELA relocations
   template <typename ELFT>
   void emitRelocation(typename ELFT::Rel &PRel, Relocation::Type CurType,
-                      uint32_t CurSymIdx, uint32_t CurOffset) const;
+                      uint32_t CurSymIdx, uint64_t CurOffset) const;
 
   template <typename ELFT>
   void emitRelocation(typename ELFT::Rela &PRel, Relocation::Type CurType,
-                      uint32_t CurSymIdx, uint32_t CurOffset,
-                      int32_t CurAddend) const;
+                      uint32_t CurSymIdx, uint64_t CurOffset,
+                      int64_t CurAddend) const;
 
 private:
   Module &ThisModule;

--- a/lib/Writers/ELFObjectWriter.cpp
+++ b/lib/Writers/ELFObjectWriter.cpp
@@ -804,20 +804,27 @@ bool ELFObjectWriter::shouldEmitReloc(const Relocation *R) const {
                                               /*IgnoreUnknown=*/true);
 }
 
-/// emitRelocation - write data to the ELF32_Rel entry
+/// emitRelocation - write data to the ELFX_Rel entry
+/// Please note that it is okay to use 64-bit types for
+/// ELFX_Rel because 64-bit signed type can represent
+/// all the values of 32-bit signed type and the conversion
+/// between 32-bit and 64-bit is well-defined as long as the
+/// value fits in the 32-bit signed range. Similar reasoning
+/// is also valid for the conversion between 32-bit and 64-bit
+/// unsigned values.
 template <typename ELFT>
 void ELFObjectWriter::emitRelocation(typename ELFT::Rel &pRel,
                                      Relocation::Type pType, uint32_t pSymIdx,
-                                     uint32_t pOffset) const {
+                                     uint64_t pOffset) const {
   pRel.r_offset = pOffset;
   pRel.setSymbolAndType(pSymIdx, pType, false);
 }
 
-/// emitRelocation - write data to the ELF32_Rela entry
+/// emitRelocation - write data to the ELFX_Rela entry
 template <typename ELFT>
 void ELFObjectWriter::emitRelocation(typename ELFT::Rela &pRel,
                                      Relocation::Type pType, uint32_t pSymIdx,
-                                     uint32_t pOffset, int32_t pAddend) const {
+                                     uint64_t pOffset, int64_t pAddend) const {
   pRel.r_offset = pOffset;
   pRel.r_addend = pAddend;
   pRel.setSymbolAndType(pSymIdx, pType, false);
@@ -855,13 +862,13 @@ template uint64_t
 ELFObjectWriter::getLastStartOffset<llvm::object::ELF64LE>() const;
 template void ELFObjectWriter::emitRelocation<llvm::object::ELF32LE>(
     llvm::object::ELF32LE::Rel &pRel, Relocation::Type pType, uint32_t pSymIdx,
-    uint32_t pOffset) const;
+    uint64_t pOffset) const;
 template void ELFObjectWriter::emitRelocation<llvm::object::ELF64LE>(
     llvm::object::ELF64LE::Rel &pRel, Relocation::Type pType, uint32_t pSymIdx,
-    uint32_t pOffset) const;
+    uint64_t pOffset) const;
 template void ELFObjectWriter::emitRelocation<llvm::object::ELF32LE>(
     llvm::object::ELF32LE::Rela &pRela, Relocation::Type pType,
-    uint32_t pSymIdx, uint32_t pOffset, int32_t Addend) const;
+    uint32_t pSymIdx, uint64_t pOffset, int64_t Addend) const;
 template void ELFObjectWriter::emitRelocation<llvm::object::ELF64LE>(
     llvm::object::ELF64LE::Rela &pRela, Relocation::Type pType,
-    uint32_t pSymIdx, uint32_t pOffset, int32_t Addend) const;
+    uint32_t pSymIdx, uint64_t pOffset, int64_t Addend) const;

--- a/test/Common/standalone/64BitRela/64BitRela.test
+++ b/test/Common/standalone/64BitRela/64BitRela.test
@@ -1,0 +1,13 @@
+UNSUPPORTED: 32BitsArch
+#---64BitRela.test--------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# This test checks that the linker generates correct RELA relocations
+# when the addend is greater than INT32_MAX.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangg0opts -o %t1.1.o %p/Inputs/1.c -c -fPIC
+RUN: %link %linkg0opts -o %t1.lib1.so %t1.1.o -shared --section-start=.data=0x80000000
+RUN: %readelf -r %t1.lib1.so | %filecheck %s
+#END_TEST
+
+CHECK: R_{{.*}}_RELATIVE 80000000

--- a/test/Common/standalone/64BitRela/Inputs/1.c
+++ b/test/Common/standalone/64BitRela/Inputs/1.c
@@ -1,0 +1,4 @@
+static int u = 11;
+int *v = &u;
+
+int foo() { return 1; }


### PR DESCRIPTION
This commit fixes the parameter types of ELFObjectWriter::emitRelocation function to use 64-bit values for r_offset and r_addend fields.

Resolves #1149