### PR TITLE
Fix evaluation order of (before/in/after)-SECTIONS assignments

### DIFF
--- a/include/eld/Object/OutputSectionEntry.h
+++ b/include/eld/Object/OutputSectionEntry.h
@@ -98,17 +98,21 @@ public:
 
   void append(RuleContainer *PInput) { Inputs.push_back(PInput); }
 
-  const SymbolAssignments &sectionsEndAssignments() const {
-    return SectionEndAssignments;
+  const SymbolAssignments &getPostOutputSectionAssignments() const {
+    return postOutputSectionAssignments;
   }
-  SymbolAssignments &sectionEndAssignments() { return SectionEndAssignments; }
+  SymbolAssignments &getPostOutputSectionAssignments() {
+    return postOutputSectionAssignments;
+  }
 
-  sym_iterator sectionendsymBegin() { return SectionEndAssignments.begin(); }
-  sym_iterator sectionendsymEnd() { return SectionEndAssignments.end(); }
+  void movePostOutputSectionAssignments(OutputSectionEntry *Out) {
+    postOutputSectionAssignments = Out->getPostOutputSectionAssignments();
+    Out->getPostOutputSectionAssignments().clear();
+  }
 
-  void moveSectionAssignments(OutputSectionEntry *Out) {
-    SectionEndAssignments = Out->sectionEndAssignments();
-    Out->sectionEndAssignments().clear();
+  template <typename Func> void forEachPostOutputSectionAssignment(Func F) {
+    for (auto *A : postOutputSectionAssignments)
+      F(A);
   }
 
   // A section may be part of multiple segments, this only returns the
@@ -221,7 +225,7 @@ private:
   size_t Order;
   bool IsDiscard;
   InputList Inputs;
-  SymbolAssignments SectionEndAssignments;
+  SymbolAssignments postOutputSectionAssignments;
   RuleContainer *FirstNonEmptyRule;
   RuleContainer *LastRule;
   std::vector<BranchIsland *> BranchIslands;

--- a/include/eld/Script/Assignment.h
+++ b/include/eld/Script/Assignment.h
@@ -35,10 +35,11 @@ class ELFSection;
 class Assignment : public ScriptCommand {
 public:
   enum Level {
-    BEFORE_SECTIONS,  // Assignments before SECTIONS command
-    AFTER_SECTIONS,   // Assignments after SECTIONS command
-    INPUT_SECTION,    // related to an input section
-    SECTIONS_END
+    BeforeSections,     // Assignments before any SECTIONS command
+    AfterInputSectDesc, // Assignments inside output section body (with input
+                        // rules)
+    AfterOutputSection, // Assignments between output sections inside SECTIONS
+    AfterSections       // Assignments after SECTIONS command
   };
 
   enum Type { DEFAULT, HIDDEN, PROVIDE, PROVIDE_HIDDEN, FILL, ASSERT, PRINT };
@@ -46,8 +47,6 @@ public:
 public:
   Assignment(Level AssignmentLevel, Type AssignmentType, std::string Symbol,
              Expression *ScriptExpression);
-
-
 
   Level level() const { return AssignmentLevel; }
 
@@ -93,12 +92,12 @@ public:
 
   /// Query functions on Assignment Kinds.
   bool isOutsideSections() const {
-    return AssignmentLevel == BEFORE_SECTIONS ||
-           AssignmentLevel == AFTER_SECTIONS;
+    return AssignmentLevel == BeforeSections ||
+           AssignmentLevel == AfterSections;
   }
 
   bool isInsideOutputSection() const {
-    return AssignmentLevel == INPUT_SECTION;
+    return AssignmentLevel == AfterInputSectDesc;
   }
 
   bool isHidden() const { return ThisType == HIDDEN; }

--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -482,7 +482,7 @@ public:
 
   void evaluateAssignments(OutputSectionEntry *output);
 
-  void evaluateAssignmentsAtEndOfOutputSection(OutputSectionEntry *output);
+  void evaluatePostOutputSectionAssignments(OutputSectionEntry *output);
 
   // Print padding between end and start fragments of adjacent rules
   std::vector<PaddingT>
@@ -961,7 +961,7 @@ private:
 
   // Evaluate defsym assignments and script assignments that appear outside
   // sections.
-  void evaluateScriptAssignments(bool evaluateAsserts = true);
+  void evaluateBeforeSectionsAssignments(bool evaluateAsserts = true);
 
   bool isRelROSection(const ELFSection *sect) const;
 

--- a/lib/LayoutMap/TextLayoutPrinter.cpp
+++ b/lib/LayoutMap/TextLayoutPrinter.cpp
@@ -1331,7 +1331,8 @@ void TextLayoutPrinter::printMapFile(eld::Module &Module) {
 
   for (const auto *X : (Script.getScriptCommands())) {
     if (const Assignment *A = llvm::dyn_cast<Assignment>(X))
-      printAssignment(*A, Module, UseColor);
+      if (A->level() == Assignment::Level::BeforeSections)
+        printAssignment(*A, Module, UseColor);
   }
 
   printLayout(Module);
@@ -1433,12 +1434,8 @@ void TextLayoutPrinter::printLayout(eld::Module &Module) {
       }
     }
 
-    // Evaluate all assignments at the end of the output section.
-    for (OutputSectionEntry::sym_iterator It = (*Out)->sectionendsymBegin(),
-                                          Ie = (*Out)->sectionendsymEnd();
-         It != Ie; ++It) {
-      printAssignment(**It, Module, UseColor);
-    }
+    (*Out)->forEachPostOutputSectionAssignment(
+        [&](const Assignment *A) { printAssignment(*A, Module, UseColor); });
   }
 }
 

--- a/lib/LayoutMap/YamlLayoutPrinter.cpp
+++ b/lib/LayoutMap/YamlLayoutPrinter.cpp
@@ -383,20 +383,18 @@ eld::YamlLayoutPrinter::buildYaml(eld::Module &Module,
     }
     Result.OutputSections.emplace_back(
         std::make_shared<eld::LDYAML::OutputSection>(std::move(Value)));
-    for (OutputSectionEntry::sym_iterator It = I->sectionendsymBegin(),
-                                          Ie = I->sectionendsymEnd();
-         It != Ie; ++It) {
+    I->forEachPostOutputSectionAssignment([&](Assignment *A) {
       eld::LDYAML::Assignment Assignment;
-      Assignment.Name = (*It)->name();
-      Assignment.Value = (*It)->value();
+      Assignment.Name = A->name();
+      Assignment.Value = A->value();
       {
         raw_string_ostream Stream(Assignment.Text);
-        (*It)->getExpression()->dump(Stream);
+        A->getExpression()->dump(Stream);
         Stream.flush();
       }
       Result.OutputSections.emplace_back(
           std::make_shared<eld::LDYAML::Assignment>(std::move(Assignment)));
-    }
+    });
   }
   Module::const_obj_iterator Obj, ObjEnd = Module.objEnd();
   for (Obj = Module.objBegin(); Obj != ObjEnd; ++Obj) {

--- a/lib/LinkerWrapper/LinkerScript.cpp
+++ b/lib/LinkerWrapper/LinkerScript.cpp
@@ -471,10 +471,11 @@ bool plugin::Script::Assignment::isGlobal() const {
   return m_Assignment->isOutsideSections();
 }
 
-// FIXME: This should return true when the assignment level
-// is SECTIONS_END or OUTSIDE_SECTIONS.
 bool plugin::Script::Assignment::isOutsideOutputSection() const {
-  return false;
+  auto Level = m_Assignment->level();
+  return Level == eld::Assignment::BeforeSections ||
+         Level == eld::Assignment::AfterSections ||
+         Level == eld::Assignment::AfterOutputSection;
 }
 
 bool plugin::Script::Assignment::isInsideOutputSection() const {
@@ -657,7 +658,6 @@ plugin::Script::Output::Output(eld::OutputCmd *Output)
 eld::ScriptCommand *plugin::Script::Output::getCommand() const {
   return m_Output;
 }
-
 
 //
 // OUTPUT_ARCH

--- a/lib/Script/Assignment.cpp
+++ b/lib/Script/Assignment.cpp
@@ -34,8 +34,6 @@ Assignment::Assignment(Level AssignmentLevel, Type AssignmentType,
       ExpressionValue(0), Name(Symbol), ExpressionToEvaluate(ScriptExpression),
       ThisSymbol(nullptr) {}
 
-
-
 void Assignment::dump(llvm::raw_ostream &Outs) const {
   bool CloseParen = true;
   switch (type()) {
@@ -75,16 +73,16 @@ void Assignment::dump(llvm::raw_ostream &Outs) const {
 
 void Assignment::trace(llvm::raw_ostream &Outs) const {
   switch (AssignmentLevel) {
-  case BEFORE_SECTIONS:
+  case BeforeSections:
     Outs << "BEFORE_SECTIONS   >>  ";
     break;
-  case AFTER_SECTIONS:
+  case AfterSections:
     Outs << "AFTER_SECTIONS    >>  ";
     break;
-  case INPUT_SECTION:
+  case AfterInputSectDesc:
     Outs << "    INSIDE_OUTPUT_SECTION    >>  ";
     break;
-  case SECTIONS_END:
+  case AfterOutputSection:
     Outs << "  OUTPUT_SECTION(EPILOGUE)   >>  ";
     break;
   }
@@ -99,14 +97,14 @@ void Assignment::dumpMap(llvm::raw_ostream &Ostream, bool Color,
                          bool UseNewLine, bool WithValues,
                          bool AddIndent) const {
   switch (AssignmentLevel) {
-  case BEFORE_SECTIONS:
-  case AFTER_SECTIONS: {
+  case BeforeSections:
+  case AfterSections: {
     if (Color)
       Ostream.changeColor(llvm::raw_ostream::GREEN);
     break;
   }
 
-  case INPUT_SECTION: {
+  case AfterInputSectDesc: {
     if (Color)
       Ostream.changeColor(llvm::raw_ostream::YELLOW);
     if (AddIndent)
@@ -114,7 +112,7 @@ void Assignment::dumpMap(llvm::raw_ostream &Ostream, bool Color,
     break;
   }
 
-  case SECTIONS_END: {
+  case AfterOutputSection: {
     if (Color)
       Ostream.changeColor(llvm::raw_ostream::MAGENTA);
     break;
@@ -176,22 +174,22 @@ eld::Expected<void> Assignment::activate(Module &CurModule) {
   ExpressionToEvaluate->setContext(getContext());
 
   switch (AssignmentLevel) {
-  case BEFORE_SECTIONS:
-  case AFTER_SECTIONS:
+  case BeforeSections:
     break;
 
-  case INPUT_SECTION: {
+  case AfterSections:
+  case AfterOutputSection: {
+    SectionMap::reference Out = Script.sectionMap().back();
+    Out->getPostOutputSectionAssignments().push_back(this);
+    break;
+  }
+
+  case AfterInputSectDesc: {
     OutputSectionEntry::reference In = Script.sectionMap().back()->back();
     In->symAssignments().push_back(this);
     break;
   }
-
-  case SECTIONS_END: {
-    SectionMap::reference Out = Script.sectionMap().back();
-    Out->sectionEndAssignments().push_back(this);
-    break;
   }
-  } // end of switch
   return eld::Expected<void>();
 }
 

--- a/lib/Script/ScriptFile.cpp
+++ b/lib/Script/ScriptFile.cpp
@@ -311,30 +311,26 @@ void ScriptFile::addAssignment(const std::string &SymbolName,
     if (ScriptStateInsideOutputSection) {
       assert(!Sections->empty());
       NewAssignment =
-          make<Assignment>(Assignment::INPUT_SECTION, AssignmentType,
+          make<Assignment>(Assignment::AfterInputSectDesc, AssignmentType,
                            SymbolName, ScriptExpression);
       NewAssignment->setInputFileInContext(getContext());
       NewAssignment->setParent(getParent());
       OutputSectionDescription->pushBack(NewAssignment);
     } else {
       NewAssignment =
-          make<Assignment>(Assignment::Level::SECTIONS_END, AssignmentType,
+          make<Assignment>(Assignment::AfterOutputSection, AssignmentType,
                            SymbolName, ScriptExpression);
       NewAssignment->setInputFileInContext(getContext());
       NewAssignment->setParent(getParent());
       Sections->pushBack(NewAssignment);
     }
   } else {
-    // Assignments encountered when not inside SECTIONS are either BEFORE or
-    // AFTER SECTIONS. Mark as AFTER if we've already seen a SECTIONS block
-    // in this script file or any previously processed script.
-    // Global state is sufficient: it is set during parsing when any
-    // SECTIONS block is entered.
-    Assignment::Level Lvl = ThisModule.getScript().linkerScriptHasSectionsCommand()
-                                ? Assignment::AFTER_SECTIONS
-                                : Assignment::BEFORE_SECTIONS;
-    NewAssignment = make<Assignment>(Lvl, AssignmentType, SymbolName,
-                                     ScriptExpression);
+    Assignment::Level Lvl =
+        ThisModule.getScript().linkerScriptHasSectionsCommand()
+            ? Assignment::AfterSections
+            : Assignment::BeforeSections;
+    NewAssignment =
+        make<Assignment>(Lvl, AssignmentType, SymbolName, ScriptExpression);
     NewAssignment->setInputFileInContext(getContext());
     NewAssignment->setParent(getParent());
     LinkerScriptCommandQueue.push_back(NewAssignment);
@@ -349,7 +345,7 @@ bool ScriptFile::linkerScriptHasSectionsCommand() const {
 void ScriptFile::enterSectionsCmd() {
   LinkerScriptHasSectionsCommand = true;
   // Also mark global script state so other scripts parsed later
-  // can correctly mark AFTER_SECTIONS assignments.
+  // can correctly set the level of assignments.
   ThisModule.getScript().setHasSectionsCmd();
   ScriptStateInSectionsCommmand = true;
   auto *Cmd = make<SectionsCmd>();

--- a/lib/Script/SectionsCmd.cpp
+++ b/lib/Script/SectionsCmd.cpp
@@ -22,8 +22,6 @@ using namespace eld;
 //===----------------------------------------------------------------------===//
 SectionsCmd::SectionsCmd() : ScriptCommand(ScriptCommand::SECTIONS) {}
 
-
-
 void SectionsCmd::dump(llvm::raw_ostream &Outs) const {
   Outs << "SECTIONS\n{\n";
 
@@ -103,12 +101,9 @@ eld::Expected<void> SectionsCmd::activate(Module &CurModule) {
       break;
     }
   }
-  // The assignment may be the last set too.
   if (!Assignments.empty()) {
-    iterator Assign, AssignEnd = Assignments.end();
-    for (Assign = Assignments.begin(); Assign != AssignEnd; ++Assign) {
-      llvm::cast<Assignment>(*Assign)->setLevel(Assignment::SECTIONS_END);
-      eld::Expected<void> E = (*Assign)->activate(CurModule);
+    for (auto *Assign : Assignments) {
+      eld::Expected<void> E = Assign->activate(CurModule);
       ELDEXP_RETURN_DIAGENTRY_IF_ERROR(E);
     }
     Assignments.clear();

--- a/lib/Target/CreateProgramHeaders.hpp
+++ b/lib/Target/CreateProgramHeaders.hpp
@@ -177,7 +177,7 @@ bool GNULDBackend::createProgramHdrs() {
     {
       eld::RegisterTimer T("Evaluate Script Assignments", "Establish Layout",
                            m_Module.getConfig().options().printTimingStats());
-      evaluateScriptAssignments(/*evaluateAsserts=*/false);
+      evaluateBeforeSectionsAssignments(/*evaluateAsserts=*/false);
     }
   };
 
@@ -319,7 +319,7 @@ bool GNULDBackend::createProgramHdrs() {
     if (curIsDebugSection || (*out)->isDiscard()) {
       cur->setAddr(dotSymbol->value());
       evaluateAssignments(*out);
-      evaluateAssignmentsAtEndOfOutputSection(*out);
+      evaluatePostOutputSectionAssignments(*out);
       cur->setWanted(cur->wantedInOutput() || cur->size());
       ++out;
       cur->setAddr(0);
@@ -600,7 +600,7 @@ bool GNULDBackend::createProgramHdrs() {
     }
 
     // Evaluate Assignments at end of output section.
-    evaluateAssignmentsAtEndOfOutputSection(*out);
+    evaluatePostOutputSectionAssignments(*out);
     cur->setWanted(cur->wantedInOutput() || cur->size());
 
     if (!config().getDiagEngine()->diagnose()) {

--- a/lib/Target/CreateScriptProgramHeaders.hpp
+++ b/lib/Target/CreateScriptProgramHeaders.hpp
@@ -81,7 +81,7 @@ bool GNULDBackend::createScriptProgramHdrs() {
     {
       eld::RegisterTimer T("Evaluate Script Assignments", "Establish Layout",
                            m_Module.getConfig().options().printTimingStats());
-      evaluateScriptAssignments(/*evaluateAsserts=*/false);
+      evaluateBeforeSectionsAssignments(/*evaluateAsserts=*/false);
     }
   };
 
@@ -203,7 +203,7 @@ bool GNULDBackend::createScriptProgramHdrs() {
     if (curIsDebugSection || (*out)->isDiscard()) {
       cur->setAddr(dotSymbol->value());
       evaluateAssignments(*out);
-      evaluateAssignmentsAtEndOfOutputSection(*out);
+      evaluatePostOutputSectionAssignments(*out);
       cur->setAddr(0);
       cur->setPaddr(0);
       ++out;
@@ -326,7 +326,7 @@ bool GNULDBackend::createScriptProgramHdrs() {
     }
 
     // Evaluate Assignments at the end of the output section.
-    evaluateAssignmentsAtEndOfOutputSection(*out);
+    evaluatePostOutputSectionAssignments(*out);
     cur->setWanted(cur->wantedInOutput() || cur->size());
     if (!config().getDiagEngine()->diagnose()) {
       return false;

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -2060,18 +2060,14 @@ void GNULDBackend::evaluateAssignments(OutputSectionEntry *out) {
   }
 }
 
-void GNULDBackend::evaluateAssignmentsAtEndOfOutputSection(
+void GNULDBackend::evaluatePostOutputSectionAssignments(
     OutputSectionEntry *out) {
   eld::RegisterTimer T("Evaluate Expressions", "Establish Layout",
                        m_Module.getConfig().options().printTimingStats());
   if (m_Module.getPrinter()->traceAssignments())
     config().raise(Diag::output_section_eval)
         << (out->name().empty() ? "<nullptr>" : out->name()) << "\n";
-  // Evaluate all assignments at the end of the output section.
-  for (OutputSectionEntry::sym_iterator it = out->sectionendsymBegin(),
-                                        ie = out->sectionendsymEnd();
-       it != ie; ++it) {
-    Assignment *assign = (*it);
+  for (auto *assign : out->getPostOutputSectionAssignments()) {
     // We do not need to evaluate PROVIDE expressions for PROVIDE
     // symbols that are not being used in the link.
     if (assign->isProvideOrProvideHidden() && !isProvideSymBeingUsed(assign))
@@ -2086,7 +2082,7 @@ void GNULDBackend::evaluateAssignmentsAtEndOfOutputSection(
       }
       continue;
     }
-    (*it)->assign(m_Module, nullptr);
+    assign->assign(m_Module, nullptr);
   }
 }
 
@@ -2564,6 +2560,7 @@ bool GNULDBackend::setOutputSectionOffset() {
   // Set initial dot symbol value.
   LDSymbol *dotSymbol = m_Module.getNamePool().findSymbol(".");
 
+  evaluateBeforeSectionsAssignments();
   while (out != outEnd) {
     ELFSection *cur = (*out)->getSection();
 
@@ -2595,7 +2592,7 @@ bool GNULDBackend::setOutputSectionOffset() {
     if (isCurAlloc && cur->size())
       changeSymbolsFromAbsoluteToGlobal(*out);
     prev = cur;
-    evaluateAssignmentsAtEndOfOutputSection(*out);
+    evaluatePostOutputSectionAssignments(*out);
     ++out;
   }
   return true;
@@ -2961,7 +2958,7 @@ bool GNULDBackend::placeOutputSections() {
         // Behavior seen from GNU.
         if ((out != sectionMap.begin() && ((*cur)->getSection()->getFlags() ==
                                            (*prev)->getSection()->getFlags())))
-          (*cur)->moveSectionAssignments(*prev);
+          (*cur)->movePostOutputSectionAssignments(*prev);
       }
     }
   }
@@ -3051,14 +3048,6 @@ bool GNULDBackend::layout() {
     if (m_Module.getPrinter()->isVerbose())
       config().raise(Diag::function_has_error) << __PRETTY_FUNCTION__;
     return false;
-  }
-
-  // Evaluate all assignments.
-  {
-    eld::RegisterTimer T("Evaluate Script Assignments and Asserts",
-                         "Establish Layout",
-                         m_Module.getConfig().options().printTimingStats());
-    evaluateScriptAssignments();
   }
 
   if (!config().getDiagEngine()->diagnose()) {
@@ -4115,11 +4104,12 @@ MemoryRegion GNULDBackend::getFileOutputRegion(llvm::FileOutputBuffer &pBuffer,
   return MemoryRegion(pBuffer.getBufferStart() + pOffset, pLength);
 }
 
-void GNULDBackend::evaluateScriptAssignments(bool evaluateAsserts) {
+void GNULDBackend::evaluateBeforeSectionsAssignments(bool evaluateAsserts) {
   for (auto &assign : m_Module.getScript().assignments()) {
-    // Evaluate assignments outside SECTIONS both before and after layout.
-    if (!(assign->level() == Assignment::BEFORE_SECTIONS ||
-          assign->level() == Assignment::AFTER_SECTIONS))
+    // Only evaluate BeforeSections assignments here.
+    // AfterSections and AfterOutputSection assignments are evaluated
+    // per-OutputSectionEntry in evaluatePostOutputSectionAssignments().
+    if (assign->level() != Assignment::BeforeSections)
       continue;
     if (shouldskipAssert(assign)) {
       if (m_Module.getPrinter()->isVerbose()) {

--- a/test/Common/standalone/Map/OutsideSectionsAssignmentsContext/OutsideSectionsAssignmentsContext.test
+++ b/test/Common/standalone/Map/OutsideSectionsAssignmentsContext/OutsideSectionsAssignmentsContext.test
@@ -10,5 +10,5 @@ RUN: %filecheck %s < %t2.map
 #END_TEST
 
 CHECK: var_u(0x1) = 0x1; # var_u = 0x1; {{.*}}script.t
-CHECK: var_w(0x5) = 0x5; # var_w = 0x5; {{.*}}script.t
 CHECK: var_v(0x3) = 0x3; # var_v = 0x3; {{.*}}script.t
+CHECK: var_w(0x5) = 0x5; # var_w = 0x5; {{.*}}script.t

--- a/test/Common/standalone/linkerscript/AssignmentOrderInSections/AssignmentOrderInSections.test
+++ b/test/Common/standalone/linkerscript/AssignmentOrderInSections/AssignmentOrderInSections.test
@@ -1,0 +1,38 @@
+#---AssignmentOrderInSections.test--------------------- Executable,LS ----------------------#
+#BEGIN_COMMENT
+# This test verifies that assignments within SECTIONS are evaluated
+# in sequential order.
+# u = v should evaluate to 0xc (the value of v at that point),
+# not 0xa (the value v is reassigned to later).
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t -Map %t1.1.map.txt
+RUN: %readelf -s %t1.1.out | %filecheck %s
+RUN: %filecheck %s --check-prefix=MAP < %t1.1.map.txt
+RUN: %link %linkopts -o %t1.1.assert.out %t1.1.o -T %p/Inputs/script.assert.t \
+RUN:   -Map %t1.1.assert.map.txt
+RUN: %filecheck %s --check-prefix=WITH_ASSERT < %t1.1.assert.map.txt
+#END_TEST
+
+CHECK-DAG: {{0+}}c {{.*}} u
+CHECK-DAG: {{0+}}a {{.*}} v
+
+MAP: Output Section and Layout
+MAP: v(0xc) = 0xc; # v = 0xc; {{.*}}script.t
+MAP: u(0xc) = v(0xc); # u = v; {{.*}}script.t
+MAP: .text
+MAP: *(.text*)
+MAP: .text {{.*}}1.o
+MAP: v(0xa) = 0xa; # v = 0xa; {{.*}}script.t
+
+WITH_ASSERT: Output Section and Layout
+WITH_ASSERT: v(0xc) = 0xc; # v = 0xc; {{.*}}script.assert.t
+WITH_ASSERT: ASSERT(v(0xa) == 0xa, "v final value is 0xa");
+WITH_ASSERT: u(0xc) = v(0xc); # u = v; {{.*}}script.assert.t
+WITH_ASSERT: ASSERT(u(0xc) == 0xc, "u final value is 0xc");
+WITH_ASSERT: .text
+WITH_ASSERT: *(.text*)
+WITH_ASSERT: .text {{.*}}1.o
+WITH_ASSERT: v(0xa) = 0xa; # v = 0xa; {{.*}}script.assert.t
+WITH_ASSERT: ASSERT(v(0xa) == 0xa, "v final value is 0xa");

--- a/test/Common/standalone/linkerscript/AssignmentOrderInSections/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/AssignmentOrderInSections/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/Common/standalone/linkerscript/AssignmentOrderInSections/Inputs/script.assert.t
+++ b/test/Common/standalone/linkerscript/AssignmentOrderInSections/Inputs/script.assert.t
@@ -1,0 +1,11 @@
+v = 0xc;
+ASSERT(v == 0xa, "v final value is 0xa");
+SECTIONS {
+  u = v;
+  ASSERT(u == 0xc, "u final value is 0xc");
+  .text : {
+    *(.text*)
+  }
+  v = 0xa;
+}
+ASSERT(v == 0xa, "v final value is 0xa");

--- a/test/Common/standalone/linkerscript/AssignmentOrderInSections/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/AssignmentOrderInSections/Inputs/script.t
@@ -1,0 +1,8 @@
+v = 0xc;
+SECTIONS {
+  u = v;
+  .text : {
+    *(.text*)
+  }
+  v = 0xa;
+}

--- a/test/Common/standalone/linkerscript/IncorrectAssignmentInLayoutReiteration/IncorrectAssignmentInLayoutReiteration.test
+++ b/test/Common/standalone/linkerscript/IncorrectAssignmentInLayoutReiteration/IncorrectAssignmentInLayoutReiteration.test
@@ -8,5 +8,5 @@ RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t -Map %t1.1.map.t
 RUN: %readelf -s %t1.1.out | %filecheck %s
 #END_TEST
 
+CHECK-DAG: {{0*300}}     0 NOTYPE  GLOBAL DEFAULT   ABS u
 CHECK-DAG: {{0*100}}     0 NOTYPE  GLOBAL DEFAULT   ABS v
-CHECK-DAG: {{0*100}}     0 NOTYPE  GLOBAL DEFAULT   ABS u

--- a/test/Common/standalone/linkerscript/IncorrectAssignmentInLayoutReiterationWithPHDRS/IncorrectAssignmentInLayoutReiterationWithPHDRS.test
+++ b/test/Common/standalone/linkerscript/IncorrectAssignmentInLayoutReiterationWithPHDRS/IncorrectAssignmentInLayoutReiterationWithPHDRS.test
@@ -9,5 +9,5 @@ RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t -Map %t1.1.map.t
 RUN: %readelf -s %t1.1.out | %filecheck %s
 #END_TEST
 
+CHECK-DAG: {{0*300}}     0 NOTYPE  GLOBAL DEFAULT   ABS u
 CHECK-DAG: {{0*100}}     0 NOTYPE  GLOBAL DEFAULT   ABS v
-CHECK-DAG: {{0*100}}     0 NOTYPE  GLOBAL DEFAULT   ABS u

--- a/test/Common/standalone/linkerscript/MultipleSectionsAssignment/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/MultipleSectionsAssignment/Inputs/1.c
@@ -1,0 +1,2 @@
+int foo() { return 1; }
+int bar = 42;

--- a/test/Common/standalone/linkerscript/MultipleSectionsAssignment/Inputs/script.assert-fail.t
+++ b/test/Common/standalone/linkerscript/MultipleSectionsAssignment/Inputs/script.assert-fail.t
@@ -1,0 +1,16 @@
+SECTIONS {
+  .text : {
+    *(.text*)
+  }
+  a = u;
+}
+u = 0x3;
+ASSERT(u == 0x3, "u value is 0x3");
+SECTIONS {
+  .data : {
+    *(.data*)
+  }
+  b = u;
+  ASSERT(b == 0x3, "b final value is 0x3");
+}
+u = 0x7;

--- a/test/Common/standalone/linkerscript/MultipleSectionsAssignment/Inputs/script.assert.t
+++ b/test/Common/standalone/linkerscript/MultipleSectionsAssignment/Inputs/script.assert.t
@@ -1,0 +1,16 @@
+SECTIONS {
+  .text : {
+    *(.text*)
+  }
+  a = u;
+}
+u = 0x3;
+ASSERT(u != 0x3, "u final value is 0x7");
+SECTIONS {
+  .data : {
+    *(.data*)
+  }
+  b = u;
+  ASSERT(b == 0x3, "b final value is 0x3");
+}
+u = 0x7;

--- a/test/Common/standalone/linkerscript/MultipleSectionsAssignment/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/MultipleSectionsAssignment/Inputs/script.t
@@ -1,0 +1,14 @@
+SECTIONS {
+  .text : {
+    *(.text*)
+  }
+  a = u;
+}
+u = 0x3;
+SECTIONS {
+  .data : {
+    *(.data*)
+  }
+  b = u;
+}
+u = 0x7;

--- a/test/Common/standalone/linkerscript/MultipleSectionsAssignment/MultipleSectionsAssignment.test
+++ b/test/Common/standalone/linkerscript/MultipleSectionsAssignment/MultipleSectionsAssignment.test
@@ -1,0 +1,59 @@
+#---MultipleSectionsAssignment.test--------------------- Executable,LS ----------------------#
+#BEGIN_COMMENT
+# This test verifies that assignments between multiple SECTIONS blocks
+# are evaluated in the correct sequential order.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections -fdata-sections
+RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t -Map %t1.1.map.txt
+RUN: %readelf -s %t1.1.out | %filecheck %s
+RUN: %filecheck %s --check-prefix=MAP < %t1.1.map.txt
+RUN: %link %linkopts -o %t1.1.assert.out %t1.1.o -T %p/Inputs/script.assert.t -Map %t1.1.assert.map.txt
+RUN: %filecheck %s --check-prefix=WITH_ASSERT < %t1.1.assert.map.txt
+RUN: %not %link %linkopts -o %t1.1.assert-fail.out %t1.1.o -T %p/Inputs/script.assert-fail.t \
+RUN:   -Map %t1.1.assert-fail.map.txt 2>&1 | %filecheck %s --check-prefix=ASSERTION_ERROR
+RUN: %filecheck %s --check-prefix=WITH_ASSERT_FAIL < %t1.1.assert-fail.map.txt
+#END_TEST
+
+CHECK-DAG: {{0+}}7 {{.*}} a
+CHECK-DAG: {{0+}}3 {{.*}} b
+CHECK-DAG: {{0+}}7 {{.*}} u
+
+MAP: Output Section and Layout
+MAP: .text
+MAP: *(.text*) #Rule 1
+MAP: .text.foo
+MAP: a(0x7) = u(0x7); # a = u;
+MAP: u(0x3) = 0x3; # u = 0x3;
+MAP: .data
+MAP: *(.data*)
+MAP: b(0x3) = u(0x3); # b = u;
+MAP: u(0x7) = 0x7; # u = 0x7;
+
+WITH_ASSERT: Output Section and Layout
+WITH_ASSERT: .text
+WITH_ASSERT: *(.text*) #Rule 1
+WITH_ASSERT: .text.foo
+WITH_ASSERT: a(0x7) = u(0x7); # a = u;
+WITH_ASSERT: u(0x3) = 0x3; # u = 0x3;
+WITH_ASSERT: ASSERT(u(0x7) != 0x3, "u final value is 0x7")
+WITH_ASSERT: .data
+WITH_ASSERT: *(.data*)
+WITH_ASSERT: b(0x3) = u(0x3); # b = u;
+WITH_ASSERT: ASSERT(b(0x3) == 0x3, "b final value is 0x3");
+WITH_ASSERT: u(0x7) = 0x7; # u = 0x7;
+
+ASSERTION_ERROR: Error: Assertion failed ASSERT(u(0x7) == 0x3, "u value is 0x3")
+
+WITH_ASSERT_FAIL: Output Section and Layout
+WITH_ASSERT_FAIL: .text
+WITH_ASSERT_FAIL: *(.text*) #Rule 1
+WITH_ASSERT_FAIL: .text.foo
+WITH_ASSERT_FAIL: a(0x7) = u(0x7); # a = u;
+WITH_ASSERT_FAIL: u(0x3) = 0x3; # u = 0x3;
+WITH_ASSERT_FAIL: ASSERT(u(0x7) == 0x3, "u value is 0x3");
+WITH_ASSERT_FAIL: .data
+WITH_ASSERT_FAIL: *(.data*)
+WITH_ASSERT_FAIL: b(0x3) = u(0x3); # b = u;
+WITH_ASSERT_FAIL: ASSERT(b(0x3) == 0x3, "b final value is 0x3");
+WITH_ASSERT_FAIL: u(0x7) = 0x7; # u = 0x7;


### PR DESCRIPTION
Until now, eld used to incorrectly evaluate before SECTIONS and after SECTIONS assignments both before and after the in-SECTIONS assignments. This results in incorrect linker script symbol values and incorrect layout.

This patch fixes this linker script assignment evaluation order. Now, we evaluate the assignments after the SECTIONS command as part of the layout re-iteration loop in create(Script)ProgramHeaders.

One of the key design change in this patch is to store AfterSections assignments with the last output section. It is required to properly evaluate the assignments when the link contains multiple SECTIONS commands.

Resolves #430
Resolves #1245 