### PR TITLE
Make last conflicting option take precedence

### DIFF
--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -202,13 +202,14 @@ void GnuLdDriver::printVersionInfo() const {
 // This function checks for such errors.
 template <class T>
 bool GnuLdDriver::checkOptions(llvm::opt::InputArgList &Args) const {
+  // TODO: Disabled since this will get replaced with a warning.
   // check --thread-count and if threads are disabled.
-  if (Args.getLastArg(T::thread_count)) {
-    if (!Config.options().threadsEnabled()) {
-      Config.raise(Diag::thread_count_with_no_threads);
-      return false;
-    }
-  }
+  // if (Args.getLastArg(T::thread_count)) {
+  //   if (!Config.options().threadsEnabled()) {
+  //     Config.raise(Diag::thread_count_with_no_threads);
+  //     return false;
+  //   }
+  // }
   return true;
 }
 
@@ -339,12 +340,9 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
   if (llvm::opt::Arg *arg = Args.getLastArg(T::sysroot))
     Config.setSysRoot(arg->getValue());
 
-  // --fatal-warnings
-  Config.options().setFatalWarnings(Args.hasArg(T::fatal_warnings));
-
-  // --no-fatal-warnings
-  if (Args.hasArg(T::no_fatal_warnings))
-    Config.options().setFatalWarnings(false);
+  // --[no-]fatal-warnings
+  Config.options().setFatalWarnings(
+      Args.hasFlag(T::fatal_warnings, T::no_fatal_warnings, /*default=*/false));
 
   // --opt-record-file
   if (Args.hasArg(T::opt_record_file)) {
@@ -480,8 +478,9 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
     }
   }
 
-  // --export-dynamic, -E
-  Config.options().setExportDynamic(Args.hasArg(T::export_dynamic));
+  // --[no-]export-dynamic, -E
+  Config.options().setExportDynamic(
+      Args.hasFlag(T::export_dynamic, T::no_export_dynamic, /*default=*/false));
 
   // --export-dynamic-symbol
   for (auto *Arg : Args.filtered(T::export_dynamic_symbol))
@@ -583,68 +582,57 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
     }
   }
 
-  // --warn-shared-textrel
-  if (Args.hasArg(T::warn_shared_textrel))
-    Config.options().setWarnSharedTextrel(true);
+  // --[no-]warn-shared-textrel
+  Config.options().setWarnSharedTextrel(Args.hasFlag(
+      T::warn_shared_textrel, T::no_warn_shared_textrel, /*default=*/false));
 
   // --warn-common
   if (Args.hasArg(T::warn_common))
     Config.options().setWarnCommon();
 
-  // --no-warn-shared_textrel
-  if (Args.hasArg(T::no_warn_shared_textrel))
-    Config.options().setWarnSharedTextrel(false);
-
-  // --enable-newdtags, --disable-newdtags
-  if (Args.hasArg(T::enable_newdtags) && Args.hasArg(T::disable_newdtags)) {
-    errs() << "Cannot specify enable and disable  DTAGS at same time!\n";
-    return false;
-  }
-
-  // --enabld-new-dtags
-  if (Args.hasArg(T::enable_newdtags))
-    Config.options().setNewDTags(true);
-
-  // --enabld-disable-new-dtags
-  if (Args.hasArg(T::disable_newdtags))
-    Config.options().setNewDTags(false);
+  // --enable-new-dtags, --disable-new-dtags
+  bool newdtags =
+      Args.hasFlag(T::enable_newdtags, T::disable_newdtags, /*default=*/false);
+  Config.options().setNewDTags(newdtags);
 
   // --enable-linker-version / --disable-linker-version
-  if (Args.hasArg(T::enable_linker_version) &&
-      Args.hasArg(T::disable_linker_version)) {
-    errs() << "Cannot specify enable and disable LINKER_VERSION at same time!\n";
-    return false;
-  }
-
-  if (Args.hasArg(T::enable_linker_version)) {
-    Config.options().setLinkerVersionDirectiveEnabled(true);
+  bool linkerVersion = Args.hasFlag(
+      T::enable_linker_version, T::disable_linker_version, /*default=*/false);
+  Config.options().setLinkerVersionDirectiveEnabled(linkerVersion);
+  if (linkerVersion)
     Config.addCommandLine(Table->getOptionName(T::enable_linker_version), true);
-  }
-
-  if (Args.hasArg(T::disable_linker_version)) {
-    Config.options().setLinkerVersionDirectiveEnabled(false);
-    Config.addCommandLine(Table->getOptionName(T::disable_linker_version), true);
-  }
+  else
+    Config.addCommandLine(Table->getOptionName(T::disable_linker_version),
+                          true);
 
   bool recordCommandLine = Args.hasFlag(
       T::record_command_line, T::no_record_command_line, /*default=*/false);
   Config.options().setRecordCommandLine(recordCommandLine);
 
