### PR TITLE
[ELD] Fix inconsistent handling of unknown -z options

### DIFF
--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -778,10 +778,8 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
       ZKind = eld::ZOption::MaxPageSize;
       ZOpt.drop_front(14).getAsInteger(0, Zval);
     }
-    if (!Config.options().addZOption(eld::ZOption(ZKind, Zval))) {
-      errs() << "Invalid -z option specified " << ZOpt << "\n";
-      return false;
-    }
+    if (!Config.options().addZOption(eld::ZOption(ZKind, Zval)))
+      Config.raise(Diag::warn_unsupported_option) << "-z " + ZOpt.str();
   }
 
   // --image-base

--- a/test/Common/standalone/CommandLine/ZDefs/ZDefs.test
+++ b/test/Common/standalone/CommandLine/ZDefs/ZDefs.test
@@ -6,9 +6,9 @@
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
 RUN: %link %linkopts -zdefs %t1.1.o -o %t2.out
 RUN: %link %linkopts -z defs %t1.1.o -o %t2.out.sep
-RUN: %not %link %linkopts -z blah %t1.1.o -o %t2.out.err 2>&1 | %filecheck %s -check-prefix=ERROPT
+RUN: %link %linkopts -z blah %t1.1.o -o %t2.out.err 2>&1 | %filecheck %s -check-prefix=WARNING
 RUN: %readelf -s %t2.out -W | %filecheck %s
 RUN: %readelf -s %t2.out.sep -W | %filecheck %s
 #CHECK: foo
-#ERROPT: blah
+#WARNING: Warning: Unrecognized option `-z blah'
 #END_TEST


### PR DESCRIPTION
Make unknown `-z` sub-options follow the same handling as unknown options by emitting a warning instead of an error.

Fix #1122