### PR TITLE
ELFReaderBase::Create now use input file format

### DIFF
--- a/include/eld/Readers/ELFReaderBase.h
+++ b/include/eld/Readers/ELFReaderBase.h
@@ -93,11 +93,9 @@ public:
 
   /// Creates and returns an instance of a reader class.
   ///
-  /// The reader class depends on the input type and the target
-  /// configuration. For example, if an input is a dyanmic input library
-  /// and the target configuration is little-endian 32-bits architecture,
-  /// then the reader class would be
-  /// DynamicELFReader<llvm::object::ELF32LE>.
+  /// The reader class depends on the input type. For example, if an input is a
+  /// dynamic input library and a little-endian 32-bits architecture, then the
+  /// reader class would be DynamicELFReader<llvm::object::ELF32LE>.
   static eld::Expected<std::unique_ptr<ELFReaderBase>>
   Create(Module &module, InputFile &inputFile);
 

--- a/lib/Readers/ELFReaderBase.cpp
+++ b/lib/Readers/ELFReaderBase.cpp
@@ -5,7 +5,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "eld/Readers/ELFReaderBase.h"
-#include "eld/Config/LinkerConfig.h"
 #include "eld/Core/Module.h"
 #include "eld/Diagnostics/DiagnosticEngine.h"
 #include "eld/Input/ObjectFile.h"
@@ -26,7 +25,6 @@ eld::Expected<std::unique_ptr<ELFReaderBase>>
 ELFReaderBase::Create(Module &module, InputFile &inputFile) {
   plugin::DiagnosticEntry diagEntry;
   std::unique_ptr<ELFReaderBase> reader;
-  LinkerConfig &config = module.getConfig();
 
   eld::Expected<ObjectFile::ELFKind> fileKind =
       ELFReaderBase::inspectELFKind(inputFile);
@@ -35,18 +33,15 @@ ELFReaderBase::Create(Module &module, InputFile &inputFile) {
   // Set the ELF kind in the object file
   llvm::dyn_cast<ObjectFile>(&inputFile)->setELFKind(*fileKind);
 
-  if (config.targets().isBigEndian() ||
-      (*fileKind == ObjectFile::ELFKind::ELF32BEKind) ||
+  if ((*fileKind == ObjectFile::ELFKind::ELF32BEKind) ||
       (*fileKind == ObjectFile::ELFKind::ELF64BEKind))
     return std::make_unique<plugin::DiagnosticEntry>(
         plugin::DiagnosticEntry(Diag::fatal_big_endian_target,
                                 {inputFile.getInput()->decoratedPath()}));
 
-  if (config.targets().is32Bits() ||
-      (*fileKind == ObjectFile::ELFKind::ELF32LEKind))
+  if (*fileKind == ObjectFile::ELFKind::ELF32LEKind)
     return createImpl<llvm::object::ELF32LE>(module, inputFile);
-  else if (config.targets().is64Bits() ||
-           (*fileKind == ObjectFile::ELFKind::ELF64LEKind))
+  else if (*fileKind == ObjectFile::ELFKind::ELF64LEKind)
     return createImpl<llvm::object::ELF64LE>(module, inputFile);
   return {};
 }


### PR DESCRIPTION
ELF files are now read based on their real format (bit width and endianness) instead of the configured target.

Previously, mismatches between the input file and target configuration could cause files to be interpreted incorrectly, leading to parsing errors or unexpected failures.

With this change, ELF files are consistently handled according to their true format, improving reliability and preventing incorrect reads when configurations do not match the input.

Fix qualcomm#1231