### PR TITLE
Add primitive support for versioned symbols in regular object files

### DIFF
--- a/docs/DeveloperDocs/SymbolVersioning.md
+++ b/docs/DeveloperDocs/SymbolVersioning.md
@@ -1,0 +1,425 @@
+# Symbol versioning
+
+All symbol versioning related functionality is guarded by the `ELD_ENABLE_SYMBOL_VERSIONING`
+build macro.
+
+## Symbol resolution of versioned symbols
+
+A versioned symbol is of two types:
+
+- **default** versioned symbol (`bar@@V1`): a default versioned symbol
+  satisfies undefined references of both the versioned and
+  unversioned references of the symbol. `bar@@V1` definition can satisfy
+  undefined references of both `bar@V1` and plain `bar`.
+- **non-default** versioned symbol (`bar@V1`): a non-default versioned
+  symbol only satisfies undefined references of the versioned references
+  of the symbol. `bar@V1` definition can only satisfy undefined references
+  of `bar@V1`.
+
+eld supports symbol resolution of versioned symbols by inserting two
+symbols for default-versioned symbols into the already-existing symbol resolution
+machinery and adding a symbol normalization phase that runs after symbol resolution
+to combine the two symbol nodes for the default-versioned symbols into one, if required.
+
+Whenever eld sees a non-default-versioned symbol defintion `bar@V1`, then eld
+inserts `bar@V1` to the symbol resolution machinery, and it automatically
+gets used to resolve `bar@V1` undefined references.
+
+Here is the interesting part, whenever eld sees a default-versioned symbol
+definition `bar@@V1`, then eld inserts two symbols to the symbol resolution
+machinery: a canonical symbol `bar@V1` and a non-canonical symbol `bar`.
+With this, `bar@@V1` definition resolves undefined references to both
+`bar` and `bar@V1`, as it should.
+
+One fundamental rule of versioned-symbol resolution is that, for a default
+versioned symbol, both the canonical symbol (`foo@V1`) and the non-canonical
+(unversioned symbol `foo`) must resolve to the same definition. Allowing them
+to resolve to different symbols is incorrect because, the unversioned
+symbol is simply an alias for the versioned symbol (`foo@V1`), and both are
+originally the same symbol (`foo@@V1`).
+
+### Why is symbol normalization required?
+
+As we saw above, for a default-versioned symbol definition `bar@@V1`,
+eld creates two symbols `bar@V1` and `bar`. Some undefined symbol references
+may have resolved to `bar@V1` definition and some may have resolved to `bar`
+definition. This is a problem because in reality there is only one symbol
+`bar@@V1`. If we keep two symbol nodes per default-versioned symbol definition,
+then we will need to also emit both these symbols into the symbol table and
+create duplicate GOT/PLT slots for these symbols.
+
+Symbol normalization resolves this duplicate symbol issue by rewriting
+all the references to non-canonical symbols (`bar`) into the canonical symbols
+(`bar@V1`). A key thing to note here is that we only require the non-canonical
+aliases during symbol resolution phase.
+
+LLD does not always normalize the symbols and thus creates duplicate GOT/PLT slots for the same
+symbol when a default versioned symbol is accessed as both plain unversioned reference
+and versioned reference.
+
+Reproducer:
+
+```bash
+#!/usr/bin/env bash
+
+cat >1.c <<\EOF
+__asm__(".symver foo1,foo@@V1");
+int foo1() {
+  return 1;
+}
+EOF
+
+cat >vs.t <<\EOF
+V1 {
+  global:
+    foo;
+};
+EOF
+
+cat >main.c <<\EOF
+#include <stdio.h>
+
+int foo();
+
+__asm__(".symver foov1, foo@V1");
+int foov1();
+
+int main() {
+  int u = foo() + foov1();
+  printf("u: %d\n",u);
+  return 0;
+}
+EOF
+
+clang-20 -o 1.o 1.c -c -fPIC
+clang-20 -o main.o main.c -c -fPIC
+
+LDs=(ld.eld ld.lld ld.bfd)
+SFs=(eld lld bfd)
+
+for i in "${!SFs[@]}"; do
+  ${LDs[$i]} -o lib1.${SFs[$i]}.so 1.o -shared --version-script vs.t
+  clang-20 -o main.${SFs[$i]}.out main.o lib1.${SFs[$i]}.so --ld-path=$(which ${LDs[$i]})
+  echo "${SFs[$i]}:"
+  llvm-readelf -r main.${SFs[$i]}.out | grep foo
+  echo ""
+done
+```
+
+Output:
+
+```bash
+eld:
+0000000000002230  0000000700000007 R_X86_64_JUMP_SLOT     0000000000000000 foo@V1 + 0
+
+lld:
+0000000000003a58  0000000600000007 R_X86_64_JUMP_SLOT     0000000000000000 foo@V1 + 0
+0000000000003a68  0000000800000007 R_X86_64_JUMP_SLOT     0000000000000000 foo@V1 + 0
+
+bfd:
+0000000000004008  0000000500000007 R_X86_64_JUMP_SLOT     0000000000000000 foo@V1 + 0
+```
+
+### Versioned symbols symbol-resolution examples
+
+Symbol resolution of versioned-symbols is largely the same as
+non-versioned symbols. However, there are (corner) cases that
+may seem surprising. Here we will see some examples of symbol resolution
+of versioned symbols. We will also note differences from GNU ld (2.46.50)
+and lld (22.0) wherever relevant.
+
+In these examples (A) and (B) are simply used to differentiate symbols and
+to avoid any confusion when referring to them. Please note that (A) and (B)
+does not mean that the symbols come from different input files.
+
+The order matters in these examples, (A) `bar@@V1`, (B) `bar@V2`, means
+that the linker first sees `bar@@V1` and then sees `bar@V2`.
+
+The symbols originates from regular object files unstated otherwise.
+
+1) (A) `bar@@V1`, (B) `bar@V1`
+
+multiple definition error.
+
+2) (A) `bar@@V1`, (B) weak `bar@V1`
+
+(A) `bar@@V1` is used to resolve undefined references to `bar@V1` and `bar`.
+
+3) (A) weak `bar@@V1`, (B) `bar@V1`
+
+(B) `bar@V1` is used to resolve undefined references to `bar@V1` and `bar`.
+
+(B) `bar@V1` becomes a default-versioned symbol, and appears as `bar@@V1` in
+the dynamic symbol table.
+
+4) (A) weak `bar@@V1`, (B) `bar`
+
+(B) `bar` is used to resolve undefined references to `bar@V1` and `bar`.
+
+(B) `bar` becomes a default-versioned symbol, and appears as `bar@@V1` in the
+dynamic symbol table.
+
+5) (A) weak `bar@@V1`, (B) `bar@@V1`
+
+(B) `bar@@V1` is used to resolve undefined references to `bar@V1` and `bar`.
+
+6) (A) `bar@@V1`, (B) `bar@@V2`
+
+eld and bfd errors out with multiple definition error.
+
+lld incorrectly links correctly. Reproducer:
+
+```bash
+#!/usr/bin/env bash
+
+cat >1.c <<\EOF
+__asm__(".symver foo1,foo@@V1");
+int foo1() {
+  return 1;
+}
+
+__asm__(".symver foo2,foo@@V2");
+int foo2() {
+  return 3;
+}
+
+__asm__(".symver bar,bar@V2");
+int bar() {
+  return 5;
+}
+EOF
+
+cat >main.c <<\EOF
+#include <stdio.h>
+
+int foo();
+int bar();
+
+int main() {
+  int u = foo() + bar();
+  printf("u: %d\n",u);
+  return 0;
+}
+EOF
+
+cat >vs.t <<\EOF
+V1 {
+  global:
+    foo;
+};
+
+V2 {
+  global:
+    foo;
+};
+EOF
+
+clang-20 -o 1.o 1.c -c -fPIC
+clang-20 -o main.o main.c -c
+
+LDs=(ld.eld ld.lld ld.bfd)
+SFs=(eld lld bfd)
+
+for i in "${!SFs[@]}"; do
+  clang-20 -o lib.${SFs[$i]}.so 1.o --ld-path=$(which ${LDs[$i]}) -shared -fPIC -Wl,--version-script,vs.t
+done
+```
+
+7) (A) weak `bar@@V1`, (B) `bar`, (C) `bar@V1`
+
+multiple definition error.
+
+8) (A) weak `bar@@V1`, (B) weak `bar`, (C) `bar@V1`
+
+(C) `bar@V1` is used to resolve undefined references to both `bar` and `bar@V1`.
+
+9) (A) weak `bar@@V1`, (B) `bar`, and version script that assigns
+   `V2` to `bar`.
+
+(B) `bar` becomes a default versioned symbol and appears as `bar@@V1`
+in the dynamic symbol table. **There will be no `bar@@V2` in the symbol table!**
+
+reproducer:
+
+```bash
+#!/usr/bin/env bash
+
+cat >1.c <<\EOF
+__asm__(".symver bar1, bar@@V1");
+__attribute__((weak))
+int bar1() {
+  return 1;
+}
+EOF
+
+cat >2.c <<\EOF
+int bar() {
+  return 3;
+}
+EOF
+
+cat >3.c <<\EOF
+int bar();
+
+__asm__(".symver bar3v1, bar@V1");
+int bar3v1();
+
+int b() {
+  return bar() + bar3v1();
+}
+EOF
+
+cat >vs.t <<\EOF
+V2 {
+  global:
+    bar;
+};
+
+V1 {
+  global:
+    bar;
+};
+EOF
+
+cat >main.c <<\EOF
+#include <stdio.h>
+#define show(x) printf("%s: %d\n", #x, x);
+
+int b();
+int bar();
+
+__asm__(".symver bar1, bar@V1");
+int bar1();
+
+int b_main() {
+  return bar() + bar1();
+}
+
+int main() {
+ show(b());
+ show(b_main());
+ return 0;
+}
+EOF
+
+TARGET="x86_64-linux-gnu"
+
+clang -target ${TARGET} -o 1.o 1.c -c -fPIC
+clang -target ${TARGET} -o 2.o 2.c -c -fPIC
+clang -target ${TARGET} -o 3.o 3.c -c -fPIC
+clang -target ${TARGET} -o main.o main.c -c
+
+LDs=(ld.eld ld.lld ld.bfd)
+SFs=(eld lld bfd)
+
+for i in "${!SFs[@]}"; do
+  ${LDs[$i]} -o lib12.${SFs[$i]}.so 1.o 2.o 3.o --version-script vs.t -shared
+  clang -target ${TARGET} --ld-path=$(which ${LDs[$i]}) -o main.${SFs[$i]}.out main.o lib12.${SFs[$i]}.so
+done
+```
+
+10) (A) `bar`, (B) weak `bar@@V1`, and version script that assigns
+   `V2` to `bar`.
+
+With GNU ld, the dynamic symbol table contains both `bar@@V1` and `bar@@V2`, and
+with lld and eld, the dynamic symbol table only contains `bar@@V1`.
+
+Additionally, GNU seems to incorrectly resolves `bar@V1` undefined references to
+weak `bar@@V1`, instead of the plain `bar`. LLD and eld correctly behaves here.
+
+Reproducer:
+
+```bash
+#!/usr/bin/env bash
+
+cat >1.c <<\EOF
+__asm__(".symver bar1, bar@@V1");
+__attribute__((weak))
+int bar1() {
+  return 1;
+}
+
+int bar() {
+  return 5;
+}
+EOF
+
+cat >2.c <<\EOF
+int baz() {
+  return 3;
+}
+EOF
+
+cat >3.c <<\EOF
+int bar();
+
+__asm__(".symver bar3v1, bar@V1");
+int bar3v1();
+
+int b() {
+  return bar() + bar3v1();
+}
+EOF
+
+cat >vs.t <<\EOF
+V2 {
+  global:
+    bar;
+};
+
+V1 {
+  global:
+    bar;
+};
+EOF
+
+cat >main.c <<\EOF
+#include <stdio.h>
+#define show(x) printf("%s: %d\n", #x, x);
+
+int b();
+int bar();
+
+__asm__(".symver bar1, bar@V1");
+int bar1();
+
+int b_main() {
+  return bar() + bar1();
+}
+
+int main() {
+ show(b());
+ show(b_main());
+ return 0;
+}
+EOF
+
+TARGET="x86_64-linux-gnu"
+
+clang -target ${TARGET} -o 1.o 1.c -c -fPIC
+clang -target ${TARGET} -o 2.o 2.c -c -fPIC
+clang -target ${TARGET} -o 3.o 3.c -c -fPIC
+clang -target ${TARGET} -o main.o main.c -c
+
+LDs=(ld.eld ld.lld ld.bfd)
+SFs=(eld lld bfd)
+
+for i in "${!SFs[@]}"; do
+  ${LDs[$i]} -o lib12.${SFs[$i]}.so 1.o 2.o 3.o --version-script vs.t -shared
+  clang -target ${TARGET} --ld-path=$(which ${LDs[$i]}) -o main.${SFs[$i]}.out main.o lib12.${SFs[$i]}.so
+done
+```
+
+11) (A) bar, (B) `bar@@V1`, and version script that assigns
+    `bar` to the version node `V2`.
+
+With GNU ld, the dynamic symbol table contains both `bar@@V1` and `bar@@V2`, and
+with lld, the dynamic symbol table only contains `bar@@V1`.
+
+> [!IMPORTANT]
+> eld currently reports multiple definition error.
+
+12) (A) `bar@@V1`, (B) `bar`, and version script that assigns
+    `bar` to the version node `V2`.
+
+Multiple definition error.

--- a/include/eld/Core/Linker.h
+++ b/include/eld/Core/Linker.h
@@ -94,14 +94,14 @@ public:
 
   bool initializeTarget(uint16_t machine, bool is64bit);
 
-private:
   bool initBackend(const eld::Target *PTarget);
 
+  bool initializeInputTree(std::vector<InputAction *> &Actions);
+
+private:
   bool initEmulator(LinkerScript &CurScript, const eld::Target *PTarget);
 
   bool activateInputs(std::vector<InputAction *> &Actions);
-
-  bool initializeInputTree(std::vector<InputAction *> &Actions);
 
   bool emulate();
 

--- a/include/eld/Diagnostics/DiagSymbolVersioning.inc
+++ b/include/eld/Diagnostics/DiagSymbolVersioning.inc
@@ -28,3 +28,16 @@ DIAG(trace_reading_symbol_versioning_section, DiagnosticEngine::Trace,
      "Reading %0[%1]")
 DIAG(trace_symbol_to_output_version_id, DiagnosticEngine::Trace,
      "Symbol '%0' -> version id %1")
