### PR TITLE
[test] Port tests to work with the internal LIT shell

### DIFF
--- a/test/Common/LTO/LTOTempObjNotWritable/LTOTempObjNotWritable.test
+++ b/test/Common/LTO/LTOTempObjNotWritable/LTOTempObjNotWritable.test
@@ -17,10 +17,12 @@ RUN: mkdir -p %t2.out.llvm-lto.1.o
 ### because it crashes only in some code paths when doing LTO.
 
 RUN: %clang %clangopts -c %p/Inputs/1.c -O2 -ffunction-sections -flto -o %t1.o
-RUN: (%not %link %linkopts --save-temps %t1.o -o %t1.out 2>&1 || true) | %filecheck %s
+RUN: %not %link %linkopts --save-temps %t1.o -o %t1.out > %t1.err 2>&1 || true
+RUN: %filecheck %s < %t1.err
 
 RUN: %clang %clangopts -c %p/Inputs/1.c -O2 -ffunction-sections -flto=thin -o %t2.o
-RUN: (%not %link %linkopts --save-temps %t2.o -o %t2.out 2>&1 || true) | %filecheck %s
+RUN: %not %link %linkopts --save-temps %t2.o -o %t2.out > %t2.err 2>&1 || true
+RUN: %filecheck %s < %t2.err
 
 CHECK: cannot compile code generator object
 CHECK: .out.llvm-lto.{{[0-9]+}}.o: {{Is a directory|is a directory}}

--- a/test/Common/standalone/ArchiveMemberReport/Script/CycleGroupTrace.test
+++ b/test/Common/standalone/ArchiveMemberReport/Script/CycleGroupTrace.test
@@ -5,10 +5,36 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/cycle_main.c -o %t.main.o
-RUN: for i in 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15; do \
-RUN:   %clang %clangopts -c %p/Inputs/cycle_a${i}.c -o %t.a${i}.o; \
-RUN:   %clang %clangopts -c %p/Inputs/cycle_b${i}.c -o %t.b${i}.o; \
-RUN: done
+RUN: %clang %clangopts -c %p/Inputs/cycle_a01.c -o %t.a01.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_b01.c -o %t.b01.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_a02.c -o %t.a02.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_b02.c -o %t.b02.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_a03.c -o %t.a03.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_b03.c -o %t.b03.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_a04.c -o %t.a04.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_b04.c -o %t.b04.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_a05.c -o %t.a05.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_b05.c -o %t.b05.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_a06.c -o %t.a06.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_b06.c -o %t.b06.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_a07.c -o %t.a07.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_b07.c -o %t.b07.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_a08.c -o %t.a08.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_b08.c -o %t.b08.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_a09.c -o %t.a09.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_b09.c -o %t.b09.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_a10.c -o %t.a10.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_b10.c -o %t.b10.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_a11.c -o %t.a11.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_b11.c -o %t.b11.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_a12.c -o %t.a12.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_b12.c -o %t.b12.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_a13.c -o %t.a13.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_b13.c -o %t.b13.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_a14.c -o %t.a14.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_b14.c -o %t.b14.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_a15.c -o %t.a15.o
+RUN: %clang %clangopts -c %p/Inputs/cycle_b15.c -o %t.b15.o
 RUN: %ar -cr %tlibA.a %t.a01.o %t.b03.o %t.a06.o %t.b08.o %t.a11.o %t.b13.o
 RUN: %ar -cr %tlibB.a %t.b01.o %t.a04.o %t.b06.o %t.a09.o %t.b11.o %t.a14.o
 RUN: %ar -cr %tlibC.a %t.a02.o %t.b04.o %t.a07.o %t.b09.o %t.a12.o %t.b14.o

--- a/test/Common/standalone/CommandLine/Reproduce/Namespec.test
+++ b/test/Common/standalone/CommandLine/Reproduce/Namespec.test
@@ -32,12 +32,12 @@ NOFLAGS-NOT: -L
 ## Run the response file.
 RUN: %rm -rf %t.arc.rep && %mkdir %t.arc.rep
 RUN: %tar %gnutaropts -xf %t.arc.tar -C %t.arc.rep --strip-components=1
