### PR TITLE
Fix issues associated with incorrect application of R_RISCV_RELAX

### DIFF
--- a/include/eld/Readers/ELFSection.h
+++ b/include/eld/Readers/ELFSection.h
@@ -338,9 +338,6 @@ public:
       R->targetSection()->setWanted(true);
   }
 
-  Relocation *findRelocation(uint64_t Offset, Relocation::Type Type,
-                             bool Reverse = true) const;
-
   Relocation *createOneReloc();
 
   // Linker Script support for sorting sections.

--- a/include/eld/Readers/ELFSection.h
+++ b/include/eld/Readers/ELFSection.h
@@ -341,10 +341,6 @@ public:
   Relocation *findRelocation(uint64_t Offset, Relocation::Type Type,
                              bool Reverse = true) const;
 
-  // Returns true if R is immediately followed by a relocation of the given
-  // type in the section's relocation list.
-  bool hasFollowing(const Relocation *R, Relocation::Type Type) const;
-
   Relocation *createOneReloc();
 
   // Linker Script support for sorting sections.

--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -703,8 +703,7 @@ public:
   /// handled here, false otherwise.
   virtual bool handleRelocation(ELFSection *pSection, Relocation::Type pType,
                                 LDSymbol &pSym, uint32_t pOffset,
-                                Relocation::Address pAddend = 0,
-                                bool pLastVisit = false) {
+                                Relocation::Address pAddend) {
     return false;
   }
 

--- a/lib/Readers/ELFSection.cpp
+++ b/lib/Readers/ELFSection.cpp
@@ -157,28 +157,6 @@ Relocation *ELFSection::createOneReloc() {
   return R;
 }
 
