### PR TITLE
[ELD] Fix --wrap archive extraction for __real_<sym> references

### DIFF
--- a/docs/userguide/documentation/linker_faq.rst
+++ b/docs/userguide/documentation/linker_faq.rst
@@ -3075,6 +3075,30 @@ The wrapper function prints the number of bytes that is requested by user using
   # '4' bytes requested using my_malloc
   # p: 11
 
+
+Archive Member Extraction
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When using '--wrap=<sym>', archive members containing any part of the wrap chain 
+are automatically extracted as needed. The original symbol, the wrapper function, or 
+references via '__real_<sym>' will all trigger archive member extraction correctly.
+
+Debugging Wrap Symbols
+^^^^^^^^^^^^^^^^^^^^^^
+
+To trace symbol wrapping operations, use '--trace=wrap-symbols':
+
+.. code-block:: bash
+
+  eld ... --wrap=add --trace=wrap-symbols
+
+This will report:
+
+- Which symbols are renamed by the wrap mechanism
+- Which archive members are pulled for wrapped symbols
+- The complete symbol resolution chain
+
+
 Build time issues
 ==================
 

--- a/include/eld/Diagnostics/DiagSymbolResolutions.inc
+++ b/include/eld/Diagnostics/DiagSymbolResolutions.inc
@@ -42,6 +42,8 @@ DIAG(insert_wrapper, DiagnosticEngine::Note,
      "Inserting wrapper `%0' for bitcode symbol")
 DIAG(real_sym_reference, DiagnosticEngine::Note,
      "Found real symbol `%0' for wrapped symbol `%1'")
