### PR TITLE
Update windows workflow runner to windows-2022.

### DIFF
--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: windows-latest
+          - runner: windows-2022
             arch: x64
             name: Windows-x86_64
 


### PR DESCRIPTION
This commit updates the windows workflow runner to windows-2022 to stay compatible with VS 2022.

Closes #1296