### PR TITLE
[fatlto] diagnose invalid/empty embedded bitcode

### DIFF
--- a/include/eld/Diagnostics/DiagReaders.inc
+++ b/include/eld/Diagnostics/DiagReaders.inc
@@ -16,6 +16,8 @@ DIAG(fatal_cannot_read_input_err, DiagnosticEngine::Fatal,
      "cannot read file %0, because of error %1")
 DIAG(fatal_cannot_make_module, DiagnosticEngine::Fatal,
      "cannot make module out of bitcode file %0 for file, error : %1 ")
+DIAG(error_invalid_embedded_bitcode, DiagnosticEngine::Error,
+     "Invalid embedded bitcode in section '%1' from input file '%0'")
 DIAG(fatal_no_codegen, DiagnosticEngine::Fatal,
      "cannot create code generator object %0")
 DIAG(fatal_no_codegen_compile, DiagnosticEngine::Fatal,

--- a/lib/Input/InputFile.cpp
+++ b/lib/Input/InputFile.cpp
@@ -48,26 +48,8 @@ InputFile *InputFile::createEmbedded(Input *I, llvm::StringRef S,
   InputFile::InputFileKind K = getInputFileKind(S);
   InputFile *EmbeddedFile = nullptr;
   switch (K) {
-  case InputFile::ELFObjFileKind:
-    EmbeddedFile = make<ELFObjectFile>(I, DiagEngine);
-    break;
-  case InputFile::ELFExecutableFileKind:
-    EmbeddedFile = make<ELFExecutableFile>(I, DiagEngine);
-    break;
-  case InputFile::ELFDynObjFileKind:
-    EmbeddedFile = make<ELFDynObjectFile>(I, DiagEngine);
-    break;
   case InputFile::BitcodeFileKind:
     EmbeddedFile = make<BitcodeFile>(I, DiagEngine);
-    break;
-  case InputFile::GNUArchiveFileKind:
-    EmbeddedFile = make<ArchiveFile>(I, DiagEngine);
-    break;
-  case InputFile::ELFSymDefFileKind:
-    EmbeddedFile = make<SymDefFile>(I, DiagEngine);
-    break;
-  case InputFile::GNULinkerScriptKind:
-    EmbeddedFile = make<LinkerScriptFile>(I, DiagEngine);
     break;
   default:
     return nullptr;

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -3907,7 +3907,7 @@ bool ObjectLinker::overrideELFObjectWithBitCode(InputFile *CurInputFile) {
   std::string Path = CurInput->decoratedPath();
 
   ELFSection *LLVMBCSection = EObj->getLLVMBCSection();
-  if (!LLVMBCSection)
+  if (!LLVMBCSection || !LLVMBCSection->size())
     return false;
 
   // Fat-LTO payloads are selected only when --fat-lto-objects is enabled.
@@ -3967,8 +3967,12 @@ bool ObjectLinker::overrideELFObjectWithBitCode(InputFile *CurInputFile) {
   InputFile *OverrideBCFile = InputFile::createEmbedded(
       CurInput, LLVMBCContents, ThisConfig.getDiagEngine());
 
-  ASSERT(OverrideBCFile->getKind() == InputFile::BitcodeFileKind,
-         CurInput->decoratedPath());
+  if (!OverrideBCFile ||
+      OverrideBCFile->getKind() != InputFile::BitcodeFileKind) {
+    ThisConfig.raise(Diag::error_invalid_embedded_bitcode)
+        << Path << LLVMBCSection->name();
+    return false;
+  }
 
   CurInput->overrideInputFile(OverrideBCFile);
 

--- a/test/Common/LTO/EmbeddedLLVMBcObjects/EmbeddedLLVMBcObjects.test
+++ b/test/Common/LTO/EmbeddedLLVMBcObjects/EmbeddedLLVMBcObjects.test
@@ -1,0 +1,51 @@
+#---EmbeddedLLVMBcObjects.test-------------------- Executable,LTO ------------#
+#BEGIN_COMMENT
+# Verify support for relocatable objects carrying an embedded .llvmbc section.
+# - Without LTO selection, linker should use native object code.
+# - With -flto, linker should select embedded bitcode from .llvmbc.
+# - Empty .llvmbc should be ignored.
+# - Invalid .llvmbc payload should diagnose instead of crashing.
+#END_COMMENT
+
+RUN: %clang %clangopts -c %p/Inputs/main.c -o %t.main.o
+RUN: %clang %clangopts -c %p/Inputs/native.c -o %t.native.o
+RUN: %clang %clangopts -emit-llvm -c %p/Inputs/lto.c -o %t.lto.bc
+
+RUN: %objcopy --add-section=.llvmbc=%t.lto.bc  \
+RUN: --set-section-flags=.llvmbc=exclude %t.native.o %t.llvmbc.o
+RUN: %readelf -S %t.llvmbc.o | %filecheck %s --check-prefix=HAS-LLVMBC-SECTION
+
+RUN: %link %linkopts -e main %t.main.o %t.llvmbc.o -o %t.no-lto.out
+RUN: %nm %t.no-lto.out | %filecheck %s --check-prefix=NO-LTO
+
+RUN: %link %linkopts -flto -e main %t.main.o %t.llvmbc.o \
+RUN: --trace=lto --verbose -o %t.lto.out 2>&1 | %filecheck %s --check-prefix=LTO-MSG
+RUN: %nm %t.lto.out | %filecheck %s --check-prefix=WITH-LTO
+
+# Empty BC
+RUN: %touch %t.empty
+RUN: %objcopy --add-section=.llvmbc=%t.empty \
+RUN: --set-section-flags=.llvmbc=exclude %t.native.o %t.empty.llvmbc.o
+RUN: %link %linkopts -flto -r %t.empty.llvmbc.o -o /dev/null \
+RUN: --trace=lto 2>&1 | %filecheck %s --check-prefix=EMPTY-LLVMBC
+
+# Invalid non-bitcode payload should diagnose instead of crashing.
+RUN: printf "eld\n" > %t.invalid
+RUN: %objcopy --add-section=.llvmbc=%t.invalid \
+RUN: --set-section-flags=.llvmbc=exclude %t.native.o %t.invalid.llvmbc.o
+RUN: %not %link %linkopts -flto -r %t.invalid.llvmbc.o  \
+RUN: -o /dev/null --trace=lto 2>&1 | %filecheck %s --check-prefix=INVALID-LLVMBC
+
+HAS-LLVMBC-SECTION: .llvmbc
+
+NO-LTO: native_symbol
+NO-LTO-NOT: lto_symbol
+
+LTO-MSG: Using embedded bitcode section from file
+
+WITH-LTO: lto_symbol
+WITH-LTO-NOT: native_symbol
+
+EMPTY-LLVMBC-NOT: Using embedded bitcode section
+
+INVALID-LLVMBC: Invalid embedded bitcode in section '.llvmbc'

--- a/test/Common/LTO/EmbeddedLLVMBcObjects/Inputs/lto.c
+++ b/test/Common/LTO/EmbeddedLLVMBcObjects/Inputs/lto.c
@@ -1,0 +1,3 @@
+__attribute__((used)) int lto_symbol = 2;
+
+int selected(void) { return lto_symbol; }

--- a/test/Common/LTO/EmbeddedLLVMBcObjects/Inputs/main.c
+++ b/test/Common/LTO/EmbeddedLLVMBcObjects/Inputs/main.c
@@ -1,0 +1,3 @@
+extern int selected(void);
+
+int main(void) { return selected(); }

--- a/test/Common/LTO/EmbeddedLLVMBcObjects/Inputs/native.c
+++ b/test/Common/LTO/EmbeddedLLVMBcObjects/Inputs/native.c
@@ -1,0 +1,3 @@
+__attribute__((used)) int native_symbol = 1;
+
+int selected(void) { return native_symbol; }

--- a/test/Common/LTO/FatLTOObjects/FatLTOObjects.test
+++ b/test/Common/LTO/FatLTOObjects/FatLTOObjects.test
@@ -9,25 +9,45 @@ RUN: %clang %clangopts -c %p/Inputs/main.c -o %t.main.o
 RUN: %clang %clangopts -c %p/Inputs/native.c -o %t.native.o
 RUN: %clang %clangopts -emit-llvm -c %p/Inputs/lto.c -o %t.lto.bc
 
-RUN: %objcopy --add-section=.llvm.lto=%t.lto.bc --set-section-flags=.llvm.lto=exclude --set-section-type=.llvm.lto=0x6fff4c0c %t.native.o %t.fat.o
+RUN: %objcopy --add-section=.llvm.lto=%t.lto.bc \
+RUN: --set-section-flags=.llvm.lto=exclude \
+RUN: --set-section-type=.llvm.lto=0x6fff4c0c %t.native.o %t.fat.o
 RUN: %readelf -S %t.fat.o | %filecheck %s --check-prefix=HAS-LTO-SECTION
 
 RUN: %link %linkopts -e main %t.main.o %t.fat.o -o %t.no-fat.out
 RUN: %nm %t.no-fat.out | %filecheck %s --check-prefix=NOFAT
 RUN: %readelf -S %t.no-fat.out | %filecheck %s --check-prefix=NO-LTO-SECTION
 
-RUN: %link %linkopts -e main %t.main.o %t.fat.o --fat-lto-objects --trace=lto --verbose -o %t.fat.out 2>&1 | %filecheck %s --check-prefix=FAT-MSG
+RUN: %link %linkopts -e main %t.main.o %t.fat.o \
+RUN: --fat-lto-objects --trace=lto --verbose \
+RUN: -o %t.fat.out 2>&1 | %filecheck %s --check-prefix=FAT-MSG
 RUN: %nm %t.fat.out | %filecheck %s --check-prefix=FAT
 RUN: %readelf -S %t.fat.out | %filecheck %s --check-prefix=NO-LTO-SECTION
 
-RUN: %link %linkopts -e main %t.main.o %t.fat.o --fat-lto-objects -Map %t.fat.map -o %t.fat.map.out
+RUN: %link %linkopts -e main %t.main.o %t.fat.o \
+RUN: --fat-lto-objects -Map %t.fat.map -o %t.fat.map.out
 RUN: %filecheck %s --check-prefix=FAT-MAP < %t.fat.map
 
-RUN: %link %linkopts -e main %t.main.o %t.fat.o -ffat-lto-objects --trace=lto --verbose -o %t.ffat.out 2>&1 | %filecheck %s --check-prefix=FAT-MSG
+RUN: %link %linkopts -e main %t.main.o %t.fat.o -ffat-lto-objects \
+RUN: --trace=lto --verbose -o %t.ffat.out 2>&1 | %filecheck %s --check-prefix=FAT-MSG
 RUN: %nm %t.ffat.out | %filecheck %s --check-prefix=FAT
 
 RUN: %link %linkopts -r %t.fat.o -o %t.reloc.o
 RUN: %readelf -S %t.reloc.o | %filecheck %s --check-prefix=NO-LTO-SECTION
+
+# Empty BC
+RUN: %touch %t.empty
+RUN: %objcopy --add-section=.llvm.lto=%t.empty --set-section-flags=.llvm.lto=exclude \
+RUN: --set-section-type=.llvm.lto=0x6fff4c0c %t.native.o %t.fat.o
+RUN: %link --fat-lto-objects -r %t.fat.o -o /dev/null \
+RUN: --trace=lto 2>&1 | %filecheck %s -check-prefix=EMBED-LTO
+
+# Invalid non-bitcode payload should diagnose instead of crashing.
+RUN: printf "eld\n" > %t.invalid
+RUN: %objcopy --add-section=.llvm.lto=%t.invalid --set-section-flags=.llvm.lto=exclude \
+RUN: --set-section-type=.llvm.lto=0x6fff4c0c %t.native.o %t.fat.invalid.o
+RUN: %not %link --fat-lto-objects -r %t.fat.invalid.o -o /dev/null \
+RUN: --trace=lto 2>&1 | %filecheck %s -check-prefix=INVALID-EMBED-LTO
 
 HAS-LTO-SECTION: .llvm.lto
 
@@ -42,3 +62,7 @@ NOFAT-NOT: lto_symbol
 
 FAT: lto_symbol
 FAT-NOT: native_symbol
+
+EMBED-LTO-NOT: Using embedded bitcode section
+
+INVALID-EMBED-LTO: Invalid embedded bitcode in section '.llvm.lto'


### PR DESCRIPTION
fatlto support for llvmbc and .llvm.lto sections is restricted to only bitcode, also support embedded bitcode for malformed files and empty content.

Closes #1195