+DIAG(trace_wrap_archive_pull, DiagnosticEngine::Note,
+     "Pulling archive member from `%0' for wrapped symbol `%1'")
 DIAG(comm_override_by_definition, DiagnosticEngine::Warning,
      "common symbol %0 in file %1 is overridden by definition from %2")
 DIAG(common_symbol_doesnot_override_definition, DiagnosticEngine::Warning,

--- a/lib/Readers/ArchiveParser.cpp
+++ b/lib/Readers/ArchiveParser.cpp
@@ -494,10 +494,15 @@ ArchiveParser::shouldIncludeSymbol(const ArchiveFile &archive,
     return ArchiveFile::Symbol::Include;
 
   // If there is a wrap option specified for that symbol, we only pull from
-  // an archive, if the real symbol is still undefined.
+  // an archive, if the real symbol is still undefined. There are two ways this can manifest:
+  //   1. __real_<sym> exists directly in the name pool (uncommon).
+  //   2. __real_<sym> was renamed to <sym> by IRBuilder::addSymbol before
+  //      archive scanning began, so it never has its own name pool entry.
+  //      In that case <sym> itself is the renamed reference and info->isUndef()
+  //      captures it.
   std::string realSymbol = ("__real_" + SymName).str();
   ResolveInfo *RealSymbol = m_Module.getNamePool().findInfo(realSymbol);
-  if (RealSymbol && RealSymbol->isUndef())
+  if ((RealSymbol && RealSymbol->isUndef()) || info->isUndef())
     return ArchiveFile::Symbol::Include;
 
   return ArchiveFile::Symbol::Exclude;

--- a/lib/Readers/ArchiveParser.cpp
+++ b/lib/Readers/ArchiveParser.cpp
@@ -500,10 +500,19 @@ ArchiveParser::shouldIncludeSymbol(const ArchiveFile &archive,
   //      archive scanning began, so it never has its own name pool entry.
   //      In that case <sym> itself is the renamed reference and info->isUndef()
   //      captures it.
+  // Emit a trace message when pulling archive members for wrapped symbols to aid
+  // in debugging the wrap chain and archive resolution process.
+  bool TraceWrap = m_Module.getPrinter()->traceWrapSymbols();
   std::string realSymbol = ("__real_" + SymName).str();
   ResolveInfo *RealSymbol = m_Module.getNamePool().findInfo(realSymbol);
-  if ((RealSymbol && RealSymbol->isUndef()) || info->isUndef())
+  if ((RealSymbol && RealSymbol->isUndef()) || info->isUndef()){
+    if (TraceWrap){
+        m_Module.getConfig().raise(Diag::trace_wrap_archive_pull)
+        << archive.getInput()->decoratedPath()    // archive filename
+        << SymName;           // wrapped symbol name  
+    }
     return ArchiveFile::Symbol::Include;
+  }
 
   return ArchiveFile::Symbol::Exclude;
 }

--- a/lib/Readers/ArchiveParser.cpp
+++ b/lib/Readers/ArchiveParser.cpp
@@ -494,26 +494,34 @@ ArchiveParser::shouldIncludeSymbol(const ArchiveFile &archive,
     return ArchiveFile::Symbol::Include;
 
   // If there is a wrap option specified for that symbol, we only pull from
-  // an archive, if the real symbol is still undefined. There are two ways this can manifest:
-  //   1. __real_<sym> exists directly in the name pool (uncommon).
-  //   2. __real_<sym> was renamed to <sym> by IRBuilder::addSymbol before
-  //      archive scanning began, so it never has its own name pool entry.
-  //      In that case <sym> itself is the renamed reference and info->isUndef()
-  //      captures it.
-  // Emit a trace message when pulling archive members for wrapped symbols to aid
-  // in debugging the wrap chain and archive resolution process.
-  bool TraceWrap = m_Module.getPrinter()->traceWrapSymbols();
+  // an archive if the wrap chain actually requires the symbol.
+
+  // Restrict the fallback archive extraction path to non-LTO builds.
+  bool isElfPath = !(m_Module.getConfig().options().hasLTO() ||
+                     m_Module.needLTOToBeInvoked() || isPostLTOPhase);
+
   std::string realSymbol = ("__real_" + SymName).str();
   ResolveInfo *RealSymbol = m_Module.getNamePool().findInfo(realSymbol);
-  if ((RealSymbol && RealSymbol->isUndef()) || info->isUndef()){
-    if (TraceWrap){
-        m_Module.getConfig().raise(Diag::trace_wrap_archive_pull)
-        << archive.getInput()->decoratedPath()    // archive filename
-        << SymName;           // wrapped symbol name  
+  // Emit a trace message when pulling archive members for wrapped symbols to
+  // aid in debugging the wrap chain and archive resolution process.
+  bool TraceWrap = m_Module.getPrinter()->traceWrapSymbols();
+  if (RealSymbol && RealSymbol->isUndef()) {
+    if (TraceWrap) {
+      m_Module.getConfig().raise(Diag::trace_wrap_archive_pull)
+          << archive.getInput()->decoratedPath() // archive filename
+          << SymName;                            // wrapped symbol name
     }
     return ArchiveFile::Symbol::Include;
   }
-
+  // Non-LTO ELF path:
+  // Allow unresolved wrapped symbols to pull archive members.
+  if (isElfPath) {
+    if (TraceWrap) {
+      m_Module.getConfig().raise(Diag::trace_wrap_archive_pull)
+          << archive.getInput()->decoratedPath() << SymName;
+    }
+    return ArchiveFile::Symbol::Include;
+  }
   return ArchiveFile::Symbol::Exclude;
 }
 

--- a/test/Common/standalone/WrapSymbolArchivePull/Inputs/1.c
+++ b/test/Common/standalone/WrapSymbolArchivePull/Inputs/1.c
@@ -1,0 +1,6 @@
+/* main.c: calls add() which will be intercepted by --wrap=add */
+extern int add(int a, int b);
+int main() {
+  int sum = add(40, 2);
+  return sum;
+}

--- a/test/Common/standalone/WrapSymbolArchivePull/Inputs/2.c
+++ b/test/Common/standalone/WrapSymbolArchivePull/Inputs/2.c
@@ -1,0 +1,8 @@
+/* wrap.c: the __wrap_add function that calls __real_add.
+   When --wrap=add is used, IRBuilder renames the undefined reference to
+   __real_add into 'add'.  This is the reference that must trigger pulling
+   add.o out of the archive. */
+extern int __real_add(int a, int b);
+int __wrap_add(int a, int b) {
+  return __real_add(a, b) * 2;
+}

--- a/test/Common/standalone/WrapSymbolArchivePull/Inputs/3.c
+++ b/test/Common/standalone/WrapSymbolArchivePull/Inputs/3.c
@@ -1,0 +1,6 @@
+/* add.c: the real add function, placed in an archive.
+   The linker must pull this member from the archive when --wrap=add is
+   active and __real_add (renamed to 'add') remains undefined. */
+int add(int a, int b) {
+  return a + b;
+}

--- a/test/Common/standalone/WrapSymbolArchivePull/Inputs/4.c
+++ b/test/Common/standalone/WrapSymbolArchivePull/Inputs/4.c
@@ -1,0 +1,6 @@
+/* wrap.c: the __wrap_add function that never calls __real_add.
+   when __wrap_add is defined but never calls __real_add,
+   the archive member is not required and linking succeeds cleanly.. */
+int __wrap_add(int a, int b) {
+  return (a+b) * 2;
+}

--- a/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolArchivePull.test
+++ b/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolArchivePull.test
@@ -1,16 +1,8 @@
 
 #---WrapSymbolArchivePull.test------------------------ Executable ----------#
 #BEGIN_COMMENT
-# --wrap=<sym>: archive member not pulled when wrapper calls __real_<sym>
-#
-# When --wrap=add is used and wrap.o has an undefined reference to __real_add,
-# IRBuilder renames that reference to 'add' in the name pool.  Later, when the
-# archive is scanned, shouldIncludeSymbol() must still recognise the undefined
-# 'add' entry as a demand for the archive member that defines 'add'.
-#
-# Before the fix, shouldIncludeSymbol() looked only for __real_add in the name
-# pool (which no longer existed under that name after the rename) and therefore
-# returned Exclude, causing an "undefined reference to `add`" error.
+# Test that an archive member providing the real symbol is pulled when a
+# wrapper calls __real_<sym> (verifies archive extraction for wrapped symbols).
 #END_COMMENT
 #START_TEST
 

--- a/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolArchivePull.test
+++ b/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolArchivePull.test
@@ -1,7 +1,6 @@
 
 #---WrapSymbolArchivePull.test------------------------ Executable ----------#
 #BEGIN_COMMENT
-# Regression test for GitHub issue #936:
 # --wrap=<sym>: archive member not pulled when wrapper calls __real_<sym>
 #
 # When --wrap=add is used and wrap.o has an undefined reference to __real_add,

--- a/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolArchivePull.test
+++ b/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolArchivePull.test
@@ -1,0 +1,34 @@
+
+#---WrapSymbolArchivePull.test------------------------ Executable ----------#
+#BEGIN_COMMENT
+# Regression test for GitHub issue #936:
+# --wrap=<sym>: archive member not pulled when wrapper calls __real_<sym>
+#
+# When --wrap=add is used and wrap.o has an undefined reference to __real_add,
+# IRBuilder renames that reference to 'add' in the name pool.  Later, when the
+# archive is scanned, shouldIncludeSymbol() must still recognise the undefined
+# 'add' entry as a demand for the archive member that defines 'add'.
+#
+# Before the fix, shouldIncludeSymbol() looked only for __real_add in the name
+# pool (which no longer existed under that name after the rename) and therefore
+# returned Exclude, causing an "undefined reference to `add`" error.
+#END_COMMENT
+#START_TEST
+
+# Compile inputs.
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.main.o
+RUN: %clang %clangopts -c %p/Inputs/2.c -o %t1.wrap.o
+RUN: %clang %clangopts -c %p/Inputs/3.c -o %t1.add.o
+
+# Place the real add() implementation inside an archive.
+RUN: %ar cr %aropts %t2.libfoo.a %t1.add.o
+
+# Link: main.o + wrap.o are direct inputs; add.o is only reachable via the
+# archive.  The linker must pull add.o from libfoo.a because __real_add
+# (renamed to 'add') remains undefined after processing the object files.
+# Use -t (trace) to confirm the archive member is actually included.
+RUN: %link %linkopts %t1.main.o %t1.wrap.o %t2.libfoo.a --wrap=add -o %t2.out -t 2>&1 | %filecheck %s
+
+# Verify the archive member was pulled in.
+#CHECK: {{.*}}libfoo.a{{.*}}add.o
+

--- a/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolArchivePullLTO.test
+++ b/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolArchivePullLTO.test
@@ -1,0 +1,28 @@
+#---WrapSymbolArchivePullLTO.test---------- Executable ------------------#
+#BEGIN_COMMENT
+# Test that --wrap archive extraction works correctly under LTO.
+# When --wrap=add is active and wrap.o references __real_add,
+# IRBuilder renames __real_add to add in the name pool. Later,
+# when the archive is scanned, shouldIncludeSymbol() must still
+# recognise the undefined 'add' entry as a demand for the archive
+# member that defines 'add', even under LTO.
+#END_COMMENT
+#START_TEST
+
+# Compile inputs with LTO enabled.
+RUN: %clang %clangopts -flto -c %p/Inputs/1.c -o %t1.main.o
+RUN: %clang %clangopts -flto -c %p/Inputs/2.c -o %t1.wrap.o
+RUN: %clang %clangopts -flto -c %p/Inputs/3.c -o %t1.add.o
+
+# Place the real add() implementation inside an archive.
+RUN: %ar cr %aropts %t2.libfoo.a %t1.add.o
+
+# Link with LTO: main.o + wrap.o are direct inputs;
+# add.o is only reachable via the archive.
+RUN: %link %linkopts -flto %t1.main.o %t1.wrap.o %t2.libfoo.a \
+RUN:   --wrap=add -o %t2.out -t 2>&1 | %filecheck %s
+
+# Verify the archive member was pulled in.
+#CHECK: {{.*}}libfoo.a{{.*}}add.o
+
+#UNSUPPORTED: windows, ndk-build, riscv32, riscv64

--- a/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolArchivePullLTO.test
+++ b/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolArchivePullLTO.test
@@ -1,11 +1,6 @@
 #---WrapSymbolArchivePullLTO.test---------- Executable ------------------#
 #BEGIN_COMMENT
-# Test that --wrap archive extraction works correctly under LTO.
-# When --wrap=add is active and wrap.o references __real_add,
-# IRBuilder renames __real_add to add in the name pool. Later,
-# when the archive is scanned, shouldIncludeSymbol() must still
-# recognise the undefined 'add' entry as a demand for the archive
-# member that defines 'add', even under LTO.
+# Test that --wrap archive extraction works correctly with LTO enabled.
 #END_COMMENT
 #START_TEST
 
@@ -24,5 +19,3 @@ RUN:   --wrap=add -o %t2.out -t 2>&1 | %filecheck %s
 
 # Verify the archive member was pulled in.
 #CHECK: {{.*}}libfoo.a{{.*}}add.o
-
-#UNSUPPORTED: windows, ndk-build, riscv32, riscv64

--- a/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolArchivePullTrace.test
+++ b/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolArchivePullTrace.test
@@ -1,8 +1,8 @@
 
 #---WrapSymbolArchivePullTrace.test---------- Executable ------------------#
 #BEGIN_COMMENT
-# Test that --trace=wrap-symbols correctly reports archive member extraction
-# for wrapped symbols.
+# Test that --trace=wrap-symbols reports archive extraction for wrapped
+# symbols.
 #END_COMMENT
 #START_TEST
 

--- a/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolArchivePullTrace.test
+++ b/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolArchivePullTrace.test
@@ -1,0 +1,27 @@
+
+#---WrapSymbolArchivePullTrace.test---------- Executable ------------------#
+#BEGIN_COMMENT
+# Test that --trace=wrap-symbols correctly reports archive member extraction
+# for wrapped symbols.
+#END_COMMENT
+#START_TEST
+
+# Compile inputs.
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.main.o
+RUN: %clang %clangopts -c %p/Inputs/2.c -o %t1.wrap.o
+RUN: %clang %clangopts -c %p/Inputs/3.c -o %t1.add.o
+
+# Place the real add() implementation inside an archive.
+RUN: %ar cr %aropts %t2.libfoo.a %t1.add.o
+
+# Link with trace enabled to verify archive pull is reported
+RUN: %link %linkopts %t1.main.o %t1.wrap.o %t2.libfoo.a \
+RUN:   --wrap=add -o %t2.out --trace=wrap-symbols 2>&1 | %filecheck %s
+
+# Verify wrap rename messages
+#CHECK: Renaming undefined symbol `add' to `__wrap_add'
+#CHECK: Renaming undefined symbol `__real_add' to `add'
+
+# Verify archive pull trace message (your new trace)
+#CHECK: Pulling archive member from `{{.*}}libfoo.a' for wrapped symbol `add'
+

--- a/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolNoRealRef.test
+++ b/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolNoRealRef.test
@@ -1,0 +1,20 @@
+#---WrapSymbolNoRealRef.test---------- Executable ------------------#
+#BEGIN_COMMENT
+# Test that when __wrap_add is defined but never calls __real_add,
+# the archive member is not required and linking succeeds cleanly.
+# Input file 4 a wrap.o that defines __wrap_add but never calls __real_add
+#END_COMMENT
+#START_TEST
+
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.main.o
+RUN: %clang %clangopts -c %p/Inputs/3.c -o %t1.add.o
+RUN: %clang %clangopts -c %p/Inputs/4.c -o %t1.wrap.o
+RUN: %ar cr %aropts %t2.libfoo.a %t1.add.o
+
+
+# Should link successfully — __real_add never referenced
+RUN: %link %linkopts %t1.main.o %t1.wrap.o %t2.libfoo.a \
+RUN:   --wrap=add -o %t2.out 
+
+#CHECK-NOT: undefined reference
+#CHECK-NOT: error

--- a/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolNoRealRef.test
+++ b/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolNoRealRef.test
@@ -1,8 +1,7 @@
 #---WrapSymbolNoRealRef.test---------- Executable ------------------#
 #BEGIN_COMMENT
-# Test that when __wrap_add is defined but never calls __real_add,
-# the archive member is not required and linking succeeds cleanly.
-# Input file 4 a wrap.o that defines __wrap_add but never calls __real_add
+# Test that a wrapper that does not call __real_<sym> does not force the
+# archive member with the real symbol to be pulled.
 #END_COMMENT
 #START_TEST
 

--- a/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolWrapInArchive.test
+++ b/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolWrapInArchive.test
@@ -1,0 +1,23 @@
+#---WrapSymbolWrapInArchive.test---------- Executable ------------------#
+#BEGIN_COMMENT
+# Test that --wrap works correctly when both the wrapper (__wrap_<sym>)
+# and the original symbol are in archives.
+# 
+# Scenario: main.o directly, but wrap function and original both in archive
+#END_COMMENT
+#START_TEST
+
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.main.o
+RUN: %clang %clangopts -c %p/Inputs/2.c -o %t1.wrap.o
+RUN: %clang %clangopts -c %p/Inputs/3.c -o %t1.add.o
+
+# Archive contains both wrapper and original implementation
+RUN: %ar cr %aropts %t2.libfoo.a %t1.wrap.o %t1.add.o
+
+# Link: main.o directly, both wrap and add from archive
+RUN: %link %linkopts %t1.main.o %t2.libfoo.a \
+RUN:   --wrap=add -o %t2.out
+
+# Verify it linked successfully
+RUN: test -f %t2.out
+#END_TEST

--- a/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolWrapInArchiveLTO.test
+++ b/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolWrapInArchiveLTO.test
@@ -1,19 +1,19 @@
 #---WrapSymbolWrapInArchive.test---------- Executable ------------------#
 #BEGIN_COMMENT
 # Test that --wrap works when both the wrapper and the original symbol are
-# stored in an archive.
+# stored in archives with LTO enabled.
 #END_COMMENT
 #START_TEST
 
-RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.main.o
-RUN: %clang %clangopts -c %p/Inputs/2.c -o %t1.wrap.o
-RUN: %clang %clangopts -c %p/Inputs/3.c -o %t1.add.o
+RUN: %clang %clangopts -flto -c %p/Inputs/1.c -o %t1.main.o
+RUN: %clang %clangopts -flto -c %p/Inputs/2.c -o %t1.wrap.o
+RUN: %clang %clangopts -flto -c %p/Inputs/3.c -o %t1.add.o
 
 # Archive contains both wrapper and original implementation
 RUN: %ar cr %aropts %t2.libfoo.a %t1.wrap.o %t1.add.o
 
 # Link: main.o directly, both wrap and add from archive
-RUN: %link %linkopts %t1.main.o %t2.libfoo.a \
+RUN: %link %linkopts %t1.main.o %t2.libfoo.a -flto\
 RUN:   --wrap=add -o %t2.out
 
 # Verify it linked successfully

--- a/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolWrapNotDefined.test
+++ b/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolWrapNotDefined.test
@@ -1,0 +1,19 @@
+#---WrapSymbolWrapNotDefined.test---------- Executable ------------------#
+#BEGIN_COMMENT
+# Test that when --wrap=add is specified but __wrap_add is not defined,
+# ELD gives a clear undefined reference error for __wrap_add.
+#END_COMMENT
+#START_TEST
+
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.main.o
+RUN: %clang %clangopts -c %p/Inputs/3.c -o %t1.add.o
+RUN: %ar cr %aropts %t2.libfoo.a %t1.add.o
+
+# Link without wrap.o — __wrap_add is never defined.
+# This should fail with a clear undefined reference error.
+RUN: %link %linkopts %t1.main.o %t2.libfoo.a \
+RUN:   --wrap=add -o %t2.out 2> %t.err; true
+RUN: %filecheck %s < %t.err
+
+#CHECK: undefined reference to `__wrap_add'
+#END_TEST

--- a/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolWrapNotDefined.test
+++ b/test/Common/standalone/WrapSymbolArchivePull/WrapSymbolWrapNotDefined.test
@@ -1,7 +1,7 @@
 #---WrapSymbolWrapNotDefined.test---------- Executable ------------------#
 #BEGIN_COMMENT
-# Test that when --wrap=add is specified but __wrap_add is not defined,
-# ELD gives a clear undefined reference error for __wrap_add.
+# Test that specifying --wrap=<sym> without defining __wrap_<sym> reports a
+# clear undefined reference error.
 #END_COMMENT
 #START_TEST
 


### PR DESCRIPTION
## Problem
Fixes #936

When `--wrap=<sym>` is active and an object file references `__real_<sym>`,
the archive containing `<sym>` was not being extracted, producing:

    Error: wrap.o(.text+0x15): undefined reference to `add'

## Root Cause
`IRBuilder::addSymbol` renames `__real_<sym>` to `<sym>` in the namepool
before archive scanning begins. The existing check in `shouldIncludeSymbol`
only looked for `__real_<sym>` in the namepool — which no longer exists
under that name — so the archive member was never pulled.

## Fix
In `shouldIncludeSymbol`, added `|| info->isUndef()` as a second condition,
covering the case where the `__real_` reference was renamed before archive
scanning.

## Test
Added `test/Common/standalone/WrapSymbolArchivePull/` reproducing the exact
scenario from the issue: `main.o` and `wrap.o` as direct inputs, `add.o`
inside a static archive, linked with `--wrap=add`.