### PR TITLE
[test] fix fatlto tests on windows

### DIFF
--- a/test/Common/LTO/EmbeddedLLVMBcObjects/EmbeddedLLVMBcObjects.test
+++ b/test/Common/LTO/EmbeddedLLVMBcObjects/EmbeddedLLVMBcObjects.test
@@ -26,7 +26,7 @@ RUN: %nm %t.lto.out | %filecheck %s --check-prefix=WITH-LTO
 RUN: %touch %t.empty
 RUN: %objcopy --add-section=.llvmbc=%t.empty \
 RUN: --set-section-flags=.llvmbc=exclude %t.native.o %t.empty.llvmbc.o
-RUN: %link %linkopts -flto -r %t.empty.llvmbc.o -o /dev/null \
+RUN: %link %linkopts -flto -r %t.empty.llvmbc.o -o %t1.out \
 RUN: --trace=lto 2>&1 | %filecheck %s --check-prefix=EMPTY-LLVMBC
 
 # Invalid non-bitcode payload should diagnose instead of crashing.
@@ -34,7 +34,7 @@ RUN: printf "eld\n" > %t.invalid
 RUN: %objcopy --add-section=.llvmbc=%t.invalid \
 RUN: --set-section-flags=.llvmbc=exclude %t.native.o %t.invalid.llvmbc.o
 RUN: %not %link %linkopts -flto -r %t.invalid.llvmbc.o  \
-RUN: -o /dev/null --trace=lto 2>&1 | %filecheck %s --check-prefix=INVALID-LLVMBC
+RUN: -o %t1.out --trace=lto 2>&1 | %filecheck %s --check-prefix=INVALID-LLVMBC
 
 HAS-LLVMBC-SECTION: .llvmbc
 

--- a/test/Common/LTO/FatLTOObjects/FatLTOObjects.test
+++ b/test/Common/LTO/FatLTOObjects/FatLTOObjects.test
@@ -39,14 +39,14 @@ RUN: %readelf -S %t.reloc.o | %filecheck %s --check-prefix=NO-LTO-SECTION
 RUN: %touch %t.empty
 RUN: %objcopy --add-section=.llvm.lto=%t.empty --set-section-flags=.llvm.lto=exclude \
 RUN: --set-section-type=.llvm.lto=0x6fff4c0c %t.native.o %t.fat.o
-RUN: %link --fat-lto-objects -r %t.fat.o -o /dev/null \
+RUN: %link --fat-lto-objects -r %t.fat.o -o %t1.out \
 RUN: --trace=lto 2>&1 | %filecheck %s -check-prefix=EMBED-LTO
 
 # Invalid non-bitcode payload should diagnose instead of crashing.
 RUN: printf "eld\n" > %t.invalid
 RUN: %objcopy --add-section=.llvm.lto=%t.invalid --set-section-flags=.llvm.lto=exclude \
 RUN: --set-section-type=.llvm.lto=0x6fff4c0c %t.native.o %t.fat.invalid.o
-RUN: %not %link --fat-lto-objects -r %t.fat.invalid.o -o /dev/null \
+RUN: %not %link --fat-lto-objects -r %t.fat.invalid.o -o %t1.out \
 RUN: --trace=lto 2>&1 | %filecheck %s -check-prefix=INVALID-EMBED-LTO
 
 HAS-LTO-SECTION: .llvm.lto


### PR DESCRIPTION
/dev/null filename is not yet supported on windows. change the file that the linker writes to.