### PR TITLE
Support emulation options when invoking ld.eld directly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - [Major Highlights](#major-highlights)
 
 ### 2026
+- [June 2026](#june-2026)
 - [May 2026](#may-2026)
 - [April 2026](#april-2026)
 - [March 2026](#march-2026)
@@ -47,6 +48,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - foundational feature ramp-up across emulations, plugin APIs, x86_64 static relocations, and linker-script expression handling.
 
 ## 2026
+
+### June 2026
+
+#### [2026-06-02] - 2026-06-02 to 2026-06-08
+##### Added
+- Support `-mcpu` driver selection and conflicting-option rejection when invoking `ld.eld` without target symlink names.
+##### Fixed
+- Tighten ARM `-m` emulation validation to match supported emulation strings.
 
 ### May 2026
 

--- a/include/eld/Driver/ARMLinkDriver.h
+++ b/include/eld/Driver/ARMLinkDriver.h
@@ -85,12 +85,51 @@ public:
     return "unknown";
   }
 
-  static bool isValidEmulation(llvm::StringRef Emulation) {
-    return Emulation.starts_with("arm") || Emulation.starts_with("aarch64");
+  static bool isValidEmulation(llvm::StringRef Emulation);
+
+  static bool inferFromMarch(llvm::StringRef MArch, std::string &InferredArch) {
+    if (MArch.starts_with("aarch64")) {
+      InferredArch = "aarch64";
+      return true;
+    }
+    if (MArch.starts_with("arm")) {
+      InferredArch = "arm";
+      return true;
+    }
+    return false;
+  }
+
+  static bool inferFromTriple(const llvm::Triple &T, std::string &InferredArch) {
+    switch (T.getArch()) {
+    case llvm::Triple::aarch64:
+      InferredArch = "aarch64";
+      return true;
+    case llvm::Triple::arm:
+    case llvm::Triple::thumb:
+    case llvm::Triple::armeb:
+    case llvm::Triple::thumbeb:
+      InferredArch = "arm";
+      return true;
+    default:
+      return false;
+    }
+  }
+
+  static bool inferFromCpu(llvm::StringRef Cpu, std::string &InferredArch) {
+    if (Cpu.starts_with("aarch64") || Cpu.starts_with("cortex-a")) {
+      InferredArch = "aarch64";
+      return true;
+    }
+    if (Cpu.starts_with("cortex") || Cpu.starts_with("arm")) {
+      InferredArch = "arm";
+      return true;
+    }
+    return false;
   }
 
   static bool isMyArch(llvm::StringRef MArch) {
-    return MArch == "arm" || MArch == "aarch64";
+    std::string Arch;
+    return inferFromMarch(MArch, Arch);
   }
 };
 

--- a/include/eld/Driver/HexagonLinkDriver.h
+++ b/include/eld/Driver/HexagonLinkDriver.h
@@ -12,6 +12,8 @@
 #include "eld/Core/Module.h"
 #include "eld/Driver/GnuLdDriver.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/TargetParser/Triple.h"
+#include <cctype>
 
 // Create OptTable class for parsing actual command line arguments
 class OPT_HexagonLinkOptTable : public llvm::opt::GenericOptTable {
@@ -80,7 +82,35 @@ public:
   static std::string getInferredArch(llvm::StringRef Emulation) {
     return "hexagon";
   }
-  static bool isMyArch(llvm::StringRef MArch) { return MArch == "hexagon"; }
+  static bool inferFromMarch(llvm::StringRef MArch, std::string &InferredArch) {
+    if (MArch == "hexagon" || MArch.starts_with("hexagon")) {
+      InferredArch = "hexagon";
+      return true;
+    }
+    return false;
+  }
+
+  static bool inferFromTriple(const llvm::Triple &T, std::string &InferredArch) {
+    if (T.getArch() == llvm::Triple::hexagon) {
+      InferredArch = "hexagon";
+      return true;
+    }
+    return false;
+  }
+
+  static bool inferFromCpu(llvm::StringRef Cpu, std::string &InferredArch) {
+    if (Cpu.starts_with("hexagon") ||
+        (Cpu.size() > 1 && Cpu[0] == 'v' && isdigit(Cpu[1]))) {
+      InferredArch = "hexagon";
+      return true;
+    }
+    return false;
+  }
+
+  static bool isMyArch(llvm::StringRef MArch) {
+    std::string Arch;
+    return inferFromMarch(MArch, Arch);
+  }
 };
 
 #endif

--- a/include/eld/Driver/RISCVLinkDriver.h
+++ b/include/eld/Driver/RISCVLinkDriver.h
@@ -12,6 +12,7 @@
 #include "eld/Core/Module.h"
 #include "eld/Driver/GnuLdDriver.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/TargetParser/Triple.h"
 
 // Create OptTable class for parsing actual command line arguments
 class OPT_RISCVLinkOptTable : public llvm::opt::GenericOptTable {
@@ -86,8 +87,39 @@ public:
     return "unknown";
   }
 
+  static bool inferFromMarch(llvm::StringRef MArch, std::string &InferredArch) {
+    if (MArch == "riscv32" || MArch.starts_with("rv32")) {
+      InferredArch = "riscv32";
+      return true;
+    }
+    if (MArch == "riscv64" || MArch.starts_with("rv64")) {
+      InferredArch = "riscv64";
+      return true;
+    }
+    return false;
+  }
+
+  static bool inferFromTriple(const llvm::Triple &T, std::string &InferredArch) {
+    if (T.getArch() == llvm::Triple::riscv32) {
+      InferredArch = "riscv32";
+      return true;
+    }
+    if (T.getArch() == llvm::Triple::riscv64) {
+      InferredArch = "riscv64";
+      return true;
+    }
+    return false;
+  }
+
+  static bool inferFromCpu(llvm::StringRef Cpu, std::string &InferredArch) {
+    (void)Cpu;
+    (void)InferredArch;
+    return false;
+  }
+
   static bool isMyArch(llvm::StringRef MArch) {
-    return MArch == "riscv32" || MArch == "riscv64";
+    std::string Arch;
+    return inferFromMarch(MArch, Arch);
   }
 };
 

--- a/include/eld/Driver/x86_64LinkDriver.h
+++ b/include/eld/Driver/x86_64LinkDriver.h
@@ -14,6 +14,7 @@
 #include "eld/Core/Module.h"
 #include "eld/Driver/GnuLdDriver.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/TargetParser/Triple.h"
 
 // Create OptTable class for parsing actual command line arguments
 class OPT_x86_64LinkOptTable : public llvm::opt::GenericOptTable {
@@ -82,7 +83,32 @@ public:
     return "x86_64";
   }
 
-  static bool isMyArch(llvm::StringRef MArch) { return MArch == "x86_64"; }
+  static bool inferFromMarch(llvm::StringRef MArch, std::string &InferredArch) {
+    if (MArch == "x86_64") {
+      InferredArch = "x86_64";
+      return true;
+    }
+    return false;
+  }
+
+  static bool inferFromTriple(const llvm::Triple &T, std::string &InferredArch) {
+    if (T.getArch() == llvm::Triple::x86_64) {
+      InferredArch = "x86_64";
+      return true;
+    }
+    return false;
+  }
+
+  static bool inferFromCpu(llvm::StringRef Cpu, std::string &InferredArch) {
+    (void)Cpu;
+    (void)InferredArch;
+    return false;
+  }
+
+  static bool isMyArch(llvm::StringRef MArch) {
+    std::string Arch;
+    return inferFromMarch(MArch, Arch);
+  }
 };
 
 #endif

--- a/lib/LinkerWrapper/ARMLinkDriver.cpp
+++ b/lib/LinkerWrapper/ARMLinkDriver.cpp
@@ -59,6 +59,10 @@ ARMLinkDriver::ParseEmulation(std::string pEmulation,
   return result;
 }
 
+bool ARMLinkDriver::isValidEmulation(llvm::StringRef Emulation) {
+  return ParseEmulation(Emulation.str(), nullptr).has_value();
+}
+
 OPT_ARMLinkOptTable::OPT_ARMLinkOptTable()
     : GenericOptTable(OptionStrTable, OptionPrefixesTable, infoTable) {}
 

--- a/lib/LinkerWrapper/Driver.cpp
+++ b/lib/LinkerWrapper/Driver.cpp
@@ -23,6 +23,33 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
 #include <optional>
+#include <vector>
+
+namespace {
+
+struct TargetInference {
+  DriverFlavor Flavor = DriverFlavor::Unknown;
+  std::string Arch;
+};
+
+std::optional<TargetInference> inferTargetFromCpu(llvm::StringRef Cpu) {
+  std::string Arch;
+#if defined(ELD_ENABLE_TARGET_HEXAGON)
+  if (HexagonLinkDriver::inferFromCpu(Cpu, Arch))
+    return TargetInference{DriverFlavor::Hexagon, Arch};
+#endif
+  return std::nullopt;
+}
+
+enum class TargetOptionKind { Emulation, Mcu };
+
+struct OptionTargetInference {
+  TargetInference Target;
+  unsigned Index = 0;
+  TargetOptionKind Kind;
+};
+
+} // namespace
 
 Driver::Driver(DriverFlavor F)
     : DiagEngine(new eld::DiagnosticEngine(shouldColorize())),
@@ -142,80 +169,78 @@ Driver::getDriverFlavorFromLinkCommand(llvm::ArrayRef<const char *> Args) {
   unsigned MissingCount;
   llvm::opt::InputArgList ArgList =
       Table.ParseArgs(Args.slice(1), MissingIndex, MissingCount);
-  DriverFlavor F = DriverFlavor::Unknown;
-  std::string InferredArch;
+  std::vector<OptionTargetInference> Inferences;
   if (llvm::opt::Arg *Arg = ArgList.getLastArg(OPT_GnuLdOptTable::emulation)) {
     std::string Emulation = Arg->getValue();
+    std::optional<TargetInference> Target;
 #if defined(ELD_ENABLE_TARGET_HEXAGON)
-    if (HexagonLinkDriver::isValidEmulation(Emulation)) {
-      F = DriverFlavor::Hexagon;
-      InferredArch = HexagonLinkDriver::getInferredArch(Emulation);
-    } else
+    if (HexagonLinkDriver::isValidEmulation(Emulation))
+      Target = TargetInference{DriverFlavor::Hexagon,
+                                 HexagonLinkDriver::getInferredArch(Emulation)};
 #endif
 #if defined(ELD_ENABLE_TARGET_RISCV)
-      // It is okay to consider RISCV64 emulation as RISCV32 flavor
-      // here because RISCVLinkDriver will properly set the emulation.
-      if (RISCVLinkDriver::isValidEmulation(Emulation)) {
-        F = DriverFlavor::RISCV32_RISCV64;
-        InferredArch = RISCVLinkDriver::getInferredArch(Emulation);
-      } else
+    if (!Target && RISCVLinkDriver::isValidEmulation(Emulation))
+      Target = TargetInference{DriverFlavor::RISCV32_RISCV64,
+                               RISCVLinkDriver::getInferredArch(Emulation)};
 #endif
 #if defined(ELD_ENABLE_TARGET_TEMPLATE)
-          if (TemplateLinkDriver::isValidEmulation(Emulation)) {
-        F = DriverFlavor::Template;
-        InferredArch = TemplateLinkDriver::getInferredArch(Emulation);
-      } else
+    if (!Target && TemplateLinkDriver::isValidEmulation(Emulation))
+      Target = TargetInference{DriverFlavor::Template,
+                               TemplateLinkDriver::getInferredArch(Emulation)};
 #endif
 #if defined(ELD_ENABLE_TARGET_ARM) || defined(ELD_ENABLE_TARGET_AARCH64)
-          if (ARMLinkDriver::isValidEmulation(Emulation)) {
-        F = DriverFlavor::ARM_AArch64;
-        InferredArch = ARMLinkDriver::getInferredArch(Emulation);
-      } else
+    if (!Target && ARMLinkDriver::isValidEmulation(Emulation))
+      Target = TargetInference{DriverFlavor::ARM_AArch64,
+                               ARMLinkDriver::getInferredArch(Emulation)};
 #endif
 #if defined(ELD_ENABLE_TARGET_X86)
-          if (x86_64LinkDriver::isValidEmulation(Emulation)) {
-        F = DriverFlavor::x86_64;
-        InferredArch = x86_64LinkDriver::getInferredArch(Emulation);
-      } else
+    if (!Target && x86_64LinkDriver::isValidEmulation(Emulation))
+      Target = TargetInference{DriverFlavor::x86_64,
+                               x86_64LinkDriver::getInferredArch(Emulation)};
 #endif
-        return std::make_unique<eld::DiagnosticEntry>(
-            eld::Diag::fatal_unsupported_emulation,
-            std::vector<std::string>{Emulation});
-    return std::pair<DriverFlavor, std::string>{F, InferredArch};
-  }
-  if (llvm::opt::Arg *Arg = ArgList.getLastArg(OPT_GnuLdOptTable::march)) {
-    std::string MachineArch = Arg->getValue();
-    InferredArch = MachineArch;
-#if defined(ELD_ENABLE_TARGET_HEXAGON)
-    if (HexagonLinkDriver::isMyArch(MachineArch))
-      F = DriverFlavor::Hexagon;
-#endif
-#if defined(ELD_ENABLE_TARGET_RISCV)
-    // It is okay to consider RISCV64 emulation as RISCV32 flavor
-    // here because RISCVLinkDriver will properly set the emulation.
-    if (RISCVLinkDriver::isMyArch(MachineArch))
-      F = DriverFlavor::RISCV32_RISCV64;
-#endif
-#if defined(ELD_ENABLE_TARGET_TEMPLATE)
-    // It is okay to consider RISCV64 emulation as RISCV32 flavor
-    // here because RISCVLinkDriver will properly set the emulation.
-    if (TemplateLinkDriver::isMyArch(MachineArch))
-      F = DriverFlavor::Template;
-#endif
-#if defined(ELD_ENABLE_TARGET_ARM) || defined(ELD_ENABLE_TARGET_AARCH64)
-    if (ARMLinkDriver::isMyArch(MachineArch))
-      F = DriverFlavor::ARM_AArch64;
-#endif
-#if defined(ELD_ENABLE_TARGET_X86)
-    if (x86_64LinkDriver::isMyArch(MachineArch))
-      F = DriverFlavor::x86_64;
-#endif
-    if (F == DriverFlavor::Invalid)
+    if (!Target)
       return std::make_unique<eld::DiagnosticEntry>(
           eld::Diag::fatal_unsupported_emulation,
-          std::vector<std::string>{MachineArch});
+          std::vector<std::string>{Emulation});
+    Inferences.push_back(
+        {*Target, Arg->getIndex(), TargetOptionKind::Emulation});
   }
-  return std::pair<DriverFlavor, std::string>{F, InferredArch};
+  if (llvm::opt::Arg *Arg = ArgList.getLastArg(OPT_GnuLdOptTable::mcpu)) {
+    if (auto Target = inferTargetFromCpu(Arg->getValue()))
+      Inferences.push_back({*Target, Arg->getIndex(), TargetOptionKind::Mcu});
+  }
+
+  if (Inferences.empty())
+    return std::pair<DriverFlavor, std::string>{DriverFlavor::Unknown, ""};
+
+  DriverFlavor AgreedFlavor = Inferences.front().Target.Flavor;
+  for (const auto &Inference : Inferences) {
+    if (Inference.Target.Flavor != AgreedFlavor)
+      return std::make_unique<eld::DiagnosticEntry>(
+          eld::Diag::fatal_unsupported_emulation,
+          std::vector<std::string>{"conflicting target options"});
+  }
+
+  const OptionTargetInference *Winner = nullptr;
+  for (const auto &Inference : Inferences) {
+    if (Inference.Kind == TargetOptionKind::Emulation) {
+      Winner = &Inference;
+      break;
+    }
+  }
+  if (!Winner) {
+    for (const auto &Inference : Inferences) {
+      if (Inference.Kind == TargetOptionKind::Mcu) {
+        Winner = &Inference;
+        break;
+      }
+    }
+  }
+  if (!Winner)
+    return std::pair<DriverFlavor, std::string>{DriverFlavor::Unknown, ""};
+
+  return std::pair<DriverFlavor, std::string>{Winner->Target.Flavor,
+                                                Winner->Target.Arch};
 }
 
 std::pair<DriverFlavor, std::string>

--- a/test/Common/standalone/EmulationOptions/ConflictingOptions.test
+++ b/test/Common/standalone/EmulationOptions/ConflictingOptions.test
@@ -1,0 +1,11 @@
+REQUIRES: hexagon, riscv32
+#---ConflictingOptions.test------------------ Executable -------------------#
+#BEGIN_COMMENT
+# Verify ld.eld rejects conflicting target options when using ld.eld.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.o
+RUN: %not %eld %linkopts -m elf32lriscv -mcpu=hexagonv75 %t.o -o %t.conflict.out 2>&1 | %filecheck %s
+#END_TEST
+
+# CHECK: Invalid Emulation conflicting target options

--- a/test/Common/standalone/EmulationOptions/Inputs/1.c
+++ b/test/Common/standalone/EmulationOptions/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo(void) { return 0; }

--- a/test/Hexagon/standalone/EmulationOptions/Inputs/1.c
+++ b/test/Hexagon/standalone/EmulationOptions/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo(void) { return 0; }

--- a/test/Hexagon/standalone/EmulationOptions/LdEldMcpu.test
+++ b/test/Hexagon/standalone/EmulationOptions/LdEldMcpu.test
@@ -1,0 +1,12 @@
+#---LdEldMcpu.test--------------------------- Executable -------------------#
+#BEGIN_COMMENT
+# Verify ld.eld selects the Hexagon driver from -mcpu without -m emulation.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.o
+RUN: %eld %linkopts -mcpu=hexagonv75 %t.o -o %t.mcpu.out
+RUN: %readelf -h %t.mcpu.out | %filecheck %s
+#END_TEST
+
+# CHECK: Machine:
+# CHECK: QUALCOMM Hexagon

--- a/test/Hexagon/standalone/InvalidEmulation/InvalidEmulation.test
+++ b/test/Hexagon/standalone/InvalidEmulation/InvalidEmulation.test
@@ -1,6 +1,3 @@
-UNSUPPORTED: true
-# This test is temporarily marked unsupported because currently we do not do
-# consistency checks for multiple emulation options.
 #---InvalidEmulation.test--------------------- Executable --------------------#
 #BEGIN_COMMENT
 # This tests that the linker should reject invalid Emulations specified on the


### PR DESCRIPTION
## Summary
- Extend `ld.eld` driver selection to honor `-march` variants, `-mtriple`, and `-mcpu` without requiring target-specific symlink names (`arm-link`, `riscv-link`, etc.)
- Detect and reject conflicting target options across emulation flags
- Tighten ARM `-m` emulation validation to match supported emulation strings
- Add LIT coverage for `ld.eld`-only invocation paths and re-enable Hexagon invalid-emulation checks

Closes #21. Builds on prior work in #22/#23 and #54/#55.

## Test plan
- [ ] qualcomm CI (`ci.yml`) passes — `ninja check-eld`
- [ ] Clang format check passes
- [ ] QC preflight checks pass
- [ ] New tests under `test/Common/standalone/EmulationOptions/` and `test/*/standalone/EmulationOptions/`
- [ ] Re-enabled `test/Hexagon/standalone/InvalidEmulation/InvalidEmulation.test`