### PR TITLE
[ARM] Add IFunc support for static links

### DIFF
--- a/docs/DeveloperDocs/IFunc.md
+++ b/docs/DeveloperDocs/IFunc.md
@@ -37,11 +37,11 @@ For the case of static executables, libc plays the role of runtime and takes on 
 that is typically unusual for a libc -- resolve symbols and patch the binary at runtime
 with the resolution information.
 
-eld emits `R_<TARGET>_IRELATIVE` relocations in `.rela.plt` section, and `__rela_iplt_start` and
-`__rela_iplt_end` symbols that store the start and end addresses of `.rela.plt` section.
+eld emits `R_<TARGET>_IRELATIVE` relocations in `.rel[a].plt` section, and `__rel[a]_iplt_start` and
+`__rela_iplt_end` symbols that store the start and end addresses of `.rel[a].plt` section.
 
 The tiny-loader in the libc process the `R_<TARGET>_IRELATIVE` relocations by
-iterating over the [`__rela_iplt_start`, `__rela_iplt_end`) range.
+iterating over the [`__rel[a]_iplt_start`, `__rel[a]_iplt_end`) range.
 
 ```
 Relocation section '.rela.plt' at offset 0x190 contains 6 entries:
@@ -137,6 +137,9 @@ into the following categories:
 *Regular* in the relocation category name here means that the relocations are
 non-TLS non-call relocations.
 
+Any relocation against an IFunc symbol that does not fall into one of the above
+categories is invalid and produces a warning.
+
 The relocations which are not supported by GNU for IFunc symbols are annotated with
 NotSupportedInGNULDForIFunc. The GNU toolchain that is used for verifying this is:
 aarch64-none-linux-gnu-gcc (Arm GNU Toolchain 15.2.Rel1 (Build arm-15.86)) 15.2.1 20251203,
@@ -151,14 +154,21 @@ Resolves to PLT[IFuncSymbol]. Sets HasDirectReference[IFuncSymbol] to true.
 
 - R_RISCV_{32, 64}
 
+- R_ARM_ABS32
+- R_ARM_ABS32_NOI
+- R_ARM_TARGET1 (treated as R_ARM_ABS32)
 
 The below relocations are currently unsupported by eld.
-For IFunc symbols, these should be resolved to the PLT[IFuncSymbol]
-as well.
+For IFunc symbols, these should be resolved to the PLT[IFuncSymbol] as well.
 
 - R_AARCH64_PREL{16, 32, 64} (NotSupportedInGNULDForIFunc)
 - R_AARCH64_PLT32
+
 - R_RISCV_PLT32
+
+- R_ARM_ABS8
+- R_ARM_ABS16
+- R_ARM_PREL{16, 32, 64}
 
 ### GOT-related data relocations
 
@@ -185,6 +195,23 @@ Resolves to PLT[IFuncSymbol].
 - R_RISCV_RVC_BRANCH
 - R_RISCV_RVC_JUMP
 
+- R_ARM_CALL
+- R_ARM_JUMP24
+- R_ARM_PC24
+- R_ARM_PLT32
+- R_ARM_THM_CALL
+- R_ARM_THM_JUMP24
+
+The below relocations should not be used with IFunc functions because
+these relocations are used with thumb instructions that does not support
+interworking (correctly transferring control between thumb-state and ARM-state)
+and PLT slot is typically always in the ARM state.
+
+- R_ARM_THM_JUMP6 (UNSUPPORTED) (NotSupportedInGNULDForIFunc)
+- R_ARM_THM_JUMP19
+- R_ARM_THM_JUMP11
+- R_ARM_THM_JUMP8
+
 ### Regular GOT-related instruction relocations
 
 Resolves-to / uses GOTPLT[IFuncSymbol] if there is no direct reference to
@@ -193,11 +220,19 @@ IFuncSymbol; otherwise uses GOT[IFuncSymbol].
 - R_AARCH64_ADR_GOT_PAGE
 - R_AARCH64_LD{32,64}_GOT_LO12_NC (LD32 variant UNSUPPORTED)
 - R_AARCH64_LD{32,64}_GOTPAGE_LO15 (LD32 variant UNSUPPORTED)
-- R_AARCH64_GOT_LD_PREL19 (UNSUPPORTED)
-- AUTH-ABI GOT relocations (UNSUPPORTED)
-- R_AARCH64_MOVW_GOTOFF_G{0,1}{_NC} (UNSUPPORTED)
 
 - R_RISCV_GOT_HI20
+
+- R_ARM_GOT_BREL
+- R_ARM_GOT_PREL
+
+The below relocations are unsupported by eld:
+
+- R_AARCH64_GOT_LD_PREL19
+- AUTH-ABI GOT relocations
+- R_AARCH64_MOVW_GOTOFF_G{0,1}{_NC}
+
+- R_ARM_GOT_ABS
 
 ### Regular absolute / PC-relative address-forming relocations
 
@@ -212,6 +247,17 @@ Resolves to PLT[IFuncSymbol]. Sets HasDirectReference[IFuncSymbol] to true.
 - R_RISCV_LO12_I
 - R_RISCV_LO12_S
 
+- R_ARM_REL32
+- R_ARM_PREL31
+- R_ARM_MOVW_ABS_NC
+- R_ARM_MOVT_ABS
+- R_ARM_MOVW_PREL_NC
+- R_ARM_MOVT_PREL
+- R_ARM_THM_MOVW_ABS_NC
+- R_ARM_THM_MOVT_ABS
+- R_ARM_THM_MOVW_PREL_NC
+- R_ARM_THM_MOVT_PREL
+
 The below relocations are resolved to the IFunc symbol:
 
 - R_AARCH64_MOVW_UABS_G{0,1,2,3}{_NC} (NotSupportedInGNULDForIFunc)
@@ -221,9 +267,9 @@ The below relocations are resolved to the IFunc symbol:
 > FIXME: We should perhaps resolve these relocations to the PLT[IFuncSymbol]
 > instead of the IFuncSymbol for ensuring pointer equality.
 
-The below relocations are currenty unsupported in eld:
+The below relocations are currently unsupported in eld:
 
-- MOVW_PREL_G{0, 1, 2, 3}{_NC}
+- R_AARCH64_MOVW_PREL_G{0, 1, 2, 3}{_NC}
 
 ### Address forming relocations used to compute both GOT and non-GOT addresses
 
@@ -239,13 +285,14 @@ The behavior of these relocations depend upon the corresponding Hi-relocation pa
 
 ### Absolute / PC-relative load/store relocations
 
+These relocations do not make sense with IFunc symbols. Loading a value at a
+function address is invalid behavior, and so is storing a value at a function
+address.
+
 - LD_PREL_LO19 (NotSupportedInGNULDForIFunc)
 - LDST{8, 16, 32, 64, 128}_ABS_LO12_NC (NotSupportedInGNULDForIFunc)
 
-These relocations does not make sense with IFunc symbols. Loading value
-at a function address is an invalid behavior, and so is storing a value
-at a function address.
-
 > [!IMPORTANT]
 > FIXME: It should be an error to use these relocations with IFunc symbols.
+
 

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -720,11 +720,13 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
   for (auto *arg : Args.filtered(T::wrap)) {
     std::string wname = arg->getValue();
     wrapString.push_back(wname);
+    // FIXME: No need for string saver here!
     std::string to_wrap_str = eld::Saver.save("__wrap_" + wname).str();
     Config.options().renameMap().insert(std::make_pair(wname, to_wrap_str));
 
     // add __real_wname -> wname
     std::string from_real_str = eld::Saver.save("__real_" + wname).str();
+    // Undefined behavior!
     Config.options().renameMap().insert(std::make_pair(from_real_str, wname));
   } // end of for
   if (Args.hasArg(T::wrap))

--- a/lib/Target/ARM/ARMLDBackend.cpp
+++ b/lib/Target/ARM/ARMLDBackend.cpp
@@ -608,6 +608,31 @@ bool ARMGNULDBackend::finalizeScanRelocations() {
       frag = *GOTPLT->getFragmentList().begin();
   if (frag)
     defineGOTSymbol(*frag);
+
+  if (!config().isCodeStatic())
+    return true;
+
+  // For an IFunc symbol that is both referenced directly (its address is
+  // taken via an absolute / PC-relative reloc, which resolves to PLT[ifunc])
+  // and referenced through the GOT, we materialize a dedicated GOT slot that
+  // holds the address of PLT[ifunc]. GOT references then resolve to this slot
+  // rather than the GOTPLT slot, so that the GOT-loaded pointer equals the
+  // direct-reference pointer (pointer equality).
+  for (auto &[symInfo, plt] : m_PLTMap) {
+    if (!symInfo->isIFunc() || !symInfo->hasIFuncDirectRef() ||
+        !symInfo->hasIFuncNeedsGOT())
+      continue;
+    ELFObjectFile *PLTSlotObjFile =
+        llvm::cast<ELFObjectFile>(plt->getOwningSection()->getInputFile());
+    ARMGOT *G = createGOT(GOT::Regular, PLTSlotObjFile, symInfo);
+    FragmentRef *PLTFragRef = make<FragmentRef>(*plt, 0);
+    Relocation *r = Relocation::Create(llvm::ELF::R_ARM_ABS32, 32,
+                                       make<FragmentRef>(*G, 0), 0);
+    PLTSlotObjFile->getGOT()->addRelocation(r);
+    r->modifyRelocationFragmentRef(PLTFragRef);
+    // createGOT(GOT::Regular, ...) already calls recordGOT for symInfo.
+    symInfo->setReserved(symInfo->reserved() | Relocator::ReserveGOT);
+  }
   return true;
 }
 
@@ -622,38 +647,39 @@ void ARMGNULDBackend::defineIRelativeRange(ResolveInfo &pSym) {
   if (m_Module.getScript().linkerScriptHasSectionsCommand())
     return;
 
-  // Define the copy symbol in the bss section and resolve it
   if (!m_pIRelativeStart && !m_pIRelativeEnd) {
     auto SymbolName = "__rel_iplt_start";
     m_pIRelativeStart =
         m_Module.getIRBuilder()
-            ->addSymbol<IRBuilder::Force, IRBuilder::Resolve>(
+            ->addSymbol<IRBuilder::AsReferred, IRBuilder::Resolve>(
                 m_Module.getInternalInput(Module::Script), SymbolName,
-                ResolveInfo::Object, ResolveInfo::Define,
-                (ResolveInfo::Binding)pSym.binding(),
+                ResolveInfo::Type::NoType, ResolveInfo::Define,
+                ResolveInfo::Binding::Local,
                 0,   // size
                 0x0, // value
-                FragmentRef::null(), (ResolveInfo::Visibility)pSym.other());
-
-    m_pIRelativeStart->setShouldIgnore(false);
-    if (m_Module.getConfig().options().isSymbolTracingRequested() &&
-        m_Module.getConfig().options().traceSymbol(SymbolName))
-      config().raise(Diag::target_specific_symbol) << SymbolName;
+                FragmentRef::null(), ResolveInfo::Visibility::Default);
+    if (m_pIRelativeStart) {
+      m_pIRelativeStart->setShouldIgnore(false);
+      if (m_Module.getConfig().options().isSymbolTracingRequested() &&
+          m_Module.getConfig().options().traceSymbol(SymbolName))
+        config().raise(Diag::target_specific_symbol) << SymbolName;
+    }
     SymbolName = "__rel_iplt_end";
     m_pIRelativeEnd =
         m_Module.getIRBuilder()
-            ->addSymbol<IRBuilder::Force, IRBuilder::Resolve>(
+            ->addSymbol<IRBuilder::AsReferred, IRBuilder::Resolve>(
                 m_Module.getInternalInput(Module::Script), SymbolName,
-                ResolveInfo::Object, ResolveInfo::Define,
-                (ResolveInfo::Binding)pSym.binding(),
-                pSym.size(), // size
-                0x0,         // value
-                FragmentRef::null(), (ResolveInfo::Visibility)pSym.other());
-
-    m_pIRelativeEnd->setShouldIgnore(false);
-    if (m_Module.getConfig().options().isSymbolTracingRequested() &&
-        m_Module.getConfig().options().traceSymbol(SymbolName))
-      config().raise(Diag::target_specific_symbol) << SymbolName;
+                ResolveInfo::Type::NoType, ResolveInfo::Define,
+                ResolveInfo::Binding::Local,
+                0,   // size
+                0x0, // value
+                FragmentRef::null(), ResolveInfo::Visibility::Default);
+    if (m_pIRelativeEnd) {
+      m_pIRelativeEnd->setShouldIgnore(false);
+      if (m_Module.getConfig().options().isSymbolTracingRequested() &&
+          m_Module.getConfig().options().traceSymbol(SymbolName))
+        config().raise(Diag::target_specific_symbol) << SymbolName;
+    }
   }
 }
 
@@ -665,6 +691,8 @@ bool ARMGNULDBackend::finalizeTargetSymbols() {
     m_pIRelativeEnd->setValue(
         getRelaPLT()->getOutputSection()->getSection()->addr() +
         getRelaPLT()->getOutputSection()->getSection()->size());
+    addSectionInfo(m_pIRelativeStart, getRelaPLT());
+    addSectionInfo(m_pIRelativeEnd, getRelaPLT());
   }
   return true;
 }

--- a/lib/Target/ARM/ARMRelocator.cpp
+++ b/lib/Target/ARM/ARMRelocator.cpp
@@ -334,13 +334,6 @@ void ARMRelocator::scanLocalReloc(InputFile &pInput, Relocation::Type Type,
 
   switch (Type) {
 
-  // Set R_ARM_TARGET1 to R_ARM_ABS32
-  // Ref: GNU gold 1.11 arm.cc, line 9892
-  // FIXME: R_ARM_TARGET1 should be set by option --target1-rel
-  // or --target1-rel
-  case llvm::ELF::R_ARM_TARGET1:
-    pReloc.setType(llvm::ELF::R_ARM_ABS32);
-    LLVM_FALLTHROUGH;
   case llvm::ELF::R_ARM_ABS32:
   case llvm::ELF::R_ARM_ABS32_NOI: {
     // If building PIC object (shared library or PIC executable),
@@ -497,13 +490,6 @@ void ARMRelocator::scanGlobalReloc(InputFile &pInput, Relocation::Type Type,
   ResolveInfo *rsym = pReloc.symInfo();
 
   switch (Type) {
-  // Set R_ARM_TARGET1 to R_ARM_ABS32
-  // Ref: GNU gold 1.11 arm.cc, line 9892
-  // FIXME: R_ARM_TARGET1 should be set by option --target1-rel
-  // or --target1-rel
-  case llvm::ELF::R_ARM_TARGET1:
-    pReloc.setType(llvm::ELF::R_ARM_ABS32);
-    LLVM_FALLTHROUGH;
   case llvm::ELF::R_ARM_ABS32:
   case llvm::ELF::R_ARM_ABS16:
   case llvm::ELF::R_ARM_ABS12:
@@ -655,16 +641,6 @@ void ARMRelocator::scanGlobalReloc(InputFile &pInput, Relocation::Type Type,
     if (rsym->reserved() & ReservePLT)
       return;
 
-    // create IRELATIVE for IFUNC symbol
-    if ((rsym->type() == ResolveInfo::IndirectFunc) &&
-        (config().isCodeStatic())) {
-      m_Target.createPLT(Obj, rsym, true);
-      rsym->setReserved(rsym->reserved() | ReservePLT);
-      ARMGNULDBackend &backend = getTarget();
-      backend.defineIRelativeRange(*rsym);
-      return;
-    }
-
     // if symbol is defined in the output file and it's not
     // preemptible, no need plt
     if (!getTarget().isSymbolPreemptible(*rsym))
@@ -782,6 +758,107 @@ void ARMRelocator::scanGlobalReloc(InputFile &pInput, Relocation::Type Type,
   } // end switch
 }
 
+bool ARMRelocator::isControlFlowRelocation(Relocation::Type relocType) const {
+  switch (relocType) {
+  case llvm::ELF::R_ARM_PC24:
+  case llvm::ELF::R_ARM_CALL:
+  case llvm::ELF::R_ARM_JUMP24:
+  case llvm::ELF::R_ARM_PLT32:
+  case llvm::ELF::R_ARM_THM_CALL:
+  case llvm::ELF::R_ARM_THM_JUMP24:
+  case llvm::ELF::R_ARM_THM_JUMP19:
+  case llvm::ELF::R_ARM_THM_JUMP11:
+  case llvm::ELF::R_ARM_THM_JUMP8:
+  case llvm::ELF::R_ARM_THM_JUMP6:
+    return true;
+  }
+  return false;
+}
+
+bool ARMRelocator::isAbsDataRelocation(Relocation::Type relocType) const {
+  switch (relocType) {
+  case llvm::ELF::R_ARM_ABS8:
+  case llvm::ELF::R_ARM_ABS16:
+  case llvm::ELF::R_ARM_ABS32:
+  case llvm::ELF::R_ARM_ABS32_NOI:
+  case llvm::ELF::R_ARM_TARGET1:
+    return true;
+  }
+  return false;
+}
+
+bool ARMRelocator::isAbsOrPCRELAddressInstrRelocation(
+    Relocation::Type relocType) const {
+  switch (relocType) {
+  case llvm::ELF::R_ARM_REL32:
+  case llvm::ELF::R_ARM_PREL31:
+  case llvm::ELF::R_ARM_MOVW_ABS_NC:
+  case llvm::ELF::R_ARM_MOVT_ABS:
+  case llvm::ELF::R_ARM_MOVW_PREL_NC:
+  case llvm::ELF::R_ARM_MOVT_PREL:
+  case llvm::ELF::R_ARM_THM_MOVW_ABS_NC:
+  case llvm::ELF::R_ARM_THM_MOVT_ABS:
+  case llvm::ELF::R_ARM_THM_MOVW_PREL_NC:
+  case llvm::ELF::R_ARM_THM_MOVT_PREL:
+    return true;
+  }
+  return false;
+}
+
+bool ARMRelocator::isRegularGOTInstrRelocation(
+    Relocation::Type relocType) const {
+  switch (relocType) {
+  case llvm::ELF::R_ARM_GOT_BREL:
+  case llvm::ELF::R_ARM_GOT_ABS:
+  case llvm::ELF::R_ARM_GOT_PREL:
+    return true;
+  }
+  return false;
+}
+
+bool ARMRelocator::isUnsupportedIFuncRelocation(
+    Relocation::Type relocType) const {
+  switch (relocType) {
+  case llvm::ELF::R_ARM_THM_JUMP19:
+  case llvm::ELF::R_ARM_THM_JUMP11:
+  case llvm::ELF::R_ARM_THM_JUMP8:
+    return true;
+  }
+  return false;
+}
+
+void ARMRelocator::handleScanForNonPreemptibleIFunc(Relocation &R,
+                                                    ELFObjectFile *Obj) {
+  std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
+  ResolveInfo *RI = R.symInfo();
+  Relocation::Type RType = R.type();
+
+  bool isValidRelocForIFunc = isControlFlowRelocation(RType) ||
+                              isAbsDataRelocation(RType) ||
+                              isAbsOrPCRELAddressInstrRelocation(RType) ||
+                              isRegularGOTInstrRelocation(RType);
+  if (!isValidRelocForIFunc)
+    config().raise(Diag::warn_invalid_reloc_for_ifunc)
+        << getName(RType)
+        << RI->getDecoratedName(config().options().shouldDemangle());
+
+  if (isUnsupportedIFuncRelocation(RType))
+    config().raise(Diag::warn_unsupported_reloc_for_ifunc)
+        << getName(RType)
+        << RI->getDecoratedName(config().options().shouldDemangle());
+
+  if (isRegularGOTInstrRelocation(RType))
+    RI->setIFuncNeedsGOT();
+  if (isAbsDataRelocation(RType) || isAbsOrPCRELAddressInstrRelocation(RType))
+    RI->setIFuncDirectRef();
+
+  if (RI->reserved() & ReservePLT)
+    return;
+  m_Target.createPLT(Obj, RI, /*isIRelative=*/true);
+  m_Target.defineIRelativeRange(*RI);
+  RI->setReserved(RI->reserved() | ReservePLT);
+}
+
 void ARMRelocator::scanRelocation(Relocation &pReloc, eld::IRBuilder &pBuilder,
                                   ELFSection &pSection, InputFile &pInputFile,
                                   CopyRelocs &CopyRelocs) {
@@ -826,6 +903,10 @@ void ARMRelocator::scanRelocation(Relocation &pReloc, eld::IRBuilder &pBuilder,
   if (!section->isAlloc())
     return;
 
+  if (pReloc.type() == llvm::ELF::R_ARM_TARGET1) {
+    pReloc.setType(llvm::ELF::R_ARM_ABS32);
+  }
+
   Relocation::Type Type = pReloc.type();
 
   // Set R_ARM_TARGET2 to R_ARM_ABS32/R_ARM_REL32/R_ARM_GOT_PREL.
@@ -842,6 +923,14 @@ void ARMRelocator::scanRelocation(Relocation &pReloc, eld::IRBuilder &pBuilder,
       break;
     }
   }
+
+  ELFObjectFile *Obj = llvm::dyn_cast<ELFObjectFile>(&pInputFile);
+
+  // A reference to a non-preemptible IFunc in a static link is resolved
+  // through an IRELATIVE PLT entry regardless of whether the symbol is local
+  // or global.
+  if (rsym->isIFunc() && config().isCodeStatic())
+    return handleScanForNonPreemptibleIFunc(pReloc, Obj);
 
   if (rsym->isLocal()) // rsym is local
     scanLocalReloc(pInputFile, Type, pReloc, *section);
@@ -979,11 +1068,24 @@ Relocator::Result gotoff32(Relocation &pReloc, ARMRelocator &pParent) {
 // R_ARM_GOT_BREL: GOT(S) + A - GOT_ORG
 Relocator::Result got_brel(Relocation &pReloc, ARMRelocator &pParent) {
   DiagnosticEngine *DiagEngine = pParent.config().getDiagEngine();
-  if (!(pReloc.symInfo()->reserved() & Relocator::ReserveGOT))
+  ResolveInfo *rsym = pReloc.symInfo();
+  bool isStaticIFunc = rsym->isIFunc() && pParent.config().isCodeStatic();
+  // For a static-context ifunc, the GOT reference resolves to its dedicated
+  // GOT slot when one exists (direct reference present, for pointer equality);
+  // otherwise it falls back to the GOTPLT slot of PLT[ifunc].
+  if ((!isStaticIFunc && !(rsym->reserved() & Relocator::ReserveGOT)) ||
+      (isStaticIFunc && !(rsym->reserved() & Relocator::ReservePLT)))
     return Relocator::BadReloc;
 
-  Relocator::Address GOT_S =
-      pParent.getTarget().findEntryInGOT(pReloc.symInfo())->getAddr(DiagEngine);
+  GOT *G = pParent.getTarget().findEntryInGOT(rsym);
+  if (!G) {
+    ASSERT(isStaticIFunc,
+           "Non-ifunc symbols reaching here must always have a GOT entry!");
+    ARMPLT *P = pParent.getTarget().findEntryInPLT(rsym);
+    G = P->getGOT();
+  }
+  Relocator::Address GOT_S = G->getAddr(DiagEngine);
+
   Relocator::DWord A = pReloc.target() + pReloc.addend();
   Relocator::Address GOT_ORG = pParent.getTarget().getGOTSymbolAddr();
   // Apply relocation.
@@ -995,11 +1097,21 @@ Relocator::Result got_brel(Relocation &pReloc, ARMRelocator &pParent) {
 // R_ARM_GOT_PREL: GOT(S) + A - P
 Relocator::Result got_prel(Relocation &pReloc, ARMRelocator &pParent) {
   DiagnosticEngine *DiagEngine = pParent.config().getDiagEngine();
-  if (!(pReloc.symInfo()->reserved() & Relocator::ReserveGOT)) {
+  ResolveInfo *rsym = pReloc.symInfo();
+  bool isStaticIFunc = rsym->isIFunc() && pParent.config().isCodeStatic();
+  if ((!isStaticIFunc && !(rsym->reserved() & Relocator::ReserveGOT)) ||
+      (isStaticIFunc && !(rsym->reserved() & Relocator::ReservePLT))) {
     return Relocator::BadReloc;
   }
-  Relocator::Address GOT_S =
-      pParent.getTarget().findEntryInGOT(pReloc.symInfo())->getAddr(DiagEngine);
+  GOT *G = pParent.getTarget().findEntryInGOT(rsym);
+  if (!G) {
+    ASSERT(isStaticIFunc,
+           "Non-ifunc symbols reaching here must always have a GOT entry!");
+    ARMPLT *P = pParent.getTarget().findEntryInPLT(rsym);
+    G = P->getGOT();
+  }
+  Relocator::Address GOT_S = G->getAddr(DiagEngine);
+
   Relocator::DWord A = pReloc.addend() + pReloc.target();
   Relocator::Address P = pReloc.place(pParent.module());
 
@@ -1318,6 +1430,14 @@ Relocator::Result movw_prel_nc(Relocation &pReloc, ARMRelocator &pParent) {
       helper_extract_movw_movt_addend(pReloc.target()) + pReloc.addend();
   if (T != 0x0)
     helper_clear_thumb_bit(S);
+  ResolveInfo *rsym = pReloc.symInfo();
+  bool isStaticIFunc =
+      (rsym && rsym->isIFunc() && pParent.config().isCodeStatic());
+  if (isStaticIFunc) {
+    DiagnosticEngine *DiagEngine = pParent.config().getDiagEngine();
+    S = pParent.getTarget().findEntryInPLT(rsym)->getAddr(DiagEngine);
+    T = 0;
+  }
   Relocator::DWord X = ((S + A) | T) - P;
   pReloc.target() = helper_insert_val_movw_movt_inst(pReloc.target(), X);
   return Relocator::OK;
@@ -1356,6 +1476,12 @@ Relocator::Result movt_prel(Relocation &pReloc, ARMRelocator &pParent) {
   Relocator::DWord P = pReloc.place(pParent.module());
   Relocator::DWord A =
       helper_extract_movw_movt_addend(pReloc.target()) + pReloc.addend();
+  ResolveInfo *rsym = pReloc.symInfo();
+  bool isStaticIFunc =
+      (rsym && rsym->isIFunc() && pParent.config().isCodeStatic());
+  if (isStaticIFunc)
+    S = pParent.getTarget().findEntryInPLT(rsym)->getAddr(
+        pParent.config().getDiagEngine());
   Relocator::DWord X = S + A - P;
   X >>= 16;
 
@@ -1413,6 +1539,14 @@ Relocator::Result thm_movw_prel_nc(Relocation &pReloc, ARMRelocator &pParent) {
   Relocator::DWord val = ((upper_inst) << 16) | (lower_inst);
   Relocator::DWord A =
       helper_extract_thumb_movw_movt_addend(val) + pReloc.addend();
+  ResolveInfo *rsym = pReloc.symInfo();
+  bool isStaticIFunc =
+      (rsym && rsym->isIFunc() && pParent.config().isCodeStatic());
+  if (isStaticIFunc) {
+    DiagnosticEngine *DiagEngine = pParent.config().getDiagEngine();
+    S = pParent.getTarget().findEntryInPLT(rsym)->getAddr(DiagEngine);
+    T = 0;
+  }
   Relocator::DWord X = ((S + A) | T) - P;
 
   val = helper_insert_val_thumb_movw_movt_inst(val, X);
@@ -1492,6 +1626,12 @@ Relocator::Result thm_movt_prel(Relocation &pReloc, ARMRelocator &pParent) {
   Relocator::DWord val = ((upper_inst) << 16) | (lower_inst);
   Relocator::DWord A =
       helper_extract_thumb_movw_movt_addend(val) + pReloc.addend();
+  ResolveInfo *rsym = pReloc.symInfo();
+  bool isStaticIFunc =
+      (rsym && rsym->isIFunc() && pParent.config().isCodeStatic());
+  if (isStaticIFunc)
+    S = pParent.getTarget().findEntryInPLT(rsym)->getAddr(
+        pParent.config().getDiagEngine());
   Relocator::DWord X = S + A - P;
   X >>= 16;
 

--- a/lib/Target/ARM/ARMRelocator.h
+++ b/lib/Target/ARM/ARMRelocator.h
@@ -80,6 +80,35 @@ private:
                        eld::IRBuilder &pBuilder, ELFSection &pSection,
                        CopyRelocs &);
 
+  /// Handle a relocation that references a non-preemptible STT_GNU_IFUNC
+  /// symbol in a static link. Classifies the relocation, records whether
+  /// the ifunc needs a GOT slot and/or has a direct reference, and
+  /// reserves an IRELATIVE PLT entry for it.
+  void handleScanForNonPreemptibleIFunc(Relocation &R, ELFObjectFile *Obj);
+
+  /// Returns true if the relocation is a control-flow (call/branch)
+  /// relocation.
+  bool isControlFlowRelocation(Relocation::Type relocType) const;
+
+  /// Returns true if the relocation is an absolute relocation designed for
+  /// the data section of the program.
+  bool isAbsDataRelocation(Relocation::Type relocType) const;
+
+  /// Returns true if the relocation is used for computing an absolute or a
+  /// PC-relative address using one or more instructions (e.g. a MOVW/MOVT
+  /// pair, or a REL32 / PREL31 word).
+  bool isAbsOrPCRELAddressInstrRelocation(Relocation::Type relocType) const;
+
+  /// Returns true if the relocation is a non-TLS instruction relocation
+  /// whose computation uses the GOT entry of the symbol.
+  bool isRegularGOTInstrRelocation(Relocation::Type relocType) const;
+
+  /// Returns true if the relocation would be valid against an STT_GNU_IFUNC
+  /// symbol in principle but cannot hold a PLT stub address, so eld does not
+  /// support it for an ifunc target. Used by
+  /// handleScanForNonPreemptibleIFunc to emit a diagnostic.
+  bool isUnsupportedIFuncRelocation(Relocation::Type relocType) const;
+
   bool isDynamicRelocSupported(const Relocation &reloc) const override;
 
   uint32_t relocType() const override { return llvm::ELF::SHT_REL; }

--- a/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/abs.c
+++ b/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/abs.c
@@ -1,0 +1,7 @@
+/* Take the address of the IFUNC `foo` as data: emits R_ARM_ABS32. */
+
+int foo();
+
+int (*foo_gp)() = foo;
+
+int (*get_foo_from_outside())() { return foo_gp; }

--- a/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/call.c
+++ b/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/call.c
@@ -1,0 +1,5 @@
+/* Call the IFUNC `foo` directly: emits R_ARM_CALL. */
+
+extern int foo();
+
+int call_foo_from_outside() { return foo(); }

--- a/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/got-and-direct.c
+++ b/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/got-and-direct.c
@@ -1,0 +1,15 @@
+/* Provides BOTH a direct (R_ARM_ABS32) and a GOT-based (R_ARM_GOT_PREL)
+ * reference to the IFUNC `foo`, in separate functions. Because the linker
+ * sees both IFuncDirectRef and IFuncNeedsGOT for `foo`, it materializes a
+ * dedicated regular GOT slot holding PLT[foo] so that the GOT-loaded pointer
+ * equals the direct-reference pointer (pointer equality). The references live
+ * in a different translation unit than `foo`'s definition so the assembler
+ * cannot fold them to the resolver address. */
+
+int foo();
+
+int (*foo_gp)() = foo; /* R_ARM_ABS32: direct data reference */
+
+int (*get_foo_direct())() { return foo_gp; }
+
+int (*get_foo_via_got())() { return foo; } /* R_ARM_GOT_PREL: GOT reference */

--- a/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/got.c
+++ b/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/got.c
@@ -1,0 +1,6 @@
+/* Take the address of the IFUNC `foo` through the GOT (compiler-emitted
+ * R_ARM_GOT_PREL when built with -fPIC). */
+
+int foo();
+
+int (*get_foo_from_outside())() { return foo; }

--- a/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/jump.s
+++ b/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/jump.s
@@ -1,0 +1,10 @@
+// Tail-call the IFUNC `foo` via an unconditional branch: emits R_ARM_JUMP24.
+
+  .text
+  .global call_foo_from_outside
+  .type call_foo_from_outside, %function
+
+call_foo_from_outside:
+  b foo
+
+  .size call_foo_from_outside, .-call_foo_from_outside

--- a/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/main-call.c
+++ b/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/main-call.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+
+int foo_impl() { return 11; }
+
+int (*foo_resolver())() { return foo_impl; }
+
+__attribute__((ifunc("foo_resolver"))) int foo();
+
+int call_foo_from_outside();
+
+int main() {
+  int foo_value_from_outside = call_foo_from_outside();
+  printf("%d %d\n", foo(), foo_value_from_outside);
+  return 0;
+}

--- a/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/main-got.c
+++ b/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/main-got.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+
+int foo_impl() { return 11; }
+
+int (*foo_resolver())() { return foo_impl; }
+
+__attribute__((ifunc("foo_resolver"))) int foo();
+
+int (*get_foo_direct())();
+int (*get_foo_via_got())();
+
+int main() {
+  int (*foo_direct)() = get_foo_direct();
+  int (*foo_via_got)() = get_foo_via_got();
+  printf("%d %d %d\n", foo(), foo_direct(), foo_via_got());
+  /* The direct (PLT) and GOT-loaded pointers must be equal. */
+  printf("%p %p %p\n", (void *)foo, (void *)foo_direct, (void *)foo_via_got);
+  return 0;
+}

--- a/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/main-local.c
+++ b/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/main-local.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+
+static int foo_impl() { return 11; }
+
+static int (*foo_resolver())() { return foo_impl; }
+
+__attribute__((ifunc("foo_resolver"))) static int foo();
+
+int (*foo_gp)() = foo;
+
+int main() {
+  int (*foo_lp)() = foo;
+  printf("%d %d %d\n", foo(), foo_lp(), foo_gp());
+  printf("%p %p %p\n", (void *)&foo, (void *)foo_lp, (void *)foo_gp);
+  return 0;
+}

--- a/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/main.c
+++ b/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/main.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+int foo_impl() { return 11; }
+
+int (*foo_resolver())() { return foo_impl; }
+
+__attribute__((ifunc("foo_resolver"))) int foo();
+
+int (*get_foo_from_outside())();
+
+int main() {
+  int (*foo_lp)() = foo;
+  int (*foo_outside)() = get_foo_from_outside();
+  printf("%d %d %d\n", foo(), foo_lp(), foo_outside());
+  printf("%p %p %p\n", (void *)&foo, (void *)foo_lp, (void *)foo_outside);
+  return 0;
+}

--- a/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/movw-movt-abs.s
+++ b/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/movw-movt-abs.s
@@ -1,0 +1,15 @@
+// Take the address of the IFUNC `foo` via a MOVW/MOVT pair forming the
+// absolute address: emits R_ARM_MOVW_ABS_NC + R_ARM_MOVT_ABS. Valid only
+// in a non-PIC link.
+
+  .arch armv7-a
+  .text
+  .global get_foo_from_outside
+  .type get_foo_from_outside, %function
+
+get_foo_from_outside:
+  movw r0, #:lower16:foo
+  movt r0, #:upper16:foo
+  bx lr
+
+  .size get_foo_from_outside, .-get_foo_from_outside

--- a/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/movw-movt-prel.s
+++ b/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/movw-movt-prel.s
@@ -1,0 +1,16 @@
+// Take the address of the IFUNC `foo` via a PC-relative MOVW/MOVT pair
+// (position-independent): emits R_ARM_MOVW_PREL_NC + R_ARM_MOVT_PREL.
+
+  .arch armv7-a
+  .text
+  .global get_foo_from_outside
+  .type get_foo_from_outside, %function
+
+get_foo_from_outside:
+  movw r0, #:lower16:(foo - (.LPC0 + 8))
+  movt r0, #:upper16:(foo - (.LPC0 + 8))
+.LPC0:
+  add r0, pc, r0
+  bx lr
+
+  .size get_foo_from_outside, .-get_foo_from_outside

--- a/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/target1.s
+++ b/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/target1.s
@@ -1,0 +1,16 @@
+// Take the address of the IFUNC `foo` as data via R_ARM_TARGET1, which eld
+// treats as R_ARM_ABS32 (a direct reference). Emitted explicitly with .reloc
+// since the compiler does not generate R_ARM_TARGET1 directly.
+
+  .text
+  .global get_foo_from_outside
+  .type get_foo_from_outside, %function
+
+get_foo_from_outside:
+  ldr r0, .Lfoo_ptr
+  bx lr
+.Lfoo_ptr:
+  .reloc ., R_ARM_TARGET1, foo
+  .word 0
+
+  .size get_foo_from_outside, .-get_foo_from_outside

--- a/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/thm-call.s
+++ b/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/thm-call.s
@@ -1,0 +1,16 @@
+// Call the IFUNC `foo` from Thumb code: emits R_ARM_THM_CALL.
+
+  .arch armv7-a
+  .syntax unified
+  .thumb
+  .text
+  .global call_foo_from_outside
+  .thumb_func
+  .type call_foo_from_outside, %function
+
+call_foo_from_outside:
+  push {lr}
+  bl foo
+  pop {pc}
+
+  .size call_foo_from_outside, .-call_foo_from_outside

--- a/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/thm-jump24.s
+++ b/test/ARM/RunTests/IFunc/StaticIFunc/Inputs/thm-jump24.s
@@ -1,0 +1,15 @@
+// Tail-call the IFUNC `foo` from Thumb code via a wide unconditional branch:
+// emits R_ARM_THM_JUMP24.
+
+  .syntax unified
+  .arch armv7-a
+  .thumb
+  .text
+  .global call_foo_from_outside
+  .thumb_func
+  .type call_foo_from_outside, %function
+
+call_foo_from_outside:
+  b.w foo
+
+  .size call_foo_from_outside, .-call_foo_from_outside

--- a/test/ARM/RunTests/IFunc/StaticIFunc/StaticIFunc.test
+++ b/test/ARM/RunTests/IFunc/StaticIFunc/StaticIFunc.test
@@ -1,0 +1,165 @@
+#---StaticIFunc.test---------------------------------- Executable --------------------#
+#BEGIN_COMMENT
+# This test checks that the IFunc functionality works correctly for static ARM
+# executables. This test covers the following relocations:
+# - control-flow (R_ARM_CALL / R_ARM_JUMP24 / R_ARM_THM_CALL / R_ARM_THM_JUMP24),
+# - absolute data (R_ARM_ABS32, R_ARM_TARGET1),
+# - GOT-based (R_ARM_GOT_PREL), and
+# - PC-relative / absolute address-forming MOVW/MOVT pairs (R_ARM_MOVW_*).
+# Each input file exercises exactly one relocation kind, linked against both a
+# non-PIC and a PIC build of the driver.
+#
+# The test asserts that:
+#  - all calls reach the resolved implementation (returns 11),
+#  - the IFunc address is the same wherever it is taken (pointer equality:
+#    &foo in the driver == the address obtained from another TU),
+#  - a regular GOT entry for the IFunc symbol is created (CHECK_GOT) exactly
+#    when the symbol has BOTH a direct and a GOT reference across the link, and
+#    is NOT created (CHECK_NO_GOT) otherwise.
+#
+# Note on how the driver references foo (`int (*foo_lp)() = foo;`):
+#  - built non-PIC (-fno-PIC), &foo emits R_ARM_ABS32  (a direct reference),
+#  - built PIC (-fPIC),        &foo emits R_ARM_GOT_PREL (a GOT reference).
+# So a single input file that holds a direct reference (abs / movw-movt) creates
+# the dedicated pointer-equality GOT entry only in the PIC driver build (direct
+# + GOT), whereas a GOT-based input file (got.c) creates it only in the non-PIC
+# driver build.
+#END_COMMENT
+#START_TEST
+
+RUN: %run_cc -o %t1.main.nopic.o %p/Inputs/main.c -c -fno-PIC
+RUN: %run_cc -o %t1.main.pic.o   %p/Inputs/main.c -c -fPIC
+
+RUN: %run_cc -o %t1.main-call.nopic.o %p/Inputs/main-call.c -c -fno-PIC
+RUN: %run_cc -o %t1.main-call.pic.o   %p/Inputs/main-call.c -c -fPIC
+
+# --- abs.c: R_ARM_ABS32 (absolute data reference / direct ref). --------------
+RUN: %run_cc -o %t1.abs.o %p/Inputs/abs.c -c
+RUN: %run_cc -o %t1.nopic.abs.out %t1.main.nopic.o %t1.abs.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run_cc -o %t1.pic.abs.out   %t1.main.pic.o   %t1.abs.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_GOT
+RUN: %run %t1.nopic.abs.out | %filecheck %s
+RUN: %run %t1.pic.abs.out   | %filecheck %s
+
+# --- target1.s: R_ARM_TARGET1, treated as R_ARM_ABS32 (a direct ref). Same
+# direct-reference pattern as abs.c: a regular GOT entry is created only in the
+# PIC driver build (driver's GOT ref + target1's direct ref).
+RUN: %run_cc -o %t1.target1.o %p/Inputs/target1.s -c
+RUN: %run_cc -o %t1.nopic.target1.out %t1.main.nopic.o %t1.target1.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run_cc -o %t1.pic.target1.out   %t1.main.pic.o   %t1.target1.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_GOT
+RUN: %run %t1.nopic.target1.out | %filecheck %s
+RUN: %run %t1.pic.target1.out   | %filecheck %s
+
+# --- got.c: R_ARM_GOT_PREL (GOT-based reference, compiler-emitted with -fPIC).
+RUN: %run_cc -o %t1.got.o %p/Inputs/got.c -c -fPIC
+RUN: %run_cc -o %t1.nopic.got.out %t1.main.nopic.o %t1.got.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_GOT
+RUN: %run_cc -o %t1.pic.got.out   %t1.main.pic.o   %t1.got.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run %t1.nopic.got.out | %filecheck %s
+RUN: %run %t1.pic.got.out   | %filecheck %s
+
+# --- movw-movt-abs.s: R_ARM_MOVW_ABS_NC + R_ARM_MOVT_ABS (direct ref). --------
+RUN: %run_cc -o %t1.movabs.o %p/Inputs/movw-movt-abs.s -c
+RUN: %run_cc -o %t1.nopic.movabs.out %t1.main.nopic.o %t1.movabs.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run_cc -o %t1.pic.movabs.out   %t1.main.pic.o   %t1.movabs.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_GOT
+RUN: %run %t1.nopic.movabs.out | %filecheck %s
+RUN: %run %t1.pic.movabs.out   | %filecheck %s
+
+# --- movw-movt-prel.s: R_ARM_MOVW_PREL_NC + R_ARM_MOVT_PREL (direct ref). -----
+RUN: %run_cc -o %t1.movprel.o %p/Inputs/movw-movt-prel.s -c
+RUN: %run_cc -o %t1.nopic.movprel.out %t1.main.nopic.o %t1.movprel.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run_cc -o %t1.pic.movprel.out   %t1.main.pic.o   %t1.movprel.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_GOT
+RUN: %run %t1.nopic.movprel.out | %filecheck %s
+RUN: %run %t1.pic.movprel.out   | %filecheck %s
+
+# --- call.c: R_ARM_CALL (direct call). ---------------------------------------
+# Control-flow inputs only call foo, so foo never has both a direct and a GOT
+# reference -> no regular GOT entry in either build.
+RUN: %run_cc -o %t1.call.o %p/Inputs/call.c -c
+RUN: %run_cc -o %t1.nopic.call.out %t1.main-call.nopic.o %t1.call.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run_cc -o %t1.pic.call.out   %t1.main-call.pic.o   %t1.call.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run %t1.nopic.call.out | %filecheck %s --check-prefix=CALL_FROM_OUTSIDE
+RUN: %run %t1.pic.call.out   | %filecheck %s --check-prefix=CALL_FROM_OUTSIDE
+
+# --- jump.s: R_ARM_JUMP24 (tail-call branch). --------------------------------
+RUN: %run_cc -o %t1.jump.o %p/Inputs/jump.s -c
+RUN: %run_cc -o %t1.nopic.jump.out %t1.main-call.nopic.o %t1.jump.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run_cc -o %t1.pic.jump.out   %t1.main-call.pic.o   %t1.jump.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run %t1.nopic.jump.out | %filecheck %s --check-prefix=CALL_FROM_OUTSIDE
+RUN: %run %t1.pic.jump.out   | %filecheck %s --check-prefix=CALL_FROM_OUTSIDE
+
+# --- thm-call.s: R_ARM_THM_CALL (Thumb call). --------------------------------
+RUN: %run_cc -o %t1.thmcall.o %p/Inputs/thm-call.s -c
+RUN: %run_cc -o %t1.nopic.thmcall.out %t1.main-call.nopic.o %t1.thmcall.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run_cc -o %t1.pic.thmcall.out   %t1.main-call.pic.o   %t1.thmcall.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run %t1.nopic.thmcall.out | %filecheck %s --check-prefix=CALL_FROM_OUTSIDE
+RUN: %run %t1.pic.thmcall.out   | %filecheck %s --check-prefix=CALL_FROM_OUTSIDE
+
+# --- thm-jump24.s: R_ARM_THM_JUMP24 (Thumb wide tail-call branch). -----------
+RUN: %run_cc -o %t1.thmjump24.o %p/Inputs/thm-jump24.s -c
+RUN: %run_cc -o %t1.nopic.thmjump24.out %t1.main-call.nopic.o %t1.thmjump24.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run_cc -o %t1.pic.thmjump24.out   %t1.main-call.pic.o   %t1.thmjump24.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run %t1.nopic.thmjump24.out | %filecheck %s --check-prefix=CALL_FROM_OUTSIDE
+RUN: %run %t1.pic.thmjump24.out   | %filecheck %s --check-prefix=CALL_FROM_OUTSIDE
+
+# --- got-and-direct.c: BOTH R_ARM_ABS32 (direct) and R_ARM_GOT_PREL (GOT) for
+# the same IFunc symbol, in a single TU separate from foo's definition. The
+# linker always sees both reference kinds, so it materializes a regular GOT
+# entry for `foo` (CHECK_GOT) holding PLT[foo] in both builds.
+RUN: %run_cc -o %t1.gd.o %p/Inputs/got-and-direct.c -c -fPIC
+RUN: %run_cc -o %t1.main-got.nopic.o %p/Inputs/main-got.c -c -fno-PIC
+RUN: %run_cc -o %t1.main-got.pic.o   %p/Inputs/main-got.c -c -fPIC
+RUN: %run_cc -o %t1.nopic.gd.out %t1.main-got.nopic.o %t1.gd.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_GOT
+RUN: %run_cc -o %t1.pic.gd.out   %t1.main-got.pic.o   %t1.gd.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_GOT
+RUN: %run %t1.nopic.gd.out | %filecheck %s
+RUN: %run %t1.pic.gd.out   | %filecheck %s
+
+# --- local ifunc symbol -------------------------
+# local_foo has visibility("hidden") making it non-preemptible, which exercises
+# the same IFunc PLT path as a LOCAL IFunc. The file is self-contained.
+RUN: %run_cc -o %t1.main-local.nopic.o %p/Inputs/main-local.c -c -fno-PIC
+RUN: %run_cc -o %t1.main-local.pic.o   %p/Inputs/main-local.c -c -fPIC
+RUN: %run_cc -o %t1.main-local.nopic.out %t1.main-local.nopic.o -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %run_cc -o %t1.main-local.pic.out   %t1.main-local.pic.o   -static \
+RUN:   -Wl,--trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_GOT
+RUN: %run %t1.main-local.nopic.out | %filecheck %s
+RUN: %run %t1.main-local.pic.out   | %filecheck %s
+
+#END_TEST
+
+# main.c output: foo() == foo_lp() == foo_outside() == 11, and the three IFunc
+# addresses (&foo, foo_lp = foo, and the address obtained from another TU) are
+# all equal (pointer equality).
+CHECK: 11 11 11
+CHECK: [[FOO_ADDR:0x[0-9a-fA-F]+]] [[FOO_ADDR]] [[FOO_ADDR]]
+
+# main-call.c output: foo() == call_foo_from_outside() == 11.
+CALL_FROM_OUTSIDE: 11 11
+
+# When an IFunc symbol is referenced both directly (resolving to PLT[foo]) and
+# through the GOT, eld creates a dedicated regular GOT entry for it so that
+# GOT-loaded pointers equal the direct pointers (pointer equality).
+CHECK_GOT: Created GOT Entry for Symbol foo{{$}}
+
+# Otherwise (only direct refs, only GOT refs, or only control-flow refs) no
+# dedicated regular GOT entry for the IFunc is needed.
+CHECK_NO_GOT-NOT: Created GOT Entry for Symbol foo{{$}}

--- a/test/ARM/RunTests/lit.local.cfg
+++ b/test/ARM/RunTests/lit.local.cfg
@@ -1,0 +1,2 @@
+if not 'run_test' in config.available_features:
+    config.unsupported = True

--- a/test/ARM/standalone/IFunc/IFunc.test
+++ b/test/ARM/standalone/IFunc/IFunc.test
@@ -8,7 +8,8 @@ UNSUPPORTED: ndk-build
 #START_TEST
 RUN: %clang %clangopts -target arm -fPIC -c %p/Inputs/m.c -o %tm.o
 RUN: %clang %clangopts -target arm -fPIC -c %p/Inputs/t.c -o %tt.o
-RUN: %link %linkopts -march arm %tm.o %tt.o -o %t.out
+RUN: %link %linkopts -march arm %tm.o %tt.o \
+RUN:   --undefined=__rel_iplt_start --undefined=__rel_iplt_end -o %t.out
 RUN: %readelf -a %t.out | %filecheck --check-prefix=STANDALONE %s
 RUN: %link %linkopts -march arm %tm.o %tt.o -pie -o %t2.out
 RUN: %readelf -a %t2.out | %filecheck --check-prefix=PIE %s

--- a/test/ARM/standalone/IFuncUnsupportedRelocations/IFuncUnsupportedRelocations.test
+++ b/test/ARM/standalone/IFuncUnsupportedRelocations/IFuncUnsupportedRelocations.test
@@ -1,0 +1,29 @@
+#---IFuncUnsupportedRelocations.test-------------- Executable --------------------#
+#BEGIN_COMMENT
+# This test checks that eld emits the correct diagnostic for each of the two
+# distinct problematic relocation categories against an STT_GNU_IFUNC symbol:
+#
+# INVALID relocation: the relocation does not belong to any recognised IFunc
+#   category -- using it against an IFunc makes no semantic sense.
+#   Produces: "Warning: Invalid relocation ... used for STT_GNU_IFUNC symbol"
+#
+# UNSUPPORTED_RELOC relocation: the relocation belongs to a valid IFunc
+#   category (it should work against an IFunc) but either eld does not yet support it,
+#   or the behavior of ifunc is risky/uncertain with this relocation.
+#   Produces: "Warning: Unsupported relocation ... used for STT_GNU_IFUNC symbol"
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -target %linuxtarget -fPIC -c %p/Inputs/1.c -o %t.1.o
+
+RUN: %clang %clangopts -target %linuxtarget -c %p/Inputs/ldrpcg1.s -o %tldrpcg1.o
+RUN: %not %link %linkopts %t.1.o %tldrpcg1.o -o %t.ldrpcg1.out \
+RUN:   2>&1 | %filecheck %s --check-prefix=INVALID
+
+RUN: %clang %clangopts -target %linuxtarget -c %p/Inputs/thmjump8.s -o %tthmjump8.o
+RUN: %link %linkopts %t.1.o %tthmjump8.o -o %t.thmjump8.out \
+RUN:   2>&1 | %filecheck %s --check-prefix=UNSUPPORTED_RELOC
+
+#END_TEST
+
+UNSUPPORTED_RELOC: Warning: Unsupported relocation R_ARM_THM_JUMP8 used for STT_GNU_IFUNC symbol 'foo'
+INVALID: Warning: Invalid relocation R_ARM_LDR_PC_G1 used for STT_GNU_IFUNC symbol 'foo'

--- a/test/ARM/standalone/IFuncUnsupportedRelocations/Inputs/1.c
+++ b/test/ARM/standalone/IFuncUnsupportedRelocations/Inputs/1.c
@@ -1,0 +1,5 @@
+int foo_impl() { return 11; }
+
+int (*foo_resolver())() { return foo_impl; }
+
+__attribute__((ifunc("foo_resolver"))) int foo();

--- a/test/ARM/standalone/IFuncUnsupportedRelocations/Inputs/ldrpcg1.s
+++ b/test/ARM/standalone/IFuncUnsupportedRelocations/Inputs/ldrpcg1.s
@@ -1,0 +1,9 @@
+// Reference an IFUNC symbol with R_ARM_LDR_PC_G1.
+// This is an INVALID use: R_ARM_LDR_PC_G1 does not belong to any recognised
+// IFunc relocation category, so eld warns about an invalid relocation.
+
+  .text
+  .global ref
+ref:
+  .reloc ., R_ARM_LDR_PC_G1, foo
+  .word 0

--- a/test/ARM/standalone/IFuncUnsupportedRelocations/Inputs/thmjump8.s
+++ b/test/ARM/standalone/IFuncUnsupportedRelocations/Inputs/thmjump8.s
@@ -1,0 +1,13 @@
+// Reference an IFUNC symbol with R_ARM_THM_JUMP8 (narrow conditional Thumb
+// branch, +/-256B range). This is an UNSUPPORTED use: R_ARM_THM_JUMP8 belongs
+// to the control-flow category but eld cannot apply it to reach an IFunc PLT.
+
+  .syntax unified
+  .arch armv7-a
+  .thumb
+  .text
+  .global ref
+  .thumb_func
+ref:
+  .reloc ., R_ARM_THM_JUMP8, foo
+  nop

--- a/test/ARM/standalone/StaticIFunc/Inputs/direct.c
+++ b/test/ARM/standalone/StaticIFunc/Inputs/direct.c
@@ -1,0 +1,5 @@
+int foo();
+
+int (*foo_gp)() = foo;
+
+int (*get_foo_from_outside())() { return foo_gp; }

--- a/test/ARM/standalone/StaticIFunc/Inputs/got.c
+++ b/test/ARM/standalone/StaticIFunc/Inputs/got.c
@@ -1,0 +1,3 @@
+int foo();
+
+int (*get_foo_from_outside())() { return foo; }

--- a/test/ARM/standalone/StaticIFunc/Inputs/main-local.c
+++ b/test/ARM/standalone/StaticIFunc/Inputs/main-local.c
@@ -1,0 +1,13 @@
+static int foo_impl() { return 11; }
+
+static int (*foo_resolver())() { return foo_impl; }
+
+__attribute__((ifunc("foo_resolver"))) static int foo();
+
+int (*foo_gp)() = foo;
+
+int main() {
+  int (*foo_lp)() = foo;
+  return foo == foo_lp && foo_lp == foo_gp;
+  return 0;
+}

--- a/test/ARM/standalone/StaticIFunc/Inputs/main.c
+++ b/test/ARM/standalone/StaticIFunc/Inputs/main.c
@@ -1,0 +1,13 @@
+int foo_impl() { return 11; }
+
+int (*foo_resolver())() { return foo_impl; }
+
+__attribute__((ifunc("foo_resolver"))) int foo();
+
+int (*get_foo_from_outside())();
+
+int main() {
+  int (*foo_lp)() = foo;
+  int (*foo_outside)() = get_foo_from_outside();
+  return foo == foo_lp && foo_lp == foo_outside;
+}

--- a/test/ARM/standalone/StaticIFunc/StaticIFunc.test
+++ b/test/ARM/standalone/StaticIFunc/StaticIFunc.test
@@ -1,0 +1,46 @@
+#---IFunc.test--------------------- Executable --------------------#
+#BEGIN_COMMENT
+# This test verifies the behavior of IFunc functions in ARM static links.
+#END_COMMENT
+#START_TEST
+
+RUN: %clang %clangopts -target %linuxtarget -o %t1.main.nopic.o -c %p/Inputs/main.c -fno-pic
+RUN: %clang %clangopts -target %linuxtarget -o %t1.main.pic.o -c %p/Inputs/main.c -fPIC
+
+# --- Case 1: direct reference only (R_ARM_ABS32). ----------------------------
+RUN: %clang %clangopts -target %linuxtarget -o %tdirect.o -c %p/Inputs/direct.c -fno-pic
+RUN: %link %linkopts -o %t1.nopic.direct.out %t1.main.nopic.o %tdirect.o \
+RUN:   --undefined=__rel_iplt_start --undefined=__rel_iplt_end \
+RUN:   --trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %readelf -s %t1.nopic.direct.out | %filecheck %s --check-prefix=READELF
+
+# --- Case 2: GOT reference only (R_ARM_GOT_BREL). ----------------------------
+RUN: %clang %clangopts -target %linuxtarget -c %p/Inputs/got.c -o %tgot.o -fPIC
+RUN: %link %linkopts -o %t1.pic.got.out %t1.main.pic.o %tgot.o \
+RUN:   --undefined=__rel_iplt_start --undefined=__rel_iplt_end \
+RUN:   --trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+RUN: %readelf -s %t1.pic.got.out | %filecheck %s --check-prefix=READELF
+
+# --- Case 3: both direct and GOT references. ---------------------------------
+RUN: %link %linkopts -o %t1.nopic.got.out %tgot.o %t1.main.nopic.o \
+RUN:   --undefined=__rel_iplt_start --undefined=__rel_iplt_end \
+RUN:   --trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_GOT
+RUN: %readelf -s %t1.nopic.got.out | %filecheck %s --check-prefix=READELF
+
+# --- Case 4: local ifunc and only direct reference ---------------------------------
+RUN: %clang %clangopts -target %linuxtarget -o %t1.main-local.nopic.o -c %p/Inputs/main-local.c -fno-pic
+RUN: %link %linkopts -o %t1.main-local.nopic.out %t1.main-local.nopic.o \
+RUN:   --trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_NO_GOT
+
+# --- Case 5: local ifunc and both direct and GOT reference ---------------------------------
+RUN: %clang %clangopts -target %linuxtarget -o %t1.main-local.pic.o -c %p/Inputs/main-local.c -fPIC
+RUN: %link %linkopts -o %t1.main-local.pic.out %t1.main-local.pic.o \
+RUN:   --trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_GOT
+#END_TEST
+
+READELF: 0 NOTYPE  LOCAL  DEFAULT     [[SECT_INDEX:[1-9]]] __rel_iplt_start
+READELF: 0 NOTYPE  LOCAL  DEFAULT     [[SECT_INDEX]] __rel_iplt_end
+
+CHECK_NO_GOT-NOT: Created GOT Entry for Symbol foo{{$}}
+
+CHECK_GOT: Created GOT Entry for Symbol foo{{$}}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -275,6 +275,7 @@ if "thin_archives" in config.available_features:
 
 lsparserverifier = 'LSParserVerifier'
 lsparserverifier_opts = ""
+linuxtarget = ''
 
 if config.test_target == 'Hexagon':
     clang = 'clang -target hexagon'
@@ -380,6 +381,7 @@ if config.test_target == 'ARM':
     if config.target_triple:
         if re.match(r'.*-android', config.target_triple):
             config.available_features.add("ndk-build")
+    linuxtarget="arm-linux-gnu"
 
 if config.test_target == 'AArch64':
     if not config.target_triple:
@@ -417,7 +419,6 @@ if config.test_target == 'AArch64':
         if re.match(r'.*-android', config.target_triple):
             config.available_features.add("ndk-build")
 
-linuxtarget = ''
 if config.test_target == 'RISCV64':
     if not config.target_triple:
         config.target_triple = "riscv64-unknown-none-elf"


### PR DESCRIPTION
This commit adds GNU IFunc support for ARM32 static executables,
bringing ARM to parity with AArch64 and RISCV.

Relocations are classified into four categories (control-flow, absolute data,
PC-relative address-forming, and GOT-based). Relocations outside any
valid category is warned as invalid; those in a valid category that eld
cannot/does-not properly support is reported as unsupported.

The MOVW_PREL / THM_MOVW_PREL apply functions are fixed to redirect S to
PLT[fn] whenever PLT slot is available, matching the existing behaviour of
their ABS counterparts.

The R_ARM_TARGET1 -> R_ARM_ABS32 rewrite is centralised into
scanRelocation rather than repeated across scanLocalReloc, scanGlobalReloc,
and handleScanForNonPreemptibleIFunc.

The __rel_iplt_start / __rel_iplt_end symbols are fixed to match RISCV:
NOTYPE LOCAL DEFAULT with a section index pointing to .rel.plt, rather
than OBJECT GLOBAL ABS.

IFunc behaviour across all relevant ARM relocation categories is documented in
IFunc.md.
