### PR TITLE
[Zephyr] Scope testing to tests/ tree only

### DIFF
--- a/.github/workflows/zephyr-nightly.yml
+++ b/.github/workflows/zephyr-nightly.yml
@@ -173,6 +173,7 @@ jobs:
           export ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/
           export LLVM_TOOLCHAIN_PATH=${CPULLVM_DIR}
           west twister -W -p ${{ matrix.target.board }} \
+            -T tests \
             --inline-logs \
             --timestamps \
             -j 3 \


### PR DESCRIPTION
Twister picks up `tests/` and `samples/` directories by default. `samples/` contains demo apps, not tests, so only run tests from `tests/`.