-RUN: cd %t.arc.rep && %link %linkopts @response.txt -o out && cd -
+RUN: %python -c "import shlex, subprocess; subprocess.check_call(shlex.split(r'%link %linkopts @response.txt -o out'), cwd=r'%t.arc.rep')"
 
 RUN: %rm -rf %t.shr.rep && %mkdir %t.shr.rep
 RUN: %tar %gnutaropts -xf %t.shr.tar -C %t.shr.rep --strip-components=1
-RUN: cd %t.shr.rep && %link %linkopts @response.txt -o out && cd -
+RUN: %python -c "import shlex, subprocess; subprocess.check_call(shlex.split(r'%link %linkopts @response.txt -o out'), cwd=r'%t.shr.rep')"
 
 RUN: %rm -rf %t.lit.rep && %mkdir %t.lit.rep
 RUN: %tar %gnutaropts -xf %t.lit.tar -C %t.lit.rep --strip-components=1
-RUN: cd %t.lit.rep && %link %linkopts @response.txt -o out
+RUN: %python -c "import shlex, subprocess; subprocess.check_call(shlex.split(r'%link %linkopts @response.txt -o out'), cwd=r'%t.lit.rep')"

--- a/test/Common/standalone/DiscardSectionRelocNotComdatGroup/DiscardSectionRelocNotComdatGroup.test
+++ b/test/Common/standalone/DiscardSectionRelocNotComdatGroup/DiscardSectionRelocNotComdatGroup.test
@@ -8,7 +8,9 @@
 RUN: %clang %clangopts -c %p/Inputs/1.s -o %t.1.o
 RUN: %clang %clangopts -c %p/Inputs/2.s -o %t.2.o
 RUN: %link %linkopts %t.1.o %t.2.o -o %t.out
-RUN: (%readelf -s %t.out; %readelf -Sgr %t.out) | %filecheck %s
+RUN: %readelf -s %t.out > %t.readelf
+RUN: %readelf -Sgr %t.out >> %t.readelf
+RUN: %filecheck %s < %t.readelf
 
 CHECK:     Symbol table '.symtab' contains
 CHECK:             Num:       Value  Size    Type  Bind      Vis           Ndx Name

--- a/test/Common/standalone/DiscardSectionRelocNotComdatGroup/DiscardSectionRelocNotComdatGroupPartial.test
+++ b/test/Common/standalone/DiscardSectionRelocNotComdatGroup/DiscardSectionRelocNotComdatGroupPartial.test
@@ -8,7 +8,9 @@
 RUN: %clang %clangopts -c %p/Inputs/1.s -o %t.1.o
 RUN: %clang %clangopts -c %p/Inputs/2.s -o %t.2.o
 RUN: %link %linkopts -r %t.1.o %t.2.o -o %t.a
-RUN: (%readelf -s %t.a; %readelf -Sgr %t.a) | %filecheck %s
+RUN: %readelf -s %t.a > %t.readelf
+RUN: %readelf -Sgr %t.a >> %t.readelf
+RUN: %filecheck %s < %t.readelf
 
 CHECK:     Symbol table '.symtab' contains
 CHECK:             Num:       Value  Size    Type  Bind      Vis                 Ndx Name

