### PR TITLE
[LTO] Support fat LTO objects

### DIFF
--- a/docs/userguide/documentation/linker_map_files.rst
+++ b/docs/userguide/documentation/linker_map_files.rst
@@ -168,6 +168,11 @@ Linker Script and Memory Map Section
         END GROUP
         LOAD $PATH/../target/hexagon/lib/v65/G0/fini.o[hexagonv65]
 
+    * ``LOAD`` entries can include trailing comments (``# ...``) with input
+      selection notes. For example, when ``--fat-lto-objects`` selects a fat
+      LTO payload, the input line is annotated with
+      ``# Fat LTO object selected``.
+
 
 Linker Scripts Used
 =====================

--- a/docs/userguide/documentation/lto_support.rst
+++ b/docs/userguide/documentation/lto_support.rst
@@ -34,9 +34,12 @@ ELD triggers LTO when it sees bitcode inputs or when it is instructed to use
 embedded bitcode sections in ELF files:
 
 * **Bitcode inputs**: `.bc` inputs are always treated as LTO inputs.
-* **Embedded bitcode**: ELD recognizes the `.llvmbc` section in ELF objects and
-  can replace the native object with the embedded bitcode when LTO is enabled.
-  This supports "fat" objects that carry both native code and LLVM bitcode.
+* **Embedded bitcode**:
+
+  * ELD recognizes `.llvmbc` sections in ELF objects and can replace the
+    native object with embedded bitcode when LTO input selection enables it.
+  * ELD also supports `.llvm.lto` (`SHT_LLVM_LTO`) sections used by fat LTO
+    objects when `--fat-lto-objects` is enabled.
 
 Selecting LTO inputs
 ~~~~~~~~~~~~~~~~~~~~
@@ -45,10 +48,15 @@ LTO is enabled in two ways:
 * `-flto` enables LTO if any bitcode input or embedded bitcode is present.
 * `--include-lto-filelist` can be used without `-flto` to select which
   ELF inputs with embedded bitcode should be upgraded to LTO inputs.
+* `--fat-lto-objects` enables consuming embedded `.llvm.lto` sections from
+  relocatable ELF inputs (alias: `-ffat-lto-objects`).
 
 When `-flto` is used, embedded bitcode is used by default unless excluded using
 `--exclude-lto-filelist`. When `-flto` is not used, only file patterns listed
 in `--include-lto-filelist` are upgraded to LTO inputs.
+
+By default, `.llvm.lto` sections are ignored. They are only consumed when
+`--fat-lto-objects` (or `-ffat-lto-objects`) is specified.
 
 File lists accept one glob pattern per line (wildcards `*`, `?`, and `[]` are
 supported). Patterns are matched against the input path as seen by the linker.
@@ -64,6 +72,10 @@ ELD performs LTO in distinct phases:
 3. **Post-LTO**: The generated objects are inserted back into the link and
    linked like normal ELF objects. Map files can include pre-LTO and post-LTO
    details.
+
+When ``--fat-lto-objects`` (or ``-ffat-lto-objects``) selects embedded
+``.llvm.lto`` from a mixed object, the pre-LTO map input record for that file
+is annotated with ``Fat LTO object selected``.
 
 Linker scripts and LTO
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -81,6 +93,10 @@ Core LTO enablement and input selection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * `-flto` or `--flto`
   Enable LTO if a bitcode file or embedded bitcode section is present.
+* `--fat-lto-objects` / `--no-fat-lto-objects`
+  Enable/disable use of `.llvm.lto` embedded bitcode sections from fat LTO
+  relocatable objects.
+  Aliases: `-ffat-lto-objects`, `-fno-fat-lto-objects`.
 * `--include-lto-filelist=<list>`
   Use this list to select which ELF inputs with embedded bitcode should be
   used for LTO when `-flto` is not present.
@@ -222,6 +238,12 @@ Emit LTO assembly for inspection:
 
   ld.eld -flto --lto-emit-asm foo.o bar.o -o app.elf
   # Output files: app.elf.llvm-lto.0.s, app.elf.llvm-lto.1.s, ...
+
+Use `.llvm.lto` from fat LTO objects:
+::
+
+  # foo.fat.o carries native code plus a .llvm.lto section.
+  ld.eld --fat-lto-objects foo.fat.o bar.bc -o app.elf
 
 References
 ----------

--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -397,6 +397,10 @@ public:
 
   bool hasLTO() const { return Lto; }
 
+  void setFatLTOObjects(bool V = true) { FatLTOObjects = V; }
+
+  bool hasFatLTOObjects() const { return FatLTOObjects; }
+
   void setLTOOptions(llvm::StringRef OptionType);
 
   void addLTOCodeGenOptions(std::string O);
@@ -1272,6 +1276,7 @@ private:
   bool BForcePACPLT = false;         // -z pac-plt
   uint32_t GPSize = 8;               // -G, --gpsize
   bool Lto = false;
+  bool FatLTOObjects = false;                    // --fat-lto-objects
   bool LTOUseAs = false;                         // -flto-use-as
   StripSymbolMode StripSymbols = KeepAllSymbols; // Strip symbols ?
   bool BPageAlignSegments = true;   // Does the linker need to align segments to

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -1089,6 +1089,20 @@ def plugin_opt_eq_minus
 def flto : Flag<["-", "--"], "flto">,
            HelpText<"Enable LTO if a Bitcode file is present.">,
            Group<grp_ltooptions>;
+def fat_lto_objects : Flag<["--"], "fat-lto-objects">,
+                      HelpText<"Use .llvm.lto section in fat LTO objects">,
+                      Group<grp_ltooptions>;
+def no_fat_lto_objects : Flag<["--"], "no-fat-lto-objects">,
+                         HelpText<"Ignore .llvm.lto section in fat LTO objects">,
+                         Group<grp_ltooptions>;
+def ffat_lto_objects : Flag<["-"], "ffat-lto-objects">,
+                       Alias<fat_lto_objects>,
+                       HelpText<"Alias for --fat-lto-objects">,
+                       Group<grp_ltooptions>;
+def fno_fat_lto_objects : Flag<["-"], "fno-fat-lto-objects">,
+                          Alias<no_fat_lto_objects>,
+                          HelpText<"Alias for --no-fat-lto-objects">,
+                          Group<grp_ltooptions>;
 defm flto_options
     : dashEqWithOpt<"flto-options", "flto-options", "flto_options",
                     "Specify various options with LTO">,

--- a/include/eld/LayoutMap/LayoutInfo.h
+++ b/include/eld/LayoutMap/LayoutInfo.h
@@ -137,6 +137,7 @@ public:
     InputKindPrefix Prefix;
     Input *Inp;
     std::string ArchFlag;
+    std::string Annotation;
   };
 
   // -------------------- Public Typedefs ----------------------------
