### PR TITLE
Improve linker error output by including output file name

### DIFF
--- a/docs/userguide/documentation/linker_faq.rst
+++ b/docs/userguide/documentation/linker_faq.rst
@@ -1417,7 +1417,7 @@ specification to do the following:
 .. list-table:: Input section patterns
    :widths: 35 65
    :header-rows: 1
-   
+
    * - Specification
      - Description
    * - dir/subdir/init.lib:init.o(.text.*)
@@ -3224,7 +3224,7 @@ Example error output::
   Error: Relocation error when applying relocation `R_ARM_SBREL32' for symbol `bar' referred from 1.o[.text] symbol defined in 1.o[.data.bar]
   Error: R_ARM_SBREL32 Relocation Mismatch for symbol bar defined in 1.o[.debug_info] has a different load segment
   Error: Relocation error when applying relocation `R_ARM_SBREL32' for symbol `bar' referred from 1.o[.debug_info] symbol defined in 1.o[.data.bar]
-  Fatal: Linking had errors.
+  Fatal: Linking had errors (a.out)
 
 **Fixed linker script for this example**
 
@@ -3814,7 +3814,7 @@ Output:
 .. error::
 
   Error: Loadable section .baz not in any load segment
-  Fatal: Linking had errors.
+  Fatal: Linking had errors (a.out)
 
 Placing NOLOAD region to LOAD segment
 """"""""""""""""""""""""""""""""""""""
@@ -4332,7 +4332,7 @@ load section is not assigned program headers automatically.
 
 .. error ::
 
-  Linking had errors.
+  Linking had errors (a.out)
 
 NOLOAD sections at the beginning of the LOAD segment
 """"""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/include/eld/Diagnostics/DiagLayouts.inc
+++ b/include/eld/Diagnostics/DiagLayouts.inc
@@ -21,7 +21,7 @@ DIAG(output_file_not_complete, DiagnosticEngine::Fatal,
      "recorded size : %2.")
 DIAG(output_file_error, DiagnosticEngine::Fatal,
      "Output file %0 not fully written because of error %1.")
