### PR TITLE
[cmake] Normalize ELD_TARGETS_TO_BUILD target names to correct casing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,13 @@ if(NOT ELD_TARGETS_TO_BUILD)
       CACHE STRING "ELD Target(Targets) to build")
 endif()
 
+# Validate ELD_TARGETS_TO_BUILD against known targets
+foreach(t ${ELD_TARGETS_TO_BUILD})
+  if(NOT t IN_LIST ELD_ALL_TARGETS)
+    message(WARNING "Unknown ELD target '${t}'. Known targets are: ${ELD_ALL_TARGETS}")
+  endif()
+endforeach()
+
 # Set ELD_ENUM_TARGETS
 set(ELD_ENUM_TARGETS_STR "")
 set(ELD_ENUM_LINKERS_STR "")


### PR DESCRIPTION
When LLVM_TARGETS_TO_BUILD contains target names with incorrect casing (e.g. 'x86' instead of 'X86'), ELD inherits them and fails at CMake step because add_subdirectory expects the correct casing.

Normalize target names case-insensitively against ELD_ALL_TARGETS to ensure correct casing regardless of how the user specifies them.

### Output:
<img width="791" height="245" alt="Screenshot from 2026-05-23 03-53-15" src="https://github.com/user-attachments/assets/cfa93d87-9a77-4b1b-acd0-8b0ab9bff635" />

Fixes #104