### PR TITLE
[lit] Set force_execute_external to True

### DIFF
--- a/test/eld_test_formats.py
+++ b/test/eld_test_formats.py
@@ -15,7 +15,7 @@ from thin_archive_test_format import ThinArchiveTestFormat
 
 class EldShellTestFormat(lit.formats.ShTest):
     def __init__(self, execute_external):
-        super().__init__(execute_external)
+        super().__init__(execute_external, force_execute_external=True)
 
     def execute(self, test, litConfig):
         if test.getSourcePath().endswith(".sh"):


### PR DESCRIPTION
The LLVM patch https://github.com/llvm/llvm-project/pull/203689 deprecates the use of execute_external=True in ShTest causing the following failure while running the ELD tests: 

> ValueError: execute_external=True is deprecated as of LLVM-23 and the option will be removed in LLVM-24. Please move to using the internal shell (execute_external=False). If you still need to force external execution to allow time for migration, set force_execute_external=True

Set force_execute_external=True until we move the ELD tests to using the internal shell.

Relevant RFC's:

https://discourse.llvm.org/t/rfc-removal-of-the-lit-external-shell/90951
https://discourse.llvm.org/t/rfc-enabling-the-lit-internal-shell-by-default/80179