### PR TITLE
[RISCV] Relax QC.E.J/JAL to CM.JT/JALT when possible

### DIFF
--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -519,7 +519,7 @@ bool RISCVLDBackend::doRelaxationJal(Relocation *reloc) {
 
 bool RISCVLDBackend::doRelaxationQCCall(Relocation *reloc) {
   // This function performs the relaxation to replace: QC.E.JAL or QC.E.J with
-  // one of JAL, C.J, or C.JAL.
+  // one of CM.JT/CM.JALT, JAL, C.J, or C.JAL.
 
   Fragment *frag = reloc->targetRef()->frag();
   RegionFragmentEx *region = llvm::dyn_cast<RegionFragmentEx>(frag);
@@ -536,19 +536,29 @@ bool RISCVLDBackend::doRelaxationQCCall(Relocation *reloc) {
   Relocator::DWord P = reloc->place(m_Module);
   Relocator::DWord X = S + A - P;
 
+  bool doRelax = config().options().getRISCVRelax();
   bool DoCompressed = config().options().getRISCVRelaxToC();
   bool canRelaxXqci =
       config().targets().is32Bits() && config().options().getRISCVRelaxXqci();
-  bool canRelax =
-      config().options().getRISCVRelax() && canRelaxXqci && llvm::isInt<21>(X);
-  bool canCompress = DoCompressed && llvm::isInt<12>(X);
+  bool canRelax = doRelax && canRelaxXqci;
+  bool canCompress = canRelax && DoCompressed && llvm::isInt<12>(X);
+  bool canRelaxTbljal = canRelax && DoCompressed &&
+                        config().options().getRISCVRelaxTbljal() &&
+                        llvm::isInt<32>(X);
+  bool canRelaxJal = canRelax && llvm::isInt<21>(X);
+  auto reportMissedQCCall = [&]() {
+    reportMissedRelaxation("RISCV_QC_E_CALL", *region, offset,
+                           (canCompress || canRelaxTbljal) ? 4 : 2,
+                           reloc->symInfo()->name());
+  };
 
   if (!canRelax) {
-    reportMissedRelaxation("RISCV_QC_E_CALL", *region, offset,
-                           canCompress ? 4 : 2, reloc->symInfo()->name());
+    reportMissedQCCall();
     return false;
   }
 
+  // Prefer direct C.J/C.JAL over table-jump since both end up 2 bytes and
+  // direct compression avoids the JVT entry overhead.
   if (canCompress) {
     uint32_t compressed = isTailCall ? 0xa001 : 0x2001;
     const char *msg = isTailCall ? "RISCV_QC_E_J_C" : "RISCV_QC_E_JAL_C";
@@ -563,19 +573,40 @@ bool RISCVLDBackend::doRelaxationQCCall(Relocation *reloc) {
                  ->getInput()
                  ->decoratedPath();
 
-    region->replaceInstruction(offset, reloc, reinterpret_cast<uint8_t *>(&compressed), 2);
+    region->replaceInstruction(offset, reloc,
+                               reinterpret_cast<uint8_t *>(&compressed), 2);
     // Replace the reloc to R_RISCV_RVC_JUMP
     reloc->setType(llvm::ELF::R_RISCV_RVC_JUMP);
     reloc->setTargetData(compressed);
-    relaxDeleteBytes(msg, *region, offset + 2, 4,
-                     reloc->symInfo()->name());
+    relaxDeleteBytes(msg, *region, offset + 2, 4, reloc->symInfo()->name());
     return true;
+  }
+
+  if (canRelaxTbljal && TableJumpFragment && TableJumpFragment->size() &&
+      m_pRISCVTableJumpSection && !m_pRISCVTableJumpSection->isIgnore() &&
+      !m_pRISCVTableJumpSection->isDiscard()) {
+    unsigned rd = isTailCall ? /*x0*/ 0 : /*ra*/ 1;
+    int EntryIndex =
+        getTableJumpEntryIndex(*TableJumpFragment, reloc->symInfo(), rd);
+    if (EntryIndex >= 0) {
+      applyTableJumpRelaxation(reloc, *region, offset,
+                               static_cast<unsigned>(EntryIndex));
+      relaxDeleteBytes("RISCV_TBJAL", *region, offset + 2, 4,
+                       reloc->symInfo()->name());
+      return true;
+    }
+  }
+
+  if (!canRelaxJal) {
+    reportMissedQCCall();
+    return false;
   }
 
   // Replace the instruction to JAL
   unsigned rd = isTailCall ? /*x0*/ 0 : /*ra*/ 1;
   uint32_t jal_instr = 0x6fu | rd << 7;
-  region->replaceInstruction(offset, reloc, reinterpret_cast<uint8_t *>(&jal_instr), 4);
+  region->replaceInstruction(offset, reloc,
+                             reinterpret_cast<uint8_t *>(&jal_instr), 4);
   // Replace the reloc to R_RISCV_JAL
   reloc->setType(llvm::ELF::R_RISCV_JAL);
   reloc->setTargetData(jal_instr);

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -544,7 +544,7 @@ bool RISCVLDBackend::doRelaxationQCCall(Relocation *reloc) {
   bool canCompress = canRelax && DoCompressed && llvm::isInt<12>(X);
   bool canRelaxTbljal = canRelax && DoCompressed &&
                         config().options().getRISCVRelaxTbljal() &&
-                        llvm::isInt<32>(X);
+                        llvm::isUInt<32>(S + A);
   bool canRelaxJal = canRelax && llvm::isInt<21>(X);
   auto reportMissedQCCall = [&]() {
     reportMissedRelaxation("RISCV_QC_E_CALL", *region, offset,

--- a/lib/Target/RISCV/RISCVTableJump.cpp
+++ b/lib/Target/RISCV/RISCVTableJump.cpp
@@ -82,7 +82,9 @@ void RISCVTableJumpFragment::scanTableJumpEntries(ELFSection &Sec) {
     if (R->type() == eld::ELF::riscv::internal::R_RISCV_QC_E_CALL_PLT &&
         (!Backend.config().options().getRISCVRelax() ||
          !Backend.config().targets().is32Bits() ||
-         !Backend.config().options().getRISCVRelaxXqci()))
+         !Backend.config().options().getRISCVRelaxXqci() ||
+         !Backend.config().options().getRISCVRelaxToC() ||
+         !llvm::isUInt<32>(Backend.getSymbolValuePLT(*R) + R->addend())))
       continue;
 
     const ResolveInfo *Sym = R->symInfo();

--- a/lib/Target/RISCV/RISCVTableJump.cpp
+++ b/lib/Target/RISCV/RISCVTableJump.cpp
@@ -97,9 +97,10 @@ void RISCVTableJumpFragment::scanTableJumpEntries(ELFSection &Sec) {
       // the rd-equivalent selector because QC.E.J does not write ra.
       Rd = (R->target() >> 15) & 0x3;
     } else {
-      // CALL/CALL_PLT pseudos use AUIPC rd=ra for calls and a scratch rd for
-      // tail calls. Table jumps only need to distinguish ra from x0.
-      Rd = (((R->target() >> 7) & 0x1f) == 1) ? 1 : 0;
+      // CALL/CALL_PLT: read the following JALR to get rd.
+      uint32_t Insn = 0;
+      R->targetRef()->memcpy(&Insn, sizeof(Insn), 4);
+      Rd = (Insn >> 7) & 0x1f;
     }
 
     // Only x0 (cm.jt) and ra (cm.jalt) are supported.

--- a/lib/Target/RISCV/RISCVTableJump.cpp
+++ b/lib/Target/RISCV/RISCVTableJump.cpp
@@ -14,6 +14,7 @@
 
 #include "RISCVTableJump.h"
 #include "RISCVLDBackend.h"
+#include "RISCVRelocationInternal.h"
 #include "eld/Core/Module.h"
 #include "eld/Readers/ELFSection.h"
 #include "eld/Readers/Relocation.h"
@@ -70,11 +71,18 @@ void RISCVTableJumpFragment::scanTableJumpEntries(ELFSection &Sec) {
     const Relocation *R = Relocs[I];
     if (R->type() != llvm::ELF::R_RISCV_JAL &&
         R->type() != llvm::ELF::R_RISCV_CALL &&
-        R->type() != llvm::ELF::R_RISCV_CALL_PLT)
+        R->type() != llvm::ELF::R_RISCV_CALL_PLT &&
+        R->type() != eld::ELF::riscv::internal::R_RISCV_QC_E_CALL_PLT)
       continue;
 
     if (I + 1 >= Relocs.size() ||
         Relocs[I + 1]->type() != llvm::ELF::R_RISCV_RELAX)
+      continue;
+
+    if (R->type() == eld::ELF::riscv::internal::R_RISCV_QC_E_CALL_PLT &&
+        (!Backend.config().options().getRISCVRelax() ||
+         !Backend.config().targets().is32Bits() ||
+         !Backend.config().options().getRISCVRelaxXqci()))
       continue;
 
     const ResolveInfo *Sym = R->symInfo();
@@ -86,6 +94,11 @@ void RISCVTableJumpFragment::scanTableJumpEntries(ELFSection &Sec) {
     if (R->type() == llvm::ELF::R_RISCV_JAL) {
       R->targetRef()->memcpy(&Insn, sizeof(Insn), 0);
       Rd = (Insn >> 7) & 0x1f;
+    } else if (R->type() == eld::ELF::riscv::internal::R_RISCV_QC_E_CALL_PLT) {
+      R->targetRef()->memcpy(&Insn, sizeof(Insn), 0);
+      // QC.E.J has func2=0b00 and QC.E.JAL has func2=0b01. Use this for
+      // selecting Rd.
+      Rd = (Insn >> 15) & 0x3;
     } else {
       // CALL/CALL_PLT: read the following JALR to get rd.
       R->targetRef()->memcpy(&Insn, sizeof(Insn), 4);
@@ -105,9 +118,21 @@ void RISCVTableJumpFragment::scanTableJumpEntries(ELFSection &Sec) {
         continue;
     }
 
-    // If the jal/j can be relaxed to a 32-bit instruction, the saving becomes
-    // actually 2 bytes (4->2), otherwise it's 6 bytes (8->2).
-    const int Saved = llvm::isInt<21>(Displace) ? 2 : 6;
+    int Saved = 0;
+    if (R->type() == eld::ELF::riscv::internal::R_RISCV_QC_E_CALL_PLT) {
+      // For qc.e.j/qc.e.jal, tbljal saves 4 bytes (6->2). If the instruction
+      // can already relax to JAL, the incremental saving is only 2 bytes
+      // (4->2), matching the profitability model used for CALL/JAL.
+      const bool CanRelaxToJAL =
+          Backend.config().targets().is32Bits() &&
+          Backend.config().options().getRISCVRelaxXqci() &&
+          llvm::isInt<21>(Displace);
+      Saved = CanRelaxToJAL ? 2 : 4;
+    } else {
+      // If the jal/j can be relaxed to a 32-bit instruction, the saving
+      // becomes actually 2 bytes (4->2), otherwise it's 6 bytes (8->2).
+      Saved = llvm::isInt<21>(Displace) ? 2 : 6;
+    }
 
     if (Rd == 0)
       addEntry(CMJTCandidates, Sym, Saved);

--- a/lib/Target/RISCV/RISCVTableJump.cpp
+++ b/lib/Target/RISCV/RISCVTableJump.cpp
@@ -89,20 +89,17 @@ void RISCVTableJumpFragment::scanTableJumpEntries(ELFSection &Sec) {
     if (!Sym || Sym->isUndef())
       continue;
 
-    uint32_t Insn = 0;
     uint8_t Rd = 0;
     if (R->type() == llvm::ELF::R_RISCV_JAL) {
-      R->targetRef()->memcpy(&Insn, sizeof(Insn), 0);
-      Rd = (Insn >> 7) & 0x1f;
+      Rd = (R->target() >> 7) & 0x1f;
     } else if (R->type() == eld::ELF::riscv::internal::R_RISCV_QC_E_CALL_PLT) {
-      R->targetRef()->memcpy(&Insn, sizeof(Insn), 0);
-      // QC.E.J has func2=0b00 and QC.E.JAL has func2=0b01. Use this for
-      // selecting Rd.
-      Rd = (Insn >> 15) & 0x3;
+      // QC.E.J has func2=0b00 and QC.E.JAL has func2=0b01. Use this as
+      // the rd-equivalent selector because QC.E.J does not write ra.
+      Rd = (R->target() >> 15) & 0x3;
     } else {
-      // CALL/CALL_PLT: read the following JALR to get rd.
-      R->targetRef()->memcpy(&Insn, sizeof(Insn), 4);
-      Rd = (Insn >> 7) & 0x1f;
+      // CALL/CALL_PLT pseudos use AUIPC rd=ra for calls and a scratch rd for
+      // tail calls. Table jumps only need to distinguish ra from x0.
+      Rd = (((R->target() >> 7) & 0x1f) == 1) ? 1 : 0;
     }
 
     // Only x0 (cm.jt) and ra (cm.jalt) are supported.

--- a/test/RISCV/standalone/Relaxation/QC_E_CALL_TO_TBLJAL/QC_E_CALL_TO_TBLJAL.s
+++ b/test/RISCV/standalone/Relaxation/QC_E_CALL_TO_TBLJAL/QC_E_CALL_TO_TBLJAL.s
@@ -1,0 +1,80 @@
+#----------QC_E_CALL_TO_TBLJAL.s----------------- Executable------------------#
+# BEGIN_COMMENT
+# Relax near QC.E.JAL/QC.E.J (Xqcilb 48-bit) to C.JAL/C.J when possible.
+# Relax far profitable calls to CM.JALT/CM.JT (Zcmt 16-bit) only when
+# compressed relaxation is enabled.
+# END_COMMENT
+#--------------------------------------------------------------------
+# REQUIRES: riscv32
+
+# RUN: %llvm-mc -filetype=obj -mattr=+relax,+c,+xqcilb \
+# RUN:   --defsym NEAR_TARGET=1 %s -o %t.near.o
+# RUN: %link %linkopts --relax-xqci --relax-tbljal %t.near.o \
+# RUN:   -o %t.near.out
+# RUN: %objdump -d -M no-aliases --mattr=+zcmt %t.near.out 2>&1 \
+# RUN:   | %filecheck %s --check-prefix=NEAR-DISASM
+# NEAR-DISASM: c.jal
+# NEAR-DISASM: c.j
+# NEAR-DISASM-NOT: cm.jalt
+# NEAR-DISASM-NOT: cm.jt
+# NEAR-DISASM-NOT: qc.e.jal
+# NEAR-DISASM-NOT: qc.e.j
+# RUN: %readelf -S %t.near.out \
+# RUN:   | %filecheck %s --check-prefix=NO-JVT
+
+# RUN: %llvm-mc -filetype=obj -mattr=+relax,+c,+xqcilb \
+# RUN:   --defsym CALL_COUNT=34 --defsym TAIL_COUNT=34 %s -o %t.far.o
+# RUN: %link %linkopts --relax-xqci --relax-tbljal \
+# RUN:   --defsym target=0x150000 %t.far.o -o %t.far.out \
+# RUN:   --verbose 2>&1 \
+# RUN:   | %filecheck %s --check-prefix=VERBOSE-TBLJAL
+# VERBOSE-TBLJAL-COUNT-68: RISCV_TBJAL : Deleting 4 bytes
+# RUN: %objdump -d -M no-aliases --mattr=+zcmt %t.far.out 2>&1 \
+# RUN:   | %filecheck %s --check-prefix=TBLJAL-DISASM
+# TBLJAL-DISASM-COUNT-34: cm.jalt
+# TBLJAL-DISASM-COUNT-34: cm.jt
+# TBLJAL-DISASM-NOT: qc.e.jal
+# TBLJAL-DISASM-NOT: qc.e.j
+# RUN: %readelf -S %t.far.out \
+# RUN:   | %filecheck %s --check-prefix=JVT
+# JVT: .riscv.jvt PROGBITS
+
+# RUN: %link %linkopts --relax-xqci --relax-tbljal --no-relax-c \
+# RUN:   --defsym target=0x90000 %t.far.o -o %t.no-relax-c.out
+# RUN: %objdump -d -M no-aliases --mattr=+zcmt \
+# RUN:   %t.no-relax-c.out 2>&1 \
+# RUN:   | %filecheck %s --check-prefix=NO-RELAX-C-DISASM \
+# RUN:   --implicit-check-not=c.jal --implicit-check-not=c.j \
+# RUN:   --implicit-check-not=cm.jalt --implicit-check-not=cm.jt \
+# RUN:   --implicit-check-not=qc.e.jal --implicit-check-not=qc.e.j
+# NO-RELAX-C-DISASM-COUNT-68: jal
+
+
+# NO-JVT-NOT: .riscv.jvt
+
+  .option exact
+  .option relax
+
+  .text
+  .align 1
+  .globl _start
+  .type _start, @function
+_start:
+.ifdef NEAR_TARGET
+  qc.e.jal target
+  qc.e.j target
+
+  .align 1
+  .type target, @function
+target:
+  ret
+  .size target, .-target
+.else
+  .rept CALL_COUNT
+  qc.e.jal target
+  .endr
+  .rept TAIL_COUNT
+  qc.e.j target
+  .endr
+.endif
+  .size _start, .-_start

--- a/test/RISCV/standalone/Relaxation/QC_E_CALL_TO_TBLJAL/QC_E_CALL_TO_TBLJAL.s
+++ b/test/RISCV/standalone/Relaxation/QC_E_CALL_TO_TBLJAL/QC_E_CALL_TO_TBLJAL.s
@@ -48,6 +48,19 @@
 # RUN:   --implicit-check-not=cm.jalt --implicit-check-not=cm.jt \
 # RUN:   --implicit-check-not=qc.e.jal --implicit-check-not=qc.e.j
 # NO-RELAX-C-DISASM-COUNT-68: jal
+# RUN: %readelf -S %t.no-relax-c.out \
+# RUN:   | %filecheck %s --check-prefix=NO-JVT
+
+# RUN: %link %linkopts --relax-xqci --relax-tbljal \
+# RUN:   --defsym target=0x100001000 %t.far.o -o %t.out-of-u32.out
+# RUN: %objdump -d -M no-aliases --mattr=+zcmt \
+# RUN:   %t.out-of-u32.out 2>&1 \
+# RUN:   | %filecheck %s --check-prefix=OUT-OF-U32-DISASM \
+# RUN:   --implicit-check-not=cm.jalt --implicit-check-not=cm.jt
+# OUT-OF-U32-DISASM-COUNT-34: qc.e.jal
+# OUT-OF-U32-DISASM-COUNT-34: qc.e.j
+# RUN: %readelf -S %t.out-of-u32.out \
+# RUN:   | %filecheck %s --check-prefix=NO-JVT
 
 # RUN: %echo "SECTIONS {" > %t.discard.t
 # RUN: %echo "  /DISCARD/ : { *(.riscv.jvt) }" >> %t.discard.t

--- a/test/RISCV/standalone/Relaxation/QC_E_CALL_TO_TBLJAL/QC_E_CALL_TO_TBLJAL.s
+++ b/test/RISCV/standalone/Relaxation/QC_E_CALL_TO_TBLJAL/QC_E_CALL_TO_TBLJAL.s
@@ -49,6 +49,21 @@
 # RUN:   --implicit-check-not=qc.e.jal --implicit-check-not=qc.e.j
 # NO-RELAX-C-DISASM-COUNT-68: jal
 
+# RUN: %echo "SECTIONS {" > %t.discard.t
+# RUN: %echo "  /DISCARD/ : { *(.riscv.jvt) }" >> %t.discard.t
+# RUN: %echo "}" >> %t.discard.t
+# RUN: %link %linkopts --relax-xqci --relax-tbljal \
+# RUN:   --defsym target=0x90000 %t.far.o -T %t.discard.t \
+# RUN:   -o %t.discard.out
+# RUN: %objdump -d -M no-aliases --mattr=+zcmt %t.discard.out 2>&1 \
+# RUN:   | %filecheck %s --check-prefix=NO-JVT-DISASM
+# RUN: %readelf -S %t.discard.out \
+# RUN:   | %filecheck %s --check-prefix=NO-JVT
+
+# NO-JVT-DISASM-NOT: cm.jalt
+# NO-JVT-DISASM-NOT: cm.jt
+# NO-JVT-DISASM-COUNT-68: jal
+
 
 # NO-JVT-NOT: .riscv.jvt
 


### PR DESCRIPTION
This can save either 2 or 4 bytes depending on whether the QC.E.J/JAL can be relaxed to a JAL.