### PR TITLE
Add support for --no-warn-mismatch for ABI information

### DIFF
--- a/lib/Target/RISCV/RISCVInfo.cpp
+++ b/lib/Target/RISCV/RISCVInfo.cpp
@@ -45,6 +45,9 @@ bool RISCVInfo::isABIFlagSet(uint64_t inputFlag, uint32_t ABIFlag) const {
 }
 
 bool RISCVInfo::isCompatible(uint64_t pFlag, const std::string &pFile) const {
+  if (m_Config.options().noWarnMismatch())
+    return true;
+
   assert(m_OutputFlag);
   if (isABIFlagSet(pFlag, llvm::ELF::EF_RISCV_FLOAT_ABI_SOFT) ^
       isABIFlagSet(*m_OutputFlag, llvm::ELF::EF_RISCV_FLOAT_ABI_SOFT)) {

--- a/test/ARM/standalone/AttributesWarn/AttributesWarn.test
+++ b/test/ARM/standalone/AttributesWarn/AttributesWarn.test
@@ -7,5 +7,7 @@
 #RUN: %clang %clangopts -c -fshort-enums %p/Inputs/foo.c -o %t1.o
 #RUN: %clang %clangopts -c -fno-short-enums %p/Inputs/bar.c -o %t2.o
 #RUN: %link --warn-mismatch -o %t1.out %linkopts %t1.o %t2.o 2>&1 | %filecheck %s --check-prefix="ENUM"
+#RUN: %link --no-warn-mismatch -o %t1.out %linkopts %t1.o %t2.o 2>&1 | %filecheck %s --check-prefix="ENUM_NOERR" --allow-empty
 #
 #ENUM:  Warning: the size of enumerated data item
+#ENUM_NOERR-NOT:  Warning: the size of enumerated data item

--- a/test/ARM/standalone/PCSAttrs/PCSAttr.test
+++ b/test/ARM/standalone/PCSAttrs/PCSAttr.test
@@ -8,12 +8,14 @@
 RUN: %clang %clangopts -fno-pie -march=armv7 -fropi -c %p/Inputs/1.c -o %t1.o
 RUN: %clang %clangopts -fno-pie -march=armv7 -frwpi -c %p/Inputs/2.c -o %t2.o
 RUN: %not %link --warn-mismatch %linkopts -Map %t1.map -march armv7 %t1.o %t2.o -o %t2.out 2>&1 | %filecheck %s
+RUN: %link --no-warn-mismatch %linkopts -Map %t1.map -march armv7 %t1.o %t2.o -o %t2.out 2>&1 | %filecheck %s -check-prefix=NOERR --allow-empty
 RUN: %filecheck %s -check-prefix MAP < %t1.map
 RUN: %not %link --warn-mismatch -MapStyle yaml %linkopts -Map %t1.yaml.map -march armv7 %t1.o %t2.o -o %t2.out.2 2>&1 | %filecheck %s
+RUN: %link --no-warn-mismatch -MapStyle yaml %linkopts -Map %t1.yaml.map -march armv7 %t1.o %t2.o -o %t2.out.2 2>&1 | %filecheck %s -check-prefix=NOERR --allow-empty
 RUN: %filecheck %s -check-prefix MAP < %t1.yaml.map
 
 CHECK: conflicting way to use R9. {{[ -\(\)_A-Za-z0-9.\\/:]+}}: `SB', previously seen: `GPR'
-
+NOERR-NOT: conflicting way to use R9. {{.*}}: `SB', previously seen: `GPR'
 
 #MAP: LOAD {{.*}}1.o[arm][blx,j1j2,movtmovw,GPR,PCRel,EnumSize 2,Application]
 #MAP: LOAD {{.*}}2.o[arm][blx,j1j2,movtmovw,SB,SBRel,EnumSize 2,Application]

--- a/test/RISCV/FromLLD/riscv-attributes.s
+++ b/test/RISCV/FromLLD/riscv-attributes.s
@@ -30,8 +30,12 @@
 # RUN: llvm-readobj --arch-specific out3 | FileCheck %s --check-prefix=CHECK3
 
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 invalid_arch1.s -o invalid_arch1.o
-# RUN: not %link %linkopts invalid_arch1.o -o /dev/null 2>&1 | FileCheck %s --check-prefix=INVALID_ARCH1 --implicit-check-not=error:
+# RUN: %not %link %linkopts --warn-mismatch invalid_arch1.o -o /dev/null 2>&1 | FileCheck %s --check-prefix=INVALID_ARCH1 --implicit-check-not=error:
+#TODO: Why this does not link with eld but does with gnu ld?
+# RUN: %not %link %linkopts --no-warn-mismatch invalid_arch1.o -o /dev/null 2>&1 | FileCheck %s --check-prefix=INVALID_ARCH1_NOERR
 # INVALID_ARCH1: Reading attributes failed for file invalid_arch1.o, Error : extension lacks version in expected format
+# INVALID_ARCH1_NOERR-NOT: Warning: Reading attributes failed for file invalid_arch1.o, Error : extension lacks version in expected format
+# INVALID_ARCH1_NOERR: Fatal: Linking had errors (/dev/null)
 
 ## A zero value attribute is not printed.
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 unaligned_access_0.s -o unaligned_access_0.o
@@ -52,13 +56,21 @@
 ## Unknown tags currently lead to warnings.
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 unknown13.s -o unknown13.o
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 unknown13a.s -o unknown13a.o
-# RUN: %not %link %linkopts -e 0 unknown13.o unknown13.o unknown13a.o -o unknown13 2>&1 | FileCheck %s --check-prefix=UNKNOWN13 --implicit-check-not=warning:
+# RUN: %not %link %linkopts --warn-mismatch -e 0 unknown13.o unknown13.o unknown13a.o -o unknown13 2>&1 | FileCheck %s --check-prefix=UNKNOWN13 --implicit-check-not=warning:
+#TODO: Why this does not link with eld but does with gnu ld?
+# RUN: %not %link %linkopts --no-warn-mismatch -e 0 unknown13.o unknown13.o unknown13a.o -o unknown13 2>&1 | FileCheck %s --check-prefix=UNKNOWN13_NOERR
 # UNKNOWN13: Reading attributes failed for file unknown13.o, Error : invalid tag 0xd at offset 0x10
+# UNKNOWN13_NOERR-NOT: Warning: Reading attributes failed for file unknown13.o, Error : invalid tag
+# UNKNOWN13_NOERR: Fatal: Linking had errors (unknown13)
 
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 unknown22.s -o unknown22.o
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 unknown22a.s -o unknown22a.o
-# RUN: %not %link %linkopts -e 0 unknown22.o unknown22.o unknown22a.o -o unknown22 2>&1 | FileCheck %s --check-prefix=UNKNOWN22 --implicit-check-not=warning:
+# RUN: %not %link %linkopts --warn-mismatch -e 0 unknown22.o unknown22.o unknown22a.o -o unknown22 2>&1 | FileCheck %s --check-prefix=UNKNOWN22 --implicit-check-not=warning:
+#TODO: Why this does not link with eld but does with gnu ld?
+# RUN: %not %link %linkopts --no-warn-mismatch -e 0 unknown22.o unknown22.o unknown22a.o -o unknown22 2>&1 | FileCheck %s --check-prefix=UNKNOWN22_NOERR
 # UNKNOWN22: Reading attributes failed for file unknown22.o, Error : invalid tag 0x16 at offset 0x10
+# UNKNOWN22_NOERR-NOT: Warning: Reading attributes failed for file unknown22.o, Error : invalid tag
+# UNKNOWN22_NOERR: Fatal: Linking had errors (unknown22)
 
 # HDR:      Name              Type             Address          Off    Size   ES Flg Lk Inf Al
 # HDR:      .riscv.attributes RISCV_ATTRIBUTES 0000000000000000 {{.*}} {{.*}} 00      0   0  1{{$}}

--- a/test/RISCV/standalone/Attributes/riscv-attributes.s
+++ b/test/RISCV/standalone/Attributes/riscv-attributes.s
@@ -33,8 +33,12 @@ UNSUPPORTED: riscv32, windows
 # RUN: llvm-readobj --arch-specific out3 | FileCheck %s --check-prefix=CHECK3
 
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 invalid_arch1.s -o invalid_arch1.o
-# RUN: not %link -march riscv64 invalid_arch1.o -o /dev/null 2>&1 | FileCheck %s --check-prefix=INVALID_ARCH1 --implicit-check-not=error:
+# RUN: %not %link --warn-mismatch -march riscv64 invalid_arch1.o -o /dev/null 2>&1 | FileCheck %s --check-prefix=INVALID_ARCH1 --implicit-check-not=error:
+#TODO: Why this does not link with eld but does with gnu ld?
+# RUN: %not %link --no-warn-mismatch -march riscv64 invalid_arch1.o -o /dev/null 2>&1 | FileCheck %s --check-prefix=INVALID_ARCH1_NOERR
 # INVALID_ARCH1: Reading attributes failed for file invalid_arch1.o, Error : extension lacks version in expected format
+# INVALID_ARCH1_NOERR-NOT: Warning: Reading attributes failed for file invalid_arch1.o, Error : extension lacks version in expected format
+# INVALID_ARCH1_NOERR: Fatal: Linking had errors (/dev/null)
 
 ## A zero value attribute is not printed.
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 unaligned_access_0.s -o unaligned_access_0.o
@@ -55,13 +59,21 @@ UNSUPPORTED: riscv32, windows
 ## Unknown tags currently lead to warnings.
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 unknown13.s -o unknown13.o
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 unknown13a.s -o unknown13a.o
-# RUN: not %link -march riscv64 -e 0 unknown13.o unknown13.o unknown13a.o -o unknown13 2>&1 | FileCheck %s --check-prefix=UNKNOWN13 --implicit-check-not=warning:
+# RUN: not %link --warn-mismatch -march riscv64 -e 0 unknown13.o unknown13.o unknown13a.o -o unknown13 2>&1 | FileCheck %s --check-prefix=UNKNOWN13 --implicit-check-not=warning:
+#TODO: Why this does not link with eld but does with gnu ld?
+# RUN: not %link --no-warn-mismatch -march riscv64 -e 0 unknown13.o unknown13.o unknown13a.o -o unknown13 2>&1 | FileCheck %s --check-prefix=UNKNOWN13_NOERR
 # UNKNOWN13: Reading attributes failed for file unknown13.o, Error : invalid tag 0xd at offset 0x10
+# UNKNOWN13_NOERR-NOT: Warning: Reading attributes failed for file unknown13.o, Error : invalid tag
+# UNKNOWN13_NOERR: Fatal: Linking had errors (unknown13)
 
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 unknown22.s -o unknown22.o
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 unknown22a.s -o unknown22a.o
-# RUN: not %link -march riscv64 -e 0 unknown22.o unknown22.o unknown22a.o -o unknown22 2>&1 | FileCheck %s --check-prefix=UNKNOWN22 --implicit-check-not=warning:
+# RUN: not %link --warn-mismatch -march riscv64 -e 0 unknown22.o unknown22.o unknown22a.o -o unknown22 2>&1 | FileCheck %s --check-prefix=UNKNOWN22 --implicit-check-not=warning:
+#TODO: Why this does not link with eld but does with gnu ld?
+# RUN: not %link --no-warn-mismatch -march riscv64 -e 0 unknown22.o unknown22.o unknown22a.o -o unknown22 2>&1 | FileCheck %s --check-prefix=UNKNOWN22_NOERR
 # UNKNOWN22: Reading attributes failed for file unknown22a.o
+# UNKNOWN22_NOERR-NOT: Warning: Reading attributes failed for file
+# UNKNOWN22_NOERR: Fatal: Linking had errors (unknown22)
 
 # HDR:      Name              Type             Address          Off    Size   ES Flg Lk Inf Al
 # HDR:      .riscv.attributes RISCV_ATTRIBUTES 0000000000000000 0000b0 {{.*}} 00      0   0  1{{$}}

--- a/test/RISCV/standalone/EFlags/EFlags.test
+++ b/test/RISCV/standalone/EFlags/EFlags.test
@@ -10,8 +10,10 @@ RUN: %clang %clangopts -mabi=ilp32f -c %p/Inputs/1.c -o %t.1.o
 RUN: %eld %t.emptyelf.o %t.1.o -o %t1.out
 RUN: %readelf -h %t1.out | %filecheck %s -check-prefix=EFLAGS
 RUN: %yaml2obj %p/Inputs/flagszero_with_exec_sections.yaml -o %t.f.o
-RUN: %not %eld %t.f.o %t.1.o -o %t1.out 2>&1 | %filecheck %s
+RUN: %not %eld --warn-mismatch %t.f.o %t.1.o -o %t1.out 2>&1 | %filecheck %s
+RUN: %eld --no-warn-mismatch %t.f.o %t.1.o -o %t1.out 2>&1 | %filecheck %s --check-prefix NOERR --allow-empty
 #END_TEST
 
 EFLAGS: Flags: 0x3
 CHECK: Error: Incompatible object files when reading {{.*}}1.o
+NOERR-NOT: Error: Incompatible object files when reading

--- a/test/RISCV/standalone/Emulation/Emulation.test
+++ b/test/RISCV/standalone/Emulation/Emulation.test
@@ -7,7 +7,8 @@ RUN: %clang %clangopts -o %t1.1.32.o %p/Inputs/1.c -c -target riscv32
 RUN: %eld -o %t1.1.32.out %t1.1.32.o -m elf32lriscv
 RUN: %readelf -h %t1.1.32.out | %filecheck %s --check-prefix RISCV32
 RUN: %clang %clangopts -o %t1.1.64.o %p/Inputs/1.c -c -target riscv64
-RUN: %not %eld -o %t1.1.64.out %t1.1.64.o -m elf32lriscv --warn-mismatch 2>&1 | %filecheck %s --check-prefix RISCV64ERR
+RUN: %not %eld --warn-mismatch -o %t1.1.64.out %t1.1.64.o -m elf32lriscv 2>&1 | %filecheck %s --check-prefix RISCV64ERR
+RUN: %eld --no-warn-mismatch -o %t1.1.64.out %t1.1.64.o -m elf32lriscv 2>&1 | %filecheck %s --check-prefix RISCV64NOERR --allow-empty
 RUN: %eld -o %t1.1.64.out %t1.1.64.o -m elf64lriscv
 RUN: %readelf -h %t1.1.64.out | %filecheck %s --check-prefix RISCV64
 #END_TEST
@@ -15,6 +16,7 @@ RISCV32: ELF32
 RISCV32: RISC-V
 
 RISCV64ERR: Error: Invalid ELF file {{.*}}1.64.o for target riscv32
+RISCV64NOERR-NOT: Error: Invalid ELF file
 
 RISCV64: ELF64
 RISCV64: RISC-V


### PR DESCRIPTION
Allow users to suppress warnings about incompatible or mismatched input files using the --no-warn-mismatch option. This change disables mismatch diagnostics while preserving normal link behavior and outcomes.

Fix: qualcomm#1215