-  // --emit-relocs
-  if (Args.hasArg(T::emit_relocs)) {
-    Config.options().setEmitGNUCompatRelocs(true);
-    Config.options().setEmitRelocs(true);
-    Config.addCommandLine(Table->getOptionName(T::emit_relocs), true);
-  }
-
-  // --emit-relocs-llvm
-  if (Args.hasArg(T::emit_relocs_llvm))
-    Config.options().setEmitRelocs(true);
-
-  // --no-emit-relocs
-  if (Args.hasArg(T::no_emit_relocs)) {
-    Config.options().setEmitGNUCompatRelocs(false);
-    Config.options().setEmitRelocs(false);
+  // --[no-]emit-relocs, --emit-relocs-llvm
+  if (llvm::opt::Arg *arg = Args.getLastArg(T::emit_relocs, T::no_emit_relocs,
+                                            T::emit_relocs_llvm)) {
+    bool emitRelocs = false;
+    switch (arg->getOption().getID()) {
+    case T::emit_relocs_llvm: {
+      emitRelocs = true;
+      break;
+    }
+    case T::emit_relocs: {
+      emitRelocs = true;
+      Config.options().setEmitGNUCompatRelocs(true);
+      Config.addCommandLine(Table->getOptionName(T::emit_relocs), true);
+      break;
+    }
+    case T::no_emit_relocs: {
+      emitRelocs = false;
+      Config.options().setEmitGNUCompatRelocs(false);
+      break;
+    }
+    default:
+      break;
+    }
+    Config.options().setEmitRelocs(emitRelocs);
   }
 
   // --no-merge-strings
@@ -652,12 +640,13 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
   Config.addCommandLine(Table->getOptionName(T::no_merge_strings),
                         Args.hasArg(T::no_merge_strings));
 
-  // --{no-}warn-mismatch
-  if (Args.getLastArg(T::no_warn_mismatch))
-    Config.options().setWarnMismatch(false);
-
-  if (Args.getLastArg(T::warn_mismatch))
-    Config.options().setWarnMismatch(true);
+  // --[no-]warn-mismatch
+  // This flag defaults to none so only set it if at least one of the two flags
+  // are present.
+  if (Args.hasArg(T::warn_mismatch) || Args.hasArg(T::no_warn_mismatch)) {
+    Config.options().setWarnMismatch(
+        Args.hasFlag(T::warn_mismatch, T::no_warn_mismatch, /*default=*/true));
+  }
 
   // --no-trampolines
   if (Args.hasArg(T::no_trampolines)) {
@@ -705,9 +694,16 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
   }
   Config.addCommandLine(Table->getOptionName(T::flto_options), ltoOptions);
 
-  // --no-align-segments
-  if (Args.hasArg(T::no_align_segments))
-    Config.options().setAlignSegments(false);
+  // --[no-]align-segments
+  // This flag sets the same thing as --script, -T, --omagic, -N. Since
+  // these flags require alignment to be false, they will take precedence over
+  // --align-segments.
+  if (Args.hasArg(T::align_segments, T::no_align_segments) &&
+      !Args.hasArg(T::T, T::omagic)) {
+    bool alignSegments =
+        Args.hasFlag(T::align_segments, T::no_align_segments, /*default=*/true);
+    Config.options().setAlignSegments(alignSegments);
+  }
 
   bool enableFatalInternalErrors = Args.hasFlag(
       T::fatal_internal_errors, T::no_fatal_internal_errors, /*default=*/false);
@@ -1014,8 +1010,9 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
 
   // Disable --gc-sections, --print-gc-sections for Partial Linking.
   if (Config.codeGenType() != eld::LinkerConfig::Object) {
-    // --gc-sections
-    bool enableGC = Args.hasArg(T::gc_sections);
+    // --[no-]gc-sections
+    bool enableGC =
+        Args.hasFlag(T::gc_sections, T::no_gc_sections, /*default=*/false);
     Config.options().setGCSections(enableGC);
     Config.addCommandLine(Table->getOptionName(T::gc_sections), enableGC);
     // --print-gc-sections
@@ -1041,28 +1038,34 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
   //
   // Thread Options.
   //
-
-  // --no-threads, --threads
-  if (!Args.getLastArg(T::no_threads) || Args.getLastArg(T::threads)) {
-    Config.options().enableThreads();
-    Config.addCommandLine(Table->getOptionName(T::threads), true);
-  } else if (Args.getLastArg(T::no_threads)) {
-    // --no-threads
-    Config.options().disableThreads();
-    Config.options().setNumThreads(1);
-    Config.addCommandLine(Table->getOptionName(T::threads), false);
-  }
-
-  // If the user user --enable-threads=all
-  if (llvm::opt::Arg *arg = Args.getLastArg(T::enable_threads)) {
-    llvm::StringRef Opt = arg->getValue();
-    if (Opt == "all") {
-      Config.setGlobalThreadingEnabled();
+  if (llvm::opt::Arg *arg =
+          Args.getLastArg(T::threads, T::no_threads, T::enable_threads)) {
+    switch (arg->getOption().getID()) {
+    case T::threads: {
       Config.options().enableThreads();
-    } else {
-      errs() << "Invalid value for" << arg->getOption().getPrefixedName()
-             << ": " << arg->getValue() << "\n";
-      return false;
+      Config.addCommandLine(Table->getOptionName(T::threads), true);
+      break;
+    }
+    case T::no_threads: {
+      Config.options().disableThreads();
+      Config.options().setNumThreads(1);
+      Config.addCommandLine(Table->getOptionName(T::threads), false);
+      break;
+    }
+    case T::enable_threads: {
+      llvm::StringRef Opt = arg->getValue();
+      if (Opt == "all") {
+        Config.setGlobalThreadingEnabled();
+        Config.options().enableThreads();
+      } else {
+        errs() << "Invalid value for" << arg->getOption().getPrefixedName()
+               << ": " << arg->getValue() << "\n";
+        return false;
+      }
+      break;
+    }
+    default:
+      break;
     }
   }
 
@@ -1117,22 +1120,30 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
   for (const auto *Arg : Args.filtered(T::plugin_config))
     Config.options().addPluginConfig(Arg->getValue());
 
-  // --demangle-style
-  if (llvm::opt::Arg *arg = Args.getLastArg(T::demangle_style)) {
-    if (!Config.options().setDemangleStyle(arg->getValue())) {
-      errs() << "Invalid value for" << arg->getOption().getPrefixedName()
-             << ": " << arg->getValue() << "\n";
-      return false;
+  // --demangle-style, --[no-]demangle
+  if (llvm::opt::Arg *arg =
+          Args.getLastArg(T::demangle_style, T::demangle, T::no_demangle)) {
+    switch (arg->getOption().getID()) {
+    case T::demangle_style: {
+      if (!Config.options().setDemangleStyle(arg->getValue())) {
+        errs() << "Invalid value for" << arg->getOption().getPrefixedName()
+               << ": " << arg->getValue() << "\n";
+        return false;
+      }
+      break;
+    }
+    case T::demangle: {
+      Config.options().setDemangleStyle("demangle");
+      break;
+    }
+    case T::no_demangle: {
+      Config.options().setDemangleStyle("none");
+      break;
+    }
+    default:
+      break;
     }
   }
-
-  // --no-demangle
-  if (Args.getLastArg(T::no_demangle))
-    Config.options().setDemangleStyle("none");
-
-  // --demangle
-  if (Args.getLastArg(T::demangle))
-    Config.options().setDemangleStyle("demangle");
 
   /// --progress-bar
   if (Args.getLastArg(T::progress_bar))
@@ -1245,12 +1256,11 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
   if (Args.hasArg(T::use_old_style_trampoline_name))
     Config.setUseOldStyleTrampolineName(true);
 
-  // --check-sections
-  if (Args.hasArg(T::enable_overlap_checks))
+  // --[no-]check-sections
+  if (Args.hasFlag(T::enable_overlap_checks, T::disable_overlap_checks,
+                   /*default=*/true))
     Config.options().setEnableCheckSectionOverlaps();
-
-  // --no-check-sections
-  if (Args.hasArg(T::disable_overlap_checks))
+  else
     Config.options().setDisableCheckSectionOverlaps();
 
   if (Args.hasArg(T::thin_archive_rule_matching_compatibility))
@@ -1293,13 +1303,11 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
   if (Args.hasArg(T::noDefaultPlugins))
     Config.options().setNoDefaultPlugins();
 
-  // --no-omagic, --omagic, -N support
-  if (Args.hasArg(T::no_omagic))
-    Config.options().setOMagic(false);
-  else if (Args.hasArg(T::omagic)) {
+  // --[no-]omagic, -N
+  bool omagic = Args.hasFlag(T::omagic, T::no_omagic, /*default=*/false);
+  Config.options().setOMagic(omagic);
+  if (omagic)
     Config.options().setAlignSegments(false);
-    Config.options().setOMagic(true);
-  }
 
   // --plugin-activity-file=<file>
   if (llvm::opt::Arg *A = Args.getLastArg(T::PluginActivityFile)) {

--- a/lib/LinkerWrapper/RISCVLinkDriver.cpp
+++ b/lib/LinkerWrapper/RISCVLinkDriver.cpp
@@ -114,9 +114,10 @@ RISCVLinkDriver::parseOptions(ArrayRef<const char *> Args,
     return LINK_SUCCESS;
   }
 
-  // --no-relax
-  if (ArgList.hasArg(OPT_RISCVLinkOptTable::no_riscv_relax))
-    Config.options().setRISCVRelax(false);
+  // --[no-]relax
+  Config.options().setRISCVRelax(
+      ArgList.hasFlag(OPT_RISCVLinkOptTable::riscv_relax,
+                      OPT_RISCVLinkOptTable::no_riscv_relax, /*default=*/true));
 
   // --no-relax-zero
   if (ArgList.hasArg(OPT_RISCVLinkOptTable::no_relax_zero))

--- a/test/Common/standalone/CommandLine/InvalidNewDTags/Inputs/1.c
+++ b/test/Common/standalone/CommandLine/InvalidNewDTags/Inputs/1.c
@@ -1,1 +1,0 @@
-int foo() { return 0; }

--- a/test/Common/standalone/CommandLine/InvalidNewDTags/InvalidNewDTags.test
+++ b/test/Common/standalone/CommandLine/InvalidNewDTags/InvalidNewDTags.test
@@ -1,8 +1,0 @@
-#---InvalidNewDTags.test--------------------------- Executable -----------------#
-#BEGIN_COMMENT
-# This checks if the linker throws error when both --enable-new-dtags and --disable-new-tags are given.
-#START_TEST
-RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
-RUN: %not %link %linkopts %t1.1.o -o %t2.out --enable-new-dtags --disable-new-dtags 2>&1 | %filecheck %s
-#CHECK: Cannot specify enable and disable DTAGS
-#END_TEST

--- a/test/Common/standalone/FlagOverwrite/FlagOverwrite.test
+++ b/test/Common/standalone/FlagOverwrite/FlagOverwrite.test
@@ -1,0 +1,152 @@
+#---FlagOverwrite.test--------------------- Executable --------------------#
+UNSUPPORTED: x86
+#BEGIN_COMMENT
+# Check that the last option is the one being used for mutually exclusive flags.
+#END_COMMENT
+#START_TEST
+COM: --[no-]fatal-warnings
+RUN: %clang %clangopts -ffunction-sections -c %p/Inputs/1.cpp -o %t.1.o
+RUN: %not %link %linkopts -o %t.1.out -shared -z=notext %t.1.o --warn-shared-textrel --no-fatal-warnings --fatal-warnings 2>&1 | %filecheck %s -check-prefix=FATAL
+RUN: %link %linkopts -o %t.1.out -shared -z=notext %t.1.o --warn-shared-textrel --fatal-warnings --no-fatal-warnings 2>&1 | %filecheck %s -check-prefix=NOFATAL
+
+COM: --[no-]check-sections
+RUN: %not %link %linkopts -T %p/Inputs/1.script %t.1.o -o %t.1.out --no-check-sections --check-sections --verbose 2>&1 | %filecheck %s -check-prefix=CHECKSECT
+RUN: %link %linkopts -T %p/Inputs/1.script %t.1.o -o %t.1.out --check-sections --no-check-sections --verbose 2>&1 | %filecheck %s -check-prefix=NOCHECKSECT
+
+COM: --[no-]gc-sections
+RUN: %link %linkopts %t.1.o -T %p/Inputs/2.script --no-gc-sections --gc-sections -o %t.1.out -M 2>&1 | %filecheck %s -check-prefix=GCSECT
+RUN: %link %linkopts %t.1.o -T %p/Inputs/2.script --gc-sections --no-gc-sections -o %t.1.out -M 2>&1 | %filecheck %s -check-prefix=NOGCSECT
+
+COM: --[no-]align-segments
+RUN: %clang %clangopts -ffunction-sections -c %p/Inputs/2.cpp -o %t.2.o
+RUN: %link %linkopts --rosegment --no-align-segments --align-segments %t.2.o -o %t.2.out --noinhibit-exec
+RUN: %readelf -l -W %t.2.out | %filecheck %s -check-prefix=ALIGN
+RUN: %link %linkopts --rosegment --align-segments --no-align-segments %t.2.o -o %t.2.out --noinhibit-exec
+RUN: %readelf -l -W %t.2.out | %filecheck %s -check-prefix=NOALIGN
+COM: Special case. omagic takes precendence over --align-segments
+RUN: %link %linkopts -o %t.1.out %t.1.o --no-omagic --omagic --align-segments -z max-page-size=0x1000
+RUN: %readelf --elf-output-style LLVM -l -W %t.1.out 2>&1 | %filecheck %s -check-prefix=OMAGIC
+
+COM: --[no-]emit-relocs
+RUN: %link %linkopts  %t.2.o -o %t.2.out --no-emit-relocs --emit-relocs --noinhibit-exec
+RUN: %readelf -r %t.2.out | %filecheck %s -check-prefix=RELOCS
+RUN: %link %linkopts  %t.2.o -o %t.2.out --emit-relocs --no-emit-relocs --noinhibit-exec
+RUN: %readelf -r %t.2.out | %filecheck %s -check-prefix=NORELOCS
+
+COM: --[no-]threads, --enable-threads
+RUN: %link %linkopts %t.1.o -o %t.1.out --emit-relocs --enable-threads=all --no-threads --threads --trace=threads 2>&1 | %filecheck %s -check-prefix=THREADS
+RUN: %link %t.1.o -o %t.1.out --emit-relocs --enable-threads=all --threads --no-threads --trace=threads 2>&1 | %filecheck %s -check-prefix=NOTHREADS
+RUN: %link %linkopts %t.1.o -o %t.1.out --emit-relocs --no-threads --threads --enable-threads=all --trace=threads 2>&1 | %filecheck %s -check-prefix=GLOBALTHREADS
+
+COM: --[no-]fat-lto-objects
+RUN: printf "eld\n" > %t.invalid
+RUN: %objcopy --add-section=.llvm.lto=%t.invalid --set-section-flags=.llvm.lto=exclude --set-section-type=.llvm.lto=0x6fff4c0c %t.1.o %t.fat.invalid.o
+RUN: %not %link -r %t.fat.invalid.o -o %t1.out --no-fat-lto-objects --fat-lto-objects --trace=lto 2>&1 | %filecheck %s -check-prefix=FATLTO
+RUN: %link -r %t.fat.invalid.o -o %t1.out --fat-lto-objects --no-fat-lto-objects --trace=lto 2>&1 | %filecheck %s -check-prefix=NOFATLTO
+
+COM: --[no-]warn-shared-textrel
+RUN: %link %linkopts -o %t.1.out -shared -z=notext %t.1.o --no-warn-shared-textrel --warn-shared-textrel 2>&1 | %filecheck %s -check-prefix=TEXTREL
+RUN: %link %linkopts -o %t.1.out -shared -z=notext %t.1.o --warn-shared-textrel --no-warn-shared-textrel 2>&1 | %filecheck %s -check-prefix=NOTEXTREL -allow-empty
+
+COM: --[no-]demangle, --demangle-style
+RUN: %link %linkopts -o %t.1.out %t.1.o --verbose --demangle-style=demangle --no-demangle --demangle 2>&1 | %filecheck %s -check-prefix=DEMANGLE
+RUN: %link %linkopts -o %t.1.out %t.1.o --verbose --demangle-style=demangle --demangle --no-demangle 2>&1 | %filecheck %s -check-prefix=NODEMANGLE
+RUN: %link %linkopts -o %t.1.out %t.1.o --verbose --demangle --no-demangle --demangle-style=demangle 2>&1 | %filecheck %s -check-prefix=DEMANGLE
+
+COM: --[no-]omagic
+RUN: %link %linkopts -o %t.1.out %t.1.o --no-omagic --omagic -z max-page-size=0x1000
+RUN: %readelf --elf-output-style LLVM -l -W %t.1.out 2>&1 | %filecheck %s -check-prefix=OMAGIC
+RUN: %link %linkopts -o %t.1.out %t.1.o --omagic -z max-page-size=0x1000 --no-omagic
+RUN: %readelf --elf-output-style LLVM -l -W %t.1.out 2>&1 | %filecheck %s -check-prefix=NOOMAGIC
+
+COM: --[disable/enable]-new-dtags
+RUN: %link %linkopts -shared %t.1.o -o %t.1.so -z now --disable-new-dtags --enable-new-dtags
+RUN: %readelf -d %t.1.so | %filecheck %s --check-prefix=NEWDTAG
+RUN: %link %linkopts -shared %t.1.o -o %t.1.so  -z now --enable-new-dtags --disable-new-dtags
+RUN: %readelf -d %t.1.so | %filecheck %s --check-prefix=NONEWDTAG
+
+COM: --[disable/enable]-linker-version
+RUN: %link %linkopts %t.1.o -T %p/Inputs/3.script -o %t.1.out --disable-linker-version --enable-linker-version
+RUN: %readelf -S -W %t.1.out | %filecheck %s --check-prefix=ENABLEDLINKVER
+RUN: %link %linkopts %t.1.o -T %p/Inputs/3.script -o %t.1.out --disable-linker-version --disable-linker-version
+RUN: %readelf -S -W %t.1.out | %filecheck %s --check-prefix=NOENABLEDLINKVER
+
+COM: --[no-]record-command-line
+RUN: %link %linkopts %t.1.o -o %t.1.out --no-record-command-line --record-command-line
+RUN: %readelf -p .comment %t.1.out | %filecheck %s --check-prefix=RECORDCOMMAND
+RUN: %link %linkopts %t.1.o -o %t.1.out --record-command-line --no-record-command-line
+RUN: %readelf -p .comment %t.1.out | %filecheck %s --check-prefix=NORECORDCOMMAND
+
+COM: --[no-]warn-mismatch
+RUN: %yaml2obj %p/Inputs/2.yaml -o %t.2.o
+RUN: %not %link %emulation %linkopts %t.1.o %t.2.o -o %t.1.out --no-warn-mismatch --warn-mismatch 2>&1 | %filecheck %s --check-prefix=WARNMISMATCH
+RUN: %link %emulation %linkopts %t.1.o %t.2.o -o %t.1.out --warn-mismatch --no-warn-mismatch 2>&1 | %filecheck %s --check-prefix=NOWARNMISMATCH  --allow-empty
+
+COM: --[no-]export-dynamic
+RUN: %clang %clangopts -flto -c %p/Inputs/1.cpp -o %t.1.o
+RUN: %link %linkopts --no-export-dynamic --export-dynamic  %t.1.o -o %t.1.out
+RUN: %readelf -s %t.1.out | %filecheck %s -check-prefix=EXPDYN
+RUN: %link %linkopts --export-dynamic --no-export-dynamic  %t.1.o -o %t.1.out
+RUN: %readelf -s %t.1.out | %filecheck %s -check-prefix=NOEXPDYN
+
+COM: --[no-]pie
+RUN: %clang %clangopts -fPIC -c %p/Inputs/1.cpp -o %t.1.o
+RUN: %link %linkopts %t.1.o -o %t.1.out --no-pie --pie
+RUN: %readelf --file-header %t.1.out 2>&1 | %filecheck %s --check-prefix=PIE
+RUN: %link %linkopts %t.1.o -o %t.1.out --pie --no-pie
+RUN: %readelf --file-header %t.1.out 2>&1 | %filecheck %s --check-prefix=NOPIE
+
+FATAL: Fatal: Linking had errors ({{.*}}1.out)
+NOFATAL-NOT: Fatal: Linking had errors
+
+CHECKSECT: section .comment file range overlaps with .text
+NOCHECKSECT-NOT: section .comment file range overlaps with .text
+
+GCSECT: # .text <GC> 0x0
+NOGCSECT-NOT: # .text <GC> 0x0
+
+ALIGN: LOAD 0x00{{[0-9]}}000 {{.*}} 0x1000
+NOALIGN-NOT: LOAD 0x00{{[0-9]}}{{[1-9]}}+ {{.*}} 0x1000
+
+RELOCS: Relocation section {{.*}} contains
+NORELOCS: There are no relocations in this file
+
+THREADS: Threads Enabled
+THREADS: Threads Disabled
+NOTHREADS-NOT: Threads Enabled
+NOTHREADS: Threads Disabled
+GLOBALTHREADS: Threads Enabled
+GLOBALTHREADS-NOT: Threads Disabled
+
+FATLTO: Invalid embedded bitcode in section '.llvm.lto'
+NOFATLTO-NOT: Invalid embedded bitcode in section '.llvm.lto'
+
+TEXTREL: Warning: Add DT_TEXTREL in a shared object!
+NOTEXTREL-NOT: Warning: Add DT_TEXTREL in a shared object!
+
+DEMANGLE: Verbose: Adding symbol foo()
+NODEMANGLE: Verbose: Adding symbol _Z3foov
+
+OMAGIC-NOT: 4096
+NOOMAGIC: 4096
+
+NEWDTAG:  0x{{[0]+}}1e (FLAGS)                BIND_NOW
+NEWDTAG:  0x{{[0]*}}6ffffffb (FLAGS_1)              NOW
+NONEWDTAG: 0x{{[0]+}}18 (BIND_NOW)             0x1
+NONEWDTAG: 0x{{[0]*}}6ffffffb (FLAGS_1)              NOW
+
+ENABLEDLINKVER: .myver {{.*}} {{[0-9a-f]+}} {{.*}}
+NOENABLEDLINKVER-NOT: .myver
+
+RECORDCOMMAND: Command:{{.*}} --no-record-command-line --record-command-line
+NORECORDCOMMAND-NOT: Command
+
+WARNMISMATCH: Error: cannot recognize the format of file
+NOWARNMISMATCH-NOT: Error: cannot recognize the format of file
+
+EXPDYN: {{.}} GLOBAL {{.*}} _Z3foov
+NOEXPDYN-NOT: {{.}} GLOBAL {{.*}} _Z3foov
+
+PIE: DYN (Shared object file)
+NOPIE: EXEC (Executable file)
+#END_TEST

--- a/test/Common/standalone/FlagOverwrite/Inputs/1.cpp
+++ b/test/Common/standalone/FlagOverwrite/Inputs/1.cpp
@@ -1,0 +1,1 @@
+int foo() { return 0; }

--- a/test/Common/standalone/FlagOverwrite/Inputs/1.script
+++ b/test/Common/standalone/FlagOverwrite/Inputs/1.script
@@ -1,0 +1,10 @@
+SECTIONS {
+  . = 0x80000;
+  .text : {
+    *(.text*)
+    . = ALIGN(64);
+    . = 0x80000+0x10-0x64;
+  } =0x3020
+  .comment : { *(.comment) }
+  /DISCARD/ : { *(.ARM.exidx*) }
+}

--- a/test/Common/standalone/FlagOverwrite/Inputs/2.cpp
+++ b/test/Common/standalone/FlagOverwrite/Inputs/2.cpp
@@ -1,0 +1,6 @@
+int printf(const char *, ...);
+int a = 100;
+int main() {
+  printf("Hello World");
+  return 0;
+}

--- a/test/Common/standalone/FlagOverwrite/Inputs/2.script
+++ b/test/Common/standalone/FlagOverwrite/Inputs/2.script
@@ -1,0 +1,5 @@
+SECTIONS {
+  .text : {
+     *(.text.foo)
+  }
+}

--- a/test/Common/standalone/FlagOverwrite/Inputs/2.yaml
+++ b/test/Common/standalone/FlagOverwrite/Inputs/2.yaml
@@ -1,0 +1,54 @@
+--- !ELF
+FileHeader:
+  Class:           ELFCLASS32
+  Data:            ELFDATA2LSB
+  Type:            [[TYPE=ET_REL]]
+  Machine:         EM_NONE
+Sections:
+  - Name:            .text
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_ALLOC, SHF_EXECINSTR ]
+    AddressAlign:    0x4
+  - Name:            .data
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_WRITE, SHF_ALLOC ]
+    AddressAlign:    0x4
+  - Name:            .bss
+    Type:            SHT_NOBITS
+    Flags:           [ SHF_WRITE, SHF_ALLOC ]
+    AddressAlign:    0x4
+  - Name:            .comment
+    Type:            SHT_PROGBITS
+    Flags:           [ SHF_MERGE, SHF_STRINGS ]
+    AddressAlign:    0x1
+    EntSize:         0x1
+    Content:         004743433A20285562756E747520342E382E312D327562756E7475317E31302E30342E312920342E382E3100
+  - Name:            .note.GNU-stack
+    Type:            SHT_PROGBITS
+    AddressAlign:    0x1
+Symbols:
+  - Name:            1.c
+    Type:            STT_FILE
+    Index:           SHN_ABS
+  - Name:            .text
+    Type:            STT_SECTION
+    Section:         .text
+  - Name:            .data
+    Type:            STT_SECTION
+    Section:         .data
+  - Name:            .bss
+    Type:            STT_SECTION
+    Section:         .bss
+  - Name:            .note.GNU-stack
+    Type:            STT_SECTION
+    Section:         .note.GNU-stack
+  - Name:            .comment
+    Type:            STT_SECTION
+    Section:         .comment
+  - Name:            a
+    Type:            STT_OBJECT
+    Index:           SHN_COMMON
+    Binding:         STB_GLOBAL
+    Value:           0x4
+    Size:            0x4
+...

--- a/test/Common/standalone/FlagOverwrite/Inputs/3.script
+++ b/test/Common/standalone/FlagOverwrite/Inputs/3.script
@@ -1,0 +1,5 @@
+SECTIONS
+{
+  .myver 0x100 : { LINKER_VERSION }
+  .text : { *(.text) }
+}

--- a/test/Hexagon/standalone/CommandLine/Threads/Threads.test
+++ b/test/Hexagon/standalone/CommandLine/Threads/Threads.test
@@ -7,9 +7,7 @@ RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
 RUN: %link %linkopts %t1.1.o -o %t2.out.enable --threads --trace=threads 2>&1 | %filecheck %s -check-prefix=ENABLETHREADS
 RUN: %link %t1.1.o -o %t2.out.disable --no-threads --trace=threads 2>&1 | %filecheck %s -check-prefix=DISABLETHREADS
 RUN: %link %linkopts %t1.1.o -o %t2.out.threadcnt --thread-count 10  --trace=threads 2>&1 | %filecheck %s -check-prefix=ENABLETHREADS-COUNT
-RUN: %not %link %linkopts %t1.1.o -o %t2.out.threadcnt --thread-count 10 --no-threads 2>&1 | %filecheck %s -check-prefix=THREADS-COUNT-ERROR
 
 #ENABLETHREADS: Threads Enabled
 #DISABLETHREADS: Threads Disabled
 #ENABLETHREADS-COUNT: Threads Enabled {{.*}}, Number of threads = 10
-#THREADS-COUNT-ERROR: Cannot disable threads and specify thread count

--- a/test/RISCV/standalone/FlagOverwrite/FlagOverwrite.test
+++ b/test/RISCV/standalone/FlagOverwrite/FlagOverwrite.test
@@ -1,0 +1,16 @@
+#---FlagOverwrite.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+# Check that the last option is the one being used for mutually exclusive flags.
+# Currently, it checks for:
+#    --[no-]relax
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.s -o %t1.1.o
+RUN: %link %linkopts --emit-relocs --no-relax --relax  -T %p/Inputs/script.t  %t1.1.o -o %t1.out
+RUN: %objdump --no-print-imm-hex -d %t1.out |  %filecheck %s -check-prefix=RELAX
+RUN: %link %linkopts --emit-relocs --relax --no-relax  -T %p/Inputs/script.t  %t1.1.o -o %t1.out
+RUN: %objdump --no-print-imm-hex -d %t1.out |  %filecheck %s -check-prefix=NORELAX
+
+RELAX-NOT: auipc	ra, 0
+NORELAX: auipc	ra, 0
+#END_TEST

--- a/test/RISCV/standalone/FlagOverwrite/Inputs/1.s
+++ b/test/RISCV/standalone/FlagOverwrite/Inputs/1.s
@@ -1,0 +1,20 @@
+.section .text.foo
+.globl foo
+.type foo, @function
+foo:
+	lui	a5,%hi(bar)
+	lw	a5,%lo(bar)(a5)
+	beqz	a5,.L4
+	call	baz
+.L4:
+	nop
+
+.section .text.baz
+.globl baz
+.type baz, @function
+baz:
+  nop
+.data
+.globl bar
+bar:
+ .word 1

--- a/test/RISCV/standalone/FlagOverwrite/Inputs/script.t
+++ b/test/RISCV/standalone/FlagOverwrite/Inputs/script.t
@@ -1,0 +1,9 @@
+SECTIONS {
+  .text (0x1233000) : {
+    *(.text.foo)
+    *(.text.baz)
+  }
+  .data (0x12345600) : {
+  *(.data)
+  }
+}


### PR DESCRIPTION
Update option handling so that the last occurrence of conflicting flags (e.g. --warn-mismatch/--no-warn-mismatch) takes precedence, matching standard command-line semantics and user expectations.

Fix: #1179