### PR TITLE
ci: prune ccache entries older than 2h in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,11 @@ jobs:
         working-directory: pr-${{ env.PR_NUMBER }}/obj
         run: ccache --show-stats --dir=$CCACHE_DIR
 
+      - name: Prune ccache after build
+        if: steps.file-check.outputs.skip_build == 'false'
+        working-directory: pr-${{ env.PR_NUMBER }}/obj
+        run: ccache --evict-older-than 7200s --dir=$CCACHE_DIR
+
       - name: Run tests
         if: steps.file-check.outputs.skip_build == 'false'
         working-directory: pr-${{ env.PR_NUMBER }}/obj

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -222,6 +222,12 @@ jobs:
           echo "Packaged shared libraries:"
           ls -la "${LIB_DIR}"
 
+      - name: Prune ccache before save
+        if: always()
+        env:
+          CCACHE_DIR: ${{ github.workspace }}/obj/ccache
+        run: ccache --evict-older-than 7200s
+
       - name: Save ccache
         if: always()
         uses: actions/cache/save@v5

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -105,6 +105,12 @@ jobs:
           cd obj
           ninja ld.eld
 
+      - name: Prune ccache before save
+        if: always()
+        env:
+          CCACHE_DIR: ${{ github.workspace }}/obj/ccache
+        run: ccache --evict-older-than 7200s
+
       - name: Save ccache
         if: always()
         uses: actions/cache/save@v5


### PR DESCRIPTION
Add ccache eviction with --evict-older-than 7200s in workflows that persist cache and in CI after build.

The CI run ccache has increased close to 50G.