### PR TITLE
Remove unnecessary and incorrect sorting of input sections

### DIFF
--- a/include/eld/Object/ObjectLinker.h
+++ b/include/eld/Object/ObjectLinker.h
@@ -269,8 +269,6 @@ public:
   bool mergeInputSections(ObjectBuilder &Builder,
                           std::vector<Section *> &Sections);
 
-  bool mayBeSortSections(std::vector<Section *> &Sections);
-
   bool createOutputSection(ObjectBuilder &Builder, OutputSectionEntry *Output,
                            bool PostLayout = false);
 

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -784,44 +784,6 @@ void ObjectLinker::markDiscardFileFormatSections() {
   }
 }
 
-bool ObjectLinker::mayBeSortSections(std::vector<Section *> &Sections) {
-  // If no linker scripts, we dont store the original input. Lets not sort.
-  if (!ThisModule->getScript().linkerScriptHasSectionsCommand())
-    return true;
-  if (ThisConfig.options().disableLTOLinkOrder())
-    return true;
-  // If we are doing partial link, lets not sort it.
-  bool IsPartialLink = (LinkerConfig::Object == ThisConfig.codeGenType());
-  if (IsPartialLink || LtoObjects.empty())
-    return true;
-  std::stable_sort(Sections.begin(), Sections.end(),
-                   [](Section *ASection, Section *BSection) {
-                     ELFSection *A = llvm::dyn_cast<ELFSection>(ASection);
-                     ELFSection *B = llvm::dyn_cast<ELFSection>(BSection);
-                     if (A == nullptr or B == nullptr)
-                       return false;
-                     // FIXME: Redundant checks. All files have original input.
-                     if (!A->originalInput())
-                       return false;
-                     if (!B->originalInput())
-                       return false;
-                     if ((A->name().starts_with(".ctors")) ||
-                         (B->name().starts_with(".ctors")))
-                       return false;
-                     if ((A->name().starts_with(".dtors")) ||
-                         (B->name().starts_with(".dtors")))
-                       return false;
-                     int64_t AOrdinal =
-                         A->originalInput()->getInput()->getInputOrdinal();
-                     int64_t BOrdinal =
-                         B->originalInput()->getInput()->getInputOrdinal();
-                     if (AOrdinal == BOrdinal)
-                       return false;
-                     return (AOrdinal < BOrdinal);
-                   });
-  return true;
-}
-
 bool ObjectLinker::mergeInputSections(ObjectBuilder &Builder,
                                       std::vector<Section *> &Sections) {
   bool IsPartialLink = ThisConfig.isLinkPartial();
@@ -1111,12 +1073,6 @@ bool ObjectLinker::initializeMerge() {
         ThisModule->getLayoutInfo()->recordSectionStat(Sect);
       }
     }
-  }
-  {
-    eld::RegisterTimer T("Sort sections if LTO enabled", "Merge Sections",
-                         ThisConfig.options().printTimingStats());
-    // Sort sections if we have LTO enabled.
-    mayBeSortSections(AllInputSections);
   }
   return true;
 }

--- a/test/Common/LTO/LinkerScript/NonLTOSectionsOrderWithLTO/Inputs/2.c
+++ b/test/Common/LTO/LinkerScript/NonLTOSectionsOrderWithLTO/Inputs/2.c
@@ -1,0 +1,1 @@
+__attribute__((section(".ctors"))) int bar() { return 6; }

--- a/test/Common/LTO/LinkerScript/NonLTOSectionsOrderWithLTO/Inputs/3.c
+++ b/test/Common/LTO/LinkerScript/NonLTOSectionsOrderWithLTO/Inputs/3.c
@@ -1,0 +1,1 @@
+int baz() { return 5; }

--- a/test/Common/LTO/LinkerScript/NonLTOSectionsOrderWithLTO/Inputs/gen.py
+++ b/test/Common/LTO/LinkerScript/NonLTOSectionsOrderWithLTO/Inputs/gen.py
@@ -1,0 +1,16 @@
+import sys
+
+N = 300
+output = sys.argv[1]
+
+with open(output, 'w') as f:
+    f.write("int bar();\n")
+    f.write("int baz();\n")
+    for i in range(N):
+        f.write(f"int foo_{i}() {{ return {i}; }}\n")
+    f.write("int main() {\n  return ")
+    for i in range(N):
+        f.write(f"foo_{i}()")
+        if i != N - 1:
+            f.write(" + ")
+    f.write(" + baz() + bar();\n}\n")

--- a/test/Common/LTO/LinkerScript/NonLTOSectionsOrderWithLTO/Inputs/script.t
+++ b/test/Common/LTO/LinkerScript/NonLTOSectionsOrderWithLTO/Inputs/script.t
@@ -1,0 +1,3 @@
+SECTIONS {
+  .text : { *(.text*) }
+}

--- a/test/Common/LTO/LinkerScript/NonLTOSectionsOrderWithLTO/NonLTOSectionsOrderWithLTO.test
+++ b/test/Common/LTO/LinkerScript/NonLTOSectionsOrderWithLTO/NonLTOSectionsOrderWithLTO.test
@@ -1,0 +1,42 @@
+UNSUPPORTED: x86
+#---NonLTOSectionsOrderWithLTO.test------------- Executable,LTO,LS ----------------#
+#BEGIN_COMMENT
+# When a linker script rule matches input sections without explicit ordering,
+# the output should contain matched input sections in input order. With LTO,
+# ordering is relaxed for LTO-generated sections, but sections from non-LTO
+# object files must still maintain their original order. This test verifies
+# that non-LTO input section ordering is preserved when mixed with LTO objects.
+#END_COMMENT
+#START_TEST
+RUN: %python %p/Inputs/gen.py %t1.1.c
+RUN: %clang %clangopts -o %t1.1.o -c %t1.1.c -ffunction-sections
+RUN: %clang %clangopts -o %t1.2.o -c %p/Inputs/2.c -flto -ffunction-sections
+RUN: %clang %clangopts -o %t1.3.o -c %p/Inputs/3.c -flto -ffunction-sections
+RUN: %link -MapStyle txt %linkopts -o %t2.out %t1.2.o %t1.1.o %t1.3.o -T %p/Inputs/script.t -e main -Map %t2.map
+RUN: %filecheck %s < %t2.map
+#END_TEST
+
+CHECK: .text.foo_0
+CHECK: .text.foo_1
+CHECK: .text.foo_2
+CHECK: .text.foo_3
+CHECK: .text.foo_4
+CHECK: .text.foo_5
+CHECK: .text.foo_6
+CHECK: .text.foo_7
+CHECK: .text.foo_8
+CHECK: .text.foo_9
+CHECK: .text.foo_10
+CHECK: .text.foo_11
+CHECK: .text.foo_12
+CHECK: .text.foo_13
+CHECK: .text.foo_14
+CHECK: .text.foo_15
+CHECK: .text.foo_16
+CHECK: .text.foo_17
+CHECK: .text.foo_18
+CHECK: .text.foo_19
+CHECK: .text.foo_20
+CHECK: .text.foo_298
+CHECK: .text.foo_299
+CHECK: .text.main


### PR DESCRIPTION
This commit removes the unnecessary and incorrect sorting of input sections before the merge input sections phase when the LTO is enabled.

Resolves #1204