### PR TITLE
Fix faulty table updates for matrix workflow runs.

### DIFF
--- a/.github/workflows/scripts/record_builds.py
+++ b/.github/workflows/scripts/record_builds.py
@@ -108,22 +108,16 @@ def updateBuildData(args):
     cursor = conn.cursor()
     workflow_table = args.workflow_build.lower()
     try:
-        if workflow_table == "picolibc":
-            cursor.execute(
-                "UPDATE "
-                + workflow_table
-                + " SET state = ? WHERE run_id = ? AND arch = ?",
-                (
-                    "pass" if args.build_status else "fail",
-                    args.run_id,
-                    args.workflow_arch,
-                ),
-            )
-        else:
-            cursor.execute(
-                "UPDATE " + workflow_table + " SET state = ? WHERE run_id = ?",
-                ("pass" if args.build_status else "fail", args.run_id),
-            )
+        cursor.execute(
+            "UPDATE "
+            + workflow_table
+            + " SET state = ? WHERE run_id = ? AND arch = ?",
+            (
+                "pass" if args.build_status else "fail",
+                args.run_id,
+                args.workflow_arch,
+            ),
+        )
     except Exception as e:
         sys.exit("Error updating build status data in " + workflow_table + ":" + str(e))
     finally:


### PR DESCRIPTION
Currently, the architecture names for matrix runs were only checked for PICOLIBC workflows when updating the build pass/fail status. This workflow specific check is removed and the table update is made generic and checks for both run-id and architecture name.

Fixes #1265