@@ -264,7 +265,10 @@ public:
   std::string getStringFromLoadSequence(InputSequenceT Ist);
 
   void recordInputActions(InputKindPrefix Prefix, Input *Input,
-                          std::string FileType = "");
+                          std::string FileType = "",
+                          std::string Annotation = "");
+
+  void annotateInputAction(Input *Input, llvm::StringRef Annotation);
 
   void resetInputActions() { InputActions.clear(); }
 

--- a/include/eld/Readers/ELFSection.h
+++ b/include/eld/Readers/ELFSection.h
@@ -20,6 +20,7 @@
 #include "eld/SymbolResolver/LDSymbol.h"
 #include "eld/Target/LDFileFormat.h"
 #include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
 #include <string>
 
@@ -141,6 +142,26 @@ public:
                        AddrAlign, Type, Info, Link, SectionSize) {}
 
   static bool classof(const Section *S) { return S->isELF(); }
+
+  // Embedded-bitcode helper predicates used by readers and LTO selection.
+  static bool isFatLTOSection(llvm::StringRef Name) {
+    return Name == ".llvm.lto";
+  }
+
+  static bool isEmbeddedBitcodeSection(llvm::StringRef Name) {
+    return Name == ".llvmbc" || isFatLTOSection(Name);
+  }
+
+  static bool isEmbeddedBitcodeMetadataSection(llvm::StringRef Name) {
+    return Name == ".llvmcmd";
+  }
+
+  static bool shouldReadEmbeddedBitcodeSection(llvm::StringRef Name,
+                                               bool UseFatLTOObjects) {
+    if (Name == ".llvmbc")
+      return true;
+    return UseFatLTOObjects && isFatLTOSection(Name);
+  }
 
   virtual ~ELFSection() {}
 

