### PR TITLE
[Input] Fix null dereference in resolvePathMappingFile

### DIFF
--- a/lib/Input/Input.cpp
+++ b/lib/Input/Input.cpp
@@ -68,6 +68,8 @@ bool Input::resolvePathMappingFile(const LinkerConfig &PConfig) {
       Input::getMemoryAreaForPath(FileName, PConfig.getDiagEngine());
   if (!InputMem)
     InputMem = createMemoryArea(FileName, PConfig.getDiagEngine());
+  if (!InputMem)
+    return false; // File does not exist;
   setMemArea(InputMem);
   // All queries to return the name of the Input return FileName for the main
   // driver.

--- a/test/Common/standalone/MissingMappingFileInput/Inputs/lib1.c
+++ b/test/Common/standalone/MissingMappingFileInput/Inputs/lib1.c
@@ -1,0 +1,1 @@
+int foo() { return 1; }

--- a/test/Common/standalone/MissingMappingFileInput/Inputs/main.c
+++ b/test/Common/standalone/MissingMappingFileInput/Inputs/main.c
@@ -1,0 +1,1 @@
+int main() { return 0; }

--- a/test/Common/standalone/MissingMappingFileInput/Inputs/script.t
+++ b/test/Common/standalone/MissingMappingFileInput/Inputs/script.t
@@ -1,0 +1,1 @@
+GROUP(/lib64/lib1.so)

--- a/test/Common/standalone/MissingMappingFileInput/MissingMappingFileInput.test
+++ b/test/Common/standalone/MissingMappingFileInput/MissingMappingFileInput.test
@@ -1,0 +1,26 @@
+#UNSUPPORTED: windows, reproduce_fail
+#---MissingMappingFileInput.test----------- Executable -----------------#
+#BEGIN_COMMENT
+# Verify that ELD does not crash when a reproduce tarball is replayed
+# and an input file referenced in a linker script is missing from the
+# sysroot. ELD should report a fatal error instead of segfaulting.
+#END_COMMENT
+#START_TEST
+RUN: rm -rf %t.dir && mkdir -p %t.dir/lib64 %t.dir/scripts
+RUN: %clang %clangopts -c %p/Inputs/main.c -o %t.main.o
+RUN: %clang %clangopts -c %p/Inputs/lib1.c -o %t.lib1.o -fPIC
+RUN: %link %linkopts -shared %t.lib1.o -o %t.dir/lib64/lib1.so
+RUN: %cp %p/Inputs/script.t %t.dir/scripts/script.t
+RUN: %link %linkopts %t.main.o \
+RUN:   --sysroot=%t.dir \
+RUN:   -T %t.dir/scripts/script.t \
+RUN:   --reproduce %t.tar \
+RUN:   --dump-response-file %t.response \
+RUN:   -o %t.out
+RUN: mkdir -p %t.reproduce
+RUN: %tar %gnutaropts -xvf %t.tar -C %t.reproduce --strip-components=1
+RUN: rm -rf %t.reproduce/SharedLibrary
+RUN: rm -rf %t.dir/lib64/lib1.so
+RUN: cd %t.reproduce && %not %link %linkopts @%t.response 2>&1 | %filecheck %s
+#END_TEST
+CHECK: cannot read file /lib64/lib1.so


### PR DESCRIPTION
ELD crashes with a segfault instead of reporting a clean fatal error when a file referenced in a linker script is missing from the reproduce tarball or mapping.ini contains an incorrect mapping.

The root cause is `Input::resolvePathMappingFile()` calls `createMemoryArea()` which returns `nullptr` when the file does not exist, but still calls `setMemArea(nullptr)` and returns `true`, propagating a null `MemArea` to `readAndProcessInput()` where it is dereferenced by `ScriptLexer`.

Fixes #1335
