### PR TITLE
[nightly] Upload ELD-only binaries to GitHub Releases biannually

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -12,12 +12,12 @@ permissions:
 jobs:
   build-and-runtest-nightly:
     if: github.repository == 'qualcomm/eld'
-    runs-on: ubuntu-latest
-
+    runs-on: ubuntu-22.04
     env:
       BASE_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
       ELD_REPO: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
       ELD_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+      SCRIPTS_DIR: ${{ github.workspace }}/llvm-project/llvm/tools/eld/.github/workflows/scripts
 
     steps:
       - name: Set up Clang 22
@@ -209,38 +209,17 @@ jobs:
       - name: Bundle binary shared library dependencies
         shell: bash
         run: |
-          set -euo pipefail
-          INSTALL_ROOT="${{ github.workspace }}/install-nightly-toolchain"
-          BIN_DIR="${INSTALL_ROOT}/bin"
-          LIB_DIR="${INSTALL_ROOT}/lib"
-          mkdir -p "${LIB_DIR}"
-
-          # Resolve runtime deps from installed tool binaries and package them.
-          tools=(clang clang++ ld.eld lld ld.lld clangd clang-tidy clang-format)
-          for tool in "${tools[@]}"; do
-            if [[ -x "${BIN_DIR}/${tool}" ]]; then
-              echo "Collecting shared libraries for ${tool}"
-              ldd "${BIN_DIR}/${tool}" | awk '/=> \// { print $3 } /^\/.*\.so/ { print $1 }' | while read -r dep; do
-                [[ -n "${dep}" && -f "${dep}" ]] || continue
-                base="$(basename "${dep}")"
-                if compgen -G "${LIB_DIR}/${base}*" > /dev/null; then
-                  continue
-                fi
-                cp -P "${dep}" "${LIB_DIR}/"
-                cp -n "$(readlink -f "${dep}")" "${LIB_DIR}/" || true
-              done
-            fi
-          done
+          bash "${SCRIPTS_DIR}/BundleSharedLibDeps.sh" \
+            "${{ github.workspace }}/install-nightly-toolchain" \
+            clang clang++ ld.eld lld ld.lld clangd clang-tidy clang-format
 
           for tool in ld.eld clang; do
-            if [[ -x "${BIN_DIR}/${tool}" ]]; then
+            BIN="${{ github.workspace }}/install-nightly-toolchain/bin/${tool}"
+            if [[ -x "${BIN}" ]]; then
               echo "${tool} RPATH/RUNPATH:"
-              readelf -d "${BIN_DIR}/${tool}" | grep -E 'RPATH|RUNPATH' || true
+              readelf -d "${BIN}" | grep -E 'RPATH|RUNPATH' || true
             fi
           done
-
-          echo "Packaged shared libraries:"
-          ls -la "${LIB_DIR}"
 
       - name: Prune ccache before save
         if: always()
@@ -255,10 +234,27 @@ jobs:
           path: ${{ github.workspace }}/obj/ccache
           key: nightly-ccache-${{ runner.os }}-${{ github.run_id }}
 
+      - name: Install ELD-only binaries
+        run: |
+          cd obj
+          DESTDIR="" cmake --install . --component ld.eld \
+            --prefix ${{ github.workspace }}/eld-unstable
+
+      - name: Bundle ld.eld shared library dependencies
+        shell: bash
+        run: |
+          bash "${SCRIPTS_DIR}/BundleSharedLibDeps.sh" \
+            "${{ github.workspace }}/eld-unstable" \
+            ld.eld
       - name: Pack toolchain tarball
         run: |
           tar -C ${{ github.workspace }}/ \
               -Jcvf install-nightly-toolchain.tar.xz install-nightly-toolchain
+
+      - name: Pack ELD-only tarball
+        run: |
+          tar -C ${{ github.workspace }}/ \
+              -Jcvf eld-unstable.tar.xz eld-unstable
 
       - name: Upload toolchain tarball
         uses: actions/upload-artifact@v7
@@ -266,6 +262,25 @@ jobs:
           name: install-nightly-toolchain.tar.xz
           path: install-nightly-toolchain.tar.xz
           retention-days: 2
+
+      - name: Check if biannual release day (Jan 1 or Jul 1)
+        id: release_day
+        run: |
+          mmdd=$(date +%m%d)
+          if [[ "${mmdd}" == "0101" || "${mmdd}" == "0701" ]]; then
+            echo "is_release_day=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_release_day=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload ELD release to GitHub
+        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && steps.release_day.outputs.is_release_day == 'true')
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
+        with:
+          tag_name: nightly
+          name: Nightly ELD Release
+          prerelease: true
+          files: eld-unstable.tar.xz
 
       - name: Run tests
         run: |

--- a/.github/workflows/scripts/BundleSharedLibDeps.sh
+++ b/.github/workflows/scripts/BundleSharedLibDeps.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Bundle shared library dependencies for a list of binaries into INSTALL_ROOT/lib.
+# Only libraries whose basename matches a pattern in ALLOWED_LIBS are packaged.
+# Usage: BundleSharedLibDeps.sh <install-root> <binary> [<binary> ...]
+
+set -euo pipefail
+
+# Allowlist of library name prefixes to package (fnmatch patterns against basename).
+ALLOWED_LIBS=(
+  "libc++.so*"
+  "libc++abi.so*"
+)
+
+INSTALL_ROOT="$1"; shift
+BIN_DIR="${INSTALL_ROOT}/bin"
+LIB_DIR="${INSTALL_ROOT}/lib"
+mkdir -p "${LIB_DIR}"
+
+is_allowed() {
+  local base="$1"
+  for pattern in "${ALLOWED_LIBS[@]}"; do
+    # shellcheck disable=SC2254
+    case "${base}" in
+      ${pattern}) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+for tool in "$@"; do
+  if [[ -x "${BIN_DIR}/${tool}" ]]; then
+    echo "Collecting shared libraries for ${tool}"
+    ldd "${BIN_DIR}/${tool}" | awk '/=> \// { print $3 } /^\/.*\.so/ { print $1 }' | while read -r dep; do
+      [[ -n "${dep}" && -f "${dep}" ]] || continue
+      base="$(basename "${dep}")"
+      if ! is_allowed "${base}"; then
+        continue
+      fi
+      if compgen -G "${LIB_DIR}/${base}*" > /dev/null; then
+        continue
+      fi
+      cp -P "${dep}" "${LIB_DIR}/"
+      cp -n "$(readlink -f "${dep}")" "${LIB_DIR}/" || true
+    done
+  fi
+done
+
+echo "Packaged shared libraries in ${LIB_DIR}:"
+ls -la "${LIB_DIR}"


### PR DESCRIPTION
- After the nightly build, install only the ld.eld component into a separate prefix using `cmake --install --component ld.eld`.
- Collect shared library dependencies for ld.eld into the install tree using a new reusable script BundleSharedLibDeps.sh, which replaces the duplicated inline logic in the full-toolchain bundling step.
- Pack the result as eld-nightly.tar.xz and upload it to a rolling 'nightly' pre-release on GitHub Releases on Jan 1 and Jul 1.
- manual workflow_dispatch triggers an upload unconditionally.

Assisted by Claude. 