### PR TITLE
Make output relocation section order deterministic

### DIFF
--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -1981,7 +1981,7 @@ void ObjectLinker::createRelocationSections() {
   // Use a MapVector so that output relocation sections are created in a
   // deterministic order.
   llvm::MapVector<SectionKey, uint32_t,
-                  llvm::DenseMap<SectionKey, unsigned, SectionKeyInfo>>
+                  llvm::DenseMap<SectionKey, uint32_t, SectionKeyInfo>>
       OutputRelocCount;
   llvm::DenseMap<SectionKey, uint32_t, SectionKeyInfo> OutputRelocAlignment;
   llvm::DenseMap<SectionKey, ELFSection *, SectionKeyInfo>

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -67,6 +67,7 @@
 #include "eld/Target/GNULDBackend.h"
 #include "eld/Target/LDFileFormat.h"
 #include "eld/Target/Relocator.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/BinaryFormat/ELF.h"
@@ -1976,8 +1977,12 @@ void ObjectLinker::createRelocationSections() {
     }
   };
 
-  // apply all relocations of all inputs
-  llvm::DenseMap<SectionKey, uint32_t, SectionKeyInfo> OutputRelocCount;
+  // Apply all relocations of all inputs.
+  // Use a MapVector so that output relocation sections are created in a
+  // deterministic order.
+  llvm::MapVector<SectionKey, uint32_t,
+                  llvm::DenseMap<SectionKey, unsigned, SectionKeyInfo>>
+      OutputRelocCount;
   llvm::DenseMap<SectionKey, uint32_t, SectionKeyInfo> OutputRelocAlignment;
   llvm::DenseMap<SectionKey, ELFSection *, SectionKeyInfo>
       OutputRelocTargetSect;

--- a/test/AArch64/standalone/EmitRelocs/EmitRelocs.test
+++ b/test/AArch64/standalone/EmitRelocs/EmitRelocs.test
@@ -1,4 +1,3 @@
-#UNSUPPORTED: asserts
 RUN: %clang %clangopts -target aarch64 -c %p/test.c -o %t1.o
 RUN: %clang %clangopts -target aarch64 -c %p/bar.c -o %t2.o
 
@@ -41,11 +40,7 @@ OBJ2: Relocation section '.relamycode_2' at offset {{.*}} contains
 OBJ2-DAG: z + 0
 OBJ2-DAG: z + 0
 
-EXE: Relocation section '.rela.text' at offset {{.*}} contains
-EXE-DAG: {{[0-9a-f]+}} {{.*}} z + 0
-EXE-DAG: {{[0-9a-f]+}} {{.*}} z + 0
-EXE-DAG: {{[0-9a-f]+}} {{.*}} y + 0
-EXE-DAG: {{[0-9a-f]+}} {{.*}} y + 0
+EXE: Relocation section '.relamycode_1' at offset {{.*}} contains
 EXE-DAG: {{[0-9a-f]+}} {{.*}} x + 0
 EXE-DAG: {{[0-9a-f]+}} {{.*}} x + 0
 
@@ -57,7 +52,11 @@ EXE-DAG: {{[0-9a-f]+}} {{.*}} bar2 + 0
 EXE-DAG: {{[0-9a-f]+}} {{.*}} z + 0
 EXE-DAG: {{[0-9a-f]+}} {{.*}} z + 0
 
-EXE: Relocation section '.relamycode_1' at offset {{.*}} contains
+EXE: Relocation section '.rela.text' at offset {{.*}} contains
+EXE-DAG: {{[0-9a-f]+}} {{.*}} z + 0
+EXE-DAG: {{[0-9a-f]+}} {{.*}} z + 0
+EXE-DAG: {{[0-9a-f]+}} {{.*}} y + 0
+EXE-DAG: {{[0-9a-f]+}} {{.*}} y + 0
 EXE-DAG: {{[0-9a-f]+}} {{.*}} x + 0
 EXE-DAG: {{[0-9a-f]+}} {{.*}} x + 0
 
@@ -95,7 +94,7 @@ SECT:  .text             PROGBITS
 SECT:  mycode_1          PROGBITS
 SECT:  mycode_2          PROGBITS
 SECT:  mydata            PROGBITS
-SECT:  .rela.text        RELA            {{.*}}
-SECT:  .relamycode_2     RELA            {{.*}}
 SECT:  .relamycode_1     RELA            {{.*}}
+SECT:  .relamycode_2     RELA            {{.*}}
+SECT:  .rela.text        RELA            {{.*}}
 SECT:  .symtab           SYMTAB


### PR DESCRIPTION
The order of output relocation sections depended on LLVM's DenseMap iteration order, which can shift across LLVM revisions and between assert/non-assert builds. Switch to a MapVector to make the order deterministic.

Fixes #1164.