### PR TITLE
[RISCV] Remove outdated `c.lui rd, 0` to `c.li rd, 0` rewriting. NFCI

### DIFF
--- a/lib/Target/RISCV/RISCVHelper.h
+++ b/lib/Target/RISCV/RISCVHelper.h
@@ -276,8 +276,6 @@ template <typename T> T encodeCJ(T Result) {
 }
 
 template <typename T> T encodeCI(T Result) {
-  // `c.lui rd, 0` is illegal, it will be converted  to `c.li rd, 0` when
-  // applying
   uint16_t Imm17 = extractBits(Result, 17, 17) << 12;
   uint16_t Imm16_12 = extractBits(Result, 16, 12) << 2;
   Result = Imm17 | Imm16_12;

--- a/lib/Target/RISCV/RISCVRelocationCompute.cpp
+++ b/lib/Target/RISCV/RISCVRelocationCompute.cpp
@@ -102,8 +102,8 @@ uint64_t clearImmediateBits(uint64_t Instr, EncodingType Type) {
     return Instr & 0x00000000C00FFFFFull;
   case EncTy_QC_ES:
     return Instr & 0x00000000C1FFF07Full;
-  /* C.LUI/C.LI clearing handled in doRelocHelper */
   case EncTy_CI:
+    return Instr & 0xEF83;
   /* No overwriting being performed */
   case EncTy_None:
   case EncTy_LEB128:
@@ -142,16 +142,9 @@ uint64_t doRelocHelper(const RelocationInfo &RelocInfo, uint64_t Instruction,
   case EncTy_CJ:
     Value = encodeCJ(Value);
     break;
-  case EncTy_CI: {
-    if (Value >> 12 == 0) {
-      // `c.lui rd, 0` is illegal, convert to `c.li rd, 0`
-      return (Instruction & 0x0F83) | 0x4000;
-    } else {
-      Instruction &= 0xEF83;
-      Value = encodeCI(Value);
-    }
+  case EncTy_CI:
+    Value = encodeCI(Value);
     break;
-  }
   case EncTy_QC_EB:
     Value = encodeQCEB(Value);
     break;

--- a/test/RISCV/standalone/Relaxation/HI20_LO12_I_TO_CLUI/HI20_LO12_I_TO_CLUI.test
+++ b/test/RISCV/standalone/Relaxation/HI20_LO12_I_TO_CLUI/HI20_LO12_I_TO_CLUI.test
@@ -170,6 +170,22 @@ CHECK-NEXT: 80402503  	lw	a0, -2044(zero)
 CHECK-NEXT: 00001137  	lui	sp, 1
 CHECK-NEXT: 80412503  	lw	a0, -2044(sp)
 
+## Check that --no-relax-zero is honored. Also check that a c.lui with imm 0
+## is not generated.
 RUN: %clang %clangopts -c  %p/Inputs/1.s -o %t.1.o
 RUN: %link %linkopts -MapStyle txt -Map %t.1.map --verbose --no-relax-zero %t.1.o -o %t.1.no-relax-zero.out -T %p/Inputs/1.t 2>&1 | %filecheck %s --check-prefix=VERBOSE-NO-RELAX-ZERO
 VERBOSE-NO-RELAX-ZERO-NOT: RISCV_LUI_ZERO : Deleting [[#]] bytes
+VERBOSE-NO-RELAX-ZERO-NOT: RISCV_LUI_C : Deleting 2 bytes for symbol 'B'
+VERBOSE-NO-RELAX-ZERO-NOT: RISCV_LUI_C : relaxing instruction {{.*}} for symbol B
+VERBOSE-NO-RELAX-ZERO-NOT: RISCV_LUI_C : Deleting 2 bytes for symbol 'C'
+VERBOSE-NO-RELAX-ZERO-NOT: RISCV_LUI_C : relaxing instruction {{.*}} for symbol C
+
+RUN: %objdump --no-print-imm-hex -d %t.1.no-relax-zero.out 2>&1 | %filecheck %s --check-prefix=NO-RELAX-ZERO-DUMP
+
+NO-RELAX-ZERO-DUMP: <.text>:
+NO-RELAX-ZERO-DUMP-NEXT: 00000537      lui     a0, 0
+NO-RELAX-ZERO-DUMP-NEXT: 00052503      lw      a0, 0(a0)
+NO-RELAX-ZERO-DUMP-NEXT: 00000537      lui     a0, 0
+NO-RELAX-ZERO-DUMP-NEXT: 7fc52503      lw      a0, 2044(a0)
+NO-RELAX-ZERO-DUMP-NEXT: 00000537      lui     a0, 0
+NO-RELAX-ZERO-DUMP-NEXT: 80452503      lw      a0, -2044(a0)


### PR DESCRIPTION
This code should be dead as `R_RISCV_RVC_LUI` is an internal relocation to help with relaxation and the only place we emit this relocation already checks that the immediate is non-zero.

Cleaning this up is also helpful as a follow up patch will introduce a new internal relocation for `c.li` (for handling GOT load relaxations). The existing code is incorrect for that case, and cleaning this up will let us handle these two consistently (and more consistently with other instruction types).