### PR TITLE
Fix base branch name in github workflows.

### DIFF
--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: write
     env:
-      BASE_BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
+      BASE_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
       ELD_REPO: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
       ELD_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
     name: ${{ matrix.name }}
@@ -68,7 +68,7 @@ jobs:
           status: "fail"
           run-id: ${{github.run_id}}
           arch-name: ${{ matrix.arch }}
-          branch-name: "${{ env.BASE_BRANCH_NAME }}"
+          branch-name: "${{ env.ELD_REF }}"
 
       - name: Configure CMake
         working-directory: nightly
@@ -116,7 +116,7 @@ jobs:
           status: "pass"
           run-id: ${{github.run_id}}
           arch-name: ${{ matrix.arch }}
-          branch-name: "${{ env.BASE_BRANCH_NAME }}"
+          branch-name: "${{ env.ELD_REF }}"
 
       - name: Clean up
         if: always()

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      BASE_BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
+      BASE_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
       ELD_REPO: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
       ELD_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
 


### PR DESCRIPTION
This commit fixes the base branch name when manually triggering workflow runs for non-main branch.

Fixes #1294