### PR TITLE
[RISCV] Error out when relax-tbljal is mixed with shared/pie

### DIFF
--- a/lib/LinkerWrapper/RISCVLinkDriver.cpp
+++ b/lib/LinkerWrapper/RISCVLinkDriver.cpp
@@ -140,9 +140,18 @@ RISCVLinkDriver::parseOptions(ArrayRef<const char *> Args,
     Config.options().setRISCVRelaxTLSDESC(false);
 
   // --relax-tbljal, --no-relax-tbljal (default)
-  Config.options().setRISCVRelaxTbljal(
+  bool EnableTbljal =
       ArgList.hasFlag(OPT_RISCVLinkOptTable::relax_tbljal,
-                      OPT_RISCVLinkOptTable::no_relax_tbljal, false));
+                      OPT_RISCVLinkOptTable::no_relax_tbljal, false);
+  if (EnableTbljal && (ArgList.hasArg(OPT_RISCVLinkOptTable::shared) ||
+                       ArgList.hasFlag(OPT_RISCVLinkOptTable::pie,
+                                       OPT_RISCVLinkOptTable::no_pie, false))) {
+    Config.raise(Diag::not_supported)
+        << "Zcmt table jump relaxation"
+        << "shared libraries or position independent code";
+    return LINK_FAIL;
+  }
+  Config.options().setRISCVRelaxTbljal(EnableTbljal);
 
   // --enable-bss-mixing
   if (ArgList.hasArg(OPT_RISCVLinkOptTable::enable_bss_mixing))

--- a/test/RISCV/FromLLD/riscv-tbljal-pic-shared.s
+++ b/test/RISCV/FromLLD/riscv-tbljal-pic-shared.s
@@ -1,0 +1,18 @@
+## Verify --relax-tbljal (Zcmt table-jump relaxation) is rejected for
+## shared libraries and position independent executables.
+#
+# RUN: %llvm-mc -filetype=obj -mattr=+relax,+zcmt %s -o %t.o
+# RUN: %not %link %linkopts --relax-tbljal -shared %t.o -o %t.so 2>&1 \
+# RUN:   | %filecheck %s
+# RUN: %not %link %linkopts --relax-tbljal -pie %t.o -o %t.pie 2>&1 \
+# RUN:   | %filecheck %s
+# RUN: %not %link %linkopts --relax-tbljal --pic-executable %t.o \
+# RUN:   -o %t.pic 2>&1 | %filecheck %s
+#
+# CHECK: Zcmt table jump relaxation is not supported for shared libraries
+# CHECK-SAME: or position independent code
+
+.text
+.global _start
+_start:
+  nop


### PR DESCRIPTION
The `RISCV Zcmt` extension is not compatible with shared libraries or when position independent code is enabled.