+
+DIAG(error_malformed_versioned_symbol_name, DiagnosticEngine::Error,
+     "%0: malformed versioned symbol name '%1'")
+
+DIAG(error_default_versioned_undef_ref, DiagnosticEngine::Error,
+     "%0: '%1' uses '@@' but is an undefined reference; "
+     "'@@' is only valid on definitions")
+
+DIAG(error_local_versioned_symbol_unsupported, DiagnosticEngine::Error,
+     "%0: local versioned symbol '%1' is not supported")
+
+DIAG(trace_object_versioned_symbol, DiagnosticEngine::Trace,
+     "Inserted versioned symbol '%0' from '%1'")

--- a/include/eld/Fragment/FragmentRef.h
+++ b/include/eld/Fragment/FragmentRef.h
@@ -70,6 +70,15 @@ public:
 
   void setOffset(Offset Offset) { ThisOffset = Offset; }
 
+  // Compare two FragmentRefs by underlying (fragment, offset). Each LDSymbol
+  // gets its own make<FragmentRef>(...), so pointer-equality is meaningless
+  // across symbols of the same definition.
+  bool operator==(const FragmentRef &O) const {
+    return ThisFragment == O.ThisFragment && ThisOffset == O.ThisOffset;
+  }
+
+  bool operator!=(const FragmentRef &O) const { return !(*this == O); }
+
   Offset getOutputOffset(Module &M) const;
 
   ELFSection *getOutputELFSection() const;

--- a/include/eld/Input/ELFDynObjectFile.h
+++ b/include/eld/Input/ELFDynObjectFile.h
@@ -100,10 +100,15 @@ public:
     return VerSyms[SymIdx] & llvm::ELF::VERSYM_VERSION;
   }
 
-  // Returns true if the versym entry is not hidden (default version).
+  // Returns true only for an actual versioned symbol whose version is the
+  // default (hidden bit clear). The reserved indices VER_NDX_LOCAL and
+  // VER_NDX_GLOBAL are not real versions and return false.
   bool isDefaultVersionedSymbol(uint32_t SymIdx) const {
     assert(SymIdx < VerSyms.size() && "Invalid SymIdx");
-    return VerSyms[SymIdx] == getSymbolVersionID(SymIdx);
+    uint16_t VerID = getSymbolVersionID(SymIdx);
+    if (VerID == llvm::ELF::VER_NDX_LOCAL || VerID == llvm::ELF::VER_NDX_GLOBAL)
+      return false;
+    return VerSyms[SymIdx] == VerID;
   }
 
   // Returns the output verneed index for an input version index.
@@ -133,16 +138,6 @@ public:
   }
 
   bool hasSymbolVersioningInfo() const { return VerSymSection != nullptr; }
-
-  // Record non-canonical symbols. For example, foo for `foo@@V1`.
-  void addNonCanonicalSymbol(LDSymbol *Sym) {
-    NonCanonicalSymbols.push_back(Sym);
-  }
-
-  // Returns the set of recorded non-canonical alias symbols
-  const std::vector<LDSymbol *> &getNonCanonicalSymbols() const {
-    return NonCanonicalSymbols;
-  }
 #endif
 
 private:
@@ -157,7 +152,6 @@ private:
   std::vector<uint16_t> VerSyms;
   /// It stores the output version ID for input version IDs.
   std::vector<uint16_t> OutputVernAuxIDMap;
-  std::vector<LDSymbol *> NonCanonicalSymbols;
 #endif
 };
 

--- a/include/eld/Input/ELFFileBase.h
+++ b/include/eld/Input/ELFFileBase.h
@@ -76,6 +76,21 @@ public:
 
   virtual bool isELFNeeded() { return true; }
 
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  // Record the synthetic non-canonical alias LDSymbol of a versioned
+  // symbol pair. For a default-versioned input definition `bar@@V1`, the
+  // pair is (canonical "bar@V1", non-canonical "bar"); the non-canonical
+  // half is recorded here so IRBuilder::normalizeSymbols can replace
+  // ResolveInfo references resolved to non-canonical symbol to the canonical
+  // symbol ResolveInfo* during the normalization pass.
+  void addNonCanonicalSymbol(LDSymbol *Sym) {
+    NonCanonicalSymbols.push_back(Sym);
+  }
+  const std::vector<LDSymbol *> &getNonCanonicalSymbols() const {
+    return NonCanonicalSymbols;
+  }
+#endif
+
   virtual ~ELFFileBase() {}
 
 protected:
@@ -84,6 +99,9 @@ protected:
   ELFSection *StringTable = nullptr;
   ELFSection *ExtendedSymbolTable = nullptr;
   ELFSection *Dynamic = nullptr;
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  std::vector<LDSymbol *> NonCanonicalSymbols;
+#endif
 };
 
 } // namespace eld

--- a/include/eld/SymbolResolver/NamePool.h
+++ b/include/eld/SymbolResolver/NamePool.h
@@ -71,6 +71,16 @@ public:
                             const LDSymbol &Sym, bool IsPostLtoPhase,
                             Resolver::Result &PResult);
 
+  /// Resolve two already-inserted NamePool entries against each other using
+  /// the ordinary symbol-resolution precedence rules, keeping \p OldRI as the
+  /// survivor. This is used by versioned-symbol reconciliation, where the
+  /// unversioned slot (`bar`) and the default-versioned slot (`bar@V1`) denote
+  /// one logical symbol and must be collapsed to a single winner. Returns true
+  /// if \p NewRI overrode \p OldRI (i.e. the caller must adopt NewRI's output
+  /// symbol). A genuine strong/strong clash raises multiple_definitions,
+  /// matching ordinary resolution.
+  bool resolvePair(ResolveInfo &OldRI, ResolveInfo &NewRI, bool IsPostLtoPhase);
+
   /// insertSymbol - insert a symbol and resolve the symbol immediately
   bool insertSymbol(InputFile *Input, std::string SymbolName,
                     bool IsSymbolInDynamicLibrary, ResolveInfo::Type Type,

--- a/include/eld/SymbolResolver/ResolveInfo.h
+++ b/include/eld/SymbolResolver/ResolveInfo.h
@@ -29,6 +29,28 @@ class InputFile;
 class LDSymbol;
 class LinkerConfig;
 
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+/// Parse result for a possibly-versioned symbol name. See parseVersionedName.
+struct ParsedVersionedName {
+  llvm::StringRef Base;    // "bar" — substring of the input name.
+  llvm::StringRef Version; // "V1"  — substring of the input name.
+  bool IsDefault;          // true if input had `@@`.
+  bool IsMalformed;        // true on `@V1`, `bar@`, `bar@@`, `bar@V1@V2`.
+};
+
+/// Parse a possibly-versioned symbol name into (base, version, isDefault).
+///
+/// Recognized inputs:
+///   "bar"         -> {"bar", "",   false, false}  (unversioned)
+///   "bar@V1"      -> {"bar", "V1", false, false}  (non-default)
+///   "bar@@V1"     -> {"bar", "V1", true,  false}  (default)
+///   "@V1"         -> malformed (no base)
+///   "bar@"        -> malformed
+///   "bar@@"       -> malformed
+///   "bar@V1@V2"   -> malformed (multiple `@` groups)
+ParsedVersionedName parseVersionedName(llvm::StringRef Name);
+#endif
+
 /** \class ResolveInfo
  *  \brief ResolveInfo records the information about how to resolve a symbol.
  *
@@ -243,18 +265,39 @@ public:
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
   llvm::StringRef getNonVersionedName() const {
     InputFile *origin = resolvedOrigin();
-    if (origin && origin->isInternal()) {
+    if (origin && origin->isInternal())
       return SymbolName;
-    }
-    llvm::StringRef::size_type pos = SymbolName.find('@');
-    return SymbolName.substr(0, pos);
+    return parseVersionedName(SymbolName).Base;
   }
 
   llvm::StringRef getVersionName() const {
-    auto pos = SymbolName.find_last_of('@');
-    if (pos == std::string::npos)
-      return "";
-    return llvm::StringRef(SymbolName).substr(pos + 1);
+    return parseVersionedName(SymbolName).Version;
+  }
+
+  /// Returns true if SymbolName literally contains an '@'. This is a
+  /// SYNTACTIC check on the name string, NOT a semantic "is this a
+  /// versioned symbol" predicate.
+  ///
+  /// Only two kinds of ResolveInfo carry '@' in the name after reading and
+  /// resolving symbols:
+  ///   - Non-default versioned canonicals          (e.g. "bar@V1")
+  ///   - Default versioned canonicals              (e.g. "bar@V1" — we
+  ///     normalize to a single '@' and track the default-ness via
+  ///     isDefaultVersion()).
+  bool hasVersionInName() const { return SymbolName.contains('@'); }
+
+  /// True for the default-version of a versioned symbol. Set on the canonical
+  /// ResolveInfo (the "bar@V1" slot) when a default-versioned definition is
+  /// inserted, and OR-preserved across overrideAttributes so a strong
+  /// non-default `bar@V1` inheriting the slot from a weak `bar@@V1` keeps the
+  /// default-version attribute.
+  bool isDefaultVersion() const { return ThisBitField & IsDefaultVersionMask; }
+
+  void setDefaultVersion(bool On) {
+    if (On)
+      ThisBitField |= IsDefaultVersionMask;
+    else
+      ThisBitField &= ~IsDefaultVersionMask;
   }
 #endif
 
@@ -326,10 +369,20 @@ private:
   static const uint32_t IFuncNeedsGOTOffset = 21;
   static const uint32_t IFuncNeedsGOTMask = 1 << IFuncNeedsGOTOffset;
 
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  static const uint32_t IsDefaultVersionOffset = 22;
+  static const uint32_t IsDefaultVersionMask = 1 << IsDefaultVersionOffset;
+#endif
+
   static const uint32_t InfoMask = 0xF;
 
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  // Bits are from 0-22.
+  static const uint32_t ResolveMask = 0x7FFFFF;
+#else
   // Bits are from 0-21.
   static const uint32_t ResolveMask = 0x3FFFFF;
+#endif
 
 public:
   static const uint32_t GlobalFlag = 0 << GlobalOffset;

--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -1123,6 +1123,26 @@ private:
   void setSymbolVersionID(const ResolveInfo *R, uint16_t VerID) {
     OutputVersionIDs[R] = VerID;
   }
+
+public:
+  // Records non-canonical versioned symbols. It is primarily used to
+  // suppress emitting of non-canonical symbols in the output symbol tables.
+  void addNonCanonicalVersionedSym(const ResolveInfo *R) {
+    NonCanonicalVersionedSyms.insert(R);
+  }
+
+  bool isNonCanonicalVersionedSym(const ResolveInfo *R) const {
+    return NonCanonicalVersionedSyms.count(R) != 0;
+  }
+
+  // Reconstruct the .symtab strtab string for a ResolveInfo:
+  //   - shared-library origin: single `@` (canonical name unchanged).
+  //   - object origin, default-version flag set: "base@@version".
+  //   - object origin, non-default:               "base@version".
+  //   - non-versioned:                            R.name() unchanged.
+  std::string getSymbolTableName(const ResolveInfo &R) const;
+
+private:
 #endif
 
 protected:
@@ -1286,6 +1306,7 @@ protected:
   ELFSection *GNUVerNeedSection = nullptr;
   GNUVerNeedFragment *GNUVerNeedFrag = nullptr;
   std::unordered_map<const ResolveInfo *, uint16_t> OutputVersionIDs;
+  std::unordered_set<const ResolveInfo *> NonCanonicalVersionedSyms;
 #endif
 
   llvm::StringMap<const Assignment *> SymbolNameToLatestAssignment;

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -522,7 +522,8 @@ void ObjectLinker::assignVersionNodesToSymbols() {
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
       if (scope && ThisConfig.getPrinter()->traceSymbolVersioning())
         ThisConfig.raise(Diag::trace_version_script_matched_scope)
-            << R->name() << getVersionDesc(scope);
+            << R->getDecoratedName(/*DoDemangle=*/false)
+            << getVersionDesc(scope);
 #endif
       return scope;
     };
