### PR TITLE
Add support for -Wno-whole-archive

### DIFF
--- a/docs/userguide/documentation/diagnostic_reports.rst
+++ b/docs/userguide/documentation/diagnostic_reports.rst
@@ -113,6 +113,8 @@ Suppression Flags
      - Disables linker script-related warnings.
    * - ``-Wno-osabi``
      - Disables OS/ABI warnings.
+   * - ``-Wno-whole-archive``
+     - Disables whole archive warnings.
 
 Archive Member Reports
 ======================

--- a/lib/Config/LinkerConfig.cpp
+++ b/lib/Config/LinkerConfig.cpp
@@ -245,6 +245,10 @@ bool LinkerConfig::setWarningOption(llvm::StringRef WarnOption) {
     setShowWholeArchiveWarning(true);
     return true;
   }
+  if (WarnOpt == "no-whole-archive") {
+    setShowWholeArchiveWarning(false);
+    return true;
+  }
   // -Wosabi and -Wno-osabi
   if (WarnOpt == "osabi") {
     setShowOSABIWarning(true);

--- a/test/Common/standalone/CommandLine/WholeArchive/WholeArchive.test
+++ b/test/Common/standalone/CommandLine/WholeArchive/WholeArchive.test
@@ -1,11 +1,16 @@
-#---WholeArchive.test--------------------------- Executable --------------------#
+#---WholeArchive.test--------------------------- Executable -------------------#
 #BEGIN_COMMENT
-# This checks for option -{,no-}whole-archive that is being handled in the linker.
+# This checks for option -{,no-}whole-archive that is being handled in the
+# linker as well as -W{,no-}whole-archive warnings.
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
 RUN: %ar cr %aropts %t1.lib1.a %t1.1.o
-RUN: %link %linkopts -whole-archive %t1.lib1.a -no-whole-archive -o %t2.out
+RUN: %link %linkopts --whole-archive -Wwhole-archive %t1.lib1.a --no-whole-archive -o %t2.out 2>&1 | %filecheck %s --check-prefix WARNING
 RUN: %readelf -s %t2.out -W | %filecheck %s
+RUN: %link %linkopts --whole-archive -Wno-whole-archive %t1.lib1.a --no-whole-archive -o %t2.out 2>&1 | %filecheck %s --allow-empty --check-prefix NOWARNING
+
+#WARNING: Warning: 'whole-archive' enabled for {{.*}}lib1.a'
 #CHECK: foo
+#NOWARNING-NOT: Warning: 'whole-archive' enabled
 #END_TEST


### PR DESCRIPTION
Allow users to disable whole-archive warnings using the -Wno-whole-archive option, consistent with other warning categories.

Fix: #273