### PR TITLE
Omit empty sections in map file output

### DIFF
--- a/lib/LayoutMap/TextLayoutPrinter.cpp
+++ b/lib/LayoutMap/TextLayoutPrinter.cpp
@@ -358,6 +358,14 @@ void TextLayoutPrinter::printGlobalPluginInfo(Module &M, bool UseColor) {
   const LinkerScript::PluginVectorT &UniversalPlugins =
       M.getPluginManager().getUniversalPlugins();
 
+  bool hasPluginInfo =
+      !UniversalPlugins.empty() || !PluginListForSectionMatcher.empty() ||
+      !PluginListForSectionIterator.empty() ||
+      !PluginListForOutputSectionIterator.empty() ||
+      !PluginListForMemorySize.empty() || !PluginListForFileSize.empty();
+  if (!hasPluginInfo)
+    return;
+
   if (UseColor)
     outputStream().changeColor(llvm::raw_ostream::GREEN);
   outputStream() << "Linker Plugin Information"
@@ -415,6 +423,9 @@ void TextLayoutPrinter::printGlobalPluginInfo(Module &M, bool UseColor) {
     for (auto &P : PluginListForFileSize)
       PrintPlugin(*P);
   }
+
+  if (!M.getScript().getPluginRunList().size())
+    return;
   outputStream() << "Linker Plugin Run Information"
                  << "\n";
   int Index = 0;

--- a/test/Common/standalone/CMakeLists.txt
+++ b/test/Common/standalone/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(EmitMapFileEvenInCrash)
+add_subdirectory(EmptyMapSections)
 add_subdirectory(PluginAPI)
 add_subdirectory(SymbolResolutionReport)

--- a/test/Common/standalone/CommandLine/BuildAndReproduce/BuildAndReproduce.test
+++ b/test/Common/standalone/CommandLine/BuildAndReproduce/BuildAndReproduce.test
@@ -20,7 +20,6 @@ RUN: %filecheck %s < %t2.out.map
 #CHECK: Linker scripts used (including INCLUDE command)
 #CHECK: {{.*}}script.t({{.*}})
 #CHECK: 	bar.t({{.*}})
-#CHECK: Linker Plugin Information
 #CHECK: foo.o*(.text*) #Rule 1, {{.*}}script.t {{.*}}
 #CHECK: bar.o*(.text*) #Rule 3, bar.t {{.*}}
 #END_TEST

--- a/test/Common/standalone/EmptyMapSections/CMakeLists.txt
+++ b/test/Common/standalone/EmptyMapSections/CMakeLists.txt
@@ -1,0 +1,21 @@
+set(SOURCES EmptyPlugin.cpp)
+
+if(NOT CYGWIN AND LLVM_ENABLE_PIC)
+  set(SHARED_LIB_SOURCES ${SOURCES})
+
+  set(bsl ${BUILD_SHARED_LIBS})
+
+  set(BUILD_SHARED_LIBS ON)
+
+  add_llvm_library(EmptyPlugin ${SHARED_LIB_SOURCES} LINK_LIBS
+                   LW)
+
+  set_target_properties(
+    EmptyPlugin
+    PROPERTIES LIBRARY_OUTPUT_DIRECTORY
+               "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/test")
+
+  set(BUILD_SHARED_LIBS ${bsl})
+endif()
+
+add_plugin(EmptyPlugin)

--- a/test/Common/standalone/EmptyMapSections/EmptyMapSections.test
+++ b/test/Common/standalone/EmptyMapSections/EmptyMapSections.test
@@ -1,0 +1,19 @@
+#---EmptyMapSections.test------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# This test checks that empty map sections are not emitted.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.o %p/Inputs/1.c -c
+RUN: %link %linkopts --no-default-plugins -o %t1.out %t1.o -Map %t1.map
+RUN: %filecheck %s < %t1.map -check-prefix=NOINFO
+
+RUN: %link %linkopts --no-default-plugins -o %t1.out %t1.o -L%libsdir/test --plugin-config %p/Inputs/PluginConfig.yaml -Map %t1.map
+RUN: %filecheck %s < %t1.map -check-prefix=NORUNINFO
+#END_TEST
+
+NOINFO-NOT: Linker Plugin Information
+
+NORUNINFO: Linker Plugin Information
+NORUNINFO: Linker Plugins
+NORUNINFO: EmptyPlugin		EmptyPlugin
+NORUNINFO-NOT: Linker Plugin Run Information

--- a/test/Common/standalone/EmptyMapSections/EmptyPlugin.cpp
+++ b/test/Common/standalone/EmptyMapSections/EmptyPlugin.cpp
@@ -1,0 +1,13 @@
+#include "LinkerPlugin.h"
+#include "PluginVersion.h"
+#include <cassert>
+#include <iostream>
+
+class ActBeforeRuleMatchingPlugin : public eld::plugin::LinkerPlugin {
+public:
+  ActBeforeRuleMatchingPlugin()
+      : eld::plugin::LinkerPlugin("ActBeforeRuleMatchingPlugin") {}
+  void ActBeforeWritingOutput() override {}
+};
+
+ELD_REGISTER_PLUGIN(ActBeforeRuleMatchingPlugin)

--- a/test/Common/standalone/EmptyMapSections/Inputs/1.c
+++ b/test/Common/standalone/EmptyMapSections/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/Common/standalone/EmptyMapSections/Inputs/PluginConfig.yaml
+++ b/test/Common/standalone/EmptyMapSections/Inputs/PluginConfig.yaml
@@ -1,0 +1,4 @@
+GlobalPlugins:
+  - Type: LinkerPlugin
+    Name: EmptyPlugin
+    Library: EmptyPlugin


### PR DESCRIPTION
Remove unused sections from the generated text map file when they contain no data. This change improves readability by only including sections with actual content.

Fix qualcomm#1169