### PR TITLE
[object] Fix reproducer crash when input file has no contents

### DIFF
--- a/lib/Input/Input.cpp
+++ b/lib/Input/Input.cpp
@@ -69,6 +69,8 @@ bool Input::resolvePathMappingFile(const LinkerConfig &PConfig) {
       Input::getMemoryAreaForPath(FileName, PConfig.getDiagEngine());
   if (!InputMem)
     InputMem = createMemoryArea(FileName, PConfig.getDiagEngine());
+  if (!InputMem)
+    return false; // File does not exist;
   setMemArea(InputMem);
   // All queries to return the name of the Input return FileName for the main
   // driver.

--- a/test/Common/standalone/MissingMappingFileInput/Inputs/main.c
+++ b/test/Common/standalone/MissingMappingFileInput/Inputs/main.c
@@ -1,0 +1,1 @@
+int main() { return 0; }

--- a/test/Common/standalone/MissingMappingFileInput/Inputs/mapping_missing.ini
+++ b/test/Common/standalone/MissingMappingFileInput/Inputs/mapping_missing.ini
@@ -1,0 +1,2 @@
+[Hash]
+missing.t=DOESNOTEXIST

--- a/test/Common/standalone/MissingMappingFileInput/Inputs/missing.t
+++ b/test/Common/standalone/MissingMappingFileInput/Inputs/missing.t
@@ -1,0 +1,1 @@
+GROUP(/lib64/libmissing.so)

--- a/test/Common/standalone/MissingMappingFileInput/MissingMappingFileInput.test
+++ b/test/Common/standalone/MissingMappingFileInput/MissingMappingFileInput.test
@@ -1,0 +1,14 @@
+#---MissingMappingFileInput.test----------- Executable -----------------#
+#BEGIN_COMMENT
+# Verify that ELD handles gracefully when --mapping-file maps an input
+# to a file that does not exist on disk.
+# ELD should report a fatal error instead of crashing with a segfault.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/main.c -o %t1.o
+RUN: %not %link %linkopts %t1.o \
+RUN:   -T %p/Inputs/missing.t \
+RUN:   --mapping-file=%p/Inputs/mapping_missing.ini \
+RUN:   2>&1 | %filecheck %s
+#END_TEST
+CHECK: cannot read file /lib64/libmissing.so


### PR DESCRIPTION
###  Problem
ELD crashes with a segfault when a reproduce tarball contains a linker script that references a file not found in the sysroot.

### Testing
Added test `SysrootScriptCrash` that verifies ELD errors out  gracefully instead of segfaulting when a linker script references an unreadable file.

### Screenshot
<img width="878" height="204" alt="Screenshot from 2026-05-12 18-52-19" src="https://github.com/user-attachments/assets/b1a62976-f2a0-4020-b0fd-3f5344b24530" />

Fixes #818

cc @quic-seaswara , @parth-07 , @quic-areg 