### PR TITLE
Remove cast in DynamicELFReader<ELFT>::readDynamic function

### DIFF
--- a/lib/Readers/DynamicELFReader.cpp
+++ b/lib/Readers/DynamicELFReader.cpp
@@ -78,9 +78,7 @@ eld::Expected<bool> DynamicELFReader<ELFT>::readDynamic() {
 
   ELFDynObjectFile *dynObjFile =
       llvm::cast<ELFDynObjectFile>(&(this->m_InputFile));
-  /// FIXME: unneeded cast?
-  ELFSection *dynamicSect =
-      llvm::dyn_cast<ELFSection>(dynObjFile->getDynamic());
+  ELFSection *dynamicSect = dynObjFile->getDynamic();
   if (!dynamicSect) {
     return std::make_unique<plugin::DiagnosticEntry>(
         plugin::DiagnosticEntry(Diag::err_cannot_read_section, {".dynamic"}));


### PR DESCRIPTION
Remove unnecessary and unsafe cast, ensuring null values are handled clearly and avoiding misleading failure behavior during linking or parsing

Fix qualcomm#1235