### PR TITLE
 [zephyr] Copy nightly libc++/libc++abi into cpullvm/lib

### DIFF
--- a/.github/workflows/zephyr-nightly.yml
+++ b/.github/workflows/zephyr-nightly.yml
@@ -96,6 +96,11 @@ jobs:
           cp inst/lib/libLW.so.4 ${CPULLVM_DIR}/lib/libLW.so.4
           ln -sf libLW.so.4 ${CPULLVM_DIR}/lib/libLW.so
 
+          # ld.eld and libLW.so.4 are linked against nightly's libc++; cpullvm/lib
+          # has none, so copy the matching libc++/libc++abi alongside them.
+          cp -P inst/lib/libc++.so.1*    ${CPULLVM_DIR}/lib/
+          cp -P inst/lib/libc++abi.so.1* ${CPULLVM_DIR}/lib/
+
           echo "Nightly ELD version:"
           ${CPULLVM_DIR}/bin/ld.eld --version
           echo "cpullvm clang version:"


### PR DESCRIPTION
ld.eld and libLW.so.4 are built against nightly's libc++, but the splice copies them into cpullvm/lib which has none. The loader falls through to ci-base's older system libc++ and link operations crash with `symbol lookup error: ... libLW.so.4: undefined symbol: ...`. Copy nightly's libc++.so.1 and libc++abi.so.1 to fix CI errors due to libc++ mismatch introduced by upgrading the host compiler to clang 22.