--- a/test/Common/standalone/Patching/Patch/Patch.test
+++ b/test/Common/standalone/Patching/Patch/Patch.test
@@ -70,7 +70,9 @@ PATCH-DAG: Symbol `__llvm_patchable_xxx_g' from Input file `{{.+}}.base' with in
 PATCH-DAG: Trace: Symbol xxx_f, application site: 0x[[#%x,PGOT]]
 PATCH-DAG: Trace: Symbol xxx_g, application site: 0x[[#%x,PGOT+XLEN]]
 
-RUN: (%readelf -s %t.base; %readelf -s %t.patch) | %filecheck %s --check-prefix=SYM --match-full-lines -D#%x,FP=0x8000
+RUN: %readelf -s %t.base > %t.sym.readelf
+RUN: %readelf -s %t.patch >> %t.sym.readelf
+RUN: %filecheck %s --check-prefix=SYM --match-full-lines -D#%x,FP=0x8000 < %t.sym.readelf
 
 ## Read value values from base image.
 SYM: Symbol table '.symtab' contains [[#]] entries:
@@ -91,7 +93,9 @@ SYM-DAG:   [[#]]: {{0*}}[[#H]]         [[#]] FUNC    GLOBAL DEFAULT       ABS xx
 SYM-DAG:   [[#]]: {{0*}}[[#K]]         [[#]] FUNC    GLOBAL DEFAULT       ABS xxx_k
 
 ## The new .pgot will have the first pointer replaced, and the other one kept as is.
-RUN: (%readelf -s %t.base; %elfcopy -O binary -j .pgot %t.patch - | od -v -Ax -t x%xlen -w%xlen) | %filecheck %s --check-prefix=PGOT --match-full-lines -D#%x,FP=0x8000 -D#XLEN=%xlen
+RUN: %readelf -s %t.base > %t.pgot.readelf
+RUN: %elfcopy -O binary -j .pgot %t.patch - | od -v -Ax -t x%xlen -w%xlen >> %t.pgot.readelf
+RUN: %filecheck %s --check-prefix=PGOT --match-full-lines -D#%x,FP=0x8000 -D#XLEN=%xlen < %t.pgot.readelf
 PGOT:      [[#]]: [[#%x,G:]]           [[#]] FUNC    GLOBAL DEFAULT     [[#]] xxx_g
 PGOT:      {{0*}}0                   {{0*}}[[#FP]]
 PGOT-NEXT: {{0*}}[[#%x,mul(XLEN,1)]] {{0*}}[[#%x,G]]

--- a/test/Common/standalone/Patching/PatchPatchPLT/PatchPatchPLT_FuncPtrCode.test
+++ b/test/Common/standalone/Patching/PatchPatchPLT/PatchPatchPLT_FuncPtrCode.test
@@ -13,7 +13,9 @@ RUN: %link %linkopts --no-emit-relocs --patch-enable --section-start=.plt=0x1000
 RUN: %clang %clangopts -mno-relax -O3 -fno-pic %p/Inputs/f.c -o %t.f.o -c
 RUN: %clang %clangopts -mno-relax -O3 -fno-pic %p/Inputs/2.riscv.s -o %t.2.o -c
 RUN: %link %linkopts --patch-base=%t.base --section-start=.text=0x8000 --section-start=.pgot=0x9000 %t.f.o %t.2.o -o %t.2
-RUN: (%readelf -s %t.2; %objdump -d -s %t.2) | %filecheck %s --match-full-lines
+RUN: %readelf -s %t.2 > %t.readelf
+RUN: %objdump -d -s %t.2 >> %t.readelf
+RUN: %filecheck %s --match-full-lines < %t.readelf
 
 ## Check that symbol values are expected.
 CHECK-DAG: [[#]]: {{0*}}1000     [[#]] NOTYPE  GLOBAL DEFAULT   ABS __llvm_patchable_xxx_f

--- a/test/Common/standalone/Patching/PatchPatchPLT/PatchPatchPLT_FuncPtrData.test
+++ b/test/Common/standalone/Patching/PatchPatchPLT/PatchPatchPLT_FuncPtrData.test
@@ -13,7 +13,9 @@ RUN: %link %linkopts --no-emit-relocs --patch-enable --section-start=.plt=0x1000
 RUN: %clang %clangopts -mno-relax -O3 -fno-pic %p/Inputs/f.c -o %t.f.o -c
 RUN: %clang %clangopts -mno-relax -O3 -fno-pic %p/Inputs/3.riscv%xlen.s -o %t.3.o -c
 RUN: %link %linkopts --patch-base=%t.base --section-start=.text=0x8000 --section-start=.data=0xa000 --section-start=.pgot=0x9000 %t.f.o %t.3.o -o %t.3
-RUN: (%readelf -s %t.3; %elfcopy -O binary -j .data %t.3 - | od -v -Ax -t x%xlen -w%xlen) | %filecheck %s --match-full-lines -D#XLEN=%xlen
+RUN: %readelf -s %t.3 > %t.readelf
+RUN: %elfcopy -O binary -j .data %t.3 - | od -v -Ax -t x%xlen -w%xlen >> %t.readelf
+RUN: %filecheck %s --match-full-lines -D#XLEN=%xlen < %t.readelf
 
 ## Read symbol values.
 CHECK-DAG: [[#]]: [[#%x,F:]]     [[#]] NOTYPE  GLOBAL DEFAULT   ABS __llvm_patchable_xxx_f

--- a/test/Common/standalone/QCLDFlags/ELDFlags.test
+++ b/test/Common/standalone/QCLDFlags/ELDFlags.test
@@ -6,9 +6,9 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c
-RUN: ELDFLAGS="--gc-sections --print-gc-sections -o %t1.output.elf" %link %linkopts %t1.1.o 2>&1 | %filecheck %s
-RUN: ELDFLAGS="" %link %linkopts %t1.1.o 2>&1 | %filecheck %s --check-prefix=EMPTY --allow-empty
-RUN: ELDFLAGS="--invalid-option" %link %linkopts %t1.1.o 2>&1 | %filecheck %s --check-prefix=INVALIDOPTION
+RUN: env ELDFLAGS="--gc-sections --print-gc-sections -o %t1.output.elf" %link %linkopts %t1.1.o 2>&1 | %filecheck %s
+RUN: env ELDFLAGS="" %link %linkopts %t1.1.o 2>&1 | %filecheck %s --check-prefix=EMPTY --allow-empty
+RUN: env ELDFLAGS="--invalid-option" %link %linkopts %t1.1.o 2>&1 | %filecheck %s --check-prefix=INVALIDOPTION
 #CHECK-DAG: ELDFlags: '--gc-sections --print-gc-sections -o {{.*}}output.elf'
 #CHECK-DAG: Note: ELDFlags({{.*}}output.elf): '--gc-sections --print-gc-sections -o {{.*}}output.elf'
 #EMPTY-NOT: ELDFlags

--- a/test/Common/standalone/linkerscript/NonAllocSectionSymbolAssignment/NonAllocSectionSymbolAssignment.test
+++ b/test/Common/standalone/linkerscript/NonAllocSectionSymbolAssignment/NonAllocSectionSymbolAssignment.test
@@ -8,7 +8,9 @@
 #START_TEST
 RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections -g
 RUN: %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t
-RUN: (%readelf -sS %t1.1.out && %readelf -S %t1.1.out) | %filecheck %s -check-prefix=READELF1
+RUN: %readelf -sS %t1.1.out > %t1.1.readelf
+RUN: %readelf -S %t1.1.out >> %t1.1.readelf
+RUN: %filecheck %s -check-prefix=READELF1 < %t1.1.readelf
 
 RUN: %link %linkopts -o %t1.1.2.out %t1.1.o -T %p/Inputs/script.2.t
 RUN: %readelf -sS %t1.1.2.out | %filecheck %s -check-prefix=READELF2

--- a/test/Common/standalone/linkerscript/RepeatedIncludes/RepeatedIncludes.test
+++ b/test/Common/standalone/linkerscript/RepeatedIncludes/RepeatedIncludes.test
@@ -7,6 +7,5 @@ include cycle error.
 RUN: %touch %t1.1.o
 RUN: %touch 1.t
 RUN: %mkdir %t1.scripts
-RUN: cd %t1.scripts && %touch 2.t && cd $(%dirname %t1.1.o)/..
+RUN: %touch %t1.scripts/2.t
 RUN: %link %emulation %linkopts %t1.1.o -T %p/Inputs/script.t -L %t1.scripts -o %t1.1.out
-


### PR DESCRIPTION
With LLVM recently making the internal shell default for the LIT tests some of the ELD tests were failing due to multiple incompatibilities with how the internal shell executes tests.

The tests relied on shell features that are not supported by lit's internal shell like subshell grouping, for-loops, inline VAR=... cmd assignment, command substitution, and cd - behavior.  Update the affected tests to use internal-shell-safe RUN lines.

Assisted by: GPT-5.3