-Relocation *ELFSection::findRelocation(uint64_t Offset, Relocation::Type Type,
-                                       bool Reverse) const {
-  if (Reverse) {
-    auto Reloc = std::find_if(
-        Relocations.rbegin(), Relocations.rend(), [&](Relocation *R) -> bool {
-          return R->type() == Type && !R->targetRef()->isNull() &&
-                 R->targetRef()->offset() == Offset;
-        });
-    if (Reloc != Relocations.rend())
-      return *Reloc;
-  } else {
-    const auto *Reloc = std::find_if(
-        Relocations.begin(), Relocations.end(), [&](Relocation *R) -> bool {
-          return R->type() == Type && !R->targetRef()->isNull() &&
-                 R->targetRef()->offset() == Offset;
-        });
-    if (Reloc != Relocations.end())
-      return *Reloc;
-  }
-  return nullptr;
-}
-
 Fragment *ELFSection::getFirstFragmentInRule() const {
   OutputSectionEntry *OE = getOutputSection();
   if (!OE || !OE->size())

--- a/lib/Readers/ELFSection.cpp
+++ b/lib/Readers/ELFSection.cpp
@@ -179,15 +179,6 @@ Relocation *ELFSection::findRelocation(uint64_t Offset, Relocation::Type Type,
   return nullptr;
 }
 
-bool ELFSection::hasFollowing(const Relocation *R,
-                              Relocation::Type Type) const {
-  auto It = std::find(Relocations.begin(), Relocations.end(), R);
-  if (It == Relocations.end())
-    return false;
-  ++It;
-  return It != Relocations.end() && (*It)->type() == Type;
-}
-
 Fragment *ELFSection::getFirstFragmentInRule() const {
   OutputSectionEntry *OE = getOutputSection();
   if (!OE || !OE->size())

--- a/lib/Target/ARM/ARMLDBackend.cpp
+++ b/lib/Target/ARM/ARMLDBackend.cpp
@@ -1188,8 +1188,7 @@ void ARMGNULDBackend::initializeAttributes() {
 bool ARMGNULDBackend::handleRelocation(ELFSection *Section,
                                        Relocation::Type Type, LDSymbol &Sym,
                                        uint32_t Offset,
-                                       Relocation::Address Addend,
-                                       bool LastVisit) {
+                                       Relocation::Address Addend) {
   if (auto *EXIDX = llvm::dyn_cast<ARMEXIDXSection>(Section)) {
     EXIDXEntry Entry = EXIDX->getEntry(Offset);
     Relocation *R = eld::IRBuilder::addRelocation(

--- a/lib/Target/ARM/ARMLDBackend.h
+++ b/lib/Target/ARM/ARMLDBackend.h
@@ -228,8 +228,7 @@ public:
 
   bool handleRelocation(ELFSection *Section, Relocation::Type Type,
                         LDSymbol &Sym, uint32_t Offset,
-                        Relocation::Address Addend = 0,
-                        bool LastVisit = false) override;
+                        Relocation::Address Addend) override;
 
   std::size_t PLTEntriesCount() const override { return m_PLTMap.size(); }
 

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -1530,10 +1530,18 @@ void RISCVLDBackend::mayBeRelax(int relaxation_pass, bool &pFinished) {
         continue;
       auto relocList = rs->getLink()->getRelocations();
       for (llvm::SmallVectorImpl<Relocation *>::iterator it = relocList.begin();
-           it != relocList.end(); ++it) {
+           config().getDiagEngine()->diagnose() && it != relocList.end();
+           ++it) {
         auto relocation = *it;
-        // Check if the next relocation is a RELAX relocation.
         Relocation::Type type = relocation->type();
+
+        // Processing of R_RISCV_ALIGN is unconditional.
+        if (relaxation_pass == RELAXATION_ALIGN) {
+          if (type == llvm::ELF::R_RISCV_ALIGN && doRelaxationAlign(relocation))
+            pFinished = false;
+          continue;
+        }
+
         llvm::SmallVectorImpl<Relocation *>::iterator it2 = it + 1;
         Relocation *nextRelax = nullptr;
         if (it2 != relocList.end()) {
@@ -1542,38 +1550,15 @@ void RISCVLDBackend::mayBeRelax(int relaxation_pass, bool &pFinished) {
             nextRelax = nullptr;
         }
 
-        // try to relax
-        switch (type) {
-        case llvm::ELF::R_RISCV_CALL:
-        case llvm::ELF::R_RISCV_CALL_PLT: {
-          if (nextRelax && relaxation_pass == RELAXATION_CALL)
-            doRelaxationCall(relocation);
-          break;
-        }
-        case llvm::ELF::R_RISCV_JAL: {
-          if (nextRelax && relaxation_pass == RELAXATION_CALL)
-            doRelaxationJal(relocation);
-          break;
-        }
-        case llvm::ELF::R_RISCV_PCREL_HI20:
-        case llvm::ELF::R_RISCV_PCREL_LO12_I:
-        case llvm::ELF::R_RISCV_PCREL_LO12_S: {
-          if (nextRelax && relaxation_pass == RELAXATION_PC)
-            doRelaxationPC(relocation, GP);
-          break;
-        }
-        case llvm::ELF::R_RISCV_LO12_S:
-        case llvm::ELF::R_RISCV_LO12_I:
-        case llvm::ELF::R_RISCV_HI20: {
-          if (nextRelax && relaxation_pass == RELAXATION_LUI)
-            doRelaxationLui(relocation, GP);
-          break;
-        }
-        case llvm::ELF::R_RISCV_TLSDESC_HI20:
-        case llvm::ELF::R_RISCV_TLSDESC_LOAD_LO12:
-        case llvm::ELF::R_RISCV_TLSDESC_ADD_LO12:
-        case llvm::ELF::R_RISCV_TLSDESC_CALL:
-          if (relaxation_pass == RELAXATION_TLSDESC) {
+        if (relaxation_pass == RELAXATION_TLSDESC) {
+          // doRelaxationTLSDESC is used for both TLSDESC optimizations and
+          // relaxations, therefore this function should be called regardless
+          // of whether relaxations are enabled.
+          switch (type) {
+          case llvm::ELF::R_RISCV_TLSDESC_HI20:
+          case llvm::ELF::R_RISCV_TLSDESC_LOAD_LO12:
+          case llvm::ELF::R_RISCV_TLSDESC_ADD_LO12:
+          case llvm::ELF::R_RISCV_TLSDESC_CALL:
             // In the TLSDESC relaxation sequence, only the instruction with
             // R_RISCV_TLSDESC_HI20 can be marked with R_RISCV_RELAX to indicate
             // that the whole sequence is relaxable. So the other three
@@ -1583,25 +1568,48 @@ void RISCVLDBackend::mayBeRelax(int relaxation_pass, bool &pFinished) {
               if (const Relocation *HIReloc = getBaseReloc(*relocation))
                 nextRelax = rs->getLink()->findRelocation(
                     HIReloc->targetRef()->offset(), llvm::ELF::R_RISCV_RELAX);
-            // Note that doRelaxationTLSDESC is used for both optimizations and
-            // relaxations, therefore this function should be called regardless
-            // of whether relaxations are enabled.
             doRelaxationTLSDESC(*relocation, nextRelax);
+            break;
+          }
+          continue;
+        }
+
+        // try to relax
+        if (!nextRelax)
+          continue;
+
+        switch (relaxation_pass) {
+        case RELAXATION_CALL:
+          switch (type) {
+          case llvm::ELF::R_RISCV_CALL:
+          case llvm::ELF::R_RISCV_CALL_PLT:
+            doRelaxationCall(relocation);
+            break;
+          case llvm::ELF::R_RISCV_JAL:
+            doRelaxationJal(relocation);
+            break;
+          case ELF::riscv::internal::R_RISCV_QC_E_CALL_PLT:
+            doRelaxationQCCall(relocation);
+            break;
           }
           break;
-        case llvm::ELF::R_RISCV_ALIGN: {
-          if (relaxation_pass == RELAXATION_ALIGN)
-            if (doRelaxationAlign(relocation))
-              pFinished = false;
+        case RELAXATION_PC:
+          switch (type) {
+          case llvm::ELF::R_RISCV_PCREL_HI20:
+          case llvm::ELF::R_RISCV_PCREL_LO12_I:
+          case llvm::ELF::R_RISCV_PCREL_LO12_S:
+            doRelaxationPC(relocation, GP);
+            break;
+          }
           break;
-        }
-        case ELF::riscv::internal::R_RISCV_QC_E_CALL_PLT: {
-          if (nextRelax && relaxation_pass == RELAXATION_CALL)
-            doRelaxationQCCall(relocation);
-          break;
-        }
-        case ELF::riscv::internal::R_RISCV_QC_E_32: {
-          if (nextRelax && relaxation_pass == RELAXATION_LUI) {
+        case RELAXATION_LUI:
+          switch (type) {
+          case llvm::ELF::R_RISCV_LO12_S:
+          case llvm::ELF::R_RISCV_LO12_I:
+          case llvm::ELF::R_RISCV_HI20:
+            doRelaxationLui(relocation, GP);
+            break;
+          case ELF::riscv::internal::R_RISCV_QC_E_32: {
             uint64_t access_offset = relocation->targetRef()->offset() + 6;
             bool relaxed = false;
             if (Relocation *acc32 = rs->getLink()->findRelocation(
@@ -1617,16 +1625,17 @@ void RISCVLDBackend::mayBeRelax(int relaxation_pass, bool &pFinished) {
                   relaxed = doRelaxationQCAccess16(relocation, acc16, GP);
             if (!relaxed)
               doRelaxationQCELi(relocation, GP);
+            break;
+          }
           }
           break;
         }
-        }
-        if (!config().getDiagEngine()->diagnose()) {
-          m_Module.setFailure(true);
-          pFinished = true;
-          return;
-        }
       } // for all relocations
+      if (!config().getDiagEngine()->diagnose()) {
+        m_Module.setFailure(true);
+        pFinished = true;
+        return;
+      }
     } // for all relocation section
   }
 

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -1703,22 +1703,6 @@ bool RISCVLDBackend::checkABIStr(llvm::StringRef abi) const {
   return true;
 }
 
-Relocation *RISCVLDBackend::findHIRelocation(ELFSection *S, uint64_t Value) {
-  Relocation *HIReloc = S->findRelocation(Value, llvm::ELF::R_RISCV_PCREL_HI20);
-  if (HIReloc)
-    return HIReloc;
-  HIReloc = S->findRelocation(Value, llvm::ELF::R_RISCV_GOT_HI20);
-  if (HIReloc)
-    return HIReloc;
-  HIReloc = S->findRelocation(Value, llvm::ELF::R_RISCV_TLS_GD_HI20);
-  if (HIReloc)
-    return HIReloc;
-  HIReloc = S->findRelocation(Value, llvm::ELF::R_RISCV_TLS_GOT_HI20);
-  if (HIReloc)
-    return HIReloc;
-  return nullptr;
-}
-
 bool RISCVLDBackend::handleRelocation(ELFSection *pSection,
                                       Relocation::Type pType, LDSymbol &pSym,
                                       uint32_t pOffset,
@@ -1789,46 +1773,16 @@ bool RISCVLDBackend::handleRelocation(ELFSection *pSection,
   case llvm::ELF::R_RISCV_TLSDESC_LOAD_LO12:
   case llvm::ELF::R_RISCV_TLSDESC_ADD_LO12:
   case llvm::ELF::R_RISCV_TLSDESC_CALL: {
-    bool pcrel = pType == llvm::ELF::R_RISCV_PCREL_LO12_I ||
-                 pType == llvm::ELF::R_RISCV_PCREL_LO12_S;
-    Relocation *hi_reloc =
-        pcrel ? findHIRelocation(pSection, pSym.value())
-              : pSection->findRelocation(pSym.value(),
-                                         llvm::ELF::R_RISCV_TLSDESC_HI20);
-    if (!hi_reloc && pLastVisit) {
-      config().raise(Diag::rv_hi20_not_found)
-          << pSym.name() << getRISCVRelocName(pType)
-          << pSection->originalInput()->getInput()->decoratedPath();
-      m_Module.setFailure(true);
-      return false;
-    }
-    if (!hi_reloc) {
-      // We might be seeing a pcrel_lo with a forward reference to pcrel_hi.
-      // Add this to the pending relocations so that it can be revisited again
-      // after processing the entire relocation table once.
-      m_PendingRelocations.push_back(
-          std::make_tuple(pSection, pType, &pSym, pOffset, pAddend));
-      return true;
-    }
     if (pAddend) {
       config().raise(Diag::warn_ignore_pcrel_lo_addend)
           << pSym.name() << getRISCVRelocName(pType)
           << pSection->originalInput()->getInput()->decoratedPath();
       pAddend = 0;
     }
-    Relocation *reloc = IRBuilder::addRelocation(
-        getRelocator(), pSection, pType, *hi_reloc->symInfo()->outSymbol(),
-        pOffset, pAddend);
-    m_BaseRelocs[reloc] = hi_reloc;
-    if (reloc) {
-      reloc->setSymInfo(hi_reloc->symInfo());
+    Relocation *reloc = IRBuilder::addRelocation(getRelocator(), pSection,
+                                                 pType, pSym, pOffset, pAddend);
+    if (reloc)
       pSection->addRelocation(reloc);
-    }
-    if (pcrel && pLastVisit) {
-      // Disable GP Relaxation for this pair to mimic GNU
-      m_DisableGPRelocs.insert(reloc);
-      m_DisableGPRelocs.insert(hi_reloc);
-    }
     return true;
   }
   default: {
@@ -1839,9 +1793,16 @@ bool RISCVLDBackend::handleRelocation(ELFSection *pSection,
     // that to translate them into their relevant internal relocation type.
     if (pType >= internal::FirstNonstandardRelocation &&
         pType <= internal::LastNonstandardRelocation) {
-      Relocation *VendorReloc =
-          pSection->findRelocation(pOffset, llvm::ELF::R_RISCV_VENDOR);
-      if (!VendorReloc) {
+      // The internal list of relocations is not sorted yet, scan the whole
+      // list.
+      auto RI =
+          std::find_if(pSection->getRelocations().begin(),
+                       pSection->getRelocations().end(), [&](Relocation *R) {
+                         return R->type() == llvm::ELF::R_RISCV_VENDOR &&
+                                !R->targetRef()->isNull() &&
+                                R->targetRef()->offset() == pOffset;
+                       });
+      if (RI == pSection->getRelocations().end()) {
         // The ABI requires that R_RISCV_VENDOR precedes any R_RISCV_CUSTOM<n>
         // Relocation.
         config().raise(Diag::error_rv_vendor_not_found)
@@ -1851,6 +1812,7 @@ bool RISCVLDBackend::handleRelocation(ELFSection *pSection,
         return false;
       }
 
+      Relocation *VendorReloc = *RI;
       std::string VendorSymbol = VendorReloc->symInfo()->getName().str();
       auto [VendorOffset, VendorFirst, VendorLast] =
           llvm::StringSwitch<std::tuple<uint32_t, uint32_t, uint32_t>>(
@@ -1939,25 +1901,24 @@ bool RISCVLDBackend::handlePendingRelocations(ELFSection *section) {
     return false;
   }
 
-  for (auto &r : m_PendingRelocations)
-    if (!handleRelocation(std::get<0>(r), std::get<1>(r), *(std::get<2>(r)),
-                          std::get<3>(r), std::get<4>(r), /*pLastVisit*/ true))
-      return false;
-
-  // Sort the relocation table, in offset order, since the pending relocations
-  // that got added at end of the relocation table may not be in offset order.
-  // Another reason to sort relocations is to make sure R_RISCV_RELAX are
-  // adjacent to the relocation they affect. The psABI is not clear if
-  // R_RISCV_RELAX must be adjacent, but using `.reloc` in assembly may generate
-  // those that are not. Note that because of this, this function must not have
-  // earlier non-error exits.
+  // Sort the relocation table in offset order to quickly find a relocation at
+  // the offset, or by the symbol offset. This is needed for several reasons:
+  // find out which relocations are relaxable, find the correponding HI20
+  // relocation for some LO12, and for "group relocation".
   std::stable_sort(section->getRelocations().begin(),
                    section->getRelocations().end(),
                    [](Relocation *A, Relocation *B) {
                      return A->getOffset() < B->getOffset();
                    });
 
-  m_PendingRelocations.clear();
+  struct Less {
+    bool operator()(const Relocation *X, uint64_t Y) const {
+      return !X->targetRef()->isNull() && X->targetRef()->offset() < Y;
+    }
+    bool operator()(uint64_t X, const Relocation *Y) const {
+      return Y->targetRef()->isNull() || X < Y->targetRef()->offset();
+    }
+  };
 
   // Iterate over groups of relocations with equal offsets.
   llvm::SmallVectorImpl<Relocation *>::iterator RI;
@@ -1978,6 +1939,54 @@ bool RISCVLDBackend::handlePendingRelocations(ELFSection *section) {
       }
 
       switch (R->type()) {
+      // R_RISCV_PCREL_LO* and TLSDESC relocations have the corresponding HI
+      // reloc as the syminfo, we need to find out the actual target by
+      // inspecting this reloc and set the appropriate relocation.
+      case llvm::ELF::R_RISCV_PCREL_LO12_I:
+      case llvm::ELF::R_RISCV_PCREL_LO12_S:
+      case llvm::ELF::R_RISCV_TLSDESC_LOAD_LO12:
+      case llvm::ELF::R_RISCV_TLSDESC_ADD_LO12:
+      case llvm::ELF::R_RISCV_TLSDESC_CALL: {
+        bool IsPCRel = R->type() == llvm::ELF::R_RISCV_PCREL_LO12_I ||
+                       R->type() == llvm::ELF::R_RISCV_PCREL_LO12_S;
+        uint64_t HiOffset = R->symInfo()->outSymbol()->value();
+        auto HiRelocRange =
+            std::equal_range(section->getRelocations().begin(),
+                             section->getRelocations().end(), HiOffset, Less());
+
+        Relocation *HiReloc = nullptr;
+        for (auto HiRI = HiRelocRange.first; HiRI != HiRelocRange.second;
+             ++HiRI) {
+          if ((IsPCRel &&
+               ((*HiRI)->type() == llvm::ELF::R_RISCV_PCREL_HI20 ||
+                (*HiRI)->type() == llvm::ELF::R_RISCV_GOT_HI20 ||
+                (*HiRI)->type() == llvm::ELF::R_RISCV_TLS_GD_HI20 ||
+                (*HiRI)->type() == llvm::ELF::R_RISCV_TLS_GOT_HI20)) ||
+              (!IsPCRel &&
+               (*HiRI)->type() == llvm::ELF::R_RISCV_TLSDESC_HI20)) {
+            HiReloc = *HiRI;
+            break;
+          }
+        }
+        if (!HiReloc) {
+          config().raise(Diag::rv_hi20_not_found)
+              << R->symInfo()->outSymbol()->name()
+              << getRISCVRelocName(R->type())
+              << section->originalInput()->getInput()->decoratedPath();
+          m_Module.setFailure(true);
+          return false;
+        }
+
+        R->setSymInfo(HiReloc->symInfo());
+        m_BaseRelocs[R] = HiReloc;
+
+        if (IsPCRel && Offset < HiOffset) {
+          // Disable GP Relaxation for this pair to mimic GNU
+          m_DisableGPRelocs.insert(R);
+          m_DisableGPRelocs.insert(HiReloc);
+        }
+        break;
+      }
       case ELF::riscv::internal::R_RISCV_QC_E_32: {
         // R_RISCV_QC_E_32 is special as in addition to knowing if it is
         // relaxable, we need to distinguish between 32-bit and 16-bit types of
@@ -1987,12 +1996,21 @@ bool RISCVLDBackend::handlePendingRelocations(ELFSection *section) {
         // because it is at a higher offset and usually follows the original
         // one in the list.
         uint64_t AccessOffset = Offset + 6;
-        if (Relocation *AccessReloc = section->findRelocation(
-                AccessOffset, ELF::riscv::internal::R_RISCV_QC_ACCESS_32))
-          m_BaseRelocs[R] = AccessReloc;
-        else if (Relocation *AccessReloc = section->findRelocation(
-                     AccessOffset, ELF::riscv::internal::R_RISCV_QC_ACCESS_16))
-          m_BaseRelocs[R] = AccessReloc;
+        auto AccessRelocRange = std::equal_range(
+            section->getRelocations().begin(), section->getRelocations().end(),
+            AccessOffset, Less());
+        if (AccessRelocRange.first != AccessRelocRange.second) {
+          for (auto AccessRI = AccessRelocRange.first + 1;
+               AccessRI != AccessRelocRange.second; ++AccessRI) {
+            if ((*AccessRI)->type() ==
+                    ELF::riscv::internal::R_RISCV_QC_ACCESS_32 ||
+                (*AccessRI)->type() ==
+                    ELF::riscv::internal::R_RISCV_QC_ACCESS_16) {
+              m_BaseRelocs[R] = *AccessRI;
+              break;
+            }
+          }
+        }
         break;
       }
       }

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -1706,8 +1706,7 @@ bool RISCVLDBackend::checkABIStr(llvm::StringRef abi) const {
 bool RISCVLDBackend::handleRelocation(ELFSection *pSection,
                                       Relocation::Type pType, LDSymbol &pSym,
                                       uint32_t pOffset,
-                                      Relocation::Address pAddend,
-                                      bool pLastVisit) {
+                                      Relocation::Address pAddend) {
   if (config().codeGenType() == LinkerConfig::Object)
     return false;
   if (SectionRelocMap.find(pSection) == SectionRelocMap.end())
@@ -1844,8 +1843,8 @@ bool RISCVLDBackend::handleRelocation(ELFSection *pSection,
       }
 
       // Allow custom handling of vendor relocations (using the internal type)
-      if (handleVendorRelocation(pSection, InternalType, pSym, pOffset, pAddend,
-                                 pLastVisit))
+      if (handleVendorRelocation(pSection, InternalType, pSym, pOffset,
+                                 pAddend))
         return true;
 
       // Add a relocation using the internal type
@@ -2023,8 +2022,7 @@ bool RISCVLDBackend::handlePendingRelocations(ELFSection *section) {
 bool RISCVLDBackend::handleVendorRelocation(ELFSection *pSection,
                                             Relocation::Type pType,
                                             LDSymbol &pSym, uint32_t pOffset,
-                                            Relocation::Address pAddend,
-                                            bool pLastVisit) {
+                                            Relocation::Address pAddend) {
   using namespace eld::ELF::riscv;
   assert((internal::FirstInternalRelocation <= pType) &&
          (pType <= internal::LastInternalRelocation) &&

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -1542,14 +1542,6 @@ void RISCVLDBackend::mayBeRelax(int relaxation_pass, bool &pFinished) {
           continue;
         }
 
-        llvm::SmallVectorImpl<Relocation *>::iterator it2 = it + 1;
-        Relocation *nextRelax = nullptr;
-        if (it2 != relocList.end()) {
-          nextRelax = *it2;
-          if (nextRelax->type() != llvm::ELF::R_RISCV_RELAX)
-            nextRelax = nullptr;
-        }
-
         if (relaxation_pass == RELAXATION_TLSDESC) {
           // doRelaxationTLSDESC is used for both TLSDESC optimizations and
           // relaxations, therefore this function should be called regardless
@@ -1558,24 +1550,28 @@ void RISCVLDBackend::mayBeRelax(int relaxation_pass, bool &pFinished) {
           case llvm::ELF::R_RISCV_TLSDESC_HI20:
           case llvm::ELF::R_RISCV_TLSDESC_LOAD_LO12:
           case llvm::ELF::R_RISCV_TLSDESC_ADD_LO12:
-          case llvm::ELF::R_RISCV_TLSDESC_CALL:
+          case llvm::ELF::R_RISCV_TLSDESC_CALL: {
             // In the TLSDESC relaxation sequence, only the instruction with
             // R_RISCV_TLSDESC_HI20 can be marked with R_RISCV_RELAX to indicate
             // that the whole sequence is relaxable. So the other three
             // relocation types will inherit this knowledge from the
             // R_RISCV_TLSDESC_HI20 relocation.
-            if (type != llvm::ELF::R_RISCV_TLSDESC_HI20)
-              if (const Relocation *HIReloc = getBaseReloc(*relocation))
-                nextRelax = rs->getLink()->findRelocation(
-                    HIReloc->targetRef()->offset(), llvm::ELF::R_RISCV_RELAX);
-            doRelaxationTLSDESC(*relocation, nextRelax);
+            bool Relax;
+            if (type == llvm::ELF::R_RISCV_TLSDESC_HI20)
+              Relax = hasRelax(*relocation);
+            else {
+              const Relocation *BaseReloc = getBaseReloc(*relocation);
+              Relax = BaseReloc && hasRelax(*BaseReloc);
+            }
+            doRelaxationTLSDESC(*relocation, Relax);
             break;
+          }
           }
           continue;
         }
 
         // try to relax
-        if (!nextRelax)
+        if (!hasRelax(*relocation))
           continue;
 
         switch (relaxation_pass) {
@@ -1610,19 +1606,17 @@ void RISCVLDBackend::mayBeRelax(int relaxation_pass, bool &pFinished) {
             doRelaxationLui(relocation, GP);
             break;
           case ELF::riscv::internal::R_RISCV_QC_E_32: {
-            uint64_t access_offset = relocation->targetRef()->offset() + 6;
             bool relaxed = false;
-            if (Relocation *acc32 = rs->getLink()->findRelocation(
-                    access_offset, ELF::riscv::internal::R_RISCV_QC_ACCESS_32))
-              if (rs->getLink()->hasFollowing(acc32, llvm::ELF::R_RISCV_RELAX))
-                relaxed = doRelaxationQCAccess32(relocation, acc32, GP);
-            if (!relaxed)
-              if (Relocation *acc16 = rs->getLink()->findRelocation(
-                      access_offset,
-                      ELF::riscv::internal::R_RISCV_QC_ACCESS_16))
-                if (rs->getLink()->hasFollowing(acc16,
-                                                llvm::ELF::R_RISCV_RELAX))
-                  relaxed = doRelaxationQCAccess16(relocation, acc16, GP);
+            if (Relocation *AccessReloc = getBaseReloc(*relocation)) {
+              if (hasRelax(*AccessReloc)) {
+                if (AccessReloc->type() ==
+                    ELF::riscv::internal::R_RISCV_QC_ACCESS_32)
+                  relaxed = doRelaxationQCAccess32(relocation, AccessReloc, GP);
+                else if (AccessReloc->type() ==
+                         ELF::riscv::internal::R_RISCV_QC_ACCESS_16)
+                  relaxed = doRelaxationQCAccess16(relocation, AccessReloc, GP);
+              }
+            }
             if (!relaxed)
               doRelaxationQCELi(relocation, GP);
             break;
@@ -1964,6 +1958,46 @@ bool RISCVLDBackend::handlePendingRelocations(ELFSection *section) {
                    });
 
   m_PendingRelocations.clear();
+
+  // Iterate over groups of relocations with equal offsets.
+  llvm::SmallVectorImpl<Relocation *>::iterator RI;
+  for (auto GroupI = section->getRelocations().begin();
+       GroupI != section->getRelocations().end(); GroupI = RI) {
+    uint64_t Offset = (*GroupI)->getOffset();
+
+    // Iterate over relocations within a group.
+    for (RI = GroupI;
+         RI != section->getRelocations().end() && (*RI)->getOffset() == Offset;
+         ++RI) {
+      Relocation *R = *RI;
+
+      if (R->type() == llvm::ELF::R_RISCV_RELAX) {
+        if (RI != GroupI)
+          m_RelocsWithRelax.insert(*(RI - 1));
+        continue;
+      }
+
+      switch (R->type()) {
+      case ELF::riscv::internal::R_RISCV_QC_E_32: {
+        // R_RISCV_QC_E_32 is special as in addition to knowing if it is
+        // relaxable, we need to distinguish between 32-bit and 16-bit types of
+        // relaxation based on the "access" relocation type. We reuse
+        // m_BaseRelocs to store the pointer to the access relocation.
+        // We look for the access relocation after loading all the relocations
+        // because it is at a higher offset and usually follows the original
+        // one in the list.
+        uint64_t AccessOffset = Offset + 6;
+        if (Relocation *AccessReloc = section->findRelocation(
+                AccessOffset, ELF::riscv::internal::R_RISCV_QC_ACCESS_32))
+          m_BaseRelocs[R] = AccessReloc;
+        else if (Relocation *AccessReloc = section->findRelocation(
+                     AccessOffset, ELF::riscv::internal::R_RISCV_QC_ACCESS_16))
+          m_BaseRelocs[R] = AccessReloc;
+        break;
+      }
+      }
+    }
+  }
 
   return true;
 }

--- a/lib/Target/RISCV/RISCVLDBackend.h
+++ b/lib/Target/RISCV/RISCVLDBackend.h
@@ -15,6 +15,7 @@
 #include "eld/Readers/ELFSection.h"
 #include "eld/SymbolResolver/IRBuilder.h"
 #include "eld/Target/GNULDBackend.h"
+#include "llvm/ADT/DenseSet.h"
 #include <unordered_set>
 
 namespace eld {
@@ -55,6 +56,10 @@ public:
   bool initBRIslandFactory() override;
 
   bool initStubFactory() override;
+
+  bool hasRelax(const Relocation &R) const {
+    return m_RelocsWithRelax.find(&R) != m_RelocsWithRelax.end();
+  }
 
   void preRelaxation() override;
 
@@ -194,7 +199,7 @@ public:
     return reloc->second;
   }
 
-  const Relocation *getBaseReloc(const Relocation &R) const {
+  Relocation *getBaseReloc(const Relocation &R) const {
     auto reloc = m_BaseRelocs.find(&R);
     if (reloc == m_BaseRelocs.end())
       return nullptr;
@@ -332,7 +337,10 @@ private:
   /// A map to keep track of the relocation that defines the base address for
   /// relative relocations. This is a concept in RISC-V and applies to
   /// relocations consisting of a HI20 and LO12 pairs.
-  llvm::DenseMap<const Relocation *, const Relocation *> m_BaseRelocs;
+  llvm::DenseMap<const Relocation *, Relocation *> m_BaseRelocs;
+
+  /// Identify relocations that have an associated R_RISCV_RELAX.
+  llvm::DenseSet<const Relocation *> m_RelocsWithRelax;
 
 private:
   /// RISCV Attribute Section

--- a/lib/Target/RISCV/RISCVLDBackend.h
+++ b/lib/Target/RISCV/RISCVLDBackend.h
@@ -86,8 +86,7 @@ public:
 
   bool handleRelocation(ELFSection *pSection, Relocation::Type pType,
                         LDSymbol &pSym, uint32_t pOffset,
-                        Relocation::Address pAddend = 0,
-                        bool pLastPass = false) override;
+                        Relocation::Address pAddend) override;
 
   // Handle the relocations that handleRelocation() could not process.
   bool handlePendingRelocations(ELFSection *S) override;
@@ -238,8 +237,7 @@ private:
   // This is `handleRelocation` for internal RISC-V relocations IDs.
   bool handleVendorRelocation(ELFSection *pSection,
                               Relocation::Type pInternalType, LDSymbol &pSym,
-                              uint32_t pOffset, Relocation::Address pAddend = 0,
-                              bool pLastPass = false);
+                              uint32_t pOffset, Relocation::Address pAddend);
 
   void relaxDeleteBytes(llvm::StringRef Name, RegionFragmentEx &Region,
                         uint64_t Offset, unsigned NumBytes,

--- a/lib/Target/RISCV/RISCVLDBackend.h
+++ b/lib/Target/RISCV/RISCVLDBackend.h
@@ -235,8 +235,6 @@ public:
 private:
   void initTableJump();
 
-  Relocation *findHIRelocation(ELFSection *S, uint64_t Value);
-
   // This is `handleRelocation` for internal RISC-V relocations IDs.
   bool handleVendorRelocation(ELFSection *pSection,
                               Relocation::Type pInternalType, LDSymbol &pSym,
@@ -360,10 +358,6 @@ private:
   llvm::DenseMap<ResolveInfo *, RISCVGOT *> m_GOTPLTMap;
   llvm::DenseMap<ResolveInfo *, RISCVPLT *> m_PLTMap;
   std::vector<ResolveInfo *> m_LabeledSymbols;
-  using PendingRelocInfo =
-      std::tuple<ELFSection *, Relocation::Type, LDSymbol *, uint32_t,
-                 Relocation::Address>;
-  std::vector<PendingRelocInfo> m_PendingRelocations;
   std::unordered_set<Relocation *> m_DisableGPRelocs;
   Relocator *m_pRelocator = nullptr;
   LDSymbol *m_pGlobalPointer = nullptr;

--- a/lib/Target/RISCV/RISCVTableJump.cpp
+++ b/lib/Target/RISCV/RISCVTableJump.cpp
@@ -73,8 +73,7 @@ void RISCVTableJumpFragment::scanTableJumpEntries(ELFSection &Sec) {
         R->type() != llvm::ELF::R_RISCV_CALL_PLT)
       continue;
 
-    if (I + 1 >= Relocs.size() ||
-        Relocs[I + 1]->type() != llvm::ELF::R_RISCV_RELAX)
+    if (!Backend.hasRelax(*R))
       continue;
 
     const ResolveInfo *Sym = R->symInfo();

--- a/test/lld/ELF/Inputs/riscv-pending-bug1276/script.t
+++ b/test/lld/ELF/Inputs/riscv-pending-bug1276/script.t
@@ -1,0 +1,12 @@
+SECTIONS {
+   .text (0x1233000) : {
+    *(.text.test)
+   }
+   .anothertext (0x1233560) : {
+    *(.text.foo)
+   }
+   .data (0x1234560) : {
+     __global_pointer$ = .;
+     *(.data.*)
+   }
+}

--- a/test/lld/ELF/Inputs/riscv-tlsdesc-bug1278/script.t
+++ b/test/lld/ELF/Inputs/riscv-tlsdesc-bug1278/script.t
@@ -1,0 +1,8 @@
+SECTIONS {
+  .text : { *(.text) }
+  .data : {
+    __global_pointer$ = .;
+    *(.data)
+  }
+  .tbss : { *(.tbss) }
+}

--- a/test/lld/ELF/riscv-pending-bug1276.s
+++ b/test/lld/ELF/riscv-pending-bug1276.s
@@ -1,0 +1,30 @@
+# REQUIRES: riscv32 || riscv64
+
+## Check that R_RISCV_RELAX does not apply to a wrong relocation.
+
+# RUN: %llvm-mc -filetype=obj -mattr=+c,+relax %s -o %t.o
+# RUN: %link %linkopts -T %p/Inputs/riscv-pending-bug1276/script.t %t.o -o %t.out
+# RUN: %objdump --no-show-raw-insn -M no-aliases -h -d %t.out | FileCheck %s --check-prefix=CHECK
+
+        .data
+num:
+        .word   1
+val:
+        .word   2
+
+# CHECK-LABEL: <.text>
+        .text
+        .option norelax
+## This lui should not get relaxed because of incorrectly ordered R_RISCV_RELAX.
+# CHECK-NEXT:    lui a3, 0x1234
+        lui     a3, %hi(num)
+        .option relax
+## GP relaxation is not applied to inverted pcrel_hi/lo pairs, see m_DisableGPRelocs
+# CHECK-NEXT:    sw zero, 0x55c(a0)
+        sw      zero, %pcrel_lo(.Lpcrel_hi5)(a0)
+.Lpcrel_hi5:
+# CHECK-LABEL: <.Lpcrel_hi5>
+# CHECK-NEXT:    auipc a0, 0x1
+        auipc   a0, %pcrel_hi(val)
+# CHECK-NEXT:    lw a1, 0x4(gp)
+        lw      a1, %pcrel_lo(.Lpcrel_hi5)(a0)

--- a/test/lld/ELF/riscv-tlsdesc-bug1278.s
+++ b/test/lld/ELF/riscv-tlsdesc-bug1278.s
@@ -1,0 +1,55 @@
+# REQUIRES: riscv32 || riscv64
+
+## A regression test for a bug when incorrect R_RISCV_RELAX relocation was used
+## to determine if a relocation is relaxable, due to shifting offsets.
+
+# RUN: %llvm-mc -filetype=obj -mattr=+c,+relax %s -o %t.o
+# RUN: %link %linkopts -T %p/Inputs/riscv-tlsdesc-bug1278/script.t %t.o -o %t.out
+# RUN: %objdump --no-show-raw-insn -M no-aliases -h -d %t.out | FileCheck %s --check-prefix=CHECK
+
+.text
+
+# CHECK-LABEL: foo_1
+# CHECK-NEXT:      addi zero, zero, 0x0
+# CHECK-NEXT:      addi zero, zero, 0x0
+# CHECK-NEXT:      addi zero, zero, 0x0
+# CHECK-NEXT:      addi a0, zero, 0x0
+
+foo_1:
+.option relax
+  lui a7, %hi(a)
+.option norelax
+.Ltlsdesc_hi_1:
+  auipc a4, %tlsdesc_hi(b)
+  lw a5, %tlsdesc_load_lo(.Ltlsdesc_hi_1)(a4)
+  addi a0, a4, %tlsdesc_add_lo(.Ltlsdesc_hi_1)
+  jalr t0, 0(a5), %tlsdesc_call(.Ltlsdesc_hi_1)
+
+# CHECK-LABEL: foo_2
+# CHECK-NEXT:      addi zero, zero, 0x0
+# CHECK-NEXT:      addi zero, zero, 0x0
+# CHECK-NEXT:      addi zero, zero, 0x0
+# CHECK-NEXT:      addi a0, zero, 0x0
+
+foo_2:
+.option relax
+  lui a7, %hi(a)
+.option norelax
+.Ltlsdesc_hi_2:
+  auipc a4, %tlsdesc_hi(b)
+.option relax
+  lw a5, %tlsdesc_load_lo(.Ltlsdesc_hi_2)(a4)
+  addi a0, a4, %tlsdesc_add_lo(.Ltlsdesc_hi_2)
+  jalr t0, 0(a5), %tlsdesc_call(.Ltlsdesc_hi_2)
+
+
+.data
+.globl a
+a:
+  .word 0
+
+.section .tbss
+.tbss
+.globl b
+b:
+  .word 0


### PR DESCRIPTION
Two related changes:
- fix issues when R_RISCV_RELAX applied to wrong relocations (#1276 and #1278)
- remove "pending relocations" logic to fix quadratic time.

Fixes #1276 and #1278.