### PR TITLE
[test] Add check-eld-summary target to aggregate lit results

### DIFF
--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -99,6 +99,11 @@ jobs:
         shell: bash
         run: cmake --build . --config Release --target check-eld
 
+      - name: Summarize test results
+        working-directory: nightly/obj
+        shell: bash
+        run: cmake --build . --config Release --target check-eld-summary
+
       - name: Update build entry
         if: github.event_name == 'schedule'
         uses: ./nightly/llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,10 @@ jobs:
 
           ninja check-eld
 
+      - name: Summarize test results
+        if: steps.file-check.outputs.skip_build == 'false'
+        working-directory: pr-${{ env.PR_NUMBER }}/obj
+        run: ninja check-eld-summary
 
       - name: Clean up
         if: always()

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -254,6 +254,11 @@ jobs:
           cd obj
           ninja -j8 check-eld
 
+      - name: Summarize test results
+        run: |
+          cd obj
+          ninja check-eld-summary
+
       - name: Update build entry
         if: github.event_name == 'schedule'
         uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder

--- a/README.md
+++ b/README.md
@@ -151,6 +151,40 @@ export ELD_AARCH64_SYSROOT=/usr/aarch64-linux-gnu
 export ELD_AARCH64_EMULATOR=qemu-aarch64
 ```
 
+### Summarizing Test Results Across Configurations
+
+After running `check-eld`, you can print a consolidated result table across all
+architecture/option configurations using the `check-eld-summary` target:
+
+```bash
+cmake --build obj -- check-eld-summary
+# or with ninja:
+ninja check-eld-summary
+```
+
+This reads the `results.json` file written by each lit sub-run and prints a
+table.
+
+If a configuration has not been run yet its row shows `(no results)`.
+`check-eld-summary` is independent of `check-eld` — it only reads result files
+and always exits successfully.
+
+#### Detailed test listing
+
+To list individual test names beneath each configuration row, set
+`ELD_SUMMARY_DETAIL=1` (shows all non-PASS codes) or
+`ELD_SUMMARY_DETAIL_CODES` (comma-separated list of codes to expand):
+
+```bash
+# Linux - PASS result codes
+ELD_SUMMARY_DETAIL=1 ninja check-eld-summary
+
+# Linux — expand only UNSUPPORTED and XFAIL
+ELD_SUMMARY_DETAIL_CODES=UNSUPPORTED,XFAIL ninja check-eld-summary
+
+# Windows (cmake --build)
+ELD_SUMMARY_DETAIL=1 cmake --build obj --config Release --target check-eld-summary
+```
 
 ### Testing Vim Integration
 

--- a/cmake/modules/LITModules.cmake
+++ b/cmake/modules/LITModules.cmake
@@ -29,12 +29,15 @@ function(add_external_eld_lit TARGET_NAME ARCH OPTION OPTIONNAME)
   string(TOLOWER ${ARCH} ARCH_LOWER)
   set(LLVM_EXTERNAL_LIT
       ${CMAKE_CURRENT_BINARY_DIR}/llvm-lit-${ARCH_LOWER}-${OPTIONNAME})
+  set(JSON_OUTPUT
+      "${CMAKE_CURRENT_BINARY_DIR}/${ARCH}-${OPTIONNAME}-config/results.json")
   add_lit_testsuite(
     ${TARGET_NAME}-test-${ARCH_LOWER}-${OPTIONNAME}
     "Running the Linker regression tests ${ADDITIONAL_TESTMSG} for option: ${OPTION} arch: ${ARCH}"
     ${CMAKE_CURRENT_BINARY_DIR}/${ARCH}-${OPTIONNAME}-config
     DEPENDS
-    ${TEST_DEPENDS})
+    ${TEST_DEPENDS}
+    ARGS --output ${JSON_OUTPUT})
   set_target_properties(${TARGET_NAME}-test-${ARCH_LOWER}-${OPTIONNAME}
                         PROPERTIES FOLDER "Tests")
   add_dependencies(${TARGET_NAME}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -78,6 +78,27 @@ add_custom_target(${TARGET_NAME})
 process_options_and_generate_lit_test_suite("${TARGET_NAME}" "${TEST_TARGETS}"
                                             "${OPTIONS}" "${OPTIONNAMES}")
 
+# Collect one JSON results path per arch+option configuration so that
+# check-eld-summary can aggregate counts into a single table.
+set(SUMMARY_JSON_FILES)
+foreach(ARCH ${TEST_TARGETS})
+  set(OPTIONCOUNT 0)
+  foreach(OPTION ${OPTIONS})
+    list(GET OPTIONNAMES ${OPTIONCOUNT} OPTIONNAME)
+    list(APPEND SUMMARY_JSON_FILES
+      "${CMAKE_CURRENT_BINARY_DIR}/${ARCH}-${OPTIONNAME}-config/results.json")
+    math(EXPR OPTIONCOUNT "${OPTIONCOUNT}+1")
+  endforeach()
+endforeach()
+
+add_custom_target(check-eld-summary
+  COMMAND ${Python3_EXECUTABLE}
+          ${CMAKE_CURRENT_SOURCE_DIR}/eld-lit-summary.py
+          ${SUMMARY_JSON_FILES}
+  COMMENT "Summarizing ELD lit test results across all configurations"
+  USES_TERMINAL)
+set_target_properties(check-eld-summary PROPERTIES FOLDER "Linker Tests")
+
 add_subdirectory(UnitTests)
 add_subdirectory(Common)
 add_subdirectory(Hexagon)

--- a/test/eld-lit-summary.py
+++ b/test/eld-lit-summary.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Summarize ELD lit test results across all arch/option configurations.
+
+Usage:
+  eld-lit-summary.py [--detail] [--detail-codes CODE[,CODE...]] <results.json> ...
+
+Each JSON file is the --output of a lit run for one arch+option configuration.
+The configuration name is derived from the parent directory name by stripping
+the trailing '-config' suffix (e.g. 'Hexagon-default-config' -> 'hexagon-default').
+
+With --detail, test names are listed beneath each configuration row for all
+non-PASS result codes (FAIL, XFAIL, UNSUPPORTED, XPASS, TIMEOUT).
+Use --detail-codes UNSUPPORTED,XFAIL to restrict which codes are expanded.
+
+Environment variables (overridden by the corresponding CLI flags):
+  ELD_SUMMARY_DETAIL=1            equivalent to --detail
+  ELD_SUMMARY_DETAIL_CODES=CODE,  equivalent to --detail-codes CODE,...
+"""
+
+import argparse
+import json
+import os
+import sys
+
+CODES = ["PASS", "FAIL", "XFAIL", "UNSUPPORTED", "XPASS", "TIMEOUT"]
+DEFAULT_DETAIL_CODES = ["FAIL", "XFAIL", "UNSUPPORTED", "XPASS", "TIMEOUT"]
+
+
+def config_label(json_path):
+    dirname = os.path.basename(os.path.dirname(os.path.abspath(json_path)))
+    if dirname.endswith("-config"):
+        dirname = dirname[: -len("-config")]
+    return dirname.lower()
+
+
+def load_results(json_path):
+    """Return (counts_dict, tests_by_code_dict, elapsed_seconds) or (None, None, None) on error."""
+    try:
+        with open(json_path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None, None, None
+
+    elapsed = data.get("elapsed")
+
+    counts = {c: 0 for c in CODES}
+    tests_by_code = {c: [] for c in CODES}
+    for test in data.get("tests", []):
+        code = test.get("code", "").upper()
+        if code in counts:
+            counts[code] += 1
+            tests_by_code[code].append(test.get("name", "<unknown>"))
+    return counts, tests_by_code, elapsed
+
+
+def _format_elapsed(seconds):
+    if seconds is None:
+        return "N/A"
+    minutes, secs = divmod(seconds, 60)
+    if minutes:
+        return f"{int(minutes)}m{secs:.1f}s"
+    return f"{secs:.1f}s"
+
+
+def print_summary(rows, detail_codes):
+    col_width = {c: max(len(c), 7) for c in CODES}
+    label_col = max((len(r[0]) for r in rows), default=len("Configuration"))
+    label_col = max(label_col, len("Configuration"))
+    time_col = len("TIME")
+
+    header = f"{'Configuration':<{label_col}}"
+    for c in CODES:
+        header += f"  {c:>{col_width[c]}}"
+    header += f"  {'TOTAL':>7}  {'TIME':>{time_col}}"
+    print(header)
+    print("-" * len(header))
+
+    for label, counts, tests_by_code, elapsed in rows:
+        if counts is None:
+            print(f"{label:<{label_col}}  (no results)")
+            continue
+
+        total = sum(counts[c] for c in CODES)
+        line = f"{label:<{label_col}}"
+        for c in CODES:
+            line += f"  {counts[c]:>{col_width[c]}}"
+        line += f"  {total:>7}  {_format_elapsed(elapsed):>{time_col}}"
+        print(line)
+
+        if detail_codes and tests_by_code is not None:
+            for code in detail_codes:
+                names = tests_by_code.get(code, [])
+                if not names:
+                    continue
+                print(f"  [{code}]")
+                for name in sorted(names):
+                    print(f"    {name}")
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "json_files",
+        nargs="*",
+        metavar="results.json",
+        help="JSON result files produced by lit --output",
+    )
+    parser.add_argument(
+        "--detail",
+        action="store_true",
+        default=False,
+        help=(
+            "List individual test names beneath each configuration row. "
+            "By default shows: " + ", ".join(DEFAULT_DETAIL_CODES) + ". "
+            "Use --detail-codes to restrict which codes are expanded."
+        ),
+    )
+    parser.add_argument(
+        "--detail-codes",
+        metavar="CODE[,CODE...]",
+        help=(
+            "Comma-separated list of result codes to expand under --detail "
+            "(implies --detail). Valid codes: " + ", ".join(CODES) + ". "
+            "Default when --detail is used alone: " + ",".join(DEFAULT_DETAIL_CODES)
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    # Environment-variable fallbacks — CLI flags take precedence.
+    if not args.detail and os.environ.get("ELD_SUMMARY_DETAIL", "").strip() == "1":
+        args.detail = True
+    if not args.detail_codes and os.environ.get("ELD_SUMMARY_DETAIL_CODES", "").strip():
+        args.detail_codes = os.environ["ELD_SUMMARY_DETAIL_CODES"].strip()
+
+    if args.detail_codes:
+        codes = [c.strip().upper() for c in args.detail_codes.split(",") if c.strip()]
+        unknown = [c for c in codes if c not in CODES]
+        if unknown:
+            parser.error(
+                f"Unknown result code(s): {', '.join(unknown)}. "
+                f"Valid codes: {', '.join(CODES)}"
+            )
+        args.detail_codes = codes
+        args.detail = True
+    elif args.detail:
+        args.detail_codes = DEFAULT_DETAIL_CODES
+
+    return args
+
+
+def main(argv):
+    args = parse_args(argv)
+
+    if not args.json_files:
+        print("No result files provided.")
+        return
+
+    rows = []
+    for path in args.json_files:
+        label = config_label(path)
+        counts, tests_by_code, elapsed = load_results(path)
+        rows.append((label, counts, tests_by_code, elapsed))
+
+    print_summary(rows, args.detail_codes or [])
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
Each check-eld sub-run now writes a JSON results file via lit's --output flag. A new check-eld-summary CMake target runs eld-lit-summary.py to read those files and print a consolidated PASS/FAIL/XFAIL/UNSUPPORTED/ XPASS/TIMEOUT table across all arch+option configurations.

Users run check-eld as before, then run check-eld-summary to get the cross-configuration overview. Missing result files are reported as (no results) without causing an error.

To get detailed results:-

ELD_SUMMARY_DETAIL=1 ninja check-eld-summary
ELD_SUMMARY_DETAIL_CODES=UNSUPPORTED,XFAIL ninja check-eld-summary

README updated with usage examples and sample output.