-DIAG(linking_had_errors, DiagnosticEngine::Fatal, "Linking had errors.")
+DIAG(linking_had_errors, DiagnosticEngine::Fatal, "Linking had errors (%0)")
 DIAG(unable_to_insert_trampoline, DiagnosticEngine::Fatal,
      "Unable to insert trampoline for symbol %0 from section %1(%3) to section %2")
 DIAG(change_section_type, DiagnosticEngine::Warning,

--- a/include/eld/Driver/GnuLdDriver.h
+++ b/include/eld/Driver/GnuLdDriver.h
@@ -147,6 +147,8 @@ public:
 
   bool isRunLTOOnly() const { return m_RunLTOOnly; }
 
+  std::string getOutputFileName() const;
+
 protected:
   int getInteger(llvm::opt::InputArgList &Args, unsigned Key,
                  int Default) const;

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -30,6 +30,7 @@
 #include "eld/Support/MappingFileReader.h"
 #include "eld/Support/MsgHandling.h"
 #include "eld/Support/OutputTarWriter.h"
+#include "eld/Support/Path.h"
 #include "eld/Support/StringUtils.h"
 #include "eld/Support/TargetRegistry.h"
 #include "eld/Support/TargetSelect.h"
@@ -40,7 +41,6 @@
 #include "llvm/Object/ELF.h"
 #include "llvm/Remarks/HotnessThresholdParser.h"
 #include "llvm/Support/FileSystem.h"
-#include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/TargetSelect.h"
@@ -1406,7 +1406,7 @@ bool GnuLdDriver::createInputActions(llvm::opt::InputArgList &Args,
         Config.raise(Diag::warn_group_is_empty);
       if (GroupMatchCount) {
         Config.raise(Diag::nested_group_not_allowed);
-        Config.raise(Diag::linking_had_errors);
+        Config.raise(Diag::linking_had_errors) << getOutputFileName();
         return false;
       }
       ++GroupMatchCount;
@@ -1427,7 +1427,7 @@ bool GnuLdDriver::createInputActions(llvm::opt::InputArgList &Args,
         Config.raise(Diag::warn_lib_is_empty);
       if (LibMatchCount) {
         Config.raise(Diag::nested_lib_not_allowed);
-        Config.raise(Diag::linking_had_errors);
+        Config.raise(Diag::linking_had_errors) << getOutputFileName();
         return false;
       }
       ++LibMatchCount;
@@ -1442,7 +1442,7 @@ bool GnuLdDriver::createInputActions(llvm::opt::InputArgList &Args,
         Config.raise(Diag::warn_lib_is_empty);
       if (LibMatchCount) {
         Config.raise(Diag::nested_lib_not_allowed);
-        Config.raise(Diag::linking_had_errors);
+        Config.raise(Diag::linking_had_errors) << getOutputFileName();
         return false;
       }
       ++LibMatchCount;
@@ -1484,19 +1484,19 @@ bool GnuLdDriver::createInputActions(llvm::opt::InputArgList &Args,
 
   if (GroupMatchCount != 0) {
     Config.raise(Diag::mismatched_group);
-    Config.raise(Diag::linking_had_errors);
+    Config.raise(Diag::linking_had_errors) << getOutputFileName();
     return false;
   }
 
   if (LibMatchCount != 0) {
     Config.raise(Diag::mismatched_lib);
-    Config.raise(Diag::linking_had_errors);
+    Config.raise(Diag::linking_had_errors) << getOutputFileName();
     return false;
   }
 
   if (input_num == 0) {
     Config.raise(Diag::err_no_inputs);
-    Config.raise(Diag::linking_had_errors);
+    Config.raise(Diag::linking_had_errors) << getOutputFileName();
     return false;
   }
 
@@ -2002,7 +2002,7 @@ bool GnuLdDriver::doLink(llvm::opt::InputArgList &Args,
   if (Config.options().displaySummary())
     Config.getDiagEngine()->finalize();
   if (!linkStatus)
-    Config.raise(Diag::linking_had_errors);
+    Config.raise(Diag::linking_had_errors) << getOutputFileName();
   eld::freeArena();
   return linkStatus;
 }
@@ -2127,6 +2127,14 @@ std::optional<int> GnuLdDriver::parseOptions(ArrayRef<const char *> Args,
 bool GnuLdDriver::processLTOOptions(llvm::lto::Config &Conf,
                                     std::vector<std::string> &LLVMOptions) {
   return GnuLdDriver::processLTOOptions<OPT_GnuLdOptTable>(Conf, LLVMOptions);
+}
+
+std::string GnuLdDriver::getOutputFileName() const {
+  std::string FileName = Config.options().outputFileName();
+  if (FileName != "/dev/null")
+    FileName = eld::sys::fs::Path(FileName).filename().native();
+
+  return FileName;
 }
 
 // Start the link step.

--- a/test/Common/Plugin/AddPluginFileToReproduceTar/AddPluginFileToReproduceInvalid.test
+++ b/test/Common/Plugin/AddPluginFileToReproduceTar/AddPluginFileToReproduceInvalid.test
@@ -10,5 +10,5 @@ RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -ffunction-sections
 RUN: %not %link %linkopts -L %p/Inputs %t1.1.o --plugin-config %p/Inputs/plugin.config -o %t.out \
 RUN:   --plugin-file=random.txt --reproduce %t1.a.tar  2>&1 | %filecheck %s -check-prefix=ERR
 #ERR: Error: The plugin generated file 'random.txt' does not exist
-#ERR: Fatal: Linking had errors.
+#ERR: Fatal: Linking had errors
 #END_TEST

--- a/test/Common/Plugin/AddPluginFileToReproduceTar/AddPluginToReproduceFlagMissing.test
+++ b/test/Common/Plugin/AddPluginFileToReproduceTar/AddPluginToReproduceFlagMissing.test
@@ -9,5 +9,5 @@ RUN: %cp %p/Inputs/plugin.txt %t1.plugin.txt
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -ffunction-sections
 RUN: %not %link %linkopts -L %p/Inputs %t1.1.o --plugin-config %p/Inputs/plugin.config -o %t.out --plugin-file=%t1.plugin.txt 2>&1 | %filecheck %s -check-prefix=ERR
 #ERR: Error: Missing reproduce flag
-#ERR: Fatal: Linking had errors.
+#ERR: Fatal: Linking had errors
 #END_TEST

--- a/test/Common/Plugin/InvalidStateOverrideLSRule/InvalidStateOverrideLSRule.test
+++ b/test/Common/Plugin/InvalidStateOverrideLSRule/InvalidStateOverrideLSRule.test
@@ -9,5 +9,5 @@ RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -ffunction-sections
 RUN: %not %link %linkopts %t1.1.o -T %p/Inputs/script.t -o %t2.out --plugin-config %p/Inputs/plugin.config 2>&1 | %filecheck %s
 
 #CHECK: Error: Link state 'ActBeforeSectionMerging' is invalid for the API '{{.*}}overrideLinkerScriptRule{{.*}}'. Valid link states: [Initializing, ActBeforeRuleMatching]
-#CHECK: Fatal: Linking had errors.
+#CHECK: Fatal: Linking had errors
 

--- a/test/Common/Plugin/MissingINIFile/MissingINIFile.test
+++ b/test/Common/Plugin/MissingINIFile/MissingINIFile.test
@@ -8,4 +8,4 @@ RUN: %clang %clangg0opts -c %p/Inputs/1.c -o %t1.1.o  -ffunction-sections -fdata
 RUN: %not %link %linkopts %t1.1.o -T %p/Inputs/script.t -o %t1.1.out -L %p/Inputs 2>&1 | %filecheck %s
 #END_TEST
 #CHECK: MissingINIFile:Fatal: File 'someFile.ini' does not exist
-#CHECK: Fatal: Linking had errors.
+#CHECK: Fatal: Linking had errors

--- a/test/Common/Plugin/UniversalPluginInitError/UniversalPluginInitError.test
+++ b/test/Common/Plugin/UniversalPluginInitError/UniversalPluginInitError.test
@@ -7,6 +7,6 @@ RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
 RUN: %not %link %linkopts -o %t1.1.out %t1.1.o -L%libsdir/test --plugin-config %p/Inputs/PluginConfig.yaml 2>&1 | %filecheck %s
 #END_TEST
 CHECK: UPInitError:Error: Something bad happened!
-CHECK: Fatal: Linking had errors.
+CHECK: Fatal: Linking had errors
 
 

--- a/test/Common/standalone/CommandLine/Reproduce/InvalidInputFile.test
+++ b/test/Common/standalone/CommandLine/Reproduce/InvalidInputFile.test
@@ -6,5 +6,5 @@
 RUN: %not %link %linkopts  nonexistent.o -lnonexistent --reproduce a.tar 2>&1 | %filecheck %s
 #CHECK: Fatal: cannot read file 'nonexistent.o'
 #CHECK: Note: Creating tarball {{.*}}.tar
-#CHECK: Fatal: Linking had errors.
+#CHECK: Fatal: Linking had errors
 #END_TEST

--- a/test/Common/standalone/Expressions/defined.test
+++ b/test/Common/standalone/Expressions/defined.test
@@ -12,6 +12,6 @@ RUN: %readelf -s %t1.1.out | %filecheck %s --check-prefix READELF
 CHECK-NOT: undefined symbol 'B' referenced in expression
 CHECK-NOT: Symbol D used before being defined
 CHECK-NOT: Assertion failed.
-CHECK-NOT: Linking had errors.
+CHECK-NOT: Linking had errors
 
 READELF: {{0+}} 0 NOTYPE {{.*}} ABS A

--- a/test/Common/standalone/MergeStrings/NullTerminatedStrings.test
+++ b/test/Common/standalone/MergeStrings/NullTerminatedStrings.test
@@ -16,11 +16,11 @@ RUN: %link %linkopts %t.4.o -o %t.4.out --verbose 2>&1 | %filecheck %s --check-p
 
 T1: Error: {{.*}}1.o:(.rodata.str1.1): string is not null terminated
 T1: Fatal: can not read section `.rodata.str1.1'.
-T1: Fatal: Linking had errors.
+T1: Fatal: Linking had errors
 
 T2: Error: {{.*}}2.o:(.rodata.str1.1+0x4): string is not null terminated
 T2: {{(Fatal: can not read section `.rodata.str1.1'.)?}}
-T2: Fatal: Linking had errors.
+T2: Fatal: Linking had errors
 
 VERBOSE1: {{.*}}3.o:(.rodata.str1.1): created mergeable string fragment with contents and align 1
 VERBOSE1: {{.*}}3.o:(.rodata.str1.1+0x1): created mergeable string fragment with contents and align 1

--- a/test/Common/standalone/linkerscript/AlignOfInvalidSection/AlignOfInvalidSection.test
+++ b/test/Common/standalone/linkerscript/AlignOfInvalidSection/AlignOfInvalidSection.test
@@ -9,5 +9,5 @@ RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o -ffunction-sections
 RUN: %not %link %linkopts -T %p/Inputs/script.t %t1.o -o %t2.out 2>&1 | %filecheck %s -check-prefix=ERR
 
 #ERR: Error: {{[ -\(\)_A-Za-z0-9.\\/:]+}}script.t: Invalid section 'NON_EXISTENT_SECTION'
-#ERR: Fatal: Linking had errors.
+#ERR: Fatal: Linking had errors
 #END_TEST

--- a/test/Common/standalone/linkerscript/BadIncludeFile/BadIncludeFile.test
+++ b/test/Common/standalone/linkerscript/BadIncludeFile/BadIncludeFile.test
@@ -9,5 +9,5 @@ RUN: %not %link %linkopts %t1.1.o -T %p/Inputs/f.t -o %t2.out 2>&1 | %filecheck 
 
 #CHECK: Fatal: cannot read file 'doenotexist.t'
 #CHECK: Linker script {{.*}}f.t has errors, Please check
-#CHECK: Linking had errors.
+#CHECK: Linking had errors
 #END_TEST

--- a/test/Hexagon/Plugin/ConfigFile/ConfigFilePathNotFoundTest/ConfigFilePathNotFoundTest.test
+++ b/test/Hexagon/Plugin/ConfigFile/ConfigFilePathNotFoundTest/ConfigFilePathNotFoundTest.test
@@ -7,5 +7,5 @@ RUN: %clang %clangopts -c %p/../Inputs/1.c -o %t1.1.o -ffunction-sections
 RUN: %not %link %linkopts %t1.1.o -o %t2.out --plugin-config=plugin.config --verbose  2>&1  | %filecheck %s -check-prefix=VERBOSE
 #VERBOSE: Trying to open `plugin.config' for plugin configuration file `plugin.config' (file path): not found
 #VERBOSE: Plugin config file plugin.config not found
-#VERBOSE: Linking had errors.
+#VERBOSE: Linking had errors
 #END_TEST

--- a/test/Hexagon/Plugin/OutputSectionIteratorWithConfig/OutputSectionIteratorWithConfig.test
+++ b/test/Hexagon/Plugin/OutputSectionIteratorWithConfig/OutputSectionIteratorWithConfig.test
@@ -21,6 +21,6 @@ MAPPING: foo.txt
 #CHECK-DAG: 2b
 #CHECK-DAG: 3c
 #CHECK-DAG: GETOUTPUTWITHCONFIG:Error: ini file {{.*}}badcharacters.ini contains non-ascii characters
-#CHECK-DAG: Fatal: Linking had errors.
+#CHECK-DAG: Fatal: Linking had errors
 
 #END_TEST


### PR DESCRIPTION
Enhance the "Fatal: Linking had errors" message to include the output file name. This provides clearer context when debugging link failures, making it easier to identify which build artifact caused the issue.

Fix qualcomm#1232