@@ -1695,6 +1696,9 @@ bool ObjectLinker::addSymbolToOutput(const ResolveInfo &PInfo) const {
 
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
   if (PInfo.isDyn() && PInfo.outSymbol() && PInfo.outSymbol()->shouldIgnore())
+    return false;
+  // Filter out non-canonical halves of a versioned alias pairs.
+  if (getTargetBackend().isNonCanonicalVersionedSym(&PInfo))
     return false;
 #endif
   // Let the backend choose to add the symbol to the output.

--- a/lib/Readers/ELFReader.cpp
+++ b/lib/Readers/ELFReader.cpp
@@ -272,6 +272,14 @@ ELFReader<ELFT>::createSymbol(llvm::StringRef stringTable, Elf_Sym rawSym,
   ELDEXP_RETURN_DIAGENTRY_IF_ERROR(expSymName);
   llvm::StringRef ldName = expSymName.value();
 
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  if (parseVersionedName(ldName).IsMalformed) {
+    m_Module.getConfig().raise(Diag::error_malformed_versioned_symbol_name)
+        << m_InputFile.getInput()->decoratedPath() << ldName;
+    return static_cast<LDSymbol *>(nullptr);
+  }
+#endif
+
   if (section && ldType != ResolveInfo::Section)
     section->setWanted(true);
 

--- a/lib/SymbolResolver/IRBuilder.cpp
+++ b/lib/SymbolResolver/IRBuilder.cpp
@@ -205,76 +205,149 @@ LDSymbol *IRBuilder::addSymbolFromObject(
     uint32_t Shndx, bool IsPostLtoPhase, uint32_t Idx) {
   // Step 1. calculate a Resolver::Result
   // ResolvedResult is a triple <resolved_info, existent, override>
-  Resolver::Result ResolvedResult = {nullptr, false, false};
   eld::RegisterTimer T("Create && Resolve symbols", "Symbol Resolution",
                        ThisConfig.options().printTimingStats());
   NamePool &NP = ThisModule.getNamePool();
+
+  // Insert one ResolveInfo into the NamePool.
+  // Used once for unversioned / non-default-versioned inputs and twice for
+  // default-versioned inputs (one call per (canonical, non-canonical)
+  // alias). Returns nullptr on error.
+  auto AddSymbol = [&](ResolveInfo InputSymbolResolveInfo,
+                       LDSymbol::ValueType ValueArg) -> LDSymbol * {
+    Resolver::Result ResolvedResult = {nullptr, false, false};
+    LDSymbol *InputSym = makeLDSymbol(nullptr);
+    InputSym->setFragmentRef(CurFragmentRef);
+    InputSym->setSectionIndex(Shndx);
+    InputSym->setSymbolIndex(Idx);
+
+    auto &PM = ThisModule.getPluginManager();
+    SymbolInfo SymInfo(&Input, Size, Binding, Type, Visibility, Desc,
+                       /*isBitcode=*/false);
+    DiagnosticPrinter *DP = ThisConfig.getPrinter();
+    auto OldErrorCount = DP->getNumErrors() + DP->getNumFatalErrors();
+    PM.callVisitSymbolHook(InputSym, InputSymbolResolveInfo.getName(), SymInfo);
+    auto NewErrorCount = DP->getNumErrors() + DP->getNumFatalErrors();
+    if (NewErrorCount != OldErrorCount)
+      return nullptr;
+
+    if (Binding == ResolveInfo::Binding::Local) {
+      ResolveInfo *RI = NP.insertLocalSymbol(InputSymbolResolveInfo, *InputSym);
+      RI->setOutSymbol(InputSym);
+      InputSym->setResolveInfo(*RI);
+      return InputSym;
+    }
+
+    if (ThisModule.getLayoutInfo() &&
+        ThisModule.getLayoutInfo()->showSymbolResolution())
+      NP.getSRI().recordSymbolInfo(InputSym, SymInfo);
+
+    bool S = NP.insertNonLocalSymbol(InputSymbolResolveInfo, *InputSym,
+                                     IsPostLtoPhase, ResolvedResult);
+    if (!S)
+      return nullptr;
+
+    if (ThisConfig.options().cref() || ThisConfig.options().buildCRef())
+      addToCref(Input, ResolvedResult);
+
+    LDSymbol *OutputSym = ResolvedResult.Info->outSymbol();
+    bool HasOutputSym = (nullptr != OutputSym);
+
+    InputSym->setResolveInfo(*ResolvedResult.Info);
+
+    LDSymbol::ValueType ValueLocal = ValueArg;
+    if (ResolvedResult.Overriden) {
+      if (CurFragmentRef && CurFragmentRef->frag()) {
+        ELFSection *Sec = CurFragmentRef->frag()->getOwningSection();
+        ValueLocal = ValueLocal - Sec->addr();
+      }
+      ResolvedResult.Info->setValue(ValueLocal, /*isFinal=*/false);
+      ResolvedResult.Info->setOutSymbol(InputSym);
+    } else if (!ResolvedResult.Overriden && !HasOutputSym) {
+      // Set the out symbol for the corresponding shared library symbol because
+      // the symbol is referenced by an object file.
+      // For shared library symbols, out symbol in ResolveInfo is only set if
+      // the symbol is referenced by a relocatable object file.
+      LDSymbol *SharedLibSym = NP.getSharedLibSymbol(ResolvedResult.Info);
+      if (SharedLibSym)
+        ResolvedResult.Info->setOutSymbol(SharedLibSym);
+    }
+
+    if (ThisModule.getPrinter()->traceSymbols())
+      ThisConfig.raise(Diag::obj_symbol_created)
+          << InputSym->name() << InputSym->sectionIndex()
+          << InputSym->resolveInfo()->infoAsString();
+    return InputSym;
+  };
+
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  ParsedVersionedName P = parseVersionedName(SymbolName);
+  assert(!P.IsMalformed &&
+         "malformed versioned symbol names must be rejected before IRBuilder");
+
+  if (!P.Version.empty()) {
+    // Versioned input. Reject the unsupported sub-cases up front; full
+    // support for these will be added in follow-up patches.
+    if (Binding == ResolveInfo::Binding::Local) {
+      ThisConfig.raise(Diag::error_local_versioned_symbol_unsupported)
+          << Input.getInput()->decoratedPath() << SymbolName;
+      return nullptr;
+    }
+    if (P.IsDefault && Desc == ResolveInfo::Undefined) {
+      ThisConfig.raise(Diag::error_default_versioned_undef_ref)
+          << Input.getInput()->decoratedPath() << SymbolName;
+      return nullptr;
+    }
+
+    // Build the canonical name: always single `@`. Default-ness is
+    // tracked by the ResolveInfo flag.
+    std::string CanonicalName = (P.Base + "@" + P.Version).str();
+
+    LDSymbol *NonCanonicalSym = nullptr;
+    LDSymbol *CanonicalSym = nullptr;
+
+    // A default-versioned definition `bar@@V1` also claims the
+    // unversioned slot `bar`, so synthesize the non-canonical alias.
+    // If the input independently defines `bar` (e.g. a body symbol from
+    // `int bar(){}` alongside `.symver bar, bar@@V1`), the alias and the
+    // body collide on the unversioned slot and a multiple-definition
+    // error is reported — that is acceptable.
+    if (P.IsDefault) {
+      ResolveInfo NonCanonRI =
+          NP.createInputSymbolRI(P.Base.str(), Input, /*isDyn=*/false, Type,
+                                 Desc, Binding, Size, Visibility, Value);
+      NonCanonicalSym = AddSymbol(NonCanonRI, Value);
+      if (!NonCanonicalSym)
+        return nullptr;
+      if (auto *EFB = llvm::dyn_cast<ELFFileBase>(&Input))
+        EFB->addNonCanonicalSymbol(NonCanonicalSym);
+    }
+
+    ResolveInfo CanonRI =
+        NP.createInputSymbolRI(CanonicalName, Input, /*isDyn=*/false, Type,
+                               Desc, Binding, Size, Visibility, Value);
+    CanonRI.setDefaultVersion(P.IsDefault);
+    CanonicalSym = AddSymbol(CanonRI, Value);
+    if (!CanonicalSym)
+      return nullptr;
+
+    if (NonCanonicalSym && CanonicalSym)
+      VersionedSymbols.push_back({CanonicalSym, NonCanonicalSym});
+
+    if (ThisModule.getPrinter()->traceSymbolVersioning())
+      ThisConfig.raise(Diag::trace_object_versioned_symbol)
+          << SymbolName << Input.getInput()->decoratedPath();
+
+    return CanonicalSym;
+  }
+#endif
+  // Unversioned: original path. Also reached when symbol versioning is
+  // enabled but the symbol carries no version (falls through the versioned
+  // block above, which returns for the versioned case).
   ResolveInfo InputSymbolResolveInfo =
       NP.createInputSymbolRI(SymbolName, Input, /*isDyn=*/false, Type, Desc,
                              Binding, Size, Visibility, Value);
-  LDSymbol *InputSym = makeLDSymbol(nullptr);
-  InputSym->setFragmentRef(CurFragmentRef);
-  InputSym->setSectionIndex(Shndx);
-  InputSym->setSymbolIndex(Idx);
-
-  auto &PM = ThisModule.getPluginManager();
-  SymbolInfo SymInfo(&Input, Size, Binding, Type, Visibility, Desc,
-                     /*isBitcode=*/false);
-  DiagnosticPrinter *DP = ThisConfig.getPrinter();
-  auto OldErrorCount = DP->getNumErrors() + DP->getNumFatalErrors();
-  PM.callVisitSymbolHook(InputSym, InputSymbolResolveInfo.getName(), SymInfo);
-  auto NewErrorCount = DP->getNumErrors() + DP->getNumFatalErrors();
-  if (NewErrorCount != OldErrorCount)
-    return nullptr;
-
-  if (Binding == ResolveInfo::Binding::Local) {
-    ResolveInfo *RI = NP.insertLocalSymbol(InputSymbolResolveInfo, *InputSym);
-    RI->setOutSymbol(InputSym);
-    InputSym->setResolveInfo(*RI);
-    return InputSym;
-  }
-
-  if (ThisModule.getLayoutInfo() &&
-      ThisModule.getLayoutInfo()->showSymbolResolution())
-    NP.getSRI().recordSymbolInfo(InputSym, SymInfo);
-
-  bool S = NP.insertNonLocalSymbol(InputSymbolResolveInfo, *InputSym,
-                                   IsPostLtoPhase, ResolvedResult);
-  if (!S)
-    return nullptr;
-
-  if (ThisConfig.options().cref() || ThisConfig.options().buildCRef())
-    addToCref(Input, ResolvedResult);
-
-  // Step 3. Set up corresponding output LDSymbol
-  LDSymbol *OutputSym = ResolvedResult.Info->outSymbol();
-
-  bool HasOutputSym = (nullptr != OutputSym);
-
-  InputSym->setResolveInfo(*ResolvedResult.Info);
-
-  if (ResolvedResult.Overriden) {
-    if (CurFragmentRef->frag()) {
-      ELFSection *S = CurFragmentRef->frag()->getOwningSection();
-      Value = Value - S->addr();
-    }
-    ResolvedResult.Info->setValue(Value, /*isFinal=*/false);
-    ResolvedResult.Info->setOutSymbol(InputSym);
-  } else if (!ResolvedResult.Overriden && !HasOutputSym) {
-    // Set the out symbol for the corresponding shared library symbol because
-    // the symbol is referenced by an object file.
-    // For shared library symbols, out symbol in ResolveInfo is only set if the
-    // symbol is referenced by a relocatable object file.
-    LDSymbol *SharedLibSym = NP.getSharedLibSymbol(ResolvedResult.Info);
-    if (SharedLibSym)
-      ResolvedResult.Info->setOutSymbol(SharedLibSym);
-  }
-
-  if (ThisModule.getPrinter()->traceSymbols())
-    ThisConfig.raise(Diag::obj_symbol_created)
-        << InputSym->name() << InputSym->sectionIndex()
-        << InputSym->resolveInfo()->infoAsString();
-  return InputSym;
+  return AddSymbol(InputSymbolResolveInfo, Value);
 }
 
 LDSymbol *IRBuilder::addSymbolFromDynObj(
@@ -682,28 +755,83 @@ LDSymbol *IRBuilder::addSymbol<IRBuilder::AsReferred, IRBuilder::Resolve>(
 }
 
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
+namespace {
+/// True if `X` and `Y` describe the same underlying input definition.
+///
+/// Comparison is by resolved origin AND FragmentRef value (frag, offset).
+/// Pointer-equality on FragmentRef would always be false here because each
+/// LDSymbol gets its own make<FragmentRef>(...). LDSymbol::value() is NOT
+/// finalized until layout, so it is intentionally not compared.
+static bool sameDefinition(LDSymbol *X, LDSymbol *Y) {
+  if (!X || !Y)
+    return false;
+  ResolveInfo *RX = X->resolveInfo();
+  ResolveInfo *RY = Y->resolveInfo();
+  if (!RX || !RY)
+    return false;
+  if (RX->resolvedOrigin() != RY->resolvedOrigin())
+    return false;
+  FragmentRef *FX = X->fragRef();
+  FragmentRef *FY = Y->fragRef();
+  if (!FX || !FY)
+    return false;
+  return *FX == *FY;
+}
+} // namespace
+
 void IRBuilder::normalizeSymbols() {
   std::unordered_map<ResolveInfo *, ResolveInfo *> RIReplacementMap;
+  GNULDBackend &Backend = ThisModule.getBackend();
+  NamePool &NP = ThisModule.getNamePool();
+  bool IsPostLtoPhase = ThisModule.isPostLTOPhase();
+
   for (const auto &P : VersionedSymbols) {
-    // P.first is the canonical version symbol, P.second is the non-canonical
-    // version symbol.
-    LDSymbol *CanonicalSym = P.first;
-    LDSymbol *NonCanonicalSym = P.second;
-    assert(CanonicalSym && NonCanonicalSym && "must not be null!");
+    LDSymbol *LDSym_canon = P.first;
+    LDSymbol *LDSym_noncanon = P.second;
+    assert(LDSym_canon && LDSym_noncanon && "must not be null!");
 
-    if (CanonicalSym->resolveInfo()->outSymbol() == CanonicalSym &&
-        NonCanonicalSym->resolveInfo()->outSymbol() == NonCanonicalSym) {
-      ResolveInfo *CanonicalRI = P.first->resolveInfo();
-      ResolveInfo *NonCanonicalRI = P.second->resolveInfo();
-      if (NonCanonicalRI->exportToDyn())
-        CanonicalRI->setExportToDyn();
+    ResolveInfo *RI_canon = LDSym_canon->resolveInfo();
+    ResolveInfo *RI_noncanon = LDSym_noncanon->resolveInfo();
+    assert(RI_canon && RI_noncanon && "must not be null!");
+    // The canonical and non-canonical halves of a pair always carry distinct
+    // names (e.g. `bar@V1` vs `bar`), so they must resolve to distinct NamePool
+    // RIs.
+    assert(RI_canon != RI_noncanon && "degenerate pair sharing one RI");
+    LDSymbol *canonWinner = RI_canon->outSymbol();
+    LDSymbol *nonCanonWinner = RI_noncanon->outSymbol();
+    // A null winner means the half is a versioned symbol pulled from a shared
+    // library that no relocatable object referenced: eld only materializes a
+    // ResolveInfo::outSymbol for a DSO symbol once an object uses it, so an
+    // unreferenced DSO alias keeps a null outSymbol. There is no output symbol
+    // to rewrite, so skip the pair.
+    if (!canonWinner || !nonCanonWinner)
+      continue;
 
-      // NonCanonicalSym should not be used anymore when both the canonical
-      // and the non-canonical versioned symbols are selected by the symbol
-      // resolver.
-      NonCanonicalSym->setShouldIgnore();
-      RIReplacementMap[NonCanonicalRI] = CanonicalRI;
+    bool canonHeldByA = (canonWinner == LDSym_canon);
+    bool nonCanonHeldByA = (nonCanonWinner == LDSym_noncanon);
+
+    // The plain `bar` (non-canonical) and default `bar@V1` (canonical) slots
+    // denote one logical symbol and must collapse to a single winner.
+    if (sameDefinition(canonWinner, nonCanonWinner)) {
+      // One definition backs both slots, so there is no precedence to resolve.
+      // If neither slot is held by this pair, an external default-versioned
+      // definition won both and its own pair performs the collapse — skip to
+      // avoid double-collapsing. Otherwise (this pair's own body backs both)
+      // fall through to the collapse below.
+      if (!canonHeldByA && !nonCanonHeldByA)
+        continue;
+    } else {
+      // Two different definitions competed for the two slots.
+      bool NonCanonOverrode =
+          NP.resolvePair(*RI_canon, *RI_noncanon, IsPostLtoPhase);
+      if (NonCanonOverrode)
+        RI_canon->setOutSymbol(nonCanonWinner);
     }
+    RI_canon->setDefaultVersion(true);
+    if (RI_noncanon->exportToDyn())
+      RI_canon->setExportToDyn();
+    Backend.addNonCanonicalVersionedSym(RI_noncanon);
+    RIReplacementMap[RI_noncanon] = RI_canon;
   }
 
   const auto &ObjectFiles = ThisModule.getObjectList();
@@ -715,29 +843,21 @@ void IRBuilder::normalizeSymbols() {
                    DynObjectFiles.end());
 
   for (InputFile *Input : AllInputs) {
-    ObjectFile *ObjFile = llvm::dyn_cast<ObjectFile>(Input);
-    if (ObjFile) {
+    if (ObjectFile *ObjFile = llvm::dyn_cast<ObjectFile>(Input)) {
       for (LDSymbol *Sym : ObjFile->getSymbols()) {
         ResolveInfo *RI = Sym->resolveInfo();
         auto it = RIReplacementMap.find(RI);
-
-        if (it != RIReplacementMap.end()) {
+        if (it != RIReplacementMap.end())
           Sym->setResolveInfo(*(it->second));
-        }
       }
     }
 
-    ELFDynObjectFile *DynObjFile = llvm::dyn_cast<ELFDynObjectFile>(Input);
-    if (!DynObjFile)
-      continue;
-
-    const auto &NonCanonicalSymbols = DynObjFile->getNonCanonicalSymbols();
-    for (LDSymbol *NonCanonicalSym : NonCanonicalSymbols) {
-      ResolveInfo *NonCanonicalRI = NonCanonicalSym->resolveInfo();
-      auto it = RIReplacementMap.find(NonCanonicalRI);
-
-      if (it != RIReplacementMap.end()) {
-        NonCanonicalSym->setResolveInfo(*(it->second));
+    if (ELFFileBase *ELFFile = llvm::dyn_cast<ELFFileBase>(Input)) {
+      for (LDSymbol *NonCanonicalSym : ELFFile->getNonCanonicalSymbols()) {
+        ResolveInfo *NonCanonicalRI = NonCanonicalSym->resolveInfo();
+        auto it = RIReplacementMap.find(NonCanonicalRI);
+        if (it != RIReplacementMap.end())
+          NonCanonicalSym->setResolveInfo(*(it->second));
       }
     }
   }

--- a/lib/SymbolResolver/NamePool.cpp
+++ b/lib/SymbolResolver/NamePool.cpp
@@ -224,6 +224,16 @@ bool NamePool::insertSymbol(
 bool NamePool::getSymbolTracingRequested() const {
   return IsSymbolTracingRequested;
 }
+
+bool NamePool::resolvePair(ResolveInfo &OldRI, ResolveInfo &NewRI,
+                           bool IsPostLtoPhase) {
+  bool Override = false;
+  LDSymbol::ValueType Value =
+      NewRI.outSymbol() ? NewRI.outSymbol()->value() : NewRI.value();
+  SymbolResolver->resolve(OldRI, NewRI, Override, Value, &ThisConfig,
+                          IsPostLtoPhase);
+  return Override;
+}
 /// findInfo - find the resolved ResolveInfo
 ResolveInfo *NamePool::findInfo(const std::string &SymbolName) {
   auto I = GlobalSymbols.find(SymbolName);

--- a/lib/SymbolResolver/ResolveInfo.cpp
+++ b/lib/SymbolResolver/ResolveInfo.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 #include "eld/SymbolResolver/ResolveInfo.h"
 #include "eld/Config/LinkerConfig.h"
+#include "eld/Input/ELFDynObjectFile.h"
 #include "eld/Readers/ELFSection.h"
 #include "eld/Support/StringRefUtils.h"
 #include "eld/Target/GNULDBackend.h"
@@ -19,6 +20,32 @@
 #include <string>
 
 using namespace eld;
+
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+ParsedVersionedName eld::parseVersionedName(llvm::StringRef Name) {
+  ParsedVersionedName R{Name, /*Version=*/llvm::StringRef(),
+                        /*IsDefault=*/false, /*IsMalformed=*/false};
+  auto At = Name.find('@');
+  if (At == llvm::StringRef::npos)
+    return R; // unversioned plain name.
+  if (At == 0) {
+    // Leading `@`, no base.
+    return {{}, {}, false, true};
+  }
+  R.Base = Name.substr(0, At);
+  llvm::StringRef Rest = Name.substr(At + 1);
+  if (!Rest.empty() && Rest.front() == '@') {
+    R.IsDefault = true;
+    Rest = Rest.substr(1);
+  }
+  if (Rest.empty() || Rest.contains('@')) {
+    // "bar@", "bar@@", or extra `@` in the version part.
+    return {{}, {}, false, true};
+  }
+  R.Version = Rest;
+  return R;
+}
+#endif
 
 /// g_NullResolveInfo - a pointer to Null
 static ResolveInfo GNullResolveInfo;
@@ -57,12 +84,21 @@ void ResolveInfo::overrideAttributes(const ResolveInfo &PFrom) {
   // exportToDyn should stay true after overriding if
   // the overriding symbol can be a preemptible symbol.
   bool PrevExportToDyn = exportToDyn();
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  // OR-preserve the default-version flag: if either side claimed the symbol
+  // is the default version of its base, the survivor keeps the identity.
+  bool PrevDefaultVersion = isDefaultVersion();
+#endif
   ThisBitField &= ~ResolveMask;
   ThisBitField |= (PFrom.ThisBitField & ResolveMask);
   shouldPreserve(P);
   setVisibility(V);
   if (PrevExportToDyn && PFrom.canBePreemptible())
     setExportToDyn();
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  if (PrevDefaultVersion || PFrom.isDefaultVersion())
+    setDefaultVersion(true);
+#endif
 }
 
 /// overrideVisibility - override the visibility
@@ -353,9 +389,34 @@ std::string ResolveInfo::getContextualLabel() const {
 }
 
 std::string ResolveInfo::getDecoratedName(bool DoDeMangle) const {
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  // Render the GNU-visible versioned form. Object-origin symbols get
+  // `bar@@V1` when default-versioned and `bar@V1` when not; DSO-origin
+  // symbols keep the canonical single-`@` form because the .gnu.version
+  // index conveys default-ness for shared-library symbols. Mirrors
+  // GNULDBackend::getSymbolTableName so diagnostics and the on-disk
+  // symbol table agree.
+  std::string BaseName = std::string(name());
+  std::string VersionSuffix;
+  if (hasVersionInName()) {
+    ParsedVersionedName P = parseVersionedName(name());
+    if (!P.IsMalformed && !P.Version.empty()) {
+      InputFile *Origin = resolvedOrigin();
+      bool IsDsoOrigin = Origin && llvm::isa<ELFDynObjectFile>(Origin);
+      const llvm::StringRef Sep =
+          (!IsDsoOrigin && isDefaultVersion()) ? "@@" : "@";
+      BaseName = P.Base.str();
+      VersionSuffix = (Sep + P.Version).str();
+    }
+  }
+  std::string DecoratedName =
+      DoDeMangle ? eld::string::getDemangledName(BaseName) : BaseName;
+  DecoratedName += VersionSuffix;
+#else
   std::string DecoratedName = name();
   if (DoDeMangle)
     DecoratedName = eld::string::getDemangledName(name());
+#endif
   std::optional<std::string> AuxSymName;
   if (ObjectFile *ObjFile =
           llvm::dyn_cast_or_null<ObjectFile>(SymbolResolvedOrigin))

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -1200,7 +1200,15 @@ void GNULDBackend::sizeSymTab() {
         m_SymbolsToRemove.count(Sym)) {
       continue;
     }
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+    // Suppressed non-canonical versioned aliases are filtered upstream by
+    // ObjectLinker::addSymbolToOutput and must not reach here.
+    assert(!isNonCanonicalVersionedSym(Sym) &&
+           "non-canonical versioned sym leaked past addSymbolToOutput");
+    std::string symName = getSymbolTableName(*Sym);
+#else
     std::string symName = Sym->outSymbol()->name();
+#endif
     strtab += symName.size() + 1;
     ++NumSymbols;
   }
@@ -1272,7 +1280,12 @@ void GNULDBackend::emitSymbol32(llvm::ELF::Elf32_Sym &pSym, LDSymbol *pSymbol,
       pSym.st_name = optSymNameOffset.value();
     } else {
       pSym.st_name = pStrtabsize;
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+      std::string SymtabName = getSymbolTableName(*pSymbol->resolveInfo());
+      strcpy((pStrtab + pStrtabsize), SymtabName.c_str());
+#else
       strcpy((pStrtab + pStrtabsize), pSymbol->name());
+#endif
     }
   }
   if ((pSymbol->resolveInfo()->isUndef()) || (pSymbol->isDyn()))
@@ -1304,7 +1317,12 @@ void GNULDBackend::emitSymbol64(llvm::ELF::Elf64_Sym &pSym, LDSymbol *pSymbol,
       pSym.st_name = optSymNameOffset.value();
     } else {
       pSym.st_name = pStrtabsize;
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+      std::string SymtabName = getSymbolTableName(*pSymbol->resolveInfo());
+      strcpy((pStrtab + pStrtabsize), SymtabName.c_str());
+#else
       strcpy((pStrtab + pStrtabsize), std::string(pSymbol->name()).data());
+#endif
     }
   }
   if ((pSymbol->resolveInfo()->isUndef()) || (pSymbol->isDyn()))
@@ -1395,6 +1413,12 @@ GNULDBackend::emitRegNamePools(llvm::FileOutputBuffer &pOutput) {
       config().raise(Diag::stripping_symbol) << S->name();
       continue;
     }
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+    // Suppressed non-canonical versioned aliases are filtered upstream by
+    // ObjectLinker::addSymbolToOutput and must not reach here.
+    assert(!isNonCanonicalVersionedSym(S) &&
+           "non-canonical versioned sym leaked past addSymbolToOutput");
+#endif
     if (config().targets().is32Bits())
       emitSymbol32(symtab32[symIdx], S->outSymbol(), strtab, strtabsize, symIdx,
                    /*IsDynSymTab=*/false);
@@ -1404,7 +1428,11 @@ GNULDBackend::emitRegNamePools(llvm::FileOutputBuffer &pOutput) {
     if (getSymbolBinding(S->outSymbol()) != llvm::ELF::STB_LOCAL &&
         !firstNonLocal)
       firstNonLocal = symIdx;
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+    std::string symName = getSymbolTableName(*S);
+#else
     std::string symName = std::string(S->name());
+#endif
     strtabsize += symName.length() + 1;
     ++symIdx;
   }
@@ -5435,6 +5463,27 @@ void GNULDBackend::initSymbolVersioningSections() {
 #endif
 
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
+std::string GNULDBackend::getSymbolTableName(const ResolveInfo &R) const {
+  if (!R.hasVersionInName())
+    return std::string(R.getName());
+
+  // Shared-library origin: keep the canonical single-`@` form. The
+  // .gnu.version index conveys default-ness for DSO symbols, so dyn-test
+  // goldens stay byte-identical.
+  InputFile *Origin = R.resolvedOrigin();
+  if (Origin && llvm::isa<ELFDynObjectFile>(Origin))
+    return std::string(R.getName());
+
+  // Object origin: reconstruct the GNU-visible form from the canonical
+  // single-`@` name plus the default-version flag.
+  ParsedVersionedName P = parseVersionedName(R.getName());
+  if (P.IsMalformed || P.Version.empty())
+    return std::string(R.getName());
+  if (R.isDefaultVersion())
+    return (P.Base + "@@" + P.Version).str();
+  return (P.Base + "@" + P.Version).str();
+}
+
 void GNULDBackend::assignOutputVersionIDs() {
   bool shouldTraceSymbolVersioning =
       m_Module.getPrinter()->traceSymbolVersioning();
@@ -5501,8 +5550,8 @@ void GNULDBackend::assignOutputVersionIDs() {
       VernID = it->second;
     }
 
-    isDefaultVersionSymbol = (Pos == std::string::npos ||
-                              (FullName.find("@@") != std::string::npos));
+    isDefaultVersionSymbol =
+        (Pos == std::string::npos) || R->isDefaultVersion();
 
     if (!isDefaultVersionSymbol)
       VernID |= llvm::ELF::VERSYM_HIDDEN;

--- a/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/1.c
+++ b/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/1.c
@@ -1,0 +1,2 @@
+__asm__(".symver foo1, foo@@V1");
+int foo1() { return 1; }

--- a/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/2.c
+++ b/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/2.c
@@ -1,0 +1,2 @@
+__asm__(".symver foo2, foo@V2");
+int foo2() { return 3; }

--- a/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/3.c
+++ b/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/3.c
@@ -1,0 +1,9 @@
+int foo();
+
+__asm__(".symver foov1, foo@V1");
+int foov1();
+
+__asm__(".symver foov2, foo@V2");
+int foov2();
+
+int fn() { return foo() + foov1() + foov2(); }

--- a/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/4.c
+++ b/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/4.c
@@ -1,0 +1,2 @@
+__asm__(".symver foo1, foo@@V1");
+__attribute__((weak)) int foo1() { return 1; }

--- a/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/5.c
+++ b/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/5.c
@@ -1,0 +1,2 @@
+__asm__(".symver foov1, foo@V1");
+int foov1() { return 3; }

--- a/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/6.c
+++ b/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/6.c
@@ -1,0 +1,6 @@
+int foo();
+
+__asm__(".symver foov1, foo@V1");
+int foov1();
+
+int fn() { return foo() + foov1(); }

--- a/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/7.c
+++ b/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/7.c
@@ -1,0 +1,1 @@
+int foo() { return 7; }

--- a/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/8.c
+++ b/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/8.c
@@ -1,0 +1,2 @@
+__asm__(".symver foov1, foo@V1");
+__attribute__((weak)) int foov1() { return 4; }

--- a/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/9.c
+++ b/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/9.c
@@ -1,0 +1,1 @@
+__attribute__((weak)) int foo() { return 8; }

--- a/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/main.1.c
+++ b/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/main.1.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#define show(x) printf("%s: %d\n", #x, x);
+int foo();
+
+__asm__(".symver foo_main_v1, foo@V1");
+int foo_main_v1();
+
+__asm__(".symver foo_main_v2, foo@V2");
+int foo_main_v2();
+
+int fn();
+
+int fn_main() { return foo() + foo_main_v1() + foo_main_v2(); }
+
+int main() {
+  show(fn());
+  show(fn_main());
+}

--- a/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/main.2.c
+++ b/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/main.2.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#define show(x) printf("%s: %d\n", #x, x);
+int foo();
+
+__asm__(".symver foo_main_v1, foo@V1");
+int foo_main_v1();
+
+int fn();
+
+int fn_main() { return foo() + foo_main_v1(); }
+
+int main() {
+  show(fn());
+  show(fn_main());
+}

--- a/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/vs.1.t
+++ b/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/Inputs/vs.1.t
@@ -1,0 +1,9 @@
+V1 {
+  global:
+    foo;
+};
+
+V2 {
+  global:
+    foo;
+};

--- a/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/VersionedSymbolsInObjectFiles.test
+++ b/test/Common/RunTests/SymbolVersioning/VersionedSymbolsInObjectFiles/VersionedSymbolsInObjectFiles.test
@@ -1,0 +1,60 @@
+REQUIRES: run_test, symbol_versioning
+#---HelloWorld.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+#END_COMMENT
+#START_TEST
+# Basic case: foo@@V1 and foo@V2
+RUN: %run_cc -o %t1.o %p/Inputs/1.c -c -fPIC
+RUN: %run_cc -o %t2.o %p/Inputs/2.c -c -fPIC
+RUN: %run_cc -o %t3.o %p/Inputs/3.c -c -fPIC
+RUN: %run_cc -o %tlib1.so %t1.o %t2.o %t3.o -shared -Wl,--version-script,%p/Inputs/vs.1.t
+RUN: %run_cc -o %tmain1.o %p/Inputs/main.1.c -c
+RUN: %run_cc -o %tmain1.out %tmain1.o %tlib1.so
+RUN: %run %tmain1.out | %filecheck %s --check-prefix=CHECK1
+
+# weak foo@@V1 and strong foo@V1
+RUN: %run_cc -o %t4.o %p/Inputs/4.c -c -fPIC
+RUN: %run_cc -o %t5.o %p/Inputs/5.c -c -fPIC
+RUN: %run_cc -o %t6.o %p/Inputs/6.c -c -fPIC
+RUN: %run_cc -o %tlib2.so %t4.o %t5.o %t6.o -shared -Wl,--version-script,%p/Inputs/vs.1.t
+RUN: %run_cc -o %tmain2.o %p/Inputs/main.2.c -c
+RUN: %run_cc -o %tmain2.out %tmain2.o %tlib2.so
+RUN: %run %tmain2.out | %filecheck %s --check-prefix=CHECK2
+
+# weak foo@@V1 and strong plain foo. The strong plain `foo` wins the
+# unversioned slot; the default `foo@V1` alias is backed by it too.
+RUN: %run_cc -o %t7.o %p/Inputs/7.c -c -fPIC
+RUN: %run_cc -o %tlib3.so %t4.o %t7.o %t6.o -shared -Wl,--version-script,%p/Inputs/vs.1.t
+RUN: %run_cc -o %tmain3.out %tmain2.o %tlib3.so
+RUN: %run %tmain3.out | %filecheck %s --check-prefix=CHECK3
+
+# weak foo@@V1, weak foo@V1, and strong plain foo. The strong plain `foo`
+# still wins the canonical foo@V1 slot over the weak foo@V1.
+RUN: %run_cc -o %t8.o %p/Inputs/8.c -c -fPIC
+RUN: %run_cc -o %tlib4.so %t4.o %t8.o %t7.o %t6.o -shared -Wl,--version-script,%p/Inputs/vs.1.t
+RUN: %run_cc -o %tmain4.out %tmain2.o %tlib4.so
+RUN: %run %tmain4.out | %filecheck %s --check-prefix=CHECK4
+
+# weak foo@@V1, strong foo@V1, and weak plain foo. The strong foo@V1 wins
+# the canonical slot; the weak plain `foo` follows the default version.
+RUN: %run_cc -o %t9.o %p/Inputs/9.c -c -fPIC
+RUN: %run_cc -o %tlib5.so %t4.o %t5.o %t9.o %t6.o -shared -Wl,--version-script,%p/Inputs/vs.1.t
+RUN: %run_cc -o %tmain5.out %tmain2.o %tlib5.so
+RUN: %run %tmain5.out | %filecheck %s --check-prefix=CHECK5
+#END_TEST
+
+CHECK1: fn(): 5
+CHECK1: fn_main(): 5
+
+CHECK2: fn(): 6
+CHECK2: fn_main(): 6
+
+CHECK3: fn(): 14
+CHECK3: fn_main(): 14
+
+CHECK4: fn(): 14
+CHECK4: fn_main(): 14
+
+CHECK5: fn(): 6
+CHECK5: fn_main(): 6
+

--- a/test/Common/standalone/SymbolVersioning/BuildingSharedLibsWithSymbolVersioning/BuildingSharedLibsWithSymbolVersioning.test
+++ b/test/Common/standalone/SymbolVersioning/BuildingSharedLibsWithSymbolVersioning/BuildingSharedLibsWithSymbolVersioning.test
@@ -16,9 +16,6 @@ RUN: %readelf --dyn-syms --version-info %t1.lib3.so | %filecheck %s --check-pref
 RUN: %clang %clangopts -o %t1.3.o %p/Inputs/3.c -c -fPIC
 RUN: %link %linkopts -o %t1.lib4.so %t1.3.o -shared --version-script %p/Inputs/vs.2.t
 RUN: %readelf --dyn-syms --version-info %t1.lib4.so | %filecheck %s --check-prefix=CHECK4
-RUN: %clang %clangopts -o %t1.4.o %p/Inputs/4.c -c -fPIC
-RUN: %link %linkopts -o %t1.lib5.so %t1.4.o -shared --version-script %p/Inputs/vs.2.t
-RUN: %readelf --dyn-syms --version-info %t1.lib5.so | %filecheck %s --check-prefix=CHECK5
 RUN: %clang %clangopts -o %t1.5.o %p/Inputs/5.c -c -fPIC
 RUN: %link %linkopts -o %t1.lib6.so %t1.5.o -shared --version-script %p/Inputs/vs.3.t
 RUN: %readelf --dyn-syms --version-info %t1.lib6.so | %filecheck %s --check-prefix=CHECK6
@@ -57,14 +54,6 @@ CHECK4: '.gnu.version_d' contains 3 entries:
 CHECK4: Name: {{[^ /\\]+}}lib4.so
 CHECK4: Name: V1
 CHECK4: Name: V2
-
-CHECK5-DAG: : {{0+}}[[#%x,VALUE:]] [[#SIZE:]] FUNC {{.*}} bar@@V1
-CHECK5-DAG: foo@V1
-CHECK5-DAG: : {{0+}}[[#VALUE]] [[#SIZE]] FUNC {{.*}} baz@@V2
-CHECK5: '.gnu.version_d' contains 3 entries:
-CHECK5: Name: {{[^ /\\]+}}lib5.so
-CHECK5: Name: V1
-CHECK5: Name: V2
 
 CHECK6-DAG: foo2
 CHECK6-DAG: baz@@V2

--- a/test/Common/standalone/SymbolVersioning/BuildingSharedLibsWithSymbolVersioning/BuildingSharedLibsWithSymbolVersioningErrors.test
+++ b/test/Common/standalone/SymbolVersioning/BuildingSharedLibsWithSymbolVersioning/BuildingSharedLibsWithSymbolVersioningErrors.test
@@ -7,7 +7,22 @@ REQUIRES: symbol_versioning
 #START_TEST
 RUN: %clang %clangopts -o %t1.2.o %p/Inputs/2.c -c -fPIC
 RUN: %not %link %linkopts -o %t1.lib1.so %t1.2.o -shared --version-script %p/Inputs/vs.5.t 2>&1 | %filecheck %s --check-prefix=ERRORS1
+# A cross-name default `.symver bar, baz@@V2` synthesizes the unversioned
+# alias `baz`, which collides with the independent `int baz()` body in the
+# same object. This is a multiple definition, matching GNU ld.
+RUN: %clang %clangopts -o %t1.4.o %p/Inputs/4.c -c -fPIC
+RUN: %not %link %linkopts -o %t1.lib2.so %t1.4.o -shared --version-script %p/Inputs/vs.2.t 2>&1 | %filecheck %s --check-prefix=ERRORS2
+# A default-versioned `foo@@V2` synthesizes the unversioned alias `foo`,
+# which collides with the independent `int foo()` body. eld rejects this
+# rather than emitting two default versions (`foo@@V1` and `foo@@V2`) of the
+# same name.
+RUN: %clang %clangopts -o %t1.idc.o %p/Inputs/independent_default_clash.c -c -fPIC
+RUN: %not %link %linkopts -o %t1.lib3.so %t1.idc.o -shared --version-script %p/Inputs/vs.3.t 2>&1 | %filecheck %s --check-prefix=ERRORS3
 #END_TEST
 
 ERRORS1: Error: {{.*}}2.o: symbol foo@V1 has undefined version V1
 ERRORS1: Error: {{.*}}2.o: symbol bar@V1 has undefined version V1
+
+ERRORS2: Error: multiple definition of symbol `baz'
+
+ERRORS3: Error: multiple definition of symbol `foo'

--- a/test/Common/standalone/SymbolVersioning/BuildingSharedLibsWithSymbolVersioning/Inputs/3.c
+++ b/test/Common/standalone/SymbolVersioning/BuildingSharedLibsWithSymbolVersioning/Inputs/3.c
@@ -1,7 +1,7 @@
 __asm__(".symver foo, foo@V1");
 int foo() { return 1; }
 
-__asm__(".symver bar, bar@@V1");
+__asm__(".symver bar, bar@@@V1");
 int bar() { return 3; }
 
 int baz() { return 5; }

--- a/test/Common/standalone/SymbolVersioning/BuildingSharedLibsWithSymbolVersioning/Inputs/5.c
+++ b/test/Common/standalone/SymbolVersioning/BuildingSharedLibsWithSymbolVersioning/Inputs/5.c
@@ -1,5 +1,3 @@
-int foo() { return 0; }
-
 __asm__(".symver foo1, foo@V1");
 int foo1() { return 1; }
 

--- a/test/Common/standalone/SymbolVersioning/BuildingSharedLibsWithSymbolVersioning/Inputs/independent_default_clash.c
+++ b/test/Common/standalone/SymbolVersioning/BuildingSharedLibsWithSymbolVersioning/Inputs/independent_default_clash.c
@@ -1,0 +1,8 @@
+// A default-versioned symbol `foo@@V2` synthesizes the unversioned alias
+// `foo`, which clashes with the independent unversioned `int foo()` body in
+// the same object. eld rejects this as a multiple definition rather than
+// emitting two default versions (`foo@@V1` and `foo@@V2`) of the same name.
+__asm__(".symver foo2, foo@@V2");
+int foo2() { return 3; }
+
+int foo() { return 0; }

--- a/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/local_versioned.s
+++ b/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/local_versioned.s
@@ -1,0 +1,5 @@
+// Local versioned symbol `bar@V1` (STB_LOCAL, no `.globl`). Local-binding
+// versioned symbols are unsupported in this work; eld must fatal.
+.data
+"bar@V1":
+    .byte 0

--- a/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/main_default.c
+++ b/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/main_default.c
@@ -1,0 +1,2 @@
+extern int bar(void);
+int main(void) { return bar(); }

--- a/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/main_nondefault.c
+++ b/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/main_nondefault.c
@@ -1,0 +1,3 @@
+__asm__(".symver bar_v1, bar@V1");
+extern int bar_v1(void);
+int main(void) { return bar_v1(); }

--- a/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/malformed_doubleat_no_version.s
+++ b/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/malformed_doubleat_no_version.s
@@ -1,0 +1,6 @@
+// Global symbol named literally `foo@@` (no version after `@@`).
+// eld must reject this as a malformed versioned symbol name.
+.data
+.globl "foo@@"
+"foo@@":
+    .byte 0

--- a/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/malformed_leading_at.s
+++ b/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/malformed_leading_at.s
@@ -1,0 +1,6 @@
+// Global symbol named literally `@V1` (no base before the `@`).
+// eld must reject this as a malformed versioned symbol name.
+.data
+.globl "@V1"
+"@V1":
+    .byte 0

--- a/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/strong_default.c
+++ b/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/strong_default.c
@@ -1,0 +1,4 @@
+/* strong default: bar@@V1 (alias on a separate underlying name so the
+ * weak/strong attribute applies cleanly to the alias body). */
+__asm__(".symver impl, bar@@V1");
+int impl(void) { return 1; }

--- a/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/strong_default_v2.c
+++ b/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/strong_default_v2.c
@@ -1,0 +1,3 @@
+/* default V2 symbol (used alongside another input's default V1). */
+__asm__(".symver impl_v2, bar@@V2");
+int impl_v2(void) { return 4; }

--- a/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/strong_nondefault.c
+++ b/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/strong_nondefault.c
@@ -1,0 +1,3 @@
+/* strong non-default: bar@V1. */
+__asm__(".symver impl, bar@V1");
+int impl(void) { return 2; }

--- a/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/strong_unversioned.c
+++ b/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/strong_unversioned.c
@@ -1,0 +1,2 @@
+/* strong unversioned bar (no .symver). */
+int bar(void) { return 3; }

--- a/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/undef_doubleat.s
+++ b/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/undef_doubleat.s
@@ -1,0 +1,4 @@
+// Undefined reference to a symbol whose name uses `@@` — reserved for
+// definitions. eld must reject.
+.data
+.long "foo@@V1"

--- a/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/vs_v1.t
+++ b/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/vs_v1.t
@@ -1,0 +1,1 @@
+V1 { global: bar; *; };

--- a/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/vs_v1_v2.t
+++ b/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/vs_v1_v2.t
@@ -1,0 +1,1 @@
+V1 { global: bar; }; V2 { global: bar; };

--- a/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/weak_default.c
+++ b/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/weak_default.c
@@ -1,0 +1,3 @@
+/* weak default: bar@@V1 (weak). */
+__asm__(".symver impl, bar@@V1");
+__attribute__((weak)) int impl(void) { return 1; }

--- a/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/weak_nondefault.c
+++ b/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/Inputs/weak_nondefault.c
@@ -1,0 +1,3 @@
+/* weak non-default: bar@V1 (weak). */
+__asm__(".symver impl, bar@V1");
+__attribute__((weak)) int impl(void) { return 2; }

--- a/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/InvalidSymbolNames.test
+++ b/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/InvalidSymbolNames.test
@@ -1,0 +1,44 @@
+REQUIRES: symbol_versioning
+#---InvalidSymbolNames.test-----------------------------------------------#
+#BEGIN_COMMENT
+# Object inputs whose symbol names eld must reject at scan time:
+#   MalformedDoubleAt  - literal `foo@@` (no version after `@@`).
+#   MalformedLeadingAt - literal `@V1` (no base before `@`).
+#   UndefDoubleAt      - UND reference named `foo@@V1` (`@@` is for
+#                        definitions only).
+#   LocalVersioned     - STB_LOCAL binding on `bar@V1` (local versioned
+#                        symbols are unsupported in this work).
+#
+# Inputs are target-agnostic hand-written .s files under Inputs/ that use
+# only .data / .globl / .byte / .long / quoted symbol names.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t.malformed_doubleat.o    -c %p/Inputs/malformed_doubleat_no_version.s
+RUN: %clang %clangopts -o %t.malformed_leading_at.o  -c %p/Inputs/malformed_leading_at.s
+RUN: %clang %clangopts -o %t.undef_doubleat.o        -c %p/Inputs/undef_doubleat.s
+RUN: %clang %clangopts -o %t.local_versioned.o       -c %p/Inputs/local_versioned.s
+
+## Case 1: literal `foo@@` (no version after `@@`) is malformed.
+RUN: %not %link %linkopts -o %t.malformed_doubleat.so %t.malformed_doubleat.o \
+RUN:     -shared --version-script %p/Inputs/vs_v1.t 2>&1 \
+RUN:   | %filecheck %s --check-prefix=MalformedDoubleAt
+MalformedDoubleAt: malformed versioned symbol name 'foo@@'
+
+## Case 2: literal `@V1` (no base before `@`) is malformed.
+RUN: %not %link %linkopts -o %t.malformed_leading_at.so %t.malformed_leading_at.o \
+RUN:     -shared --version-script %p/Inputs/vs_v1.t 2>&1 \
+RUN:   | %filecheck %s --check-prefix=MalformedLeadingAt
+MalformedLeadingAt: {{.*}}malformed_leading_at.o: malformed versioned symbol name '@V1'
+
+## Case 3: undefined reference named `foo@@V1` (`@@` is defs only).
+RUN: %not %link %linkopts -o %t.undef_doubleat.so %t.undef_doubleat.o \
+RUN:     -shared --version-script %p/Inputs/vs_v1.t 2>&1 \
+RUN:   | %filecheck %s --check-prefix=UndefDoubleAt
+UndefDoubleAt: {{.*}}undef_doubleat.o: 'foo@@V1' uses '@@' but is an undefined reference
+
+## Case 4: STB_LOCAL binding on `bar@V1` (local versioned unsupported).
+RUN: %not %link %linkopts -o %t.local_versioned.so %t.local_versioned.o \
+RUN:     -shared --version-script %p/Inputs/vs_v1.t 2>&1 \
+RUN:   | %filecheck %s --check-prefix=LocalVersioned
+LocalVersioned: {{.*local_versioned.o}}: local versioned symbol 'bar@V1' is not supported
+#END_TEST

--- a/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/MultipleDefinitionErrors.test
+++ b/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/MultipleDefinitionErrors.test
@@ -1,0 +1,64 @@
+REQUIRES: symbol_versioning
+#---MultipleDefinitionErrors.test-----------------------------------------#
+#BEGIN_COMMENT
+# All object-side symbol-versioning inputs that must fail with a
+# `multiple definition of symbol` diagnostic. Each case builds only the
+# objects it needs and pipes through FileCheck with a distinct prefix.
+#
+#   TwoStrongDefault         - two strong `bar@@V1` (same-name default
+#                              clash).
+#   TwoStrongNonDefault      - two strong `bar@V1`.
+#   DefaultVsNonDefault      - strong `bar@@V1` + strong `bar@V1`.
+#   DistinctVersions         - `bar@@V1` + `bar@@V2` under a two-version
+#                              script; the synthesized non-canonical `bar`
+#                              alias clashes.
+#   WeakDefaultSplitOverride - weak `bar@@V1` + strong bare `bar` + strong
+#                              `bar@V1`: both halves of the weak pair get
+#                              overridden by different strong definitions
+#                              that disagree with each other.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t.strong_default.o    %p/Inputs/strong_default.c    -c -fPIC
+RUN: %clang %clangopts -o %t.strong_nondefault.o %p/Inputs/strong_nondefault.c -c -fPIC
+RUN: %clang %clangopts -o %t.strong_unversioned.o %p/Inputs/strong_unversioned.c -c -fPIC
+RUN: %clang %clangopts -o %t.strong_default_v2.o %p/Inputs/strong_default_v2.c -c -fPIC
+RUN: %clang %clangopts -o %t.weak_default.o      %p/Inputs/weak_default.c      -c -fPIC
+
+## Case 1: two strong bar@@V1 clash on the canonical `bar@V1` slot.
+RUN: %not %link %linkopts -o %t.two_strong_default.so \
+RUN:     %t.strong_default.o %t.strong_default.o \
+RUN:     -shared --version-script %p/Inputs/vs_v1.t 2>&1 \
+RUN:   | %filecheck %s --check-prefix=TwoStrongDefault
+TwoStrongDefault: multiple definition of symbol `bar@V1'
+
+## Case 2: two strong bar@V1 clash on the canonical `bar@V1` slot.
+RUN: %not %link %linkopts -o %t.two_strong_nondefault.so \
+RUN:     %t.strong_nondefault.o %t.strong_nondefault.o \
+RUN:     -shared --version-script %p/Inputs/vs_v1.t 2>&1 \
+RUN:   | %filecheck %s --check-prefix=TwoStrongNonDefault
+TwoStrongNonDefault: multiple definition of symbol `bar@V1'
+
+## Case 3: strong bar@@V1 + strong bar@V1 clash on the canonical `bar@V1`.
+RUN: %not %link %linkopts -o %t.default_vs_nondefault.so \
+RUN:     %t.strong_default.o %t.strong_nondefault.o \
+RUN:     -shared --version-script %p/Inputs/vs_v1.t 2>&1 \
+RUN:   | %filecheck %s --check-prefix=DefaultVsNonDefault
+DefaultVsNonDefault: multiple definition of symbol `bar@V1'
+
+## Case 4: bar@@V1 + bar@@V2 under a two-version script. Both synthesize
+## a non-canonical `bar` alias which clashes.
+RUN: %not %link %linkopts -o %t.distinct_versions.so \
+RUN:     %t.strong_default.o %t.strong_default_v2.o \
+RUN:     -shared --version-script %p/Inputs/vs_v1_v2.t 2>&1 \
+RUN:   | %filecheck %s --check-prefix=DistinctVersions
+DistinctVersions: multiple definition of symbol
+
+## Case 5: weak bar@@V1 + strong bare bar + strong bar@V1. Weak default's
+## alias slot loses to bare bar; weak default's canonical slot loses to
+## strong bar@V1; the two winners disagree with each other -> multi-def.
+RUN: %not %link %linkopts -o %t.weak_default_split_override.so \
+RUN:     %t.weak_default.o %t.strong_unversioned.o %t.strong_nondefault.o \
+RUN:     -shared --version-script %p/Inputs/vs_v1.t 2>&1 \
+RUN:   | %filecheck %s --check-prefix=WeakDefaultSplitOverride
+WeakDefaultSplitOverride: multiple definition of symbol
+#END_TEST

--- a/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/ResolutionInStaticExecutable.test
+++ b/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/ResolutionInStaticExecutable.test
@@ -1,0 +1,22 @@
+REQUIRES: symbol_versioning
+#---ResolutionInStaticExecutable.test---------------------------------------#
+#BEGIN_COMMENT
+# Validate versioned symbols in executable static symbol tables.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t.strong_default.o %p/Inputs/strong_default.c -c -fPIC
+RUN: %clang %clangopts -o %t.strong_nondefault.o %p/Inputs/strong_nondefault.c -c -fPIC
+RUN: %clang %clangopts -o %t.main_default.o %p/Inputs/main_default.c -c
+RUN: %clang %clangopts -o %t.main_nondefault.o %p/Inputs/main_nondefault.c -c
+
+RUN: %link %linkopts -o %t.exec_default.exe %t.strong_default.o %t.main_default.o
+RUN: %readelf -sW %t.exec_default.exe | %filecheck %s --check-prefix=ExecDefault
+
+RUN: %link %linkopts -o %t.exec_nondefault.exe %t.strong_nondefault.o %t.main_nondefault.o
+RUN: %readelf -sW %t.exec_nondefault.exe | %filecheck %s --check-prefix=ExecNonDefault
+#END_TEST
+
+ExecDefault-DAG:           bar@@V1
+
+ExecNonDefault-DAG:        bar@V1
+ExecNonDefault-NOT:        bar@@V1

--- a/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/ValidResolution.test
+++ b/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/ValidResolution.test
@@ -1,0 +1,129 @@
+REQUIRES: symbol_versioning
+#---ValidResolution.test--------------------------------------------------#
+#BEGIN_COMMENT
+# All object-side symbol-versioning inputs that must link *successfully*.
+# Each case builds only the objects it needs, links its own tmp .so / .exe,
+# and pipes the resulting symbol tables through FileCheck with a distinct
+# prefix.
+# For every multi-object case, we also link with -Map and grep the map's
+# `#<Pattern: bar>` section to assert *which* input actually won the
+# resolution — the dyn-syms table shows only the resolved name, not the
+# owning input.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t.strong_default.o     %p/Inputs/strong_default.c     -c -fPIC
+RUN: %clang %clangopts -o %t.strong_nondefault.o  %p/Inputs/strong_nondefault.c  -c -fPIC
+RUN: %clang %clangopts -o %t.strong_unversioned.o %p/Inputs/strong_unversioned.c -c -fPIC
+RUN: %clang %clangopts -o %t.weak_default.o       %p/Inputs/weak_default.c       -c -fPIC
+RUN: %clang %clangopts -o %t.weak_nondefault.o    %p/Inputs/weak_nondefault.c    -c -fPIC
+
+## Case 1: single strong bar@@V1 (dynsym + static symtab shape).
+RUN: %link %linkopts -o %t.single_default.so %t.strong_default.o \
+RUN:     -shared --version-script %p/Inputs/vs_v1.t
+RUN: %readelf --dyn-syms --version-info %t.single_default.so \
+RUN:   | %filecheck %s --check-prefix=SingleDefaultDyn
+RUN: %readelf -sW %t.single_default.so \
+RUN:   | %filecheck %s --check-prefix=SingleDefaultSymtab
+
+SingleDefaultDyn-DAG:      bar@@V1
+SingleDefaultDyn-DAG:      Name: V1
+SingleDefaultDyn-NOT:      bar@V1{{$}}
+SingleDefaultDyn-NOT:      {{ }}bar{{$}}
+SingleDefaultSymtab-DAG:   impl
+SingleDefaultSymtab-DAG:   bar@@V1
+SingleDefaultSymtab-NOT:   {{ }}bar{{$}}
+
+## Case 2: single strong bar@V1 alone.
+RUN: %link %linkopts -o %t.single_nondefault.so %t.strong_nondefault.o \
+RUN:     -shared --version-script %p/Inputs/vs_v1.t
+RUN: %readelf --dyn-syms --version-info %t.single_nondefault.so \
+RUN:   | %filecheck %s --check-prefix=SingleNonDefault
+
+SingleNonDefault-DAG:      bar@V1
+SingleNonDefault-DAG:      Name: V1
+SingleNonDefault-NOT:      bar@@V1
+SingleNonDefault-NOT:      {{ }}bar{{$}}
+
+## Case 3: strong bar@@V1 + weak bar@V1. Strong wins both halves.
+RUN: %link %linkopts -o %t.strong_weak.so %t.strong_default.o %t.weak_nondefault.o \
+RUN:     -shared --version-script %p/Inputs/vs_v1.t -Map %t.strong_weak.map.txt
+RUN: %readelf --dyn-syms --version-info %t.strong_weak.so \
+RUN:   | %filecheck %s --check-prefix=StrongDefWeakNonDef
+# The canonical `bar@V1` must be backed by strong_default.o, NOT weak_nondefault.o.
+RUN: %filecheck %s --check-prefix=StrongDefWeakNonDefMap < %t.strong_weak.map.txt
+
+StrongDefWeakNonDef-DAG:   bar@@V1
+StrongDefWeakNonDef-NOT:   bar@V1{{$}}
+StrongDefWeakNonDef-NOT:   {{ }}bar{{$}}
+StrongDefWeakNonDefMap:      #{{[[:space:]]+}}bar@V1{{[[:space:]]+}}{{.*}}strong_default.o
+StrongDefWeakNonDefMap-NOT:  #{{[[:space:]]+}}bar@V1{{[[:space:]]+}}{{.*}}weak_nondefault.o
+
+## Case 4: weak bar@@V1 + strong bar@V1. Trace enabled. Strong
+## non-default wins the canonical slot; default identity transfers to it.
+RUN: %link %linkopts -o %t.weak_strong_nd.so %t.weak_default.o %t.strong_nondefault.o \
+RUN:     -shared --version-script %p/Inputs/vs_v1.t -Map %t.weak_strong_nd.map.txt \
+RUN:     --trace=symbol-versioning 2>&1 \
+RUN:   | %filecheck %s --check-prefix=WeakDefStrongNonDefTrace
+RUN: %readelf --dyn-syms --version-info %t.weak_strong_nd.so \
+RUN:   | %filecheck %s --check-prefix=WeakDefStrongNonDef
+# Default identity transferred from weak_default.o -> strong_nondefault.o.
+RUN: %filecheck %s --check-prefix=WeakDefStrongNonDefMap < %t.weak_strong_nd.map.txt
+
+WeakDefStrongNonDefTrace-DAG: Inserted versioned symbol 'bar@@V1' from '{{.*}}weak_default.o'
+WeakDefStrongNonDefTrace-DAG: Inserted versioned symbol 'bar@V1' from '{{.*}}strong_nondefault.o'
+WeakDefStrongNonDef-DAG:   bar@@V1
+WeakDefStrongNonDef-NOT:   bar@V1{{$}}
+WeakDefStrongNonDef-NOT:   {{ }}bar{{$}}
+WeakDefStrongNonDefMap:      #{{[[:space:]]+}}bar@V1{{[[:space:]]+}}{{.*}}strong_nondefault.o
+WeakDefStrongNonDefMap-NOT:  #{{[[:space:]]+}}bar@V1{{[[:space:]]+}}{{.*}}weak_default.o
+
+## Case 5: weak bar@@V1 + strong unversioned bar. Trace enabled.
+## The bare `bar` wins the alias slot and default-version identity
+## transfers to strong_unversioned.o.
+RUN: %link %linkopts -o %t.weak_strong_bare.so %t.weak_default.o %t.strong_unversioned.o \
+RUN:     -shared --version-script %p/Inputs/vs_v1.t -Map %t.weak_strong_bare.map.txt \
+RUN:     --trace=symbol-versioning 2>&1 \
+RUN:   | %filecheck %s --check-prefix=WeakDefStrongUnversionedTrace
+RUN: %readelf --dyn-syms --version-info %t.weak_strong_bare.so \
+RUN:   | %filecheck %s --check-prefix=WeakDefStrongUnversioned
+# The resolved `bar@V1` canonical must point at strong_unversioned.o
+# (bare `bar` won the alias slot and default identity transferred to it).
+RUN: %filecheck %s --check-prefix=WeakDefStrongUnversionedMap < %t.weak_strong_bare.map.txt
+
+WeakDefStrongUnversionedTrace: Inserted versioned symbol 'bar@@V1' from '{{.*}}weak_default.o'
+WeakDefStrongUnversioned-DAG: bar@@V1
+WeakDefStrongUnversioned-NOT: bar@V1{{$}}
+WeakDefStrongUnversioned-NOT: {{ }}bar{{$}}
+WeakDefStrongUnversionedMap:      #{{[[:space:]]+}}bar@V1{{[[:space:]]+}}{{.*}}strong_unversioned.o
+WeakDefStrongUnversionedMap-NOT:  #{{[[:space:]]+}}bar@V1{{[[:space:]]+}}{{.*}}weak_default.o
+
+## Case 6: weak bar@@V1 + strong bar@@V1. Strong overrides weak on both
+## pair slots via the sameDefinition() guard.
+RUN: %link %linkopts -o %t.weak_strong_def.so %t.weak_default.o %t.strong_default.o \
+RUN:     -shared --version-script %p/Inputs/vs_v1.t -Map %t.weak_strong_def.map.txt
+RUN: %readelf --dyn-syms --version-info %t.weak_strong_def.so \
+RUN:   | %filecheck %s --check-prefix=WeakDefStrongDef
+# Strong beats weak on the same default-versioned name.
+RUN: %filecheck %s --check-prefix=WeakDefStrongDefMap < %t.weak_strong_def.map.txt
+
+WeakDefStrongDef-DAG:      bar@@V1
+WeakDefStrongDef-NOT:      bar@V1{{$}}
+WeakDefStrongDef-NOT:      {{ }}bar{{$}}
+WeakDefStrongDefMap:      #{{[[:space:]]+}}bar@V1{{[[:space:]]+}}{{.*}}strong_default.o
+WeakDefStrongDefMap-NOT:  #{{[[:space:]]+}}bar@V1{{[[:space:]]+}}{{.*}}weak_default.o
+
+## Case 7: same as case 6 but with reversed link order.
+RUN: %link %linkopts -o %t.weak_strong_def_swap.so %t.strong_default.o %t.weak_default.o \
+RUN:     -shared --version-script %p/Inputs/vs_v1.t -Map %t.weak_strong_def_swap.map.txt
+RUN: %readelf --dyn-syms --version-info %t.weak_strong_def_swap.so \
+RUN:   | %filecheck %s --check-prefix=WeakDefStrongDefSwapped
+# Same as case 6; strong must still win regardless of link order.
+RUN: %filecheck %s --check-prefix=WeakDefStrongDefSwappedMap < %t.weak_strong_def_swap.map.txt
+
+WeakDefStrongDefSwapped-DAG: bar@@V1
+WeakDefStrongDefSwapped-NOT: bar@V1{{$}}
+WeakDefStrongDefSwapped-NOT: {{ }}bar{{$}}
+WeakDefStrongDefSwappedMap:      #{{[[:space:]]+}}bar@V1{{[[:space:]]+}}{{.*}}strong_default.o
+WeakDefStrongDefSwappedMap-NOT:  #{{[[:space:]]+}}bar@V1{{[[:space:]]+}}{{.*}}weak_default.o
+
+#END_TEST

--- a/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/VersionedSymbolsInArchive.test
+++ b/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/VersionedSymbolsInArchive.test
@@ -1,0 +1,21 @@
+REQUIRES: symbol_versioning
+#---VersionedSymbolsInArchive.test------------------------------------------#
+#BEGIN_COMMENT
+# Validate versioned-symbol resolution when a weak default definition is in an
+# archive and a strong unversioned definition is linked directly.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t.strong_unversioned.o %p/Inputs/strong_unversioned.c -c -fPIC
+RUN: %clang %clangopts -o %t.weak_default.o %p/Inputs/weak_default.c -c -fPIC
+RUN: %ar rcs %t.weak_default.a %t.weak_default.o
+
+RUN: %link %linkopts -o %t.archive.so %t.strong_unversioned.o %t.weak_default.a \
+RUN:     -shared --version-script %p/Inputs/vs_v1.t -u bar -Map %t.archive.map.txt
+RUN: %readelf --dyn-syms --version-info %t.archive.so \
+RUN:   | %filecheck %s --check-prefix=Archive
+RUN: %filecheck %s --check-prefix=ArchiveMap < %t.archive.map.txt
+#END_TEST
+
+Archive-DAG:               bar@@V1
+ArchiveMap:      #{{[[:space:]]+}}bar{{[[:space:]]+}}{{.*}}strong_unversioned.o
+ArchiveMap-NOT:  #{{[[:space:]]+}}bar{{.*}}weak_default.o

--- a/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/VersionedSymbolsWithGC.test
+++ b/test/Common/standalone/SymbolVersioning/VersionedSymbolsInRelocatableObjects/VersionedSymbolsWithGC.test
@@ -1,0 +1,15 @@
+REQUIRES: symbol_versioning
+#---VersionedSymbolsWithGC.test---------------------------------------------#
+#BEGIN_COMMENT
+# Validate a strong default-versioned definition survives --gc-sections.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t.gc.o %p/Inputs/strong_default.c -c -fPIC -ffunction-sections
+RUN: %link %linkopts -o %t.gc.so %t.gc.o -shared \
+RUN:     --version-script %p/Inputs/vs_v1.t --gc-sections
+RUN: %readelf --dyn-syms --version-info %t.gc.so \
+RUN:   | %filecheck %s --check-prefix=GcSections
+#END_TEST
+
+GcSections-DAG:            bar@@V1
+GcSections-NOT:            {{ }}bar{{$}}

--- a/test/UnitTests/SymbolResolutionTests/CMakeLists.txt
+++ b/test/UnitTests/SymbolResolutionTests/CMakeLists.txt
@@ -1,4 +1,12 @@
-add_eld_unittest(SymbolResolutionTests SymbolResolutionTest.cpp)
+set(SYMBOL_RESOLUTION_TEST_SOURCES SymbolResolutionTest.cpp)
+
+if(ELD_ENABLE_SYMBOL_VERSIONING)
+  list(APPEND SYMBOL_RESOLUTION_TEST_SOURCES
+       VersionedSymbolsSymbolResolutionTest.cpp)
+endif()
+
+add_eld_unittest(SymbolResolutionTests ${SYMBOL_RESOLUTION_TEST_SOURCES}
+  PARTIAL_SOURCES_INTENDED)
 
 target_link_libraries(
   SymbolResolutionTests

--- a/test/UnitTests/SymbolResolutionTests/VersionedSymbolsSymbolResolutionTest.cpp
+++ b/test/UnitTests/SymbolResolutionTests/VersionedSymbolsSymbolResolutionTest.cpp
@@ -1,0 +1,395 @@
+//===- VersionedSymbolsSymbolResolutionTest.cpp---------------------------===//
+//
+//                     The MCLinker Project
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "SymbolResolutionTest.h"
+#include "eld/Config/LinkerConfig.h"
+#include "eld/Core/Linker.h"
+#include "eld/Core/Module.h"
+#include "eld/Diagnostics/DiagnosticEngine.h"
+#include "eld/Diagnostics/DiagnosticInfos.h"
+#include "eld/Input/ELFObjectFile.h"
+#include "eld/Input/Input.h"
+#include "eld/Readers/ELFSection.h"
+#include "eld/Support/Target.h"
+#include "eld/SymbolResolver/IRBuilder.h"
+#include "eld/SymbolResolver/LDSymbol.h"
+#include "eld/SymbolResolver/NamePool.h"
+#include "eld/Target/GNULDBackend.h"
+#include "eld/Target/TargetInfo.h"
+#include "llvm/BinaryFormat/ELF.h"
+#include "gtest/gtest.h"
+
+using namespace eld;
+
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+namespace {
+
+class FakeTargetInfo final : public TargetInfo {
+public:
+  explicit FakeTargetInfo(LinkerConfig &Config) : TargetInfo(Config) {}
+
+  uint32_t machine() const override { return llvm::ELF::EM_NONE; }
+  std::string getMachineStr() const override { return "fake"; }
+  uint64_t flags() const override { return 0; }
+  uint64_t startAddr(bool, bool, bool) const override { return 0; }
+};
+
+class FakeBackend final : public GNULDBackend {
+public:
+  FakeBackend(Module &M, TargetInfo *Info) : GNULDBackend(M, Info) {}
+
+  bool finalizeTargetSymbols() override { return true; }
+  Relocator *getRelocator() const override { return nullptr; }
+  Stub *getBranchIslandStub(Relocation *, int64_t) const override {
+    return nullptr;
+  }
+  bool initRelocator() override { return true; }
+  void initTargetSections(ObjectBuilder &) override {}
+  void initTargetSymbols() override {}
+  size_t getRelEntrySize() override { return 0; }
+  size_t getRelaEntrySize() override { return 0; }
+  ELFDynamic *dynamic() override { return nullptr; }
+  std::size_t PLTEntriesCount() const override { return 0; }
+  std::size_t GOTEntriesCount() const override { return 0; }
+};
+
+GNULDBackend *createFakeBackend(Module &M) {
+  return make<FakeBackend>(M, make<FakeTargetInfo>(M.getConfig()));
+}
+
+class VersionedSymbolsSymbolResolutionTest : public SymbolResolutionTest {
+public:
+  VersionedSymbolsSymbolResolutionTest() : SymbolResolutionTest() {
+    Linker *L = make<Linker>(*m_Module, *m_Config);
+    Target T;
+    T.Name = "fake";
+    T.Machine = llvm::ELF::EM_NONE;
+    T.Is64bit = true;
+    T.GNULDBackendCtorFn = createFakeBackend;
+    EXPECT_TRUE(L->initBackend(&T));
+    std::vector<InputAction *> InputActions;
+    EXPECT_TRUE(L->initializeInputTree(InputActions));
+  }
+
+protected:
+  InputFile *object(llvm::StringRef Name) {
+    Input *I = make<Input>(Name.str(), m_DiagEngine);
+    I->setResolvedPath(Name.str());
+    ELFObjectFile *Obj = make<ELFObjectFile>(I, m_DiagEngine);
+    m_Module->getObjectList().push_back(Obj);
+    return Obj;
+  }
+
+  ELFSection *textSection() {
+    return make<ELFSection>(LDFileFormat::Kind::Regular, ".text.foo",
+                            llvm::ELF::SHF_ALLOC | llvm::ELF::SHF_EXECINSTR, 0,
+                            0, llvm::ELF::SHT_PROGBITS, 0, nullptr, 0, 0);
+  }
+
+  LDSymbol *define(InputFile &File, llvm::StringRef Name,
+                   ResolveInfo::Binding Binding, uint64_t Value) {
+    return m_IRBuilder->addSymbol(
+        File, Name.str(), ResolveInfo::Type::Function,
+        ResolveInfo::Desc::Define, Binding, /*pSize=*/12, Value, textSection(),
+        ResolveInfo::Visibility::Default, /*isPostLTOPhase=*/false,
+        /*shndx=*/1, /*idx=*/1);
+  }
+
+  LDSymbol *ref(InputFile &File, llvm::StringRef Name) {
+    return m_IRBuilder->addSymbol(
+        File, Name.str(), ResolveInfo::Type::Function,
+        ResolveInfo::Desc::Undefined, ResolveInfo::Binding::Global,
+        /*pSize=*/0, /*pValue=*/0, /*pSection=*/nullptr,
+        ResolveInfo::Visibility::Default, /*isPostLTOPhase=*/false,
+        /*shndx=*/0, /*idx=*/1);
+  }
+
+  LDSymbol *findInfo(llvm::StringRef Name) {
+    ResolveInfo *Info = m_Module->getNamePool().findInfo(Name.str());
+    return Info ? Info->outSymbol() : nullptr;
+  }
+
+  void normalizeSymbols() { m_IRBuilder->normalizeSymbols(); }
+};
+
+} // namespace
+
+TEST_F(VersionedSymbolsSymbolResolutionTest,
+       StrongDefaultDefinitionResolvesPlainReference) {
+  InputFile *File1 = object("1.o");
+  LDSymbol *FooDefault = define(*File1, "foo@@V1", ResolveInfo::Binding::Global,
+                                /*Value=*/0x10);
+
+  InputFile *File2 = object("2.o");
+  LDSymbol *FooRef = ref(*File2, "foo");
+
+  normalizeSymbols();
+  ASSERT_NE(FooDefault, nullptr);
+  ASSERT_NE(FooRef, nullptr);
+  EXPECT_EQ(FooRef->resolveInfo()->outSymbol(), FooDefault);
+  EXPECT_TRUE(FooDefault->resolveInfo()->isDefaultVersion());
+}
+
+TEST_F(VersionedSymbolsSymbolResolutionTest,
+       StrongDefaultDefinitionResolvesVersionedReference) {
+  InputFile *File1 = object("1.o");
+  LDSymbol *FooDefault = define(*File1, "foo@@V1", ResolveInfo::Binding::Global,
+                                /*Value=*/0x10);
+
+  InputFile *File2 = object("2.o");
+  LDSymbol *FooV1Ref = ref(*File2, "foo@V1");
+
+  normalizeSymbols();
+  ASSERT_NE(FooDefault, nullptr);
+  ASSERT_NE(FooV1Ref, nullptr);
+  EXPECT_EQ(FooV1Ref->resolveInfo()->outSymbol(), FooDefault);
+  EXPECT_EQ(FooV1Ref->resolveInfo(), FooDefault->resolveInfo());
+}
+
+TEST_F(VersionedSymbolsSymbolResolutionTest,
+       StrongNonDefaultDefinitionResolvesVersionedReference) {
+  InputFile *File1 = object("1.o");
+  LDSymbol *FooV1 = define(*File1, "foo@V1", ResolveInfo::Binding::Global,
+                           /*Value=*/0x10);
+
+  InputFile *File2 = object("2.o");
+  LDSymbol *FooV1Ref = ref(*File2, "foo@V1");
+
+  normalizeSymbols();
+  ASSERT_NE(FooV1, nullptr);
+  ASSERT_NE(FooV1Ref, nullptr);
+  EXPECT_EQ(FooV1Ref->resolveInfo()->outSymbol(), FooV1);
+  EXPECT_EQ(FooV1Ref->resolveInfo(), FooV1->resolveInfo());
+  EXPECT_FALSE(FooV1->resolveInfo()->isDefaultVersion());
+}
+
+TEST_F(VersionedSymbolsSymbolResolutionTest,
+       StrongDefaultBeatsWeakNonDefaultForVersionedReference) {
+  InputFile *File1 = object("1.o");
+  LDSymbol *FooDefault = define(*File1, "foo@@V1", ResolveInfo::Binding::Global,
+                                /*Value=*/0x10);
+
+  InputFile *File2 = object("2.o");
+  LDSymbol *FooWeakV1 = define(*File2, "foo@V1", ResolveInfo::Binding::Weak,
+                               /*Value=*/0x20);
+
+  InputFile *File3 = object("3.o");
+  LDSymbol *FooV1Ref = ref(*File3, "foo@V1");
+
+  normalizeSymbols();
+  ASSERT_NE(FooDefault, nullptr);
+  ASSERT_NE(FooWeakV1, nullptr);
+  ASSERT_NE(FooV1Ref, nullptr);
+  EXPECT_EQ(FooV1Ref->resolveInfo()->outSymbol(), FooDefault);
+  EXPECT_EQ(FooWeakV1->resolveInfo()->outSymbol(), FooDefault);
+  EXPECT_EQ(FooV1Ref->resolveInfo(), FooDefault->resolveInfo());
+}
+
+TEST_F(VersionedSymbolsSymbolResolutionTest,
+       StrongNonDefaultBeatsWeakDefaultForVersionedSlot) {
+  InputFile *File1 = object("1.o");
+  LDSymbol *FooWeakDefault =
+      define(*File1, "foo@@V1", ResolveInfo::Binding::Weak, /*Value=*/0x10);
+
+  InputFile *File2 = object("2.o");
+  LDSymbol *FooV1 = define(*File2, "foo@V1", ResolveInfo::Binding::Global,
+                           /*Value=*/0x20);
+
+  InputFile *File3 = object("3.o");
+  LDSymbol *FooRef = ref(*File3, "foo");
+  LDSymbol *FooV1Ref = ref(*File3, "foo@V1");
+
+  normalizeSymbols();
+  ASSERT_NE(FooWeakDefault, nullptr);
+  ASSERT_NE(FooV1, nullptr);
+  ASSERT_NE(FooRef, nullptr);
+  ASSERT_NE(FooV1Ref, nullptr);
+  EXPECT_EQ(FooRef->resolveInfo()->outSymbol(), FooV1);
+  EXPECT_EQ(FooV1Ref->resolveInfo()->outSymbol(), FooV1);
+  EXPECT_EQ(FooRef->resolveInfo(), FooV1->resolveInfo());
+  EXPECT_EQ(FooRef->resolveInfo(), FooV1->resolveInfo());
+  EXPECT_TRUE(FooV1->resolveInfo()->isDefaultVersion());
+}
+
+TEST_F(VersionedSymbolsSymbolResolutionTest,
+       StrongPlainBeatsWeakDefaultForPlainSlot) {
+  InputFile *File1 = object("1.o");
+  LDSymbol *FooWeakDefault =
+      define(*File1, "foo@@V1", ResolveInfo::Binding::Weak, /*Value=*/0x10);
+
+  InputFile *File2 = object("2.o");
+  LDSymbol *Foo = define(*File2, "foo", ResolveInfo::Binding::Global,
+                         /*Value=*/0x20);
+
+  InputFile *File3 = object("3.o");
+  LDSymbol *FooRef = ref(*File3, "foo");
+  LDSymbol *FooV1Ref = ref(*File3, "foo@V1");
+
+  normalizeSymbols();
+  ASSERT_NE(FooWeakDefault, nullptr);
+  ASSERT_NE(Foo, nullptr);
+  ASSERT_NE(FooRef, nullptr);
+  ASSERT_NE(FooV1Ref, nullptr);
+  EXPECT_EQ(FooRef->resolveInfo()->outSymbol(), Foo);
+  EXPECT_EQ(FooV1Ref->resolveInfo()->outSymbol(), Foo);
+  EXPECT_EQ(FooWeakDefault->resolveInfo()->outSymbol(), Foo);
+  EXPECT_EQ(FooRef->resolveInfo(), Foo->resolveInfo());
+  EXPECT_EQ(FooV1Ref->resolveInfo(), FooWeakDefault->resolveInfo());
+}
+
+TEST_F(VersionedSymbolsSymbolResolutionTest,
+       StrongDefaultBeatsWeakPlainAndWeakNonDefault) {
+  InputFile *File1 = object("1.o");
+  LDSymbol *FooDefault = define(*File1, "foo@@V1", ResolveInfo::Binding::Global,
+                                /*Value=*/0x10);
+
+  InputFile *File2 = object("2.o");
+  LDSymbol *FooWeakV1 = define(*File2, "foo@V1", ResolveInfo::Binding::Weak,
+                               /*Value=*/0x20);
+
+  InputFile *File3 = object("3.o");
+  LDSymbol *FooWeak = define(*File3, "foo", ResolveInfo::Binding::Weak,
+                             /*Value=*/0x30);
+
+  InputFile *File4 = object("4.o");
+  LDSymbol *FooRef = ref(*File4, "foo");
+  LDSymbol *FooV1Ref = ref(*File4, "foo@V1");
+
+  normalizeSymbols();
+  ASSERT_NE(FooDefault, nullptr);
+  ASSERT_NE(FooWeakV1, nullptr);
+  ASSERT_NE(FooWeak, nullptr);
+  ASSERT_NE(FooRef, nullptr);
+  ASSERT_NE(FooV1Ref, nullptr);
+  EXPECT_EQ(FooRef->resolveInfo()->outSymbol(), FooDefault);
+  EXPECT_EQ(FooV1Ref->resolveInfo()->outSymbol(), FooDefault);
+  EXPECT_EQ(FooWeakV1->resolveInfo()->outSymbol(), FooDefault);
+  EXPECT_EQ(FooWeak->resolveInfo()->outSymbol(), FooDefault);
+  EXPECT_EQ(FooWeakV1->resolveInfo(), FooDefault->resolveInfo());
+  EXPECT_EQ(FooWeak->resolveInfo(), FooRef->resolveInfo());
+  EXPECT_EQ(FooV1Ref->resolveInfo(), FooDefault->resolveInfo());
+}
+
+TEST_F(VersionedSymbolsSymbolResolutionTest,
+       StrongDefaultKeepsVersionedSlotOverStrongNonDefault) {
+  InputFile *File1 = object("1.o");
+  LDSymbol *FooDefault = define(*File1, "foo@@V1", ResolveInfo::Binding::Global,
+                                /*Value=*/0x10);
+
+  InputFile *File2 = object("2.o");
+  m_DiagEngine->setInfoMap(std::make_unique<DiagnosticInfos>(*m_Config));
+  testing::internal::CaptureStderr();
+  LDSymbol *FooV1 = define(*File2, "foo@V1", ResolveInfo::Binding::Global,
+                           /*Value=*/0x20);
+  std::string Output = testing::internal::GetCapturedStderr();
+
+  normalizeSymbols();
+  ASSERT_NE(FooDefault, nullptr);
+  ASSERT_NE(FooV1, nullptr);
+  EXPECT_NE(Output.find("Error: multiple definition"), std::string::npos);
+}
+
+TEST_F(VersionedSymbolsSymbolResolutionTest,
+       TwoStrongDefaultsKeepSeparateVersionedSlots) {
+  InputFile *File1 = object("1.o");
+  LDSymbol *FooDefaultV1 =
+      define(*File1, "foo@@V1", ResolveInfo::Binding::Global,
+             /*Value=*/0x10);
+
+  InputFile *File2 = object("2.o");
+  m_DiagEngine->setInfoMap(std::make_unique<DiagnosticInfos>(*m_Config));
+  testing::internal::CaptureStderr();
+  LDSymbol *FooDefaultV2 =
+      define(*File2, "foo@@V2", ResolveInfo::Binding::Global,
+             /*Value=*/0x20);
+
+  normalizeSymbols();
+  std::string Output = testing::internal::GetCapturedStderr();
+  ASSERT_NE(FooDefaultV1, nullptr);
+  ASSERT_NE(FooDefaultV2, nullptr);
+  ASSERT_NE(findInfo("foo"), nullptr);
+  EXPECT_NE(Output.find("Error: multiple definition of symbol `foo' in file "
+                        "1.o and 2.o\n"),
+            std::string::npos);
+  EXPECT_NE(Output.find("Error: multiple definition of symbol `foo@V2' in "
+                        "file 2.o and 1.o\n"),
+            std::string::npos);
+  EXPECT_EQ(findInfo("foo")->resolveInfo()->value(),
+            static_cast<uint64_t>(0x20));
+  EXPECT_EQ(findInfo("foo@V1"), FooDefaultV1);
+  EXPECT_EQ(findInfo("foo@V2"), FooDefaultV2);
+  EXPECT_TRUE(FooDefaultV1->resolveInfo()->isDefaultVersion());
+  EXPECT_TRUE(FooDefaultV2->resolveInfo()->isDefaultVersion());
+}
+
+TEST_F(VersionedSymbolsSymbolResolutionTest,
+       StrongPlainAndStrongNonDefaultBeatWeakDefaultSlots) {
+  InputFile *File1 = object("1.o");
+  LDSymbol *FooWeakDefault =
+      define(*File1, "foo@@V1", ResolveInfo::Binding::Weak, /*Value=*/0x10);
+
+  InputFile *File2 = object("2.o");
+  LDSymbol *FooV1 = define(*File2, "foo@V1", ResolveInfo::Binding::Global,
+                           /*Value=*/0x20);
+
+  InputFile *File3 = object("3.o");
+  LDSymbol *Foo = define(*File3, "foo", ResolveInfo::Binding::Global,
+                         /*Value=*/0x30);
+
+  m_DiagEngine->setInfoMap(std::make_unique<DiagnosticInfos>(*m_Config));
+  testing::internal::CaptureStderr();
+  normalizeSymbols();
+  std::string Output = testing::internal::GetCapturedStderr();
+  ASSERT_NE(FooWeakDefault, nullptr);
+  ASSERT_NE(FooV1, nullptr);
+  ASSERT_NE(Foo, nullptr);
+  EXPECT_NE(Output.find("Error: multiple definition of symbol `foo@V1' in "
+                        "file 2.o and 3.o\n"),
+            std::string::npos);
+  EXPECT_EQ(findInfo("foo@V1"), FooV1);
+  EXPECT_EQ(findInfo("foo"), Foo);
+  EXPECT_TRUE(FooV1->resolveInfo()->isDefaultVersion());
+}
+
+TEST_F(VersionedSymbolsSymbolResolutionTest,
+       StrongNonDefaultBeatsWeakDefaultAndWeakPlainForVersionedReference) {
+  InputFile *File1 = object("1.o");
+  LDSymbol *FooWeakDefault =
+      define(*File1, "foo@@V1", ResolveInfo::Binding::Weak, /*Value=*/0x10);
+
+  InputFile *File2 = object("2.o");
+  LDSymbol *FooWeak = define(*File2, "foo", ResolveInfo::Binding::Weak,
+                             /*Value=*/0x20);
+
+  InputFile *File3 = object("3.o");
+  LDSymbol *FooV1 = define(*File3, "foo@V1", ResolveInfo::Binding::Global,
+                           /*Value=*/0x30);
+
+  InputFile *File4 = object("4.o");
+  LDSymbol *FooRef = ref(*File4, "foo");
+  LDSymbol *FooV1Ref = ref(*File4, "foo@V1");
+
+  normalizeSymbols();
+  ASSERT_NE(FooWeakDefault, nullptr);
+  ASSERT_NE(FooWeak, nullptr);
+  ASSERT_NE(FooV1, nullptr);
+  ASSERT_NE(FooRef, nullptr);
+  ASSERT_NE(FooV1Ref, nullptr);
+  EXPECT_EQ(FooRef->resolveInfo()->outSymbol(), FooV1);
+  EXPECT_EQ(FooV1Ref->resolveInfo()->outSymbol(), FooV1);
+  EXPECT_EQ(FooWeak->resolveInfo()->outSymbol(), FooV1);
+  EXPECT_EQ(FooWeakDefault->resolveInfo()->outSymbol(), FooV1);
+  EXPECT_TRUE(FooV1->resolveInfo()->isDefaultVersion());
+}
+
+#else
+TEST_F(SymbolResolutionTest, VersionedSymbolsRequireSymbolVersioning) {
+  GTEST_SKIP() << "ELD_ENABLE_SYMBOL_VERSIONING is disabled";
+}
+#endif


### PR DESCRIPTION
This patch adds support for properly resolving versioned symbols in
regular object files.

The patch extends the canonical/non-canonical alias-pair model that is
used for shared-library versioned symbols to the relocatable object versioned
symbols.

Detailed developer documentation for symbol resolution of versioned
symbols with examples is added in docs/DeveloperDocs/SymbolVersioning.md
as part of this patch.

This patch does not add support for local versioned symbols. The local
versioned symbol support will be added as a follow-up patch.