--- a/lib/LayoutMap/LayoutInfo.cpp
+++ b/lib/LayoutMap/LayoutInfo.cpp
@@ -295,6 +295,8 @@ std::string LayoutInfo::getStringFromLoadSequence(InputSequenceT Ist) {
     }
     K = Input->getInputFile()->getKind();
   }
+  if (!Ist.Annotation.empty())
+    appendRemapComment(Ist.Annotation);
 
   std::string FileType;
   if (ArchFlag.empty()) {
@@ -341,12 +343,33 @@ std::string LayoutInfo::getStringFromLoadSequence(InputSequenceT Ist) {
 }
 
 void LayoutInfo::recordInputActions(InputKindPrefix Prefix, Input *Input,
-                                    std::string FileType) {
+                                    std::string FileType,
+                                    std::string Annotation) {
   InputSequenceT IS;
   IS.Prefix = Prefix;
   IS.Inp = Input;
   IS.ArchFlag = FileType;
+  IS.Annotation = Annotation;
   InputActions.push_back(IS);
+}
+
+void LayoutInfo::annotateInputAction(Input *Input, llvm::StringRef Annotation) {
+  if (!Input || Annotation.empty())
+    return;
+
+  for (auto It = InputActions.rbegin(); It != InputActions.rend(); ++It) {
+    if (It->Inp != Input)
+      continue;
+    if (It->Annotation.empty()) {
+      It->Annotation = Annotation.str();
+    } else if (!llvm::StringRef(It->Annotation).contains(Annotation)) {
+      It->Annotation += ", ";
+      It->Annotation += Annotation.str();
+    }
+    return;
+  }
+
+  recordInputActions(LayoutInfo::Load, Input, "", Annotation.str());
 }
 
 void LayoutInfo::recordGroup() { LinkStats.NumGroupTraversal++; }

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -671,6 +671,13 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
   Config.options().setLTO(opt_flto);
   Config.addCommandLine(Table->getOptionName(T::flto), opt_flto);
 
+  // --{no-,}fat-lto-objects / -f{no-,}fat-lto-objects
+  bool fatLTOObjects =
+      Args.hasFlag(T::fat_lto_objects, T::no_fat_lto_objects, false);
+  Config.options().setFatLTOObjects(fatLTOObjects);
+  Config.addCommandLine(Table->getOptionName(T::fat_lto_objects),
+                        fatLTOObjects);
+
   // --save-temps
   Config.options().setSaveTemps(Args.hasArg(T::save_temps));
 

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -3888,9 +3888,10 @@ bool ObjectLinker::readAndProcessInput(Input *Input, bool IsPostLto) {
 }
 
 bool ObjectLinker::overrideELFObjectWithBitCode(InputFile *CurInputFile) {
-  // If -flto option is not passed to the linker, and there is not a list
-  // to include, then just move on.
-  if (!ThisConfig.options().hasLTO() && !LTOPatternList.size())
+  // If neither -flto nor list-driven selection nor --fat-lto-objects is used,
+  // then just move on.
+  if (!ThisConfig.options().hasLTO() && !LTOPatternList.size() &&
+      !ThisConfig.options().hasFatLTOObjects())
     return false;
 
   eld::RegisterTimer T("Read Mixed ELF/Bitcode Object Files",
@@ -3907,6 +3908,11 @@ bool ObjectLinker::overrideELFObjectWithBitCode(InputFile *CurInputFile) {
 
   ELFSection *LLVMBCSection = EObj->getLLVMBCSection();
   if (!LLVMBCSection)
+    return false;
+
+  // Fat-LTO payloads are selected only when --fat-lto-objects is enabled.
+  if (ELFSection::isFatLTOSection(LLVMBCSection->name()) &&
+      !ThisConfig.options().hasFatLTOObjects())
     return false;
 
   bool MatchedPattern = false;
@@ -3932,15 +3938,25 @@ bool ObjectLinker::overrideELFObjectWithBitCode(InputFile *CurInputFile) {
   if (ThisConfig.options().hasLTO()) {
     if (MatchedPattern)
       return false;
-  } else {
+  } else if (LTOPatternList.size()) {
     // The file needs to be included, if
     // -flto option is not used and there is a match.
     if (!MatchedPattern)
       return false;
+  } else if (!(ThisConfig.options().hasFatLTOObjects() &&
+               ELFSection::isFatLTOSection(LLVMBCSection->name()))) {
+    // We have to delay this to make sure llvmbc sections are handled using
+    // exclude-lto-filelist and include-lto-filelist accordingly.
+    return false;
   }
 
   if (ThisModule->getPrinter()->isVerbose())
     ThisConfig.raise(Diag::use_embedded_bitcode) << Path;
+
+  if (ELFSection::isFatLTOSection(LLVMBCSection->name())) {
+    if (LayoutInfo *layoutInfo = ThisModule->getLayoutInfo())
+      layoutInfo->annotateInputAction(CurInput, "Fat LTO object selected");
+  }
 
   // LTO is needed. Since Bitcode was chosen.
   ThisModule->setLTONeeded();

--- a/lib/Readers/ELFReader.cpp
+++ b/lib/Readers/ELFReader.cpp
@@ -129,7 +129,9 @@ void ELFReader<ELFT>::setSectionInInputFile(ELFSection *S,
     break;
   }
 
-  if (!isDynObj && S->name() == ".llvmbc") {
+  bool ReadFatLTOSections = m_Module.getConfig().options().hasFatLTOObjects();
+  if (!isDynObj && ELFSection::shouldReadEmbeddedBitcodeSection(
+                       S->name(), ReadFatLTOSections)) {
     ELFObjectFile *EObj = llvm::cast<ELFObjectFile>(&m_InputFile);
     EObj->setLLVMBCSection(S);
   }

--- a/lib/Readers/ExecELFReader.cpp
+++ b/lib/Readers/ExecELFReader.cpp
@@ -64,7 +64,8 @@ eld::Expected<ELFSection *> ExecELFReader<ELFT>::createSection(
   // that follow these sections will need to have proper index in section
   // header table. We thus read them and then set to ignore to have no effect
   // on linking.
-  if (sectName == ".llvmbc" || sectName == ".llvmcmd")
+  if (ELFSection::isEmbeddedBitcodeSection(sectName) ||
+      ELFSection::isEmbeddedBitcodeMetadataSection(sectName))
     SectionIsIgnore = true;
 
   if (this->getInputFile()->getInput()->getAttribute().isPatchBase()) {

--- a/lib/Readers/RelocELFReader.cpp
+++ b/lib/Readers/RelocELFReader.cpp
@@ -65,7 +65,8 @@ eld::Expected<ELFSection *> RelocELFReader<ELFT>::createSection(
   // that follow these sections will need to have proper index in section
   // header table. We thus read them and then set to ignore to have no effect
   // on linking.
-  if (sectName == ".llvmbc" || sectName == ".llvmcmd")
+  if (ELFSection::isEmbeddedBitcodeSection(sectName) ||
+      ELFSection::isEmbeddedBitcodeMetadataSection(sectName))
     LLVMBCSectionIsIgnore = true;
 
   ELFSection *section = nullptr;

--- a/test/Common/LTO/FatLTOObjects/FatLTOObjects.test
+++ b/test/Common/LTO/FatLTOObjects/FatLTOObjects.test
@@ -1,0 +1,44 @@
+#---FatLTOObjects.test--------------------------- Executable,LTO -----------------#
+#BEGIN_COMMENT
+# Verify support for fat LTO objects carrying a .llvm.lto section.
+# --fat-lto-objects (and -ffat-lto-objects alias) should select embedded
+# bitcode from .llvm.lto, while default mode should use the native object.
+#END_COMMENT
+
+RUN: %clang %clangopts -c %p/Inputs/main.c -o %t.main.o
+RUN: %clang %clangopts -c %p/Inputs/native.c -o %t.native.o
+RUN: %clang %clangopts -emit-llvm -c %p/Inputs/lto.c -o %t.lto.bc
+
+RUN: %objcopy --add-section=.llvm.lto=%t.lto.bc --set-section-flags=.llvm.lto=exclude --set-section-type=.llvm.lto=0x6fff4c0c %t.native.o %t.fat.o
+RUN: %readelf -S %t.fat.o | %filecheck %s --check-prefix=HAS-LTO-SECTION
+
+RUN: %link %linkopts -e main %t.main.o %t.fat.o -o %t.no-fat.out
+RUN: %nm %t.no-fat.out | %filecheck %s --check-prefix=NOFAT
+RUN: %readelf -S %t.no-fat.out | %filecheck %s --check-prefix=NO-LTO-SECTION
+
+RUN: %link %linkopts -e main %t.main.o %t.fat.o --fat-lto-objects --trace=lto --verbose -o %t.fat.out 2>&1 | %filecheck %s --check-prefix=FAT-MSG
+RUN: %nm %t.fat.out | %filecheck %s --check-prefix=FAT
+RUN: %readelf -S %t.fat.out | %filecheck %s --check-prefix=NO-LTO-SECTION
+
+RUN: %link %linkopts -e main %t.main.o %t.fat.o --fat-lto-objects -Map %t.fat.map -o %t.fat.map.out
+RUN: %filecheck %s --check-prefix=FAT-MAP < %t.fat.map
+
+RUN: %link %linkopts -e main %t.main.o %t.fat.o -ffat-lto-objects --trace=lto --verbose -o %t.ffat.out 2>&1 | %filecheck %s --check-prefix=FAT-MSG
+RUN: %nm %t.ffat.out | %filecheck %s --check-prefix=FAT
+
+RUN: %link %linkopts -r %t.fat.o -o %t.reloc.o
+RUN: %readelf -S %t.reloc.o | %filecheck %s --check-prefix=NO-LTO-SECTION
+
+HAS-LTO-SECTION: .llvm.lto
+
+NO-LTO-SECTION-NOT: .llvm.lto
+
+FAT-MSG: Using embedded bitcode section from file
+
+FAT-MAP: LOAD {{.*}}fat.o{{.*}} # Fat LTO object selected
+
+NOFAT: native_symbol
+NOFAT-NOT: lto_symbol
+
+FAT: lto_symbol
+FAT-NOT: native_symbol

--- a/test/Common/LTO/FatLTOObjects/Inputs/lto.c
+++ b/test/Common/LTO/FatLTOObjects/Inputs/lto.c
@@ -1,0 +1,3 @@
+__attribute__((used)) int lto_symbol = 2;
+
+int selected(void) { return lto_symbol; }

--- a/test/Common/LTO/FatLTOObjects/Inputs/main.c
+++ b/test/Common/LTO/FatLTOObjects/Inputs/main.c
@@ -1,0 +1,3 @@
+extern int selected(void);
+
+int main(void) { return selected(); }

--- a/test/Common/LTO/FatLTOObjects/Inputs/native.c
+++ b/test/Common/LTO/FatLTOObjects/Inputs/native.c
@@ -1,0 +1,3 @@
+__attribute__((used)) int native_symbol = 1;
+
+int selected(void) { return native_symbol; }


### PR DESCRIPTION
https://llvm.org/docs/FatLTO.html

FatLTO objects are a special type of fat object file that contain LTO compatible IR in addition to generated object code, instead of containing object code for multiple target architectures.

This allows users to defer the choice of whether to use LTO or not to link-time Under FatLTO the compiler can emit standard object files which contain both the machine code in the .text section and LLVM bitcode in the .llvm.lto section.

Closes #1181