### PR TITLE
Remove usage of deprecated command-line flags in eld

### DIFF
--- a/docs/userguide/GenerateOptionsDocsFromTblGen.py
+++ b/docs/userguide/GenerateOptionsDocsFromTblGen.py
@@ -102,15 +102,15 @@ class Option:
         One of the complication transformations it performs is transforming
         documentation such as:
 
-        -trace=linker-script
-        -trace=files
-        -trace=LTO
+        --trace=linker-script
+        --trace=files
+        --trace=LTO
 
         to:
 
-        * -trace=linker-script
-        * -trace=files
-        * -trace=LTO
+        * --trace=linker-script
+        * --trace=files
+        * --trace=LTO
 
         This transformation is required to improve formatting in the sphinx
         documentation output.

--- a/docs/userguide/documentation/diagnostic_reports.rst
+++ b/docs/userguide/documentation/diagnostic_reports.rst
@@ -135,8 +135,8 @@ Schema (per ``ArchiveMembers`` entry):
 - ``ReferrerArchive`` / ``ReferrerMember``: Requester when another archive
   member caused the pull-in.
 - ``Symbol``: Symbol that triggered inclusion for non-whole-archive pulls.
-- ``WholeArchive`` and ``Reason``: Present when ``-whole-archive`` caused
-  inclusion (for example ``Reason: -whole-archive``).
+- ``WholeArchive`` and ``Reason``: Present when ``--whole-archive`` caused
+  inclusion (for example ``Reason: --whole-archive``).
 - ``MemberReferencedSymbols``: Symbols referenced by the included member; this
   enables tracing symbol chains such as ``sys_init_tls -> malloc``.
 - ``MemberSymbols``: Symbols defined by the included member.
@@ -149,8 +149,8 @@ Behavior notes:
 
 - The report is emitted even when map files are not requested.
 - Both regular archives and thin archives are supported.
-- For ``-whole-archive`` inclusion, ``WholeArchive`` is ``true`` and
-  ``Reason`` is emitted as ``-whole-archive``.
+- For ``--whole-archive`` inclusion, ``WholeArchive`` is ``true`` and
+  ``Reason`` is emitted as ``--whole-archive``.
 
 Example JSON snippet::
 

--- a/docs/userguide/documentation/elf_tools.rst
+++ b/docs/userguide/documentation/elf_tools.rst
@@ -236,7 +236,7 @@ This sections documents llvm ELF command-line tools along with detailed examples
       00000000 T bar
       0000000c T foo
 
-  - **-D** = **-dynamic**
+  - **-D** = **--dynamic**
 
     List dynamic symbols
 

--- a/docs/userguide/documentation/getting_image_details.rst
+++ b/docs/userguide/documentation/getting_image_details.rst
@@ -17,7 +17,7 @@ Supported Diagnostic Options
     * **-MapStyle=[Text|YAML|Binary]**
             Display the Map information in Text/YAML/Binary format.
 
-    * **-MapDetail <value>**
+    * **--MapDetail <value>**
           Detail information in the map file
 
     * **--verbose**
@@ -34,7 +34,7 @@ Supported Diagnostic Options
             * **Trampolines** - tracing of trampolines.
             * **LTO** - Allows tracing of LTO.
 
-    * **-color <value>**
+    * **--color <value>**
               Enable color output for diagnostics
 
     * **-display_hotness <value>**
@@ -43,7 +43,7 @@ Supported Diagnostic Options
     * **--emit-timing-stats <value>**
             Emit time statistics of various linker operations to the specified file
 
-    * **-print-timing-stats**
+    * **--print-timing-stats**
             Print time statistics of various linker operations to console
 
     * **--time-region <value>**

--- a/docs/userguide/documentation/linker_faq.rst
+++ b/docs/userguide/documentation/linker_faq.rst
@@ -258,7 +258,7 @@ filename, or ``a.out.tar`` if ``-o`` is not given).
 .. note::
 
     If the tarball is big and you want the linker to compress the tarball
-    automatically, you can use the switch -reproduce-compressed.
+    automatically, you can use the switch --reproduce-compressed.
 
 .. note::
 
@@ -281,7 +281,7 @@ Multiple ways to invoke ELD linker
     int main(){return 0;}
 
     clang -target  armv7-none-eabi  -g  -c bar.c  -o bar.o
-    arm-link -m armelf_linux_eabi -dynamic-linker /lib/ld-linux.so.3 -o bar.elf --strip-debug bar.o
+    arm-link -m armelf_linux_eabi --dynamic-linker /lib/ld-linux.so.3 -o bar.elf --strip-debug bar.o
 
 * Pass -fuse-ld=eld flag to clang driver, so that eld is used for linking
 
@@ -292,7 +292,7 @@ Multiple ways to invoke ELD linker
 .. note::
 
     ELD linker flags can be passed to clang driver using -Wl prefix.
-    Example : clang ...... -Wl,-shared -Wl,-gc-sections bar.o -o bar.elf
+    Example : clang ...... -Wl,-shared -Wl,--gc-sections bar.o -o bar.elf
 
 * Pass -v (verbose) when linking using clang binary, pick the link command line,
   edit and execute it
@@ -305,9 +305,9 @@ Multiple ways to invoke ELD linker
   Target: armv7-none-unknown-eabi
   Thread model: posix
   InstalledDir: /pkg/qct/software/llvm/release/arm/16.0.0/bin
-   "/pkg/qct/software/llvm/release/arm/16.0.0/bin/ld.eld" -EL -X --eh-frame-hdr -m armelf_linux_eabi -dynamic-linker /lib/ld-linux.so.3 -o bar.elf bar.o -L/pkg/qct/software/llvm/release/arm/16.0.0/armv7-none-eabi/libc/lib -L/afs/localcell/cm/gv2.6/sysname/pkg.@sys/qct/software/llvm/release/arm/16.0.0/lib/clang/16.0.0/lib/baremetal --start-group -lc -lclang_rt.builtins-armv7 --end-group -lc
+   "/pkg/qct/software/llvm/release/arm/16.0.0/bin/ld.eld" -EL -X --eh-frame-hdr -m armelf_linux_eabi --dynamic-linker /lib/ld-linux.so.3 -o bar.elf bar.o -L/pkg/qct/software/llvm/release/arm/16.0.0/armv7-none-eabi/libc/lib -L/afs/localcell/cm/gv2.6/sysname/pkg.@sys/qct/software/llvm/release/arm/16.0.0/lib/clang/16.0.0/lib/baremetal --start-group -lc -lclang_rt.builtins-armv7 --end-group -lc
 
-  $ ld.eld -EL -X --eh-frame-hdr -m armelf_linux_eabi -dynamic-linker /lib/ld-linux.so.3 -o bar.elf bar.o -L/pkg/qct/software/llvm/release/arm/16.0.0/armv7-none-eabi/libc/lib -L/afs/localcell/cm/gv2.6/sysname/pkg.@sys/qct/software/llvm/release/arm/16.0.0/lib/clang/16.0.0/lib/baremetal --start-group -lc -lclang_rt.builtins-armv7 --end-group -lc --strip-debug
+  $ ld.eld -EL -X --eh-frame-hdr -m armelf_linux_eabi --dynamic-linker /lib/ld-linux.so.3 -o bar.elf bar.o -L/pkg/qct/software/llvm/release/arm/16.0.0/armv7-none-eabi/libc/lib -L/afs/localcell/cm/gv2.6/sysname/pkg.@sys/qct/software/llvm/release/arm/16.0.0/lib/clang/16.0.0/lib/baremetal --start-group -lc -lclang_rt.builtins-armv7 --end-group -lc --strip-debug
 
 Ignore multiple definition errors and continue with the link
 --------------------------------------------------------------
@@ -467,12 +467,12 @@ mapfiles of the two output images which you are interested in.
 By default, mapfiles layout section also contains virtual addresses associated
 with the layout. This brings in too much unnecessary noise when comparing the two
 layouts, because a small change in the layout can result in change of virtual
-address of many sections. This can be fixed by using '-MapDetail only-layout'
+address of many sections. This can be fixed by using '--MapDetail only-layout'
 option.
 
 .. code-block:: bash
 
-  // Run link commands with '-MapDetail only-layout' when generating the two output images.
+  // Run link commands with '--MapDetail only-layout' when generating the two output images.
   vim -d image1.map image2.map # To compare the two output images layouts.
 
 How to embed a binary and use it in 'C' code
@@ -1060,7 +1060,7 @@ Example:
 .. code-block:: bash
 
   $ clang -c  main.c -ffunction-sections
-  $ ld.eld main.o -T script.t -Map x -no-reuse-trampolines-file=noreuse
+  $ ld.eld main.o -T script.t -Map x --no-reuse-trampolines-file=noreuse
 
 **Symbols from readelf:**
 
@@ -1088,7 +1088,7 @@ the existing trampoline is not possible.
 
 .. note::
 
-  The reuse was not possible because of ``-no-reuse-trampolines-file=noreuse``.
+  The reuse was not possible because of ``--no-reuse-trampolines-file=noreuse``.
 
 Case3:
 ^^^^^^^
@@ -1202,7 +1202,7 @@ Example:
 .. code-block:: bash
 
   $ clang -c  main.c -ffunction-sections
-  $ ld.eld main.o -T script.t -Map x -no-reuse-trampolines-file=noreuse
+  $ ld.eld main.o -T script.t -Map x --no-reuse-trampolines-file=noreuse
 
 **Symbols from readelf:**
 

--- a/docs/userguide/documentation/linker_plugin.rst
+++ b/docs/userguide/documentation/linker_plugin.rst
@@ -142,7 +142,7 @@ The linker performs the following sequence of operations with respect to plugins
 
           ::
 
-            -trace=plugin
+            --trace=plugin
 
 Plugin data structures
 --------------------------

--- a/docs/userguide/documentation/lto_support.rst
+++ b/docs/userguide/documentation/lto_support.rst
@@ -49,14 +49,14 @@ LTO is enabled in two ways:
 * `--include-lto-filelist` can be used without `-flto` to select which
   ELF inputs with embedded bitcode should be upgraded to LTO inputs.
 * `--fat-lto-objects` enables consuming embedded `.llvm.lto` sections from
-  relocatable ELF inputs (alias: `-ffat-lto-objects`).
+  relocatable ELF inputs (alias: `--ffat-lto-objects`).
 
 When `-flto` is used, embedded bitcode is used by default unless excluded using
 `--exclude-lto-filelist`. When `-flto` is not used, only file patterns listed
 in `--include-lto-filelist` are upgraded to LTO inputs.
 
 By default, `.llvm.lto` sections are ignored. They are only consumed when
-`--fat-lto-objects` (or `-ffat-lto-objects`) is specified.
+`--fat-lto-objects` (or `--ffat-lto-objects`) is specified.
 
 File lists accept one glob pattern per line (wildcards `*`, `?`, and `[]` are
 supported). Patterns are matched against the input path as seen by the linker.
@@ -73,7 +73,7 @@ ELD performs LTO in distinct phases:
    linked like normal ELF objects. Map files can include pre-LTO and post-LTO
    details.
 
-When ``--fat-lto-objects`` (or ``-ffat-lto-objects``) selects embedded
+When ``--fat-lto-objects`` (or ``--ffat-lto-objects``) selects embedded
 ``.llvm.lto`` from a mixed object, the pre-LTO map input record for that file
 is annotated with ``Fat LTO object selected``.
 
@@ -82,7 +82,7 @@ Linker scripts and LTO
 ELD supports LTO with linker scripts. When a script uses `SECTIONS` ordering,
 ELD preserves input order for LTO-generated sections. If you need to disable
 this ordering for performance or to match non-script ordering, use
-`-flto-options=disable-linkorder`.
+`--flto-options=disable-linkorder`.
 
 LTO switch reference
 --------------------
@@ -96,7 +96,7 @@ Core LTO enablement and input selection
 * `--fat-lto-objects` / `--no-fat-lto-objects`
   Enable/disable use of `.llvm.lto` embedded bitcode sections from fat LTO
   relocatable objects.
-  Aliases: `-ffat-lto-objects`, `-fno-fat-lto-objects`.
+  Aliases: `--ffat-lto-objects`, `--fno-fat-lto-objects`.
 * `--include-lto-filelist=<list>`
   Use this list to select which ELF inputs with embedded bitcode should be
   used for LTO when `-flto` is not present.
@@ -122,9 +122,9 @@ LTO output control and artifacts
   Prefix for LTO-generated object files. When provided, output objects are not
   deleted after LTO.
   Alias: `--plugin-opt=obj-path=`.
-* `-flto-options=lto-asm-file=<file[,file2,...]>`
+* `--flto-options=lto-asm-file=<file[,file2,...]>`
   Use pre-generated LTO assembly files as inputs to the external assembler.
-* `-flto-options=lto-output-file=<file[,file2,...]>`
+* `--flto-options=lto-output-file=<file[,file2,...]>`
   Use pre-generated LTO object files as outputs (bypasses LTO code generation).
 
 LTO optimization control
@@ -161,39 +161,39 @@ LLVM option passthrough
 * `--plugin-opt=-<llvm-option>`
   Pass a raw LLVM option to LTO (LLVMgold compatibility). For example,
   `--plugin-opt=-debug-pass-manager`.
-* `-flto-options=codegen=<llvm-arg>`
+* `--flto-options=codegen=<llvm-arg>`
   Pass LLVM codegen options to LTO (supports `-O`, `-mcpu=`, `-mattr=`, and
   arbitrary LLVM options).
-* `-flto-options=<string>`
+* `--flto-options=<string>`
   Passes additional LTO plugin options through. For example, tests use
-  `-flto-options=no-merge-modules` and `-flto-options=codegen=-split-lto-cg`.
+  `--flto-options=no-merge-modules` and `--flto-options=codegen=-split-lto-cg`.
 
 Assembler control
 ~~~~~~~~~~~~~~~~~
-* `-flto-use-as`
+* `--flto-use-as`
   Use the external assembler instead of the integrated assembler for LTO.
-* `-flto-options=asmopts=<arg>`
+* `--flto-options=asmopts=<arg>`
   Extra arguments passed to the external assembler during LTO.
 
 LTO caching
 ~~~~~~~~~~~
-* `-flto-options=cache`
+* `--flto-options=cache`
   Enable ThinLTO caching. By default, cache output is written to
   `<output>.ltocache`.
-* `-flto-options=cache=<dir>`
+* `--flto-options=cache=<dir>`
   Enable ThinLTO caching using the specified directory.
 
 Symbol preservation and ordering
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-* `-flto-options=preserveall`
+* `--flto-options=preserveall`
   Preserve all bitcode symbols during LTO.
-* `-flto-options=preserve-sym=<sym1,sym2,...>`
+* `--flto-options=preserve-sym=<sym1,sym2,...>`
   Preserve the specified symbols in LTO.
-* `-flto-options=preserve-file=<file>`
+* `--flto-options=preserve-file=<file>`
   Preserve the symbols listed in the given file (one symbol per line).
-* `-flto-options=disable-linkorder`
+* `--flto-options=disable-linkorder`
   Disable link order enforcement when linker scripts are present.
-* `-flto-options=verbose`
+* `--flto-options=verbose`
   Enable verbose LTO diagnostics and trace output.
 
 Diagnostics and tracing

--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -392,7 +392,7 @@ public:
 
   void setGCCref(std::string PSym) { GcCrefSym = PSym; }
 
-  // LTO Functions, -flto -flto-options
+  // LTO Functions, -flto --flto-options
   void setLTO(bool PLto = false) { Lto = PLto; }
 
   bool hasLTO() const { return Lto; }
@@ -1273,21 +1273,21 @@ private:
   uint32_t GPSize = 8;               // -G, --gpsize
   bool Lto = false;
   bool FatLTOObjects = false;                    // --fat-lto-objects
-  bool LTOUseAs = false;                         // -flto-use-as
+  bool LTOUseAs = false;                         // --flto-use-as
   StripSymbolMode StripSymbols = KeepAllSymbols; // Strip symbols ?
   bool BPageAlignSegments = true;   // Does the linker need to align segments to
                                     // a page.
   bool HasShared = false;           // -shared
   unsigned int HashStyle = SystemV; // HashStyle
-  bool Savetemps = false;           // -save-temps
-  std::optional<std::string> SaveTempsDir; // -save-temps=
+  bool Savetemps = false;           // --save-temps
+  std::optional<std::string> SaveTempsDir; // --save-temps=
   bool Rosegment = false; // merge read only with readonly/execute segments.
   SeparateSegmentKind SeparateSegments =
       SeparateSegmentKind::None; // -z separate-code
   std::optional<std::string> LTOObjPath; // --lto-obj-path=
   std::vector<std::string>
-      UnparsedLTOOptions;          // Unparsed -flto-options, to pass to plugin.
-  uint32_t LTOOptions = 0;         // -flto-options
+      UnparsedLTOOptions;  // Unparsed --flto-options, to pass to plugin.
+  uint32_t LTOOptions = 0; // --flto-options
   llvm::StringRef ThinLTOJobs;     // --thinlto-jobs=
   unsigned LTOPartitions = 1;      // --lto-partitions=
   bool Verify = true;              // Linker verifies output file.
@@ -1327,7 +1327,7 @@ private:
   bool HasMappingFile = false;      // --Mapping-file
   bool DumpMappings = false;        // --Dump-Mapping-file
   bool DumpResponse = false;        // --Dump-Response-file
-  bool InsertTimingStats = false;        // -emit-timing-stats-in-output
+  bool InsertTimingStats = false;   // --emit-timing-stats-in-output
   bool FatalInternalErrors = false;      // --fatal-internal-errors
   bool EnableLinkerVersionDirective = false; // --enable/disable-linker-version
   bool RecordCommandLine = false;            // --{no-,}record-command-line

--- a/include/eld/Diagnostics/DiagCommonKinds.inc
+++ b/include/eld/Diagnostics/DiagCommonKinds.inc
@@ -149,7 +149,7 @@ DIAG(unable_to_find_mergestr_fragment, DiagnosticEngine::Error,
      "Unable to find merge string fragment at offset %0 in section %1 from "
      "file %2")
 DIAG(error_invalid_option_symdef_style, DiagnosticEngine::Error,
-     "Invalid options specified for -symdef-style=%0 valid values are "
+     "Invalid options specified for --symdef-style=%0 valid values are "
      "default/provide")
 DIAG(error_unknown_symdef_style, DiagnosticEngine::Error,
      "Unknown symdef style detected")

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -1440,7 +1440,7 @@ defm lto_sample_profile
 
 defm plugin_opt_sample_profile
     : mDashDeprEqOnlyAlias<"plugin-opt=sample-profile", "lto_sample_profile",
-                           "Alias for -lto-sample-profile=">,
+                           "Alias for --lto-sample-profile=">,
       Group<grp_ltooptions>;
 
 def lto_partitions : JJ<"lto-partitions=">,

--- a/include/eld/LayoutMap/LayoutInfo.h
+++ b/include/eld/LayoutMap/LayoutInfo.h
@@ -364,7 +364,7 @@ public:
     return std::make_pair(memberPath, referred);
   }
 
-  std::string getWholeArchiveString() const { return "-whole-archive"; }
+  std::string getWholeArchiveString() const { return "--whole-archive"; }
 
   llvm::DenseSet<plugin::LinkerWrapper *> &getPlugins() { return Plugins; }
 
@@ -460,7 +460,7 @@ private:
   std::unordered_map<MergeableString *, std::vector<MergeableString *>>
       MergedStrings;
   LinkerConfig &ThisConfig;
-  /// It is required to compute relative path when -MapDetail
+  /// It is required to compute relative path when --MapDetail
   /// 'show-relative-path=...' is used.
   // It needs to be 'static' because LayoutInfo::setLayoutDetail member
   // function is static.

--- a/include/eld/Object/ObjectLinker.h
+++ b/include/eld/Object/ObjectLinker.h
@@ -395,7 +395,7 @@ public:
   }
 
   static llvm::StringRef getWholeArchiveStringForReport() {
-    return "-whole-archive";
+    return "--whole-archive";
   }
 
   bool emitArchiveMemberReport(llvm::StringRef Filename) const;

--- a/include/eld/PluginAPI/PluginADT.h
+++ b/include/eld/PluginAPI/PluginADT.h
@@ -1465,13 +1465,13 @@ struct DLL_A_EXPORT LinkerConfig {
   bool hasGCSections() const;
   bool hasUniqueOutputSections() const;
 
-  /// Return options set by -flto-options.
+  /// Return options set by --flto-options.
   const std::vector<std::string> &getLTOOptions() const;
 
-  /// Return options set by -flto-options=codegen=
+  /// Return options set by --flto-options=codegen=
   std::vector<std::string> getLTOCodeGenOptions() const;
 
-  /// return true if the `-flto-options=cache` is specified.
+  /// return true if the `--flto-options=cache` is specified.
   bool isLTOCacheEnabled() const;
 
   // Trace options.

--- a/include/eld/Script/ScriptFile.h
+++ b/include/eld/Script/ScriptFile.h
@@ -66,7 +66,7 @@ public:
     ExcludeFile,           // EXCLUDE_FILE(...)
     ExternList,            // --extern-list
     DuplicateCodeList,     // --copy-farcalls-from-file
-    NoReuseTrampolineList, // -no-reuse-trampolines-file
+    NoReuseTrampolineList, // --no-reuse-trampolines-file
     Memory,                // MEMORY
     Unknown
   };

--- a/include/eld/Writers/ELFObjectWriter.h
+++ b/include/eld/Writers/ELFObjectWriter.h
@@ -39,7 +39,7 @@ public:
 
   std::error_code writeObject(llvm::FileOutputBuffer &CurOutput);
 
-  // write timing stats into .note.qc.timing when -emit-timing-stats-in-output
+  // write timing stats into .note.qc.timing when --emit-timing-stats-in-output
   // enabled
   void writeLinkTimeStats(uint64_t BeginningOfTime, uint64_t Duration);
 

--- a/lib/Config/GeneralOptions.cpp
+++ b/lib/Config/GeneralOptions.cpp
@@ -412,7 +412,7 @@ std::vector<llvm::StringRef> GeneralOptions::getLTOOptionsAsString() const {
     ReturnValue.push_back("asmopts");
   if ((LTOOptions & LTODisableLinkOrder) == LTODisableLinkOrder)
     ReturnValue.push_back("Disable link order with linker scripts/LTO");
-  // Extend this later or for other -flto-options
+  // Extend this later or for other --flto-options
   return ReturnValue;
 }
 

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -516,7 +516,7 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
                           arg->getValue());
   }
 
-  // -flto-use-as
+  // --flto-use-as
   if (Args.hasArg(T::flto_use_as)) {
     Config.options().setLTOUseAs();
     Config.addCommandLine(Table->getOptionName(T::flto_use_as), true);
@@ -528,7 +528,7 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
   // If -M option is used, lets try to use color.
   Config.options().setMapFileWithColor(Args.hasArg(T::PrintMap));
 
-  // -MapDetail
+  // --MapDetail
   for (llvm::opt::Arg *arg : Args.filtered(T::MapDetail)) {
     eld::Expected<void> E = eld::LayoutInfo::setLayoutDetail(
         arg->getValue(), Config.getDiagEngine());
@@ -562,7 +562,7 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
   if (!Config.options().rosegment())
     Config.options().setROSegment(Args.hasArg(T::rosegment));
 
-  // -emit-timing-stats-in-output
+  // --emit-timing-stats-in-output
   if (Args.hasArg(T::emit_timing_stats_in_output))
     Config.options().setInsertTimingStats(true);
 
@@ -1730,7 +1730,7 @@ bool GnuLdDriver::processReproduceOption(
     }
   }
   if (!outputTar->getLTOObjects().empty()) {
-    os << "-flto-options=lto-output-file=";
+    os << "--flto-options=lto-output-file=";
     auto &LTOObjects = outputTar->getLTOObjects();
     for (size_t i = 0; i < LTOObjects.size() - 1; ++i)
       os << outputTar->rewritePath(LTOObjects[i]) << ",";

--- a/lib/Object/ArchiveMemberReport.cpp
+++ b/lib/Object/ArchiveMemberReport.cpp
@@ -39,9 +39,9 @@ using namespace eld;
 //       // Pull-in cause for non-whole-archive inclusion.
 //       "Symbol": "malloc",
 //
-//       // Present for -whole-archive inclusion.
+//       // Present for --whole-archive inclusion.
 //       "WholeArchive": true,
-//       "Reason": "-whole-archive",
+//       "Reason": "--whole-archive",
 //
 //       // Metadata.
 //       "MemberIsBitcode": false,

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -489,7 +489,7 @@ ObjectLinker::createLTOTempFile(size_t Number, bool Asm,
   if (Asm) {
     Suffix = "s";
     // Also use non-temporary location for output asm file with -emit-asm,
-    // independently from -save-temps.
+    // independently from --save-temps.
     Prefix = ThisModule->getLinker()->getLinkerDriver()->isRunLTOOnly()
                  ? getLTOTempPrefix()
                  : MLtoTempPrefix;
@@ -3000,8 +3000,8 @@ bool ObjectLinker::finalizeLtoSymbolResolution(
   /// The definition of this symbol is visible outside of the LTO unit.
 
   /// LinkerRedefined = True
-  /// Linker redefined version of the symbol which appeared in -wrap or
-  /// -defsym linker option.
+  /// Linker redefined version of the symbol which appeared in --wrap or
+  /// --defsym linker option.
 
   bool HasSectionsCmd =
       ThisModule->getScript().linkerScriptHasSectionsCommand();

--- a/test/AArch64/linux/CommonsGnuHash/CommonsGnuHash.test
+++ b/test/AArch64/linux/CommonsGnuHash/CommonsGnuHash.test
@@ -9,7 +9,7 @@
 #START_TEST
 
 RUN: %clang %clangopts -c -fpic %p/Inputs/1.c -o %t.o
-RUN: %link %linkopts -shared -hash-style=gnu -o %t.so %t.o
+RUN: %link %linkopts -shared --hash-style=gnu -o %t.so %t.o
 RUN: %readelf -I %t.so
 
 CHECK: Histogram for `.gnu.hash' bucket list length (total of 3 buckets):

--- a/test/AArch64/linux/Start_Addr/Start.test
+++ b/test/AArch64/linux/Start_Addr/Start.test
@@ -4,7 +4,7 @@ RUN: %link -mtriple aarch64-gnu-linux %t1.o -o %t1.out -pie
 RUN: %readelf -a %t1.out | %filecheck %s --check-prefix=AARCH64-PIE
 
 RUN: %clang --target=aarch64-gnu-linux %t1.c -c -o %t2.o -fno-pie
-RUN: %link -mtriple aarch64-gnu-linux %t2.o -o %t2.out -dynamic-linker /dev/null
+RUN: %link -mtriple aarch64-gnu-linux %t2.o -o %t2.out --dynamic-linker /dev/null
 RUN: %readelf -a %t2.out | %filecheck %s --check-prefix=AARCH64-NOPIE
 
 RUN: %clang --target=aarch64-gnu-linux %t1.c -c -o %t3.o -static
@@ -17,7 +17,7 @@ RUN: %link -mtriple aarch64-unknown-linux %t4.o -o %t4.out -pie
 RUN: %readelf -a %t4.out | %filecheck %s --check-prefix=AARCH64-PIE
 
 RUN: %clang --target=aarch64-unknown-linux %t1.c -c -o %t5.o -fno-pie
-RUN: %link -mtriple aarch64-unknown-linux %t5.o -o %t5.out -dynamic-linker /dev/null
+RUN: %link -mtriple aarch64-unknown-linux %t5.o -o %t5.out --dynamic-linker /dev/null
 RUN: %readelf -a %t5.out | %filecheck %s --check-prefix=AARCH64-NOPIE
 
 RUN: %clang --target=aarch64-unknown-linux %t1.c -c -o %t6.o -static

--- a/test/AArch64/standalone/DefaultLinkerScript/DefaultLinkerScript.test
+++ b/test/AArch64/standalone/DefaultLinkerScript/DefaultLinkerScript.test
@@ -1,8 +1,8 @@
 RUN: %clang %clangopts -target aarch64  -ffunction-sections -c %p/test.c -o %t.o
-RUN: %link %linkopts -march=aarch64  -static %t.o -default-script=%p/default.ld --script=%p/test.ld -o %t1.override.out
+RUN: %link %linkopts -march=aarch64  -static %t.o --default-script=%p/default.ld --script=%p/test.ld -o %t1.override.out
 RUN: %readelf -W -S -s %t1.override.out | %filecheck %s --check-prefix=OVERRIDE
 
-RUN: %link %linkopts -march=aarch64  -static %t.o -default-script=%p/default.ld  -o %t2.default.out
+RUN: %link %linkopts -march=aarch64  -static %t.o --default-script=%p/default.ld  -o %t2.default.out
 RUN: %readelf -W -S -s %t2.default.out | %filecheck %s --check-prefix=DEFAULTONLY
 
 OVERRIDE-NOT: DEFAULT_CODE

--- a/test/AArch64/standalone/EmitRelocs/EmitRelocs_gnu_compat.test
+++ b/test/AArch64/standalone/EmitRelocs/EmitRelocs_gnu_compat.test
@@ -1,8 +1,8 @@
 RUN: %clang %clangopts -mcpu=cortex-a53 -target aarch64 -c %p/test1.c -o %test1.o
 RUN: %clang %clangopts -mcpu=cortex-a53 -target aarch64 -ffunction-sections -c %p/test2.c -o %test2.o
 
-RUN: %link %linkopts -emit-relocs-llvm -march aarch64 -Ttext=0x1000 --noinhibit-exec %test1.o -o %test1.out
-RUN: %link %linkopts -emit-relocs-llvm -march aarch64 -Ttext=0x1000 --noinhibit-exec %test2.o -o %test2.out
+RUN: %link %linkopts --emit-relocs-llvm -march aarch64 -Ttext=0x1000 --noinhibit-exec %test1.o -o %test1.out
+RUN: %link %linkopts --emit-relocs-llvm -march aarch64 -Ttext=0x1000 --noinhibit-exec %test2.o -o %test2.out
 RUN: %link %linkopts -emit-relocs -Ttext=0x1000 -march aarch64 --noinhibit-exec %test1.o -z max-page-size=0x1000 -o %test1.gnu.out
 RUN: %link %linkopts -emit-relocs -Ttext=0x1000 -march aarch64 --noinhibit-exec %test2.o -z max-page-size=0x1000 -o %test2.gnu.out
 

--- a/test/AArch64/standalone/ForceDynPerm/ForceDynPerm.test
+++ b/test/AArch64/standalone/ForceDynPerm/ForceDynPerm.test
@@ -1,6 +1,6 @@
 # Test that hidden symbols are not exported.
 RUN: %clang %clangopts -target aarch64 -c %p/Inputs/1.c -o %t1.o
-RUN: %link %linkopts -march aarch64 --rosegment -force-dynamic %t1.o -o %t.out 2>&1
+RUN: %link %linkopts -march aarch64 --rosegment --force-dynamic %t1.o -o %t.out 2>&1
 RUN: %readelf -l -W %t.out |   %filecheck %s
 
 # CHECK:  PHDR            {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  R E {{[x0-9a-z]+}}

--- a/test/AArch64/standalone/GCWithSym/GC.test
+++ b/test/AArch64/standalone/GCWithSym/GC.test
@@ -1,7 +1,7 @@
 RUN: %clang %clangopts -target aarch64-linux-gnu -w %p/Inputs/1.c -c -o %t1.o
 RUN: %clang %clangopts -target aarch64-linux-gnu -w %p/Inputs/2.c -c -o %t2.o
 RUN: %ar cr %tlib2.a %t2.o
-RUN: %link %linkopts -march=aarch64 -T %p/Inputs/t.sym -T %p/Inputs/t.t %t1.o %tlib2.a -gc-sections -M -o %t.out 2>&1 | %filecheck %s
+RUN: %link %linkopts -march=aarch64 -T %p/Inputs/t.sym -T %p/Inputs/t.t %t1.o %tlib2.a --gc-sections -M -o %t.out 2>&1 | %filecheck %s
 
 CHECK: foo
 CHECK-NOT: bar

--- a/test/AArch64/standalone/GNUHash/Hash.test
+++ b/test/AArch64/standalone/GNUHash/Hash.test
@@ -1,5 +1,5 @@
 RUN: %clang %clangopts -target aarch64 %p/Inputs/t.c -c -o %t.o
-RUN: %link %linkopts -march aarch64 -hash-style=gnu %t.o -shared -o %t.so
+RUN: %link %linkopts -march aarch64 --hash-style=gnu %t.o -shared -o %t.so
 # Make sure %readelf doesnot error out, if there is an error that means the gnu
 # hash emitted is wrong.
 RUN: %readelf --dyn-syms %t.so

--- a/test/AArch64/standalone/LTO/DynamicListPreserve/DynamicListPreserve.test
+++ b/test/AArch64/standalone/LTO/DynamicListPreserve/DynamicListPreserve.test
@@ -5,7 +5,7 @@
 #END_COMMENT
 
 RUN: %clang %clangopts -c %p/Inputs/1.c -O2 -ffunction-sections -flto -o %t1.o
-RUN: %link %linkopts --gc-sections -print-gc-sections --dynamic-list %p/Inputs/list -flto-options=codegen="-function-sections" --force-dynamic --trace=lto -e bar %t1.o  -o %t1.out 2>&1 | %filecheck  %s
+RUN: %link %linkopts --gc-sections --print-gc-sections --dynamic-list %p/Inputs/list --flto-options=codegen="-function-sections" --force-dynamic --trace=lto -e bar %t1.o  -o %t1.out 2>&1 | %filecheck  %s
 
 CHECK: Marking symbol foo to be preserved (found in dynamic list)
 CHECK-DAG: Preserving symbol foo

--- a/test/AArch64/standalone/LTO/GetSetSectionName/GetSetSectionName.test
+++ b/test/AArch64/standalone/LTO/GetSetSectionName/GetSetSectionName.test
@@ -7,7 +7,7 @@ RUN: %clang %clangopts -target aarch64 -c %p/Inputs/c.c -o %t4
 RUN: %ar cr %aropts %t5 %t2
 RUN: %ar cr %aropts %t6 %t3
 RUN: %ar cr %aropts %t7 %t4
-RUN: %link %linkopts -march aarch64 -M  -flto-options=preserveall %t1 --start-group %t5 %t7 %t6 --end-group -o %t8
+RUN: %link %linkopts -march aarch64 -M  --flto-options=preserveall %t1 --start-group %t5 %t7 %t6 --end-group -o %t8
 RUN: %readelf -s %t8 | %grep "foo" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "bar" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "baz" | %filecheck %s -check-prefix YES

--- a/test/AArch64/standalone/LTO/LTOGroups/ltogroups.test
+++ b/test/AArch64/standalone/LTO/LTOGroups/ltogroups.test
@@ -7,7 +7,7 @@ RUN: %clang %clangopts -target aarch64 -c %p/Inputs/c.c -o %t4
 RUN: %ar cr %aropts %t5 %t2
 RUN: %ar cr %aropts %t6 %t3
 RUN: %ar cr %aropts %t7 %t4
-RUN: %link %linkopts -march aarch64 -M  -flto-options=preserveall %t1 --start-group %t5 %t7 %t6 --end-group -o %t8
+RUN: %link %linkopts -march aarch64 -M  --flto-options=preserveall %t1 --start-group %t5 %t7 %t6 --end-group -o %t8
 RUN: %readelf -s %t8 | %grep "foo" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "bar" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "baz" | %filecheck %s -check-prefix YES

--- a/test/AArch64/standalone/LTO/LTOGroupsNoMerge/ltogroupsnomerge.test
+++ b/test/AArch64/standalone/LTO/LTOGroupsNoMerge/ltogroupsnomerge.test
@@ -8,7 +8,7 @@ RUN: %clang %clangopts -target aarch64 -c %p/Inputs/crap.c -o %t1.crap.o
 RUN: %ar cr %t2.libb1.a %t1.b1.o
 RUN: %ar cr %aropts %t2.libb2.a %t1.b2.o
 RUN: %ar cr %aropts %t2.libc.a %t1.c.o
-RUN: %link %linkopts -march aarch64 -flto-options=no-merge-modules  -M %t1.a.o --start-group %t2.libb1.a %t2.libb2.a %t2.libc.a %t1.crap.o --end-group --trace=lto -t 2>&1 | %filecheck %s
+RUN: %link %linkopts -march aarch64 --flto-options=no-merge-modules  -M %t1.a.o --start-group %t2.libb1.a %t2.libb2.a %t2.libc.a %t1.crap.o --end-group --trace=lto -t 2>&1 | %filecheck %s
 
 #CHECK: {{[ -\(\)_A-Za-z0-9.\\/:]+}}crap
 

--- a/test/AArch64/standalone/LTO/LTONoGroupArchives/ltonogrouparchives.test
+++ b/test/AArch64/standalone/LTO/LTONoGroupArchives/ltonogrouparchives.test
@@ -7,7 +7,7 @@ RUN: %clang %clangopts -target aarch64 -c %p/Inputs/c.c -o %t4
 RUN: %ar cr %aropts %t5 %t2
 RUN: %ar cr %aropts %t6 %t3
 RUN: %ar cr %aropts %t7 %t4
-RUN: %link %linkopts -march aarch64 -M -flto-options=preserveall %t1 %t5 %t7 %t6 -o %t8
+RUN: %link %linkopts -march aarch64 -M --flto-options=preserveall %t1 %t5 %t7 %t6 -o %t8
 RUN: %readelf -s %t8 | %grep "foo" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "bar" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "baz" | %filecheck %s -check-prefix YES

--- a/test/AArch64/standalone/LTO/LTONoGroupObjs/ltonogroupobjs.test
+++ b/test/AArch64/standalone/LTO/LTONoGroupObjs/ltonogroupobjs.test
@@ -3,7 +3,7 @@ RUN: %clang %clangopts -target aarch64 -c %p/Inputs/a.c -flto -o %t1
 RUN: %clang %clangopts -target aarch64 -c %p/Inputs/b1.c -o %t2
 RUN: %clang %clangopts -target aarch64 -c %p/Inputs/b2.c -o %t3
 RUN: %clang %clangopts -target aarch64 -c %p/Inputs/c.c -o %t4
-RUN: %link %linkopts -march aarch64 -M -flto-options=preserveall %t1 %t2 %t4 %t3 -o %t5
+RUN: %link %linkopts -march aarch64 -M --flto-options=preserveall %t1 %t2 %t4 %t3 -o %t5
 RUN: %readelf -s %t5 | %grep "foo" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t5 | %grep "bar" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t5 | %grep "baz" | %filecheck %s -check-prefix YES

--- a/test/AArch64/standalone/LTO/Map/Archive/mapfileltoarchive.test
+++ b/test/AArch64/standalone/LTO/Map/Archive/mapfileltoarchive.test
@@ -3,7 +3,7 @@ RUN: %clang %clangopts -fcommon -target aarch64 -c %p/Inputs/main.c -o %t1.main.
 RUN: %clang %clangopts -fcommon -target aarch64 -c %p/Inputs/foo.c -o %t1.foo.o -flto
 RUN: %clang %clangopts -fcommon -target aarch64 -c %p/Inputs/bar.c -o %t1.bar.o -flto
 RUN: %ar cr %t1.library.a %t1.foo.o %t1.bar.o
-RUN: %link %linkopts -march aarch64 -flto-options=codegen="-Os -relocation-model=static -function-sections -data-sections" %t1.main.o %t1.library.a -M -o %t2.out 2>&1 | %filecheck %s
+RUN: %link %linkopts -march aarch64 --flto-options=codegen="-Os -relocation-model=static -function-sections -data-sections" %t1.main.o %t1.library.a -M -o %t2.out 2>&1 | %filecheck %s
 
 
 #CHECK: =======================================

--- a/test/AArch64/standalone/LTO/Map/Cref/cref.test
+++ b/test/AArch64/standalone/LTO/Map/Cref/cref.test
@@ -3,7 +3,7 @@ RUN: %clang %clangopts -target aarch64 -c %p/Inputs/main.c -o %t1.main.o
 RUN: %clang %clangopts -target aarch64 -c %p/Inputs/foo.c -o %t1.foo.o -flto
 RUN: %clang %clangopts -target aarch64 -c %p/Inputs/bar.c -o %t1.bar.o -flto
 RUN: %ar cr %t1.library.a %t1.foo.o %t1.bar.o
-RUN: %link %linkopts -march aarch64 --cref -flto-options=codegen="-Os -relocation-model=static -function-sections -data-sections" %t1.main.o %t1.library.a -o %t2.out 2>&1 | %filecheck %s
+RUN: %link %linkopts -march aarch64 --cref --flto-options=codegen="-Os -relocation-model=static -function-sections -data-sections" %t1.main.o %t1.library.a -o %t2.out 2>&1 | %filecheck %s
 
 #CHECK: Cross Reference Table - Pre LTO phase
 #CHECK: Symbol                                                File

--- a/test/AArch64/standalone/LTO/PreserveFile/preservefile.test
+++ b/test/AArch64/standalone/LTO/PreserveFile/preservefile.test
@@ -1,7 +1,7 @@
 # Check if LTO works for no groups and only archives and bitcodes
 RUN: %clang %clangopts -target aarch64 -c %p/Inputs/a.c -flto -o %t1
 RUN: %clang %clangopts -target aarch64 -c %p/Inputs/b.c -flto -o %t2
-RUN: %link %linkopts -march aarch64 -M -flto-options preserve-file=%p/Inputs/preserve1 %t1 %t2 -o %t3
+RUN: %link %linkopts -march aarch64 -M --flto-options preserve-file=%p/Inputs/preserve1 %t1 %t2 -o %t3
 RUN: %readelf -s %t3 | %grep "boo" | wc -l | %filecheck %s -check-prefix YES
 
 YES: 1

--- a/test/AArch64/standalone/LTO/PreserveSym/preservesym.test
+++ b/test/AArch64/standalone/LTO/PreserveSym/preservesym.test
@@ -7,7 +7,7 @@ RUN: %clang %clangopts -target aarch64 -c %p/Inputs/c.c -o %t4
 RUN: %ar cr %aropts %t5 %t2
 RUN: %ar cr %aropts %t6 %t3
 RUN: %ar cr %aropts %t7 %t4
-RUN: %link %linkopts -march aarch64 -M -flto-options preserve-sym=foo %t1 %t5 %t7 %t6 -o %t8
+RUN: %link %linkopts -march aarch64 -M --flto-options preserve-sym=foo %t1 %t5 %t7 %t6 -o %t8
 RUN: %readelf -s %t8 | %grep "foo" | %filecheck %s -check-prefix YES
 
 YES: 1

--- a/test/AArch64/standalone/LTO/Verbose/verbose.test
+++ b/test/AArch64/standalone/LTO/Verbose/verbose.test
@@ -1,7 +1,7 @@
 # Check if LTO works for no groups and only archives and bitcodes
 RUN: %clang %clangopts -target aarch64 -c %p/Inputs/a.c -flto -o %t1
 RUN: %clang %clangopts -target aarch64 -c %p/Inputs/b.c -flto -o %t2
-RUN: %link %linkopts --save-temps -march aarch64 -M -flto-options verbose %t1 %t2 -o %t3 2>&1\
+RUN: %link %linkopts --save-temps -march aarch64 -M --flto-options verbose %t1 %t2 -o %t3 2>&1\
 RUN:  | %filecheck %s -check-prefix YES
 
 YES: Note: Beginning LTO Phase 1

--- a/test/AArch64/standalone/Map/WholeArchive/mapfilewholearchive.test
+++ b/test/AArch64/standalone/Map/WholeArchive/mapfilewholearchive.test
@@ -10,9 +10,9 @@ RUN: %link %linkopts -march aarch64 %t1.main.o --whole-archive %t1.library.a -M 
 
 #CHECK: Archive member included because of file (symbol)
 #CHECK: {{[ -\(\)_A-Za-z0-9.\\/:]+}}foo.o
-#CHECK: 		-whole-archive
+#CHECK: 		--whole-archive
 #CHECK: {{[ -\(\)_A-Za-z0-9.\\/:]+}}bar.o
-#CHECK: 		-whole-archive
+#CHECK: 		--whole-archive
 #CHECK: Common symbol	size	file
 #CHECK: common_array	0x50	{{[ -\(\)_A-Za-z0-9.\\/:]+}}main.o
 #CHECK: Linker Script and memory map

--- a/test/AArch64/standalone/Options/Opt.test
+++ b/test/AArch64/standalone/Options/Opt.test
@@ -1,5 +1,5 @@
 RUN: %clang %clangopts -target aarch64 -c %p/Inputs/t.c -o %t.o
-RUN: %link %linkopts -march=aarch64 -no-gc-sections %t.o -o %t.out
+RUN: %link %linkopts -march=aarch64 --no-gc-sections %t.o -o %t.out
 RUN: %nm %t.o | %filecheck %s
 
 CHECK: main

--- a/test/AArch64/standalone/Shndx/Shndx.test
+++ b/test/AArch64/standalone/Shndx/Shndx.test
@@ -1,5 +1,5 @@
 RUN: %clang %clangopts -target aarch64 -c %p/Inputs/t.c -o %t.o
-RUN: %link %linkopts -march=aarch64 -shared %t.o -o %t.out -trace=all-symbols 2>&1 | %filecheck %s
+RUN: %link %linkopts -march=aarch64 -shared %t.o -o %t.out --trace=all-symbols 2>&1 | %filecheck %s
 
 CHECK: [main]: (SHNDX
 

--- a/test/ARM/linux/CommonsGnuHash/CommonsGnuHash.test
+++ b/test/ARM/linux/CommonsGnuHash/CommonsGnuHash.test
@@ -9,7 +9,7 @@
 #START_TEST
 
 RUN: %clang %clangopts -c -fpic %p/Inputs/1.c -o %t.o
-RUN: %link %linkopts -shared -hash-style=gnu -o %t.so %t.o
+RUN: %link %linkopts -shared --hash-style=gnu -o %t.so %t.o
 RUN: %readelf -I %t.so
 
 CHECK: Histogram for `.gnu.hash' bucket list length (total of 3 buckets):

--- a/test/ARM/standalone/Common/Common.test
+++ b/test/ARM/standalone/Common/Common.test
@@ -1,6 +1,6 @@
 RUN: %clang %clangopts -fcommon -target arm -c %p/Inputs/t.c -o %t1.o
 RUN: %clang %clangopts -fcommon -target arm -flto -c %p/Inputs/f.c -o %t2.o
-RUN: %link -o %t1.out %linkopts -march arm %t1.o %t2.o -trace=lto 2>&1 | %filecheck %s
+RUN: %link -o %t1.out %linkopts -march arm %t1.o %t2.o --trace=lto 2>&1 | %filecheck %s
 
 CHECK: Preserving symbol array
 

--- a/test/ARM/standalone/EXIDXLink/link.test
+++ b/test/ARM/standalone/EXIDXLink/link.test
@@ -7,7 +7,7 @@
 RUN: %clang %clangopts -target arm -c %p/Inputs/t.cpp -o %t.o
 RUN: %link %linkopts -r %t.o -o %t.out
 RUN: %readelf -S -W %t.out | %filecheck %s
-RUN: %link %linkopts -T %p/Inputs/t.l   %t.o -o %t2.out -defsym=__aeabi_unwind_cpp_pr0=0x0 -defsym=__cxa_allocate_exception=0x0 -defsym=__cxa_throw=0x0 -defsym=__cxa_begin_catch=0x0 -defsym=__cxa_end_catch=0x0 -defsym=__gxx_personality_v0=0x0 -defsym=_ZTIi=0x0
+RUN: %link %linkopts -T %p/Inputs/t.l   %t.o -o %t2.out --defsym=__aeabi_unwind_cpp_pr0=0x0 --defsym=__cxa_allocate_exception=0x0 --defsym=__cxa_throw=0x0 --defsym=__cxa_begin_catch=0x0 --defsym=__cxa_end_catch=0x0 --defsym=__gxx_personality_v0=0x0 --defsym=_ZTIi=0x0
 RUN: %readelf -S -W %t2.out | %filecheck %s -check-prefix EXE
 
 CHECK: .ARM.exidx        ARM_EXIDX       00000000 {{[0-9a-f]+}} {{[0-9a-f]+}} 00  AL  2

--- a/test/ARM/standalone/ExcludeLibs/ExcludeLibs.test
+++ b/test/ARM/standalone/ExcludeLibs/ExcludeLibs.test
@@ -17,7 +17,7 @@ RUN: %rm -rf %t.tmpdir
 
 ONE-NOT: foo
 
-RUN: %link %linkopts -dy -dynamic-list %p/Inputs/list %t1.o %tlib.a --exclude-libs %tlib.a %t3.so -o %t2.out
+RUN: %link %linkopts -dy --dynamic-list %p/Inputs/list %t1.o %tlib.a --exclude-libs %tlib.a %t3.so -o %t2.out
 RUN: %readelf --dyn-symbols %t2.out |%filecheck --check-prefix="TWO" %s
 TWO-NOT: foo
 
@@ -53,6 +53,6 @@ RUN: %link %linkopts -shared %tpic1.o %tlib2.a --exclude-libs %tlib2.a %t3.o -o 
 RUN: %readelf --dyn-symbols %t4.out.so |%filecheck --check-prefix="FOUR" %s
 FOUR-NOT: foo
 
-RUN: %link %linkopts -shared %tpic1.o %tlib2.a --exclude-libs %tlib2.a %t3.o -version-script %p/Inputs/script -o %t5.out.so
+RUN: %link %linkopts -shared %tpic1.o %tlib2.a --exclude-libs %tlib2.a %t3.o --version-script %p/Inputs/script -o %t5.out.so
 RUN: %readelf --dyn-symbols %t5.out.so |%filecheck --check-prefix="FIVE" %s
 FIVE-NOT: foo

--- a/test/ARM/standalone/ForceDynPerm/ForceDynPerm.test
+++ b/test/ARM/standalone/ForceDynPerm/ForceDynPerm.test
@@ -1,6 +1,6 @@
 # Test that hidden symbols are not exported.
 RUN: %clang %clangopts -target arm -c %p/Inputs/1.c -o %t1.o
-RUN: %link %linkopts -march arm --rosegment -force-dynamic -T %p/Inputs/script.t %t1.o -o %t.out 2>&1
+RUN: %link %linkopts -march arm --rosegment --force-dynamic -T %p/Inputs/script.t %t1.o -o %t.out 2>&1
 RUN: %readelf -l -W %t.out |   %filecheck %s
 
 # CHECK:  PHDR            {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  R E {{[x0-9a-z]+}}

--- a/test/ARM/standalone/Interp/Interp.test
+++ b/test/ARM/standalone/Interp/Interp.test
@@ -1,5 +1,5 @@
 RUN: %clang %clangopts -target arm -c %p/Inputs/t.c -fPIC -o %t.o
-RUN: %link %linkopts -march arm -pie -dynamic-linker /system/bin/linker %t.o -o %t.out
+RUN: %link %linkopts -march arm -pie --dynamic-linker /system/bin/linker %t.o -o %t.out
 RUN: %readelf -a %t.out | %filecheck %s
 
 CHECK: .interp           PROGBITS

--- a/test/ARM/standalone/JUMP24/JUMP.test
+++ b/test/ARM/standalone/JUMP24/JUMP.test
@@ -6,9 +6,9 @@ RUN: llvm-objdump -d --start-address=0x100000 %t.out | %filecheck %s -check-pref
 # different combination as veneer.
 #
 # T2T thunks should be compatible with Cortex-M3.
-RUN: %link %linkopts -static %t.o -o %t2.out -defsym=foo=0x10000000 --use-mov-veneer
+RUN: %link %linkopts -static %t.o -o %t2.out --defsym=foo=0x10000000 --use-mov-veneer
 RUN: llvm-objdump --start-address=0x100000 -d --triple=thumbv8 %t2.out | %filecheck %s -check-prefix MOV_T2A
-RUN: %link %linkopts -static %t.o -o %t3.out -defsym=foo=0x10000001 --use-mov-veneer
+RUN: %link %linkopts -static %t.o -o %t3.out --defsym=foo=0x10000001 --use-mov-veneer
 RUN: llvm-objdump --start-address=0x100000 -d --triple=thumbv8 %t3.out | %filecheck %s -check-prefix MOV_T2T
 
 #LDR_T2A: {{.*}} <__foo_T2A_veneer@island-1>:

--- a/test/ARM/standalone/LTO/GetSetSectionName/GetSetSectionName.test
+++ b/test/ARM/standalone/LTO/GetSetSectionName/GetSetSectionName.test
@@ -7,7 +7,7 @@ RUN: %clang %clangopts -target arm -c %p/Inputs/c.c -o %t4
 RUN: %ar cr %aropts %t5 %t2
 RUN: %ar cr %aropts %t6 %t3
 RUN: %ar cr %aropts %t7 %t4
-RUN: %link %linkopts -march arm -M  -flto-options=preserveall %t1 --start-group %t5 %t7 %t6 --end-group -o %t8
+RUN: %link %linkopts -march arm -M  --flto-options=preserveall %t1 --start-group %t5 %t7 %t6 --end-group -o %t8
 RUN: %readelf -s %t8 | %grep "foo" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "bar" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "baz" | %filecheck %s -check-prefix YES

--- a/test/ARM/standalone/LTO/LTOCommonSymbolsGC/LTOCommonSymbolsGC.test
+++ b/test/ARM/standalone/LTO/LTOCommonSymbolsGC/LTOCommonSymbolsGC.test
@@ -4,5 +4,5 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c -flto -ffunction-sections -fdata-sections %p/Inputs/common.c -o %t1.1.o -target arm
-RUN: %link %linkopts --gc-sections %t1.1.o -flto-options=codegen="-function-sections -data-sections" -o %t2.out -e foo -march arm
+RUN: %link %linkopts --gc-sections %t1.1.o --flto-options=codegen="-function-sections -data-sections" -o %t2.out -e foo -march arm
 #END_TEST

--- a/test/ARM/standalone/LTO/LTOFlow/Flow.test
+++ b/test/ARM/standalone/LTO/LTOFlow/Flow.test
@@ -1,6 +1,6 @@
 RUN: %clang %clangopts  -target arm -flto %p/Inputs/t.c -c -o %t.o
-RUN: %link %linkopts -march arm -trace=lto %t.o -o %t.out 2>&1 | %filecheck %s
-RUN: %link %linkopts -march arm -trace=lto %t.o -save-temps -flto-options=codegen=-mattr=+neon -o %t.out 2>&1 | %filecheck %s --check-prefix=SAVE
+RUN: %link %linkopts -march arm --trace=lto %t.o -o %t.out 2>&1 | %filecheck %s
+RUN: %link %linkopts -march arm --trace=lto %t.o --save-temps --flto-options=codegen=-mattr=+neon -o %t.out 2>&1 | %filecheck %s --check-prefix=SAVE
 
 CHECK: Inserting generated LTO object
 

--- a/test/ARM/standalone/LTO/LTOGroups/ltogroups.test
+++ b/test/ARM/standalone/LTO/LTOGroups/ltogroups.test
@@ -7,7 +7,7 @@ RUN: %clang %clangopts -target arm -c %p/Inputs/c.c -o %t4
 RUN: %ar cr %aropts %t5 %t2
 RUN: %ar cr %aropts %t6 %t3
 RUN: %ar cr %aropts %t7 %t4
-RUN: %link %linkopts -march arm -M  -flto-options=preserveall %t1 --start-group %t5 %t7 %t6 --end-group -o %t8
+RUN: %link %linkopts -march arm -M  --flto-options=preserveall %t1 --start-group %t5 %t7 %t6 --end-group -o %t8
 RUN: %readelf -s %t8 | %grep "foo" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "bar" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "baz" | %filecheck %s -check-prefix YES

--- a/test/ARM/standalone/LTO/LTOGroupsNoMerge/ltogroupsnomerge.test
+++ b/test/ARM/standalone/LTO/LTOGroupsNoMerge/ltogroupsnomerge.test
@@ -8,7 +8,7 @@ RUN: %clang %clangopts -target arm -c %p/Inputs/crap.c -o %t1.crap.o
 RUN: %ar cr %t2.libb1.a %t1.b1.o
 RUN: %ar cr %aropts %t2.libb2.a %t1.b2.o
 RUN: %ar cr %aropts %t2.libc.a %t1.c.o
-RUN: %link %linkopts -march arm -flto-options=no-merge-modules  -M %t1.a.o --start-group %t2.libb1.a %t2.libb2.a %t2.libc.a %t1.crap.o --end-group --trace=lto -t 2>&1 | %filecheck %s
+RUN: %link %linkopts -march arm --flto-options=no-merge-modules  -M %t1.a.o --start-group %t2.libb1.a %t2.libb2.a %t2.libc.a %t1.crap.o --end-group --trace=lto -t 2>&1 | %filecheck %s
 
 #CHECK: {{[ -\(\)_A-Za-z0-9.\\/:]+}}crap
 

--- a/test/ARM/standalone/LTO/LTONoGroupArchives/ltonogrouparchives.test
+++ b/test/ARM/standalone/LTO/LTONoGroupArchives/ltonogrouparchives.test
@@ -7,7 +7,7 @@ RUN: %clang %clangopts -target arm -c %p/Inputs/c.c -o %t4
 RUN: %ar cr %aropts %t5 %t2
 RUN: %ar cr %aropts %t6 %t3
 RUN: %ar cr %aropts %t7 %t4
-RUN: %link %linkopts -march arm -M -flto-options=preserveall %t1 %t5 %t7 %t6 -o %t8
+RUN: %link %linkopts -march arm -M --flto-options=preserveall %t1 %t5 %t7 %t6 -o %t8
 RUN: %readelf -s %t8 | %grep "foo" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "bar" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "baz" | %filecheck %s -check-prefix YES

--- a/test/ARM/standalone/LTO/LTONoGroupObjs/ltonogroupobjs.test
+++ b/test/ARM/standalone/LTO/LTONoGroupObjs/ltonogroupobjs.test
@@ -3,7 +3,7 @@ RUN: %clang %clangopts -target arm -c %p/Inputs/a.c -flto -o %t1
 RUN: %clang %clangopts -target arm -c %p/Inputs/b1.c -o %t2
 RUN: %clang %clangopts -target arm -c %p/Inputs/b2.c -o %t3
 RUN: %clang %clangopts -target arm -c %p/Inputs/c.c -o %t4
-RUN: %link %linkopts -march arm -M -flto-options=preserveall %t1 %t2 %t4 %t3 -o %t5
+RUN: %link %linkopts -march arm -M --flto-options=preserveall %t1 %t2 %t4 %t3 -o %t5
 RUN: %readelf -s %t5 | %grep "foo" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t5 | %grep "bar" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t5 | %grep "baz" | %filecheck %s -check-prefix YES

--- a/test/ARM/standalone/LTO/Map/Archive/mapfileltoarchive.test
+++ b/test/ARM/standalone/LTO/Map/Archive/mapfileltoarchive.test
@@ -3,7 +3,7 @@ RUN: %clang %clangopts -fcommon -target arm -c %p/Inputs/main.c -o %t1.main.o
 RUN: %clang %clangopts -fcommon -target arm -c %p/Inputs/foo.c -o %t1.foo.o -flto
 RUN: %clang %clangopts -fcommon -target arm -c %p/Inputs/bar.c -o %t1.bar.o -flto
 RUN: %ar cr %t1.library.a %t1.foo.o %t1.bar.o
-RUN: %link %linkopts -march arm -flto-options=codegen="-Os -relocation-model=static -function-sections -data-sections" %t1.main.o %t1.library.a -M -o %t2.out -z max-page-size=0x1000 2>&1 | %filecheck %s
+RUN: %link %linkopts -march arm --flto-options=codegen="-Os -relocation-model=static -function-sections -data-sections" %t1.main.o %t1.library.a -M -o %t2.out -z max-page-size=0x1000 2>&1 | %filecheck %s
 
 
 #CHECK: =======================================

--- a/test/ARM/standalone/LTO/Map/Cref/cref.test
+++ b/test/ARM/standalone/LTO/Map/Cref/cref.test
@@ -3,7 +3,7 @@ RUN: %clang %clangopts -target arm -c %p/Inputs/main.c -o %t1.main.o
 RUN: %clang %clangopts -target arm -c %p/Inputs/foo.c -o %t1.foo.o -flto
 RUN: %clang %clangopts -target arm -c %p/Inputs/bar.c -o %t1.bar.o -flto
 RUN: %ar cr %t1.library.a %t1.foo.o %t1.bar.o
-RUN: %link %linkopts -march arm --cref -flto-options=codegen="-Os -relocation-model=static -function-sections -data-sections" %t1.main.o %t1.library.a -o %t2.out 2>&1 | %filecheck %s
+RUN: %link %linkopts -march arm --cref --flto-options=codegen="-Os -relocation-model=static -function-sections -data-sections" %t1.main.o %t1.library.a -o %t2.out 2>&1 | %filecheck %s
 
 #CHECK: Cross Reference Table - Pre LTO phase
 #CHECK: Symbol                                                File

--- a/test/ARM/standalone/LTO/PreserveFile/preservefile.test
+++ b/test/ARM/standalone/LTO/PreserveFile/preservefile.test
@@ -1,7 +1,7 @@
 # Check if LTO works for no groups and only archives and bitcodes
 RUN: %clang %clangopts -target arm -c %p/Inputs/a.c -flto -o %t1
 RUN: %clang %clangopts -target arm -c %p/Inputs/b.c -flto -o %t2
-RUN: %link %linkopts -march arm -M -flto-options preserve-file=%p/Inputs/preserve1 %t1 %t2 -o %t3
+RUN: %link %linkopts -march arm -M --flto-options preserve-file=%p/Inputs/preserve1 %t1 %t2 -o %t3
 RUN: %readelf -s %t3 | %grep "boo" | wc -l | %filecheck %s -check-prefix YES
 
 YES: 1

--- a/test/ARM/standalone/LTO/PreserveSym/preservesym.test
+++ b/test/ARM/standalone/LTO/PreserveSym/preservesym.test
@@ -7,7 +7,7 @@ RUN: %clang %clangopts -target arm -c %p/Inputs/c.c -o %t4
 RUN: %ar cr %aropts %t5 %t2
 RUN: %ar cr %aropts %t6 %t3
 RUN: %ar cr %aropts %t7 %t4
-RUN: %link %linkopts -march arm -M -flto-options preserve-sym=foo %t1 %t5 %t7 %t6 -o %t8
+RUN: %link %linkopts -march arm -M --flto-options preserve-sym=foo %t1 %t5 %t7 %t6 -o %t8
 RUN: %readelf -s %t8 | %grep "foo" | %filecheck %s -check-prefix YES
 
 YES: 1

--- a/test/ARM/standalone/LTO/Verbose/verbose.test
+++ b/test/ARM/standalone/LTO/Verbose/verbose.test
@@ -1,7 +1,7 @@
 # Check if LTO works for no groups and only archives and bitcodes
 RUN: %clang %clangopts -target arm -c %p/Inputs/a.c -flto -o %t1
 RUN: %clang %clangopts -target arm -c %p/Inputs/b.c -flto -o %t2
-RUN: %link %linkopts --save-temps -march arm -M -flto-options verbose %t1 %t2 -o %t3 2>&1\
+RUN: %link %linkopts --save-temps -march arm -M --flto-options verbose %t1 %t2 -o %t3 2>&1\
 RUN:  | %filecheck %s -check-prefix YES
 
 YES: Note: Beginning LTO Phase 1

--- a/test/ARM/standalone/Map/WholeArchive/mapfilewholearchive.test
+++ b/test/ARM/standalone/Map/WholeArchive/mapfilewholearchive.test
@@ -10,9 +10,9 @@ RUN: %link %linkopts -march arm %t1.main.o --whole-archive %t1.library.a -M -o %
 
 #CHECK: Archive member included because of file (symbol)
 #CHECK: {{[ -\(\)_A-Za-z0-9.\\/:]+}}foo.o
-#CHECK: 		-whole-archive
+#CHECK: 		--whole-archive
 #CHECK: {{[ -\(\)_A-Za-z0-9.\\/:]+}}bar.o
-#CHECK: 		-whole-archive
+#CHECK: 		--whole-archive
 #CHECK: Common symbol	size	file
 #CHECK: common_array	0x50	{{[ -\(\)_A-Za-z0-9.\\/:]+}}main.o
 #CHECK: Linker Script and memory map

--- a/test/ARM/standalone/NoUnknownOpt/unknown.test
+++ b/test/ARM/standalone/NoUnknownOpt/unknown.test
@@ -4,7 +4,7 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -target arm %p/Inputs/t.c -c -o %t.o
-RUN: %link %linkopts  -trace=lto -asdfasdfasd %t.o -o %t.out --ignore-unknown-opts 2>&1 | %filecheck %s
+RUN: %link %linkopts  --trace=lto -asdfasdfasd %t.o -o %t.out --ignore-unknown-opts 2>&1 | %filecheck %s
 RUN: %nm %t.out | %filecheck %s -check-prefix NMCHECK
 
 CHECK-NOT: Warning

--- a/test/ARM/standalone/OrphanSectionDiagnostic/OrphanInternalSectionsWarn.test
+++ b/test/ARM/standalone/OrphanSectionDiagnostic/OrphanInternalSectionsWarn.test
@@ -5,6 +5,6 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -ffunction-sections
-RUN: %link %linkopts -orphan-handling=warn -emit-timing-stats-in-output %t1.1.o -T %p/Inputs/script.t -o %t2.out 2>&1 | %filecheck %s
+RUN: %link %linkopts --orphan-handling=warn --emit-timing-stats-in-output %t1.1.o -T %p/Inputs/script.t -o %t2.out 2>&1 | %filecheck %s
 
 #CHECK:Warning: no linker script rule for section .text.bar

--- a/test/ARM/standalone/OrphanSectionDiagnostic/OrphanSectionPartialLinking.test
+++ b/test/ARM/standalone/OrphanSectionDiagnostic/OrphanSectionPartialLinking.test
@@ -6,6 +6,6 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -ffunction-sections
-RUN: %link %linkopts -orphan-handling=warn -r %t1.1.o -o %t2.r.o.script -T %p/Inputs/script.t 2>&1 | %filecheck %s
+RUN: %link %linkopts --orphan-handling=warn -r %t1.1.o -o %t2.r.o.script -T %p/Inputs/script.t 2>&1 | %filecheck %s
 
 #CHECK:Warning: no linker script rule for section .text.bar

--- a/test/ARM/standalone/SectionSymbol/Section.test
+++ b/test/ARM/standalone/SectionSymbol/Section.test
@@ -7,7 +7,7 @@
 RUN: %clang %clangopts -target arm -w -c %p/Inputs/f.c -o %tf.o
 RUN: %clang %clangopts -target arm -w -c %p/Inputs/m.c -o %tm.o
 RUN: %clang %clangopts -target arm -w -c %p/Inputs/t.c -o %tt.o
-RUN: %link %linkopts  -march arm %tm.o %tf.o %tt.o -gc-sections -entry=main -o %t.out
+RUN: %link %linkopts  -march arm %tm.o %tf.o %tt.o --gc-sections --entry=main -o %t.out
 RUN: %nm %t.out | %filecheck %s
 
 CHECK: __start_llvm_profile_data

--- a/test/ARM/standalone/linkerscript/ForceDynPerm/ForceDynPerm.test
+++ b/test/ARM/standalone/linkerscript/ForceDynPerm/ForceDynPerm.test
@@ -1,6 +1,6 @@
 # Test that hidden symbols are not exported.
 RUN: %clang %clangopts -target arm -c %p/Inputs/1.c -o %t1.o
-RUN: %link %linkopts -march arm --rosegment -force-dynamic -T %p/Inputs/script.t %t1.o -o %t.out 2>&1
+RUN: %link %linkopts -march arm --rosegment --force-dynamic -T %p/Inputs/script.t %t1.o -o %t.out 2>&1
 RUN: %readelf -l -W %t.out |   %filecheck %s
 
 # CHECK:  PHDR            {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  R E {{[x0-9a-z]+}}

--- a/test/Common/LTO/ArchiveErrMsg/ArchRrrMsg.test
+++ b/test/Common/LTO/ArchiveErrMsg/ArchRrrMsg.test
@@ -1,8 +1,8 @@
 # Check if LTO works for no groups and only archives and bitcodes
 UNSUPPORTED: windows
 RUN: %clang %clangopts -c -flto  %p/Inputs/main.c -o %t1.o
-RUN: %not %link %linkopts -flto-options=preserveall  -M --whole-archive %p/Inputs/Arch.a --no-whole-archive -o %t.out 2>&1 | %filecheck %s -check-prefix=NO-MEMHDR
-RUN: %not %link %linkopts -flto-options=preserveall  -M %t1.o %p/Inputs/ArchNoSymtab.a -o %t.out 2>&1 | %filecheck %s -check-prefix=NO-SYMTAB
+RUN: %not %link %linkopts --flto-options=preserveall  -M --whole-archive %p/Inputs/Arch.a --no-whole-archive -o %t.out 2>&1 | %filecheck %s -check-prefix=NO-MEMHDR
+RUN: %not %link %linkopts --flto-options=preserveall  -M %t1.o %p/Inputs/ArchNoSymtab.a -o %t.out 2>&1 | %filecheck %s -check-prefix=NO-SYMTAB
 
 #NO-MEMHDR: {{(`[ -\(\)_A-Za-z0-9.\\/:]+Arch.a': Could not read archive member)|(Fatal: LLVM: truncated or malformed archive \(remaining size of archive too small for next archive member header for NotASymbolTable)}}
 #NO-SYMTAB: `{{[ -\(\)_A-Za-z0-9.\\/:]+}}ArchNoSymtab.a': Could not read symbol table. Run ranlib to generate one.

--- a/test/Common/LTO/EmbeddedBCLists/EmbeddedBCLists.test
+++ b/test/Common/LTO/EmbeddedBCLists/EmbeddedBCLists.test
@@ -14,14 +14,14 @@ RUN: %clangxx %embedclangxxopts -c -fembed-bitcode -fpic %p/Inputs/3.cpp -o %t1.
 RUN: %ar crs %aropts %tlibembed.a %t1.2.o %t1.3.o
 
 RUN: %link %linkopts  -flto -shared -o %t.shlib.so --whole-archive %tlibembed.a --no-whole-archive
-RUN: %link %linkopts -M -include-lto-filelist=%p/Inputs/list1 -e main %t1.1.o %tlibembed.a -o %t.typical.out --noinhibit-exec --verbose=1 2>&1 | %filecheck --check-prefix="TYPICAL" %s
-RUN: %link %linkopts -M -include-lto-filelist=%p/Inputs/list1 -r --whole-archive %tlibembed.a --no-whole-archive -o %t.reloc.o 2>&1| %filecheck --check-prefix="RELOC" %s
-RUN: %link %linkopts -M -include-lto-filelist=%p/Inputs/list2 -dy -e main %t1.1.o  %t.shlib.so -o %t.dyn.out --noinhibit-exec 2>&1 |  %filecheck --check-prefix="DYN" %s
+RUN: %link %linkopts -M --include-lto-filelist=%p/Inputs/list1 -e main %t1.1.o %tlibembed.a -o %t.typical.out --noinhibit-exec --verbose=1 2>&1 | %filecheck --check-prefix="TYPICAL" %s
+RUN: %link %linkopts -M --include-lto-filelist=%p/Inputs/list1 -r --whole-archive %tlibembed.a --no-whole-archive -o %t.reloc.o 2>&1| %filecheck --check-prefix="RELOC" %s
+RUN: %link %linkopts -M --include-lto-filelist=%p/Inputs/list2 -dy -e main %t1.1.o  %t.shlib.so -o %t.dyn.out --noinhibit-exec 2>&1 |  %filecheck --check-prefix="DYN" %s
 
 TYPICAL: Verbose: Using embedded bitcode section from file
 TYPICAL: Bitcode type
 RELOC: Bitcode origin
 DYN: Bitcode origin
 
-RUN: %link %linkopts -M -flto -exclude-lto-filelist=%p/Inputs/list2 -dy -e main %t1.1.o  %t.shlib.so -o %t.dyn.out --noinhibit-exec 2>&1 |  %filecheck --check-prefix="EXCLUDE" %s
+RUN: %link %linkopts -M -flto --exclude-lto-filelist=%p/Inputs/list2 -dy -e main %t1.1.o  %t.shlib.so -o %t.dyn.out --noinhibit-exec 2>&1 |  %filecheck --check-prefix="EXCLUDE" %s
 EXCLUDE-NOT: Bitcode origin

--- a/test/Common/LTO/ExcludeListAndLTOListEmbeddedBitCode/ExcludeListAndLTOListEmbeddedBitCode.test
+++ b/test/Common/LTO/ExcludeListAndLTOListEmbeddedBitCode/ExcludeListAndLTOListEmbeddedBitCode.test
@@ -12,15 +12,15 @@ RUN: %clang %clangopts -c %p/Inputs/2.c -fembed-bitcode -o %t1.3.o
 RUN: %ar cr %aropts %t1.lib2.a %t1.3.o
 
 # Check that include-lto-filelist, selects the files to be chosen.
-RUN: %link %linkopts %t1.1.o %t1.3.o -include-lto-filelist=%p/Inputs/lto.lst -o %t2.out --verbose 2>&1 | %filecheck %s
-RUN: %link %linkopts %t1.1.o %t1.lib2.a -include-lto-filelist=%p/Inputs/lto.lst -o %t2.out --verbose 2>&1 | %filecheck %s
+RUN: %link %linkopts %t1.1.o %t1.3.o --include-lto-filelist=%p/Inputs/lto.lst -o %t2.out --verbose 2>&1 | %filecheck %s
+RUN: %link %linkopts %t1.1.o %t1.lib2.a --include-lto-filelist=%p/Inputs/lto.lst -o %t2.out --verbose 2>&1 | %filecheck %s
 #CHECK: Using embedded bitcode section from file {{.*}}1.o
 #CHECK: Using embedded bitcode section from file {{.*}}3.o
 
-RUN: %link %linkopts %t1.1.o %t1.lib2.a -include-lto-filelist=%p/Inputs/archiveincludelto.lst -o %t2.out --verbose 2>&1 | %filecheck %s -check-prefix=ARCHIVE
+RUN: %link %linkopts %t1.1.o %t1.lib2.a --include-lto-filelist=%p/Inputs/archiveincludelto.lst -o %t2.out --verbose 2>&1 | %filecheck %s -check-prefix=ARCHIVE
 #ARCHIVE: Using embedded bitcode section from file {{.*}}3.o
 
 # Check that exclude-lto-filelist, selects the files not to be chosen.
-RUN: %link %linkopts -flto %t1.1.o %t1.3.o -exclude-lto-filelist=%p/Inputs/lto.lst --trace=lto -o %t2.out --verbose 2>&1 | %filecheck %s -check-prefix=EMBED
-RUN: %link %linkopts -flto %t1.1.o %t1.lib2.a -exclude-lto-filelist=%p/Inputs/lto.lst --trace=lto -o %t2.out --verbose 2>&1 | %filecheck %s -check-prefix=EMBED
+RUN: %link %linkopts -flto %t1.1.o %t1.3.o --exclude-lto-filelist=%p/Inputs/lto.lst --trace=lto -o %t2.out --verbose 2>&1 | %filecheck %s -check-prefix=EMBED
+RUN: %link %linkopts -flto %t1.1.o %t1.lib2.a --exclude-lto-filelist=%p/Inputs/lto.lst --trace=lto -o %t2.out --verbose 2>&1 | %filecheck %s -check-prefix=EMBED
 #EMBED-NOT: Using embedded bitcode section

--- a/test/Common/LTO/FatLTOObjects/FatLTOObjects.test
+++ b/test/Common/LTO/FatLTOObjects/FatLTOObjects.test
@@ -1,7 +1,7 @@
 #---FatLTOObjects.test--------------------------- Executable,LTO -----------------#
 #BEGIN_COMMENT
 # Verify support for fat LTO objects carrying a .llvm.lto section.
-# --fat-lto-objects (and -ffat-lto-objects alias) should select embedded
+# --fat-lto-objects (and --ffat-lto-objects alias) should select embedded
 # bitcode from .llvm.lto, while default mode should use the native object.
 #END_COMMENT
 
@@ -28,7 +28,7 @@ RUN: %link %linkopts -e main %t.main.o %t.fat.o \
 RUN: --fat-lto-objects -Map %t.fat.map -o %t.fat.map.out
 RUN: %filecheck %s --check-prefix=FAT-MAP < %t.fat.map
 
-RUN: %link %linkopts -e main %t.main.o %t.fat.o -ffat-lto-objects \
+RUN: %link %linkopts -e main %t.main.o %t.fat.o --ffat-lto-objects \
 RUN: --trace=lto --verbose -o %t.ffat.out 2>&1 | %filecheck %s --check-prefix=FAT-MSG
 RUN: %nm %t.ffat.out | %filecheck %s --check-prefix=FAT
 

--- a/test/Common/LTO/GetSetSectionName/GetSetSectionName.test
+++ b/test/Common/LTO/GetSetSectionName/GetSetSectionName.test
@@ -8,7 +8,7 @@ RUN: %clang %clangopts -c  %p/Inputs/c.c -o %t4
 RUN: %ar cr %aropts %t5 %t2
 RUN: %ar cr %aropts %t6 %t3
 RUN: %ar cr %aropts %t7 %t4
-RUN: %link %linkopts -M  -flto-options=preserveall  %t1 --start-group %t5 %t7 %t6 --end-group -o %t8
+RUN: %link %linkopts -M  --flto-options=preserveall  %t1 --start-group %t5 %t7 %t6 --end-group -o %t8
 RUN: %readelf -s %t8 | %grep "foo" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "bar" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "baz" | %filecheck %s -check-prefix YES

--- a/test/Common/LTO/LTOAsmOpts/ltoasmopts.test
+++ b/test/Common/LTO/LTOAsmOpts/ltoasmopts.test
@@ -2,7 +2,7 @@ UNSUPPORTED: x86
 # Check that LTO passes on assembler options
 RUN: %clang %clangopts -fcommon -c   %p/Inputs/main.c -o %t1.main.o %clangg0opts
 RUN: %clang %clangopts -fcommon -c  -flto %p/Inputs/foo.c -o %t1.foo.o %clangg0opts
-RUN: %link %linkopts  %linkg0opts   %t1.main.o %t1.foo.o -flto-options=asmopts="-gpsize=0" -o %t2.out.nosdata --trace=lto  2>&1
+RUN: %link %linkopts  %linkg0opts   %t1.main.o %t1.foo.o --flto-options=asmopts="-gpsize=0" -o %t2.out.nosdata --trace=lto  2>&1
 RUN: %readelf -S %t2.out.nosdata | %filecheck %s -check-prefix=ASMOPTS
 
 #ASMOPTS-NOT: sdata

--- a/test/Common/LTO/LTOCommonSymbols/ltocommonsymbols.test
+++ b/test/Common/LTO/LTOCommonSymbols/ltocommonsymbols.test
@@ -3,7 +3,7 @@ UNSUPPORTED: riscv32, riscv64
 # Checks that commons are selected from the right files even after LTO.
 RUN: %clang %clangopts -fcommon -c -flto -ffunction-sections -fdata-sections %p/Inputs/1.c -o %t1.1.o
 RUN: %clang %clangopts -fcommon -c -flto -ffunction-sections -fdata-sections %p/Inputs/2.c -o %t1.2.o
-RUN: %link %linkopts  %t1.1.o %t1.2.o -flto-options=codegen="-function-sections -data-sections" -T %p/Inputs/script.t -o %t2.out
+RUN: %link %linkopts  %t1.1.o %t1.2.o --flto-options=codegen="-function-sections -data-sections" -T %p/Inputs/script.t -o %t2.out
 RUN: %readelf -S -W %t2.out | %filecheck %s
 
 #CHECK-NOT: mysmallcommons1 PROGBITS

--- a/test/Common/LTO/LTOCommonSymbolsGC/LTOCommonSymbolsGC.test
+++ b/test/Common/LTO/LTOCommonSymbolsGC/LTOCommonSymbolsGC.test
@@ -4,5 +4,5 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c -flto -ffunction-sections -fdata-sections %p/Inputs/common.c -o %t1.1.o
-RUN: %link %linkopts --gc-sections %t1.1.o -flto-options=codegen="-function-sections -data-sections" -o %t2.out -e foo --emit-timing-stats=%t.time.stats
+RUN: %link %linkopts --gc-sections %t1.1.o --flto-options=codegen="-function-sections -data-sections" -o %t2.out -e foo --emit-timing-stats=%t.time.stats
 #END_TEST

--- a/test/Common/LTO/LTODeleteTemps/LTODeleteTemps.test
+++ b/test/Common/LTO/LTODeleteTemps/LTODeleteTemps.test
@@ -1,16 +1,16 @@
 #---LTODeleteTemps.test--------------------- Executable,LTO -------------#
 #BEGIN_COMMENT
-#Test if LTO temporary files are deleted without -save-temps
+#Test if LTO temporary files are deleted without --save-temps
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -O2 -ffunction-sections -flto -o %t1.o
 
 # First, check if the LTO output is deleted
-RUN: %link %linkopts %t1.o -flto-options=verbose -o %t1.out 2>&1 | %filecheck --check-prefix=DELETETEMP %s
+RUN: %link %linkopts %t1.o --flto-options=verbose -o %t1.out 2>&1 | %filecheck --check-prefix=DELETETEMP %s
 DELETETEMP: Deleting temporary file
 
 # Second, check that a.out.llvm-lto.* are not created
-# Note, -flto-options=verbose implies creation of the bincode files, so cannot be used here
+# Note, --flto-options=verbose implies creation of the bincode files, so cannot be used here
 RUN: %link %linkopts %t1.o -o %t2.out 2>&1 | %filecheck --check-prefix=DELETEGEN %s
 DELETEGEN: LTO code generation
 

--- a/test/Common/LTO/LTODwoDir/LTODwoDir.test
+++ b/test/Common/LTO/LTODwoDir/LTODwoDir.test
@@ -1,6 +1,6 @@
-## Check the -dwodir= option.
+## Check the --dwodir= option.
 RUN: %rm -rf %t.dwo
 RUN: %clang %clangopts -g -flto -c %p/Inputs/main.c -o %t.main.o
-RUN: %link %linkopts %t.main.o -dwodir=%t.dwo -o %t.out --trace=lto
+RUN: %link %linkopts %t.main.o --dwodir=%t.dwo -o %t.out --trace=lto
 RUN: llvm-readobj -h %t.dwo/0.dwo | FileCheck %s
 CHECK: ElfHeader

--- a/test/Common/LTO/LTOFlags/ltoflags.test
+++ b/test/Common/LTO/LTOFlags/ltoflags.test
@@ -1,6 +1,6 @@
 # Check if the linker recognizes -M and -M-options flags
 RUN: %clang %clangopts -c -flto %p/Inputs/1.c -o %t1.o
-RUN: %link %linkopts -flto %t1.o --trace=command-line -M  -flto-options=verbose -o %t.out 2>&1 \
+RUN: %link %linkopts -flto %t1.o --trace=command-line -M  --flto-options=verbose -o %t.out 2>&1 \
 RUN:   | %filecheck %s -check-prefix YES
 
 YES: LTO Flag: Enabled

--- a/test/Common/LTO/LTOForceDynamic/ltoforcedynamic.test
+++ b/test/Common/LTO/LTOForceDynamic/ltoforcedynamic.test
@@ -1,6 +1,6 @@
 # Test that LTO sets the mode to static when --force-dynamic is used.
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -flto
-RUN: %link %linkopts  %t1.1.o --force-dynamic -flto-options=preserve-sym=foo -o %t2.out --trace=lto 2>&1 | %filecheck %s
+RUN: %link %linkopts  %t1.1.o --force-dynamic --flto-options=preserve-sym=foo -o %t2.out --trace=lto 2>&1 | %filecheck %s
 RUN: %link %linkopts  %t1.1.o --force-dynamic -E -o %t2.out.export --trace=lto 2>&1
 #CHECK: Note: LTO Set codemodel to Auto Detect
 RUN: %readelf --dyn-syms %t2.out.export | %filecheck %s -check-prefix=EXPORT

--- a/test/Common/LTO/LTOGroups/ltogroups.test
+++ b/test/Common/LTO/LTOGroups/ltogroups.test
@@ -8,7 +8,7 @@ RUN: %clang %clangopts -c  %p/Inputs/c.c -o %t4
 RUN: %ar cr %aropts %t5 %t2
 RUN: %ar cr %aropts %t6 %t3
 RUN: %ar cr %aropts %t7 %t4
-RUN: %link %linkopts -M  -flto-options=preserveall  %t1 --start-group %t5 %t7 %t6 --end-group -o %t8
+RUN: %link %linkopts -M  --flto-options=preserveall  %t1 --start-group %t5 %t7 %t6 --end-group -o %t8
 RUN: %readelf -s %t8 | %grep "foo" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "bar" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "baz" | %filecheck %s -check-prefix YES

--- a/test/Common/LTO/LTOGroupsNoMerge/ltogroupsnomerge.test
+++ b/test/Common/LTO/LTOGroupsNoMerge/ltogroupsnomerge.test
@@ -9,7 +9,7 @@ RUN: %clang %clangopts -c  %p/Inputs/crap.c -o %t1.crap.o
 RUN: %ar cr %t2.libb1.a %t1.b1.o
 RUN: %ar cr %aropts %t2.libb2.a %t1.b2.o
 RUN: %ar cr %aropts %t2.libc.a %t1.c.o
-RUN: %link %linkopts -flto-options=no-merge-modules  -M  %t1.a.o --start-group %t2.libb1.a %t2.libb2.a %t2.libc.a %t1.crap.o --end-group --trace=lto -t 2>&1 | %filecheck %s
+RUN: %link %linkopts --flto-options=no-merge-modules  -M  %t1.a.o --start-group %t2.libb1.a %t2.libb2.a %t2.libc.a %t1.crap.o --end-group --trace=lto -t 2>&1 | %filecheck %s
 
 #CHECK: {{[ -\(\)_A-Za-z0-9.\\/:]+}}crap
 

--- a/test/Common/LTO/LTONoGroupArchives/ltonogrouparchives.test
+++ b/test/Common/LTO/LTONoGroupArchives/ltonogrouparchives.test
@@ -8,7 +8,7 @@ RUN: %clang %clangopts -c  %p/Inputs/c.c -o %t4
 RUN: %ar cr %aropts %t5 %t2
 RUN: %ar cr %aropts %t6 %t3
 RUN: %ar cr %aropts %t7 %t4
-RUN: %link %linkopts -M -flto-options=preserveall  %t1 %t5 %t7 %t6 -o %t8
+RUN: %link %linkopts -M --flto-options=preserveall  %t1 %t5 %t7 %t6 -o %t8
 RUN: %readelf -s %t8 | %grep "foo" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "bar" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "baz" | %filecheck %s -check-prefix YES

--- a/test/Common/LTO/LTONoGroupObjs/ltonogroupobjs.test
+++ b/test/Common/LTO/LTONoGroupObjs/ltonogroupobjs.test
@@ -4,7 +4,7 @@ RUN: %clang %clangopts -c  %p/Inputs/a.c -flto -o %t1
 RUN: %clang %clangopts -c  %p/Inputs/b1.c -o %t2
 RUN: %clang %clangopts -c  %p/Inputs/b2.c -o %t3
 RUN: %clang %clangopts -c  %p/Inputs/c.c -o %t4
-RUN: %link %linkopts -M -flto-options=preserveall  %t1 %t2 %t4 %t3 -o %t5
+RUN: %link %linkopts -M --flto-options=preserveall  %t1 %t2 %t4 %t3 -o %t5
 RUN: %readelf -s %t5 | %grep "foo" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t5 | %grep "bar" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t5 | %grep "baz" | %filecheck %s -check-prefix YES

--- a/test/Common/LTO/LTOOptions/LTOOptions.test
+++ b/test/Common/LTO/LTOOptions/LTOOptions.test
@@ -4,5 +4,5 @@ UNSUPPORTED: riscv32, riscv64
 # Check that input assembler files are not deleted.
 RUN: %clang %clangopts -flto -c %p/Inputs/main.c -o %t.main.o
 RUN: %cp %p/Inputs/foo.s %t.foo.s
-RUN: %link %linkopts -mtriple %triple %t.main.o -flto-options=lto-asm-file=%t.foo.s -o %t.out
+RUN: %link %linkopts -mtriple %triple %t.main.o --flto-options=lto-asm-file=%t.foo.s -o %t.out
 RUN: ls %t.foo.s

--- a/test/Common/LTO/LTOPartition/SimpleLTOPartition/ltopartition.disable
+++ b/test/Common/LTO/LTOPartition/SimpleLTOPartition/ltopartition.disable
@@ -1,5 +1,5 @@
 # Module partitioning can currently only produce assembly files so it won't
-# work without -save-temps; however, after the recent re-externalization
+# work without --save-temps; however, after the recent re-externalization
 # changes, it is no longer working correctly anyway. So XFAIL it for now.
 #
 # This tests that partitioning with LTO works.
@@ -7,7 +7,7 @@ RUN: %clang -c %p/Inputs/main.c -ffunction-sections -fdata-sections -o %t1.main.
 RUN: %clang -c %p/Inputs/3.c -ffunction-sections -fdata-sections -o %t1.3.o
 RUN: %clang -c %p/Inputs/1.c -ffunction-sections -fdata-sections -o %t1.1.o -flto
 RUN: %clang -c %p/Inputs/2.c -ffunction-sections -fdata-sections -o %t1.2.o -flto
-RUN: %link -T %p/Inputs/script.t %t1.main.o %t1.1.o %t1.2.o %t1.3.o -flto-options=no-merge-modules -flto-options=codegen="-resolved-sections-conservatively=false -Os -split-lto-cg   -data-sections -function-sections" --gc-sections --print-gc-sections 2>&1 | %filecheck %s
-RUN: %link  %t1.main.o %t1.1.o %t1.2.o %t1.3.o -flto-options=no-merge-modules -flto-options=codegen="-resolved-sections-conservatively=false -Os -split-lto-cg   -data-sections -function-sections"  --gc-sections --print-gc-sections 2>&1 | %filecheck %s
+RUN: %link -T %p/Inputs/script.t %t1.main.o %t1.1.o %t1.2.o %t1.3.o --flto-options=no-merge-modules --flto-options=codegen="-resolved-sections-conservatively=false -Os -split-lto-cg   -data-sections -function-sections" --gc-sections --print-gc-sections 2>&1 | %filecheck %s
+RUN: %link  %t1.main.o %t1.1.o %t1.2.o %t1.3.o --flto-options=no-merge-modules --flto-options=codegen="-resolved-sections-conservatively=false -Os -split-lto-cg   -data-sections -function-sections"  --gc-sections --print-gc-sections 2>&1 | %filecheck %s
 #CHECK-NOT: foostr
 #CHECK-NOT: barstr

--- a/test/Common/LTO/LTOSaveTempsEq/LTOSaveTempsEq.test
+++ b/test/Common/LTO/LTOSaveTempsEq/LTOSaveTempsEq.test
@@ -1,12 +1,12 @@
 #---LTOSaveTempsEq.test--------------------- Executable,LTO -------------#
 #BEGIN_COMMENT
-#Test that -save-temps=dir places the files in the right dir
+#Test that --save-temps=dir places the files in the right dir
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -O2 -ffunction-sections -flto -o %t1.o
 
 RUN: mkdir -p %t-dir
-RUN: %link %linkopts %t1.o -save-temps=%t-dir -o %t1.out
+RUN: %link %linkopts %t1.o --save-temps=%t-dir -o %t1.out
 
 # Only check for file presence
 CHECK: {{^}}

--- a/test/Common/LTO/LTOSaveTempsNotWritable/LTOSaveTempsNotWritable.test
+++ b/test/Common/LTO/LTOSaveTempsNotWritable/LTOSaveTempsNotWritable.test
@@ -6,7 +6,7 @@
 RUN: %clang %clangopts -c %p/Inputs/1.c -O2 -ffunction-sections -flto -o %t1.o
 
 # this directory does not exist
-RUN: %not %link %linkopts %t1.o -save-temps=%t-dir -o %t1.out 2>&1 | %filecheck %s
+RUN: %not %link %linkopts %t1.o --save-temps=%t-dir -o %t1.out 2>&1 | %filecheck %s
 CHECK-NOT: LLVM ERROR:
 
 #END_TEST

--- a/test/Common/LTO/LTOSymDef/LTOSymDef.test
+++ b/test/Common/LTO/LTOSymDef/LTOSymDef.test
@@ -9,7 +9,7 @@ UNSUPPORTED: x86
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o %clangg0opts -ffunction-sections -fdata-sections -flto
 RUN: %clang %clangopts -c %p/Inputs/2.c -o %t1.2.o %clangg0opts -ffunction-sections -fdata-sections -flto
-RUN: %link %linkopts %p/Inputs/r.symdef %t1.1.o %t1.2.o -o %t2.out -T %p/Inputs/script.t -flto-options=preserve-sym=foo,boo
+RUN: %link %linkopts %p/Inputs/r.symdef %t1.1.o %t1.2.o -o %t2.out -T %p/Inputs/script.t --flto-options=preserve-sym=foo,boo
 RUN: %nm -n %t2.out | %filecheck %s -check-prefix=SYM
 #SYM-DAG: 008782c0 A baz
 #SYM-DAG: 00080000 A bar

--- a/test/Common/LTO/LTOTraceTest/LTOTraceTest.test
+++ b/test/Common/LTO/LTOTraceTest/LTOTraceTest.test
@@ -1,13 +1,13 @@
 UNSUPPORTED: x86
 #---LTOTraceTest.test-------------------------------------------------#
 #BEGIN_COMMENT
-# Print same traces for lto using --trace-lto and -trace=lto
+# Print same traces for lto using --trace-lto and --trace=lto
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -fcommon -c -flto %p/Inputs/1.c -o %t1.o
 RUN: %clang %clangopts -fcommon -c %p/Inputs/2.c -o %t2.o
 RUN: %link %linkopts -M  %t1.o %t2.o -o %t3.out --trace-lto 2>&1 | %filecheck %s
-RUN: %link %linkopts -M  %t1.o %t2.o -o %t3.out -trace=lto 2>&1 | %filecheck %s
+RUN: %link %linkopts -M  %t1.o %t2.o -o %t3.out --trace=lto 2>&1 | %filecheck %s
 
 #CHECK: Note: Preserving symbol common
 #END_TEST

--- a/test/Common/LTO/PreserveFile/preservefile.test
+++ b/test/Common/LTO/PreserveFile/preservefile.test
@@ -2,7 +2,7 @@ UNSUPPORTED: x86
 # Check if LTO works for no groups and only archives and bitcodes
 RUN: %clang %clangopts -c  %p/Inputs/a.c -flto -o %t1
 RUN: %clang %clangopts -c  %p/Inputs/b.c -flto -o %t2
-RUN: %link %linkopts -flto-options=preserve-file=%p/Inputs/preserve1  %t1 %t2 -o %t3
+RUN: %link %linkopts --flto-options=preserve-file=%p/Inputs/preserve1  %t1 %t2 -o %t3
 RUN: %readelf -s %t3 | %filecheck %s
 
 #CHECK: boo

--- a/test/Common/LTO/PreserveFileDOS/PreserveFileDOS.test
+++ b/test/Common/LTO/PreserveFileDOS/PreserveFileDOS.test
@@ -6,7 +6,7 @@ UNSUPPORTED: x86
 #START_TEST
 RUN: %clang %clangopts -c  %p/Inputs/a.c -flto -o %t1
 RUN: %clang %clangopts -c  %p/Inputs/b.c -flto -o %t2
-RUN: %link %linkopts -flto-options=preserve-file=%p/Inputs/preserve1  %t1 %t2 -o %t3
+RUN: %link %linkopts --flto-options=preserve-file=%p/Inputs/preserve1  %t1 %t2 -o %t3
 RUN: %readelf -s %t3 | %filecheck %s
 #CHECK: boo
 #END_TEST

--- a/test/Common/LTO/PreserveSym/preservesym.test
+++ b/test/Common/LTO/PreserveSym/preservesym.test
@@ -8,7 +8,7 @@ RUN: %clang %clangopts -c  %p/Inputs/c.c -o %t4
 RUN: %ar cr %aropts %t5 %t2
 RUN: %ar cr %aropts %t6 %t3
 RUN: %ar cr %aropts %t7 %t4
-RUN: %link %linkopts -M -flto-options=preserve-sym=foo  %t1 %t5 %t7 %t6 -o %t8
+RUN: %link %linkopts -M --flto-options=preserve-sym=foo  %t1 %t5 %t7 %t6 -o %t8
 RUN: %readelf -s %t8 | %filecheck %s
 
 #CHECK: foo

--- a/test/Common/LTO/SampleProfile/SampleProfile.test
+++ b/test/Common/LTO/SampleProfile/SampleProfile.test
@@ -5,7 +5,7 @@ RUN: %link %linkopts --lto-sample-profile=%p/Inputs/sample-profile.prof %t.f.o -
 RUN: %opt -S %t.1.out.llvm-lto.0.4.opt.bc
 
 RUN: rm -f %t.f.o.4.opt.bc
-RUN: %link %linkopts -plugin-opt=sample-profile=%p/Inputs/sample-profile.prof %t.f.o --save-temps -o %t.2.out
+RUN: %link %linkopts --plugin-opt=sample-profile=%p/Inputs/sample-profile.prof %t.f.o --save-temps -o %t.2.out
 RUN: %opt -S %t.2.out.llvm-lto.0.4.opt.bc
 
 CHECK: ![[#]] = !{i32 1, !"ProfileSummary", ![[#]]}

--- a/test/Common/LTO/StartLibEndLib/StartLibEndLibLTO.test
+++ b/test/Common/LTO/StartLibEndLib/StartLibEndLibLTO.test
@@ -9,7 +9,7 @@ RUN: %clang %clangopts -flto -c %p/Inputs/bar.c -o %t.bar.o
 RUN: %clang %clangopts -flto -c %p/Inputs/baz.c -o %t.baz.o
 RUN: %clang %clangopts -flto -c %p/Inputs/main.c -o %t.main.o
 
-RUN: %link %linkopts %t.main.o --start-lib %t.foo.o %t.bar.o %t.baz.o --end-lib -o %t.out -print-timing-stats 2>&1 | %filecheck %s -check-prefix=TIMING
+RUN: %link %linkopts %t.main.o --start-lib %t.foo.o %t.bar.o %t.baz.o --end-lib -o %t.out --print-timing-stats 2>&1 | %filecheck %s -check-prefix=TIMING
 
 #TIMING: Build --start-lib archive
 #TIMING-NOT: Build --start-lib archive

--- a/test/Common/LTO/StoreComFile/StoreComFile.test
+++ b/test/Common/LTO/StoreComFile/StoreComFile.test
@@ -4,7 +4,7 @@ UNSUPPORTED: ndk-build
 RUN: %clang %clangopts -fcommon %clangg0opts -c -fdata-sections %p/Inputs/1.c -o %t1.o
 RUN: %clang %clangopts -fcommon %clangg0opts -c -flto -fdata-sections %p/Inputs/2.c -o %t2.o
 RUN: %clang %clangopts -fcommon %clangg0opts -c -flto -fdata-sections %p/Inputs/3.c -o %t3.o
-RUN: %link %linkopts %linkg0opts -flto -e main -T %p/Inputs/script.t -flto-options=codegen= %t1.o %t2.o %t3.o -o %t.out
+RUN: %link %linkopts %linkg0opts -flto -e main -T %p/Inputs/script.t --flto-options=codegen= %t1.o %t2.o %t3.o -o %t.out
 RUN: %readelf -s -S %t.out | %filecheck %s
 
 #CHECK:  2] .script_data      NOBITS

--- a/test/Common/LTO/ThinLTOCaching/ThinLTOCaching.test
+++ b/test/Common/LTO/ThinLTOCaching/ThinLTOCaching.test
@@ -6,7 +6,7 @@ RUN: %clang %clangopts -flto=thin -O2 -c %p/Inputs/2.c -o %t.2.bc
 ## Test --save-temps with thin LTO cache
 RUN: rm -rf %t.cache
 RUN: mkdir -p %t.t
-RUN: %link %linkopts -flto-options=cache=%t.cache --save-temps=%t.t -e _start -o out %t.2.bc %t.1.bc -M 2>&1 | FileCheck %s --check-prefix=MAP
+RUN: %link %linkopts --flto-options=cache=%t.cache --save-temps=%t.t -e _start -o out %t.2.bc %t.1.bc -M 2>&1 | FileCheck %s --check-prefix=MAP
 MAP: .text {{.*}} {{.*}}out.llvm-lto.[[#]].o
 
 RUN: ls %t.t | FileCheck %s --check-prefix=OUT

--- a/test/Common/LTO/ThinLTONoLS/ThinLTONoLS.test
+++ b/test/Common/LTO/ThinLTONoLS/ThinLTONoLS.test
@@ -10,7 +10,7 @@ UNSUPPORTED: arm && ndk-build
 RUN: %clang %clangopts -c %p/Inputs/1.c -O2 -ffunction-sections -flto=thin -o %t1.1.o
 RUN: %clang %clangopts -c %p/Inputs/2.c -O2 -ffunction-sections -flto=thin -o %t1.2.o
 RUN: %clang %clangopts -c %p/Inputs/3.c -O2 -ffunction-sections -o %t1.3.o
-RUN: %link %linkopts --gc-sections -print-gc-sections -flto-options=codegen=-function-sections -flto-options=codegen=-data-sections --save-temps -e main %t1.1.o %t1.2.o %t1.3.o -o %t1.out 2>&1 | %filecheck --check-prefix=GARBAGE %s
+RUN: %link %linkopts --gc-sections --print-gc-sections --flto-options=codegen=-function-sections --flto-options=codegen=-data-sections --save-temps -e main %t1.1.o %t1.2.o %t1.3.o -o %t1.out 2>&1 | %filecheck --check-prefix=GARBAGE %s
 
 GARBAGE: GC :{{.*}}[.text.otherfun]
 

--- a/test/Common/LTO/Verbose/verbose.test
+++ b/test/Common/LTO/Verbose/verbose.test
@@ -3,7 +3,7 @@ UNSUPPORTED: ndk-build
 # Check if LTO works for no groups and only archives and bitcodes
 RUN: %clang %clangopts -c  %p/Inputs/a.c -flto -o %t1
 RUN: %clang %clangopts -c  %p/Inputs/b.c -flto -o %t2
-RUN: %link %linkopts --save-temps -M -flto-options verbose  %t1 %t2 -o %t3 2>&1\
+RUN: %link %linkopts --save-temps -M --flto-options verbose  %t1 %t2 -o %t3 2>&1\
 RUN:  | %filecheck %s -check-prefix YES
 
 YES: Note: Beginning LTO Phase 1

--- a/test/Common/Plugin/SignedDiagnostics/SignedDiagnostics.test
+++ b/test/Common/Plugin/SignedDiagnostics/SignedDiagnostics.test
@@ -1,7 +1,7 @@
 ## Checks that the linker can emit diagnostics for int64_t types.
 RUN: split-file %s %t
 RUN: %clang %clangopts -c %t/1.s -o %t.o
-RUN: %link %linkopts %t.o -L%libsdir/test --T %t/script.t 2>&1 | %filecheck %s
+RUN: %link %linkopts %t.o -L%libsdir/test -T %t/script.t 2>&1 | %filecheck %s
 CHECK: positive 64-bit value: 9223372036854775807
 CHECK: negative 64-bit value: -9223372036854775808
 

--- a/test/Common/standalone/ArchiveMemberReport/ArchiveMemberReportWholeArchive.test
+++ b/test/Common/standalone/ArchiveMemberReport/ArchiveMemberReportWholeArchive.test
@@ -13,7 +13,7 @@ RUN: %filecheck %s --check-prefix=WHOLE < %t.report.json
 #END_TEST
 
 WHOLE-DAG: "WholeArchive": true
-WHOLE-DAG: "Reason": "-whole-archive"
+WHOLE-DAG: "Reason": "--whole-archive"
 WHOLE-DAG: "MemberIsArchiveMember": true
 WHOLE-DAG: "MemberPath": "{{.*\.a\([^)]*foo[^)]*\.o\)}}"
 WHOLE-DAG: "MemberPath": "{{.*\.a\([^)]*bar[^)]*\.o\)}}"

--- a/test/Common/standalone/CommandLine/BuildID/BuildID.test
+++ b/test/Common/standalone/CommandLine/BuildID/BuildID.test
@@ -1,6 +1,6 @@
 #---BuildID.test--------------------------- Executable -----------------#
 #BEGIN_COMMENT
-# This checks for option -build-id=<xxx> that is being handled in the linker.
+# This checks for option --build-id=<xxx> that is being handled in the linker.
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o

--- a/test/Common/standalone/CommandLine/Color/Color.test
+++ b/test/Common/standalone/CommandLine/Color/Color.test
@@ -1,9 +1,9 @@
 #---Color.test--------------------------- Executable -----------------#
 #BEGIN_COMMENT
-# This checks if the linker supports -color option.
+# This checks if the linker supports --color option.
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
-RUN: %link %linkopts %t1.1.o -o %t2.out -color="auto" 2>&1 | %filecheck %s --allow-empty
+RUN: %link %linkopts %t1.1.o -o %t2.out --color="auto" 2>&1 | %filecheck %s --allow-empty
 #CHECK-NOT: Not Implemented
 #END_TEST

--- a/test/Common/standalone/CommandLine/Entry/Entry.test
+++ b/test/Common/standalone/CommandLine/Entry/Entry.test
@@ -8,6 +8,4 @@ RUN: %link %linkopts %t1.1.o -o %t2.out.dashe1 -e 0
 RUN: %link %linkopts %t1.1.o -o %t2.out.dashe2 -e0
 RUN: %link %linkopts %t1.1.o -o %t2.out.dashe3 --entry 0
 RUN: %link %linkopts %t1.1.o -o %t2.out.dashe4 --entry=0
-RUN: %link %linkopts %t1.1.o -o %t2.out.dashe5 -entry=0
-RUN: %link %linkopts %t1.1.o -o %t2.out.dashe6 -entry 0
 #END_TEST

--- a/test/Common/standalone/CommandLine/ExternDynamicList/ExternDynamicList.test
+++ b/test/Common/standalone/CommandLine/ExternDynamicList/ExternDynamicList.test
@@ -1,13 +1,13 @@
 #---ExternDynamicList.test--------------------------- Executable -----------------#
 #BEGIN_COMMENT
-# This checks for option -extern-list/-dynamic-list that is being handled in the linker.
+# This checks for option --extern-list/--dynamic-list that is being handled in the linker.
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
-RUN: %link %linkopts %t1.1.o --trace=symbol=foo -extern-list %p/Inputs/extern_list -o %t2.1.single 2>&1 | %filecheck %s
-RUN: %link %linkopts %t1.1.o --trace=symbol=foo -extern-list %p/Inputs/extern_list -o %t2.1.double 2>&1 | %filecheck %s
-RUN: %link %linkopts %t1.1.o --trace=symbol=foo -dynamic-list %p/Inputs/dynamic_list -o %t2.2.single 2>&1 | %filecheck %s
-RUN: %link %linkopts %t1.1.o --trace=symbol=foo -dynamic-list %p/Inputs/dynamic_list -o %t2.2.double 2>&1 | %filecheck %s
+RUN: %link %linkopts %t1.1.o --trace=symbol=foo --extern-list %p/Inputs/extern_list -o %t2.1.single 2>&1 | %filecheck %s
+RUN: %link %linkopts %t1.1.o --trace=symbol=foo --extern-list %p/Inputs/extern_list -o %t2.1.double 2>&1 | %filecheck %s
+RUN: %link %linkopts %t1.1.o --trace=symbol=foo --dynamic-list %p/Inputs/dynamic_list -o %t2.2.single 2>&1 | %filecheck %s
+RUN: %link %linkopts %t1.1.o --trace=symbol=foo --dynamic-list %p/Inputs/dynamic_list -o %t2.2.double 2>&1 | %filecheck %s
 
 #CHECK-NOT: Not implemented
 #END_TEST

--- a/test/Common/standalone/CommandLine/MappingFile/SharedObjects.test
+++ b/test/Common/standalone/CommandLine/MappingFile/SharedObjects.test
@@ -7,7 +7,7 @@ UNSUPPORTED: riscv32, riscv64
 #START_TEST
 RUN: %clang %clangopts -c -fPIC %p/Inputs/1.c -o %t1.1.o
 RUN: %link %linkopts -shared %t1.1.o -o 98765
-RUN: %link -MapStyle txt %linkopts -dynamic %t1.1.o 98765 --mapping-file=%p/Inputs/mapping.ini -Map=%t0.map -o %t2.out.dynexec
+RUN: %link -MapStyle txt %linkopts --dynamic %t1.1.o 98765 --mapping-file=%p/Inputs/mapping.ini -Map=%t0.map -o %t2.out.dynexec
 RUN: %filecheck %s < %t0.map
 CHECK: SharedObjects : 1
 CHECK: foo.so

--- a/test/Common/standalone/CommandLine/NoUndefined/NoUndefined.test
+++ b/test/Common/standalone/CommandLine/NoUndefined/NoUndefined.test
@@ -4,7 +4,6 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
-RUN: %link %linkopts %t1.1.o --trace=symbol=foo -o %t2.out -no-undefined 2>&1 | %filecheck %s
 RUN: %link %linkopts %t1.1.o --trace=symbol=foo -o %t2.out --no-undefined 2>&1 | %filecheck %s
 #CHECK-NOT: Not Implemented
 #END_TEST

--- a/test/Common/standalone/CommandLine/PrintTimingStats/PrintTimingStats.test
+++ b/test/Common/standalone/CommandLine/PrintTimingStats/PrintTimingStats.test
@@ -4,6 +4,6 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
-RUN: %link %linkopts %t1.1.o -o %t2.out -print-timing-stats 2>&1 | %filecheck %s --allow-empty
+RUN: %link %linkopts %t1.1.o -o %t2.out --print-timing-stats 2>&1 | %filecheck %s --allow-empty
 #CHECK-NOT: Not Implemented
 #END_TEST

--- a/test/Common/standalone/CommandLine/Reproduce/AbsolutePaths.test
+++ b/test/Common/standalone/CommandLine/Reproduce/AbsolutePaths.test
@@ -8,7 +8,7 @@ RUN: %clang %clangopts -c -fPIC %p/Inputs/1.c -o %t1.1.o
 RUN: %clang %clangopts -c %p/Inputs/2.c -o %t.AbsolutePaths.2.o
 RUN: %link %linkopts -shared %t1.1.o -o %t1.dll
 RUN: %link %linkopts -shared %t.AbsolutePaths.2.o -o %t.AbsolutePaths.2.dll
-RUN: %link %linkopts -dynamic %t1.1.o %t.AbsolutePaths.2.o %t1.dll %t.AbsolutePaths.2.dll -T %p/Inputs/script1.t --reproduce %t0.tar \
+RUN: %link %linkopts --dynamic %t1.1.o %t.AbsolutePaths.2.o %t1.dll %t.AbsolutePaths.2.dll -T %p/Inputs/script1.t --reproduce %t0.tar \
 RUN:  --dump-mapping-file %t1.dump --dump-response-file %t1.response -o %t1.out.AbsPaths
 RUN %filecheck %s < %t1.dump
 CHECK-DAG: /tmp1.1.o

--- a/test/Common/standalone/CommandLine/Reproduce/Bitcode.test
+++ b/test/Common/standalone/CommandLine/Reproduce/Bitcode.test
@@ -23,6 +23,6 @@ CHECK_TEMPS: internalize.bc
 CHECK_TEMPS: opt.bc
 CHECK_TEMPS: precodegen.bc
 CHECK_TEMPS: resolution.txt
-CHECK_LTORESPONSE: -flto-options=lto-output-file=
+CHECK_LTORESPONSE: --flto-options=lto-output-file=
 CHECK_LTORESPONSE-NOT: llvm-lto.o
 CHECK_LTORESPONSE-NOT: ,

--- a/test/Common/standalone/CommandLine/Reproduce/LTO.test
+++ b/test/Common/standalone/CommandLine/Reproduce/LTO.test
@@ -10,7 +10,7 @@
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o -flto
 RUN: %clang %clangopts -c %p/Inputs/lto1.s -o %t1.lto1.o
 RUN: %clang %clangopts -c %p/Inputs/lto2.s -o %t1.lto2.o
-RUN: %link %linkg0opts %emulation -flto-options=preserve-sym=foo %t1.o --save-temps -flto-options=lto-asm-file=%p/Inputs/lto1.s,%p/Inputs/lto2.s \
+RUN: %link %linkg0opts %emulation --flto-options=preserve-sym=foo %t1.o --save-temps --flto-options=lto-asm-file=%p/Inputs/lto1.s,%p/Inputs/lto2.s \
 RUN:  -o %t.out --reproduce %t.tar --dump-response-file %t.response
 RUN: %filecheck %s < %t.response
 RUN: %rm -rf %t.tmpdir

--- a/test/Common/standalone/CommandLine/Reproduce/MultiMapStyleReproduce.test
+++ b/test/Common/standalone/CommandLine/Reproduce/MultiMapStyleReproduce.test
@@ -4,7 +4,7 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
-RUN: %link %linkopts %t1.1.o -o %t2.out.reproduce -MapStyle txt -MapStyle yaml --reproduce foo.tar -dump-response-file %t2.out.reproduce.dump
+RUN: %link %linkopts %t1.1.o -o %t2.out.reproduce -MapStyle txt -MapStyle yaml --reproduce foo.tar --dump-response-file %t2.out.reproduce.dump
 RUN: %filecheck %s -check-prefix=DUMP < %t2.out.reproduce.dump
 #DUMP: -MapStyle txt -MapStyle yaml
 #END_TEST

--- a/test/Common/standalone/CommandLine/Reproduce/Namespec.test
+++ b/test/Common/standalone/CommandLine/Reproduce/Namespec.test
@@ -14,12 +14,12 @@ RUN: %link %linkopts %t.1.o -L%t.libs -larc --reproduce %t.arc.tar \
 RUN:   --dump-response-file %t.arc.response -o %t.arc.out
 
 ## Shared library found via -l<namespec>.
-RUN: %link %linkopts -dynamic %t.1.o %t.2.o -L%t.libs -lshr \
+RUN: %link %linkopts --dynamic %t.1.o %t.2.o -L%t.libs -lshr \
 RUN:   --reproduce %t.shr.tar --dump-response-file %t.shr.response \
 RUN:   -o %t.shr.out
 
 ## Shared library found via -l:<filename>.
-RUN: %link %linkopts -dynamic %t.1.o %t.2.o -L%t.libs -l:libshr.so \
+RUN: %link %linkopts --dynamic %t.1.o %t.2.o -L%t.libs -l:libshr.so \
 RUN:   --reproduce %t.lit.tar --dump-response-file %t.lit.response \
 RUN:   -o %t.lit.out
 

--- a/test/Common/standalone/CommandLine/Reproduce/reproduceDLL.test
+++ b/test/Common/standalone/CommandLine/Reproduce/reproduceDLL.test
@@ -4,5 +4,5 @@
 #START_TEST
 RUN: %clang %clangopts -c -fPIC %p/Inputs/1.c -o %t1.1.o
 RUN: %link %linkopts -shared %t1.1.o -o %t1.1.dll
-RUN: %link %linkopts -dynamic %t1.1.o %t1.1.dll --reproduce %t0.tar -o %t1.out.runDLL --dump-response-file %t0.response
+RUN: %link %linkopts --dynamic %t1.1.o %t1.1.dll --reproduce %t0.tar -o %t1.out.runDLL --dump-response-file %t0.response
 #END_TEST

--- a/test/Common/standalone/CommandLine/SectionStart/SectionStart.test
+++ b/test/Common/standalone/CommandLine/SectionStart/SectionStart.test
@@ -1,10 +1,10 @@
 #---SectionStart.test--------------------------- Executable,LS -----------------#
 #BEGIN_COMMENT
-# This checks for option -section-start that is being handled in the linker.
+# This checks for option --section-start that is being handled in the linker.
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
-RUN: %link %linkopts %t1.1.o -o %t2.out -section-start .text=0xF0000000
+RUN: %link %linkopts %t1.1.o -o %t2.out --section-start .text=0xF0000000
 RUN: %readelf -s %t2.out -W | %filecheck %s
 #CHECK: f0000000
 #END_TEST

--- a/test/Common/standalone/CommandLine/WarnWholeArchive/WarnWholeArchive.s
+++ b/test/Common/standalone/CommandLine/WarnWholeArchive/WarnWholeArchive.s
@@ -11,7 +11,7 @@ foo:
 
 // RUN: %clang %clangopts -c %s -o %t.o
 // RUN: %ar cr %aropts %t1.lib1.a %t.o
-// RUN: %link %emulation %linkopts -whole-archive %t1.lib1.a -o %t2.out -Wwhole-archive \
+// RUN: %link %emulation %linkopts --whole-archive %t1.lib1.a -o %t2.out -Wwhole-archive \
 // RUN: 2>&1 | %filecheck %s --check-prefix=WARN1
 // WARN1: Warning: 'whole-archive' enabled for{{.*}}lib1.a
 // RUN: %link %emulation %linkopts %t1.lib1.a -o %t2.out -Wwhole-archive --verbose \
@@ -19,7 +19,7 @@ foo:
 // WARN2-NOT: Warning: 'whole-archive' enabled for{{.*}}lib1.a
 // RUN: %clang %clangopts -c %s -flto -o %t.lto.o
 // RUN: %ar cr %aropts %t1.ltolib1.a %t.lto.o
-// RUN: %link %emulation %linkopts -whole-archive %t1.ltolib1.a -o %t2.ltoout -Wwhole-archive \
+// RUN: %link %emulation %linkopts --whole-archive %t1.ltolib1.a -o %t2.ltoout -Wwhole-archive \
 // RUN: 2>&1 | %filecheck %s --check-prefix=WARN3
 // WARN3-COUNT-1: Warning: 'whole-archive' enabled for{{.*}}ltolib1.a
 //END_TEST

--- a/test/Common/standalone/CommandLine/WarnWholeArchive/WarnWholeArchiveReproduce.test
+++ b/test/Common/standalone/CommandLine/WarnWholeArchive/WarnWholeArchiveReproduce.test
@@ -8,7 +8,7 @@ UNSUPPORTED: x86
 RUN: %clang %clangopts -fcommon -c %p/Inputs/1.c -o %t1.1.o
 RUN: %clang %clangopts -fcommon -c %p/Inputs/2.c -o %t1.2.o
 RUN: %ar cr %aropts %t1.lib1.a %t1.1.o
-RUN: %link %linkopts --reproduce %t1.1.reproduce.tar -whole-archive %t1.lib1.a \
+RUN: %link %linkopts --reproduce %t1.1.reproduce.tar --whole-archive %t1.lib1.a \
 RUN: %t1.2.o --warn-common -o %t2.out -Wwhole-archive \
 RUN: --dump-response-file %t1.1.response.txt
 RUN: %filecheck %s --check-prefix=WARN < %t1.1.response.txt

--- a/test/Common/standalone/Diagnostics/OptimizationRemarks/OptimizationRemarks.test
+++ b/test/Common/standalone/Diagnostics/OptimizationRemarks/OptimizationRemarks.test
@@ -6,10 +6,10 @@
 
 RUN: %clang %clangopts -O3 -g -c  %p/Inputs/foo.c -flto -o %t1.1.o
 RUN: %clang %clangopts -O3 -g -c  %p/Inputs/main.c -flto -o %t2.1.o
-RUN: %link %linkopts %t1.1.o %t2.1.o -flto -e main -o %t.out -g -mllvm -pass-remarks=.* -mllvm -pass-remarks-missed=.* -mllvm -pass-remarks-analysis=.* -opt-record-file 2>&1 | %filecheck %s
+RUN: %link %linkopts %t1.1.o %t2.1.o -flto -e main -o %t.out -g -mllvm -pass-remarks=.* -mllvm -pass-remarks-missed=.* -mllvm -pass-remarks-analysis=.* --opt-record-file 2>&1 | %filecheck %s
 RUN: cat %t.out-LTO.opt.yaml | %filecheck %s -check-prefix=YAML
 
-# Checking -opt-record-file flag
+# Checking --opt-record-file flag
 #YAML: --- !Passed
 #YAML: Pass:            inline
 #YAML: Name:            Inlined

--- a/test/Common/standalone/DynamicExecutableSymbols/DynamicExecutableSymbols.test
+++ b/test/Common/standalone/DynamicExecutableSymbols/DynamicExecutableSymbols.test
@@ -7,7 +7,7 @@
 RUN: %clang %clangg0opts -o %t1.1.o %p/Inputs/1.c -c -fPIC -ffunction-sections -fdata-sections
 RUN: %link %linkopts -o %t1.lib1.so %t1.1.o -shared
 RUN: %clang %clangg0opts -o %t1.main.o %p/Inputs/main.c -c
-RUN: %link %linkopts -o %t1.main.elf %t1.main.o -dynamic %t1.lib1.so -e main
+RUN: %link %linkopts -o %t1.main.elf %t1.main.o --dynamic %t1.lib1.so -e main
 RUN: %readelf -s %t1.main.elf 2>&1 | %filecheck %s
 #CHECK-DAG: foo
 #CHECK-DAG: common_a

--- a/test/Common/standalone/ExcludeLibs/ExcludeLibs.test
+++ b/test/Common/standalone/ExcludeLibs/ExcludeLibs.test
@@ -18,7 +18,7 @@ RUN: %rm -rf %t.tmpdir
 
 ONE-NOT: foo
 
-RUN: %link %linkopts -dy -dynamic-list %p/Inputs/list %t1.o %tlib.a --exclude-libs %tlib.a %t3.so -o %t2.out
+RUN: %link %linkopts -dy --dynamic-list %p/Inputs/list %t1.o %tlib.a --exclude-libs %tlib.a %t3.so -o %t2.out
 RUN: %readelf --dyn-symbols %t2.out |%filecheck --check-prefix="TWO" %s
 TWO-NOT: foo
 
@@ -54,6 +54,6 @@ RUN: %link %linkopts -shared %tpic1.o %tlib2.a --exclude-libs %tlib2.a %t3.o -o 
 RUN: %readelf --dyn-symbols %t4.out.so |%filecheck --check-prefix="FOUR" %s
 FOUR-NOT: foo
 
-RUN: %link %linkopts -shared %tpic1.o %tlib2.a --exclude-libs %tlib2.a %t3.o -version-script %p/Inputs/script -o %t5.out.so
+RUN: %link %linkopts -shared %tpic1.o %tlib2.a --exclude-libs %tlib2.a %t3.o --version-script %p/Inputs/script -o %t5.out.so
 RUN: %readelf --dyn-symbols %t5.out.so |%filecheck --check-prefix="FIVE" %s
 FIVE-NOT: foo

--- a/test/Common/standalone/ExternListGC/ExternListGC.test
+++ b/test/Common/standalone/ExternListGC/ExternListGC.test
@@ -9,7 +9,7 @@ RUN: %clang %clangopts -c %p/Inputs/2.c -ffunction-sections -o %t2.o
 RUN: %clang %clangopts -c %p/Inputs/3.c -fdata-sections -o %t3.o
 RUN: %ar crs %aropts %t.a %t1.o %t2.o %t3.o
 RUN: %clang %clangopts -c %p/Inputs/main.c -ffunction-sections -o %tmain.o
-RUN: %link %linkopts --force-dynamic --entry=main --gc-sections --extern-list %p/Inputs/ExtList --dynamic-list %p/Inputs/DynList %tmain.o %t.a -o %t.out -print-gc-sections 2>&1 | %filecheck %s --check-prefix="TRACE"
+RUN: %link %linkopts --force-dynamic --entry=main --gc-sections --extern-list %p/Inputs/ExtList --dynamic-list %p/Inputs/DynList %tmain.o %t.a -o %t.out --print-gc-sections 2>&1 | %filecheck %s --check-prefix="TRACE"
 RUN: %readelf -s %t.out | %filecheck %s
 
 TRACE: .text.func_exe

--- a/test/Common/standalone/ForceDynPerm/ForceDynPerm.test
+++ b/test/Common/standalone/ForceDynPerm/ForceDynPerm.test
@@ -1,6 +1,6 @@
 # Test that hidden symbols are not exported.
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o
-RUN: %link %linkopts --rosegment -force-dynamic %t1.o -o %t.out 2>&1
+RUN: %link %linkopts --rosegment --force-dynamic %t1.o -o %t.out 2>&1
 RUN: %readelf -l -W %t.out |   %filecheck %s
 
 # CHECK:  PHDR            {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  R E {{[x0-9a-z]+}}

--- a/test/Common/standalone/JustSymbols/JustSymbolsOptionsForSharedObjectFiles.test
+++ b/test/Common/standalone/JustSymbols/JustSymbolsOptionsForSharedObjectFiles.test
@@ -8,7 +8,7 @@ RUN: %clang %clangopts %p/Inputs/1.c -o %t1.1.o -c -ffunction-sections -fdata-se
 RUN: %clang %clangopts %p/Inputs/2.c -o %t1.2.o -c -ffunction-sections -fdata-sections
 RUN: %clang %clangopts %p/Inputs/3.c -o %t1.3.o -c -ffunction-sections -fdata-sections
 RUN: %link %linkopts -shared %t1.3.o -o %t3.so
-RUN: %link -dynamic -MapStyle txt %linkopts %t1.1.o %t1.2.o --just-symbols=%t3.so -T %p/Inputs/script.t -o %t.out.sharedlibrary -Map %t.map --trace=symbol=bar --verbose 2>&1 | %filecheck %s
+RUN: %link --dynamic -MapStyle txt %linkopts %t1.1.o %t1.2.o --just-symbols=%t3.so -T %p/Inputs/script.t -o %t.out.sharedlibrary -Map %t.map --trace=symbol=bar --verbose 2>&1 | %filecheck %s
 RUN: %filecheck %s --check-prefix=MAPCHECK < %t.map
 RUN: %readelf -s %t.out.sharedlibrary 2>&1 | %filecheck %s --check-prefix=ELFCHECK
 #CHECK-COUNT-1: Using just symbols for input

--- a/test/Common/standalone/JustSymbols/MultipleJustSymbolsUsageForSharedObject.test
+++ b/test/Common/standalone/JustSymbols/MultipleJustSymbolsUsageForSharedObject.test
@@ -10,7 +10,7 @@ RUN: %clang %clangopts %p/Inputs/3.c -o %t1.3.o -c -ffunction-sections
 RUN: %clang %clangopts %p/Inputs/4.c -o %t1.4.o -c -ffunction-sections
 RUN: %link %linkopts -shared %t1.3.o -T %p/Inputs/image.t -o %t3.so
 RUN: %link %linkopts -shared %t1.4.o -T %p/Inputs/image.t -o %t4.so
-RUN: %link -MapStyle txt %linkopts -dynamic %t1.1.o %t1.2.o --just-symbols=%t3.so --just-symbols=%t4.so -T %p/Inputs/script.t -o %t.out.sharedlibrary -Map %t.map --trace=symbol=baz --verbose 2>&1 | %filecheck %s
+RUN: %link -MapStyle txt %linkopts --dynamic %t1.1.o %t1.2.o --just-symbols=%t3.so --just-symbols=%t4.so -T %p/Inputs/script.t -o %t.out.sharedlibrary -Map %t.map --trace=symbol=baz --verbose 2>&1 | %filecheck %s
 RUN: %readelf -s %t.out.sharedlibrary 2>&1 | %filecheck %s --check-prefix=ELFCHECK
 RUN: %filecheck %s --check-prefix=MAPCHECK < %t.map
 #CHECK-COUNT-2: Using just symbols for input

--- a/test/Common/standalone/JustSymbols/UseSymbolFromLinkerScriptForSharedObject.test
+++ b/test/Common/standalone/JustSymbols/UseSymbolFromLinkerScriptForSharedObject.test
@@ -9,7 +9,7 @@ RUN: %clang %clangopts %p/Inputs/1.c -o %t1.1.o -c -ffunction-sections -fdata-se
 RUN: %clang %clangopts %p/Inputs/2.c -o %t1.2.o -c -ffunction-sections -fdata-sections
 RUN: %clang %clangopts %p/Inputs/3.c -o %t1.3.o -c -ffunction-sections -fdata-sections
 RUN: %link %linkopts -shared %t1.3.o -T %p/Inputs/image.t -o %t3.so
-RUN: %link -MapStyle txt %linkopts -dynamic %t1.1.o %t1.2.o --just-symbols=%t3.so -T %p/Inputs/script.t -o %t.out.sharedlibrary -Map %t.map --trace=symbol=a1 2>&1 | %filecheck %s
+RUN: %link -MapStyle txt %linkopts --dynamic %t1.1.o %t1.2.o --just-symbols=%t3.so -T %p/Inputs/script.t -o %t.out.sharedlibrary -Map %t.map --trace=symbol=a1 2>&1 | %filecheck %s
 RUN: %readelf -s %t.out.sharedlibrary 2>&1 | %filecheck %s --check-prefix=ELFCHECK
 RUN: %filecheck %s --check-prefix=MAPCHECK < %t.map
 #CHECK: Resolving symbol 'a1' from provide style sym def file '{{.*}}/Inputs/script.t'

--- a/test/Common/standalone/Map/AbsolutePath/AbsolutePath.test
+++ b/test/Common/standalone/Map/AbsolutePath/AbsolutePath.test
@@ -5,7 +5,7 @@
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -ffunction-sections -o %t1.1.o
 RUN: %clang %clangopts -c %p/Inputs/2.c -ffunction-sections -o %t1.2.o
-RUN: %link -MapStyle txt %linkopts %t1.1.o %t1.2.o -Map %t2.map -MapDetail absolute-path -o %t2.out -T %p/Inputs/script.t
+RUN: %link -MapStyle txt %linkopts %t1.1.o %t1.2.o -Map %t2.map --MapDetail absolute-path -o %t2.out -T %p/Inputs/script.t
 RUN: %filecheck %s < %t2.map
 #END_TEST
 

--- a/test/Common/standalone/Map/DebugStrings/DebugStrings.test
+++ b/test/Common/standalone/Map/DebugStrings/DebugStrings.test
@@ -1,7 +1,7 @@
 #---DebugStrings.test----------------------- Executable -----------------#
 # START_COMMENT
 # Checks that merged debug strings are not shown by default
-# and are shown with -MapDetail=show-debug-strings in txt map file
+# and are shown with --MapDetail=show-debug-strings in txt map file
 # END_COMMENT
 # START_TEST
 RUN: %clang %clangopts -c -g %p/Inputs/1.c -o %t1.o

--- a/test/Common/standalone/Map/HeaderDetails/DisplayHeaderDetails.test
+++ b/test/Common/standalone/Map/HeaderDetails/DisplayHeaderDetails.test
@@ -4,7 +4,7 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -ffunction-sections -o %t1.1.o
-RUN: %link %linkopts %t1.1.o -Map %t2.map -MapDetail=show-header-details -o %t2.out -shared
+RUN: %link %linkopts %t1.1.o -Map %t2.map --MapDetail=show-header-details -o %t2.out -shared
 RUN: %filecheck %s < %t2.map
 #END_TEST
 

--- a/test/Common/standalone/Map/HeaderDetails/NoDisplayHeaderDetails.test
+++ b/test/Common/standalone/Map/HeaderDetails/NoDisplayHeaderDetails.test
@@ -1,7 +1,7 @@
 #---DisplayHeaderDetails.test--------------------- Executable---------------------#
 #BEGIN_COMMENT
 # This tests that the linker is not printing program headers or file headers
-# in the Mapfile without -MapDetail=--show-header-details option
+# in the Mapfile without --MapDetail=--show-header-details option
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -ffunction-sections -o %t1.1.o

--- a/test/Common/standalone/Map/InitialLayout/InitialLayout.test
+++ b/test/Common/standalone/Map/InitialLayout/InitialLayout.test
@@ -4,7 +4,7 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
-RUN: %link -MapStyle txt %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t -MapDetail show-initial-layout -Map %t1.main.map.txt
+RUN: %link -MapStyle txt %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.t --MapDetail show-initial-layout -Map %t1.main.map.txt
 RUN: %filecheck %s < %t1.main.map.txt
 #END_TEST
 CHECK: Initial layout:

--- a/test/Common/standalone/Map/InitialLayout/InitialLayoutIgnoreSections.test
+++ b/test/Common/standalone/Map/InitialLayout/InitialLayoutIgnoreSections.test
@@ -5,7 +5,7 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -g -c -ffunction-sections
-RUN: %link -MapStyle txt %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.ignore.t -MapDetail show-initial-layout -Map %t1.main.map.txt
+RUN: %link -MapStyle txt %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script.ignore.t --MapDetail show-initial-layout -Map %t1.main.map.txt
 RUN: %filecheck %s < %t1.main.map.txt
 #END_TEST
 CHECK: Initial layout:

--- a/test/Common/standalone/Map/InitialLayoutMergeStrings/InitialLayoutMergeStrings.test
+++ b/test/Common/standalone/Map/InitialLayoutMergeStrings/InitialLayoutMergeStrings.test
@@ -7,7 +7,7 @@
 #START_TEST
 RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections -g
 RUN: %clang %clangopts -o %t1.2.o %p/Inputs/2.c -c -ffunction-sections -g
-RUN: %link -MapStyle txt %linkopts -o %t1.1.out %t1.1.o %t1.2.o -T %p/Inputs/script.t -MapDetail show-initial-layout -Map %t1.main.map.txt
+RUN: %link -MapStyle txt %linkopts -o %t1.1.out %t1.1.o %t1.2.o -T %p/Inputs/script.t --MapDetail show-initial-layout -Map %t1.main.map.txt
 RUN: %filecheck %s < %t1.main.map.txt
 #END_TEST
 CHECK: Initial layout:

--- a/test/Common/standalone/Map/RelativePath/AbsAndRelPathError.test
+++ b/test/Common/standalone/Map/RelativePath/AbsAndRelPathError.test
@@ -1,13 +1,13 @@
 #---AbsAndRelPathError.test--------------------- Executable---------------------#
 #BEGIN_COMMENT
-# This test checks the reported error when both -MapDetail absolute-path and
-# -MapDetail relative-path=<BasePath> are used.
+# This test checks the reported error when both --MapDetail absolute-path and
+# --MapDetail relative-path=<BasePath> are used.
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c
 RUN: %clang %clangopts -o %t1.2.o %p/Inputs/2.c -c
 RUN: %ar cr %t1.lib2.a %t1.2.o
-RUN: %not %link -MapStyle txt %linkopts -o %t1.1.out %t1.1.o %t1.lib2.a -MapDetail relative-path=%t.tmpdir -MapDetail absolute-path -Map %t1.1.map.txt 2>&1 | %filecheck %s
+RUN: %not %link -MapStyle txt %linkopts -o %t1.1.out %t1.1.o %t1.lib2.a --MapDetail relative-path=%t.tmpdir --MapDetail absolute-path -Map %t1.1.map.txt 2>&1 | %filecheck %s
 #END_TEST
 CHECK: The absolute-path and relative-path MapDetail options can not be used together
 

--- a/test/Common/standalone/Map/RelativePath/InvalidBasePathWarning.test
+++ b/test/Common/standalone/Map/RelativePath/InvalidBasePathWarning.test
@@ -6,6 +6,6 @@
 RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c
 RUN: %clang %clangopts -o %t1.2.o %p/Inputs/2.c -c
 RUN: %ar cr %t1.lib2.a %t1.2.o
-RUN: %link -MapStyle txt %linkopts -o %t1.1.out %t1.1.o %t1.lib2.a -MapDetail relative-path="a/b/c" -Map %t1.1.map.txt 2>&1 | %filecheck %s
+RUN: %link -MapStyle txt %linkopts -o %t1.1.out %t1.1.o %t1.lib2.a --MapDetail relative-path="a/b/c" -Map %t1.1.map.txt 2>&1 | %filecheck %s
 #END_TEST
 CHECK: Warning: Unable to compute relative path of '{{.*}}1.o' for '{{.*}}a{{[\\/]}}b{{[\\/]}}c'

--- a/test/Common/standalone/Map/RelativePath/RelativePath.test
+++ b/test/Common/standalone/Map/RelativePath/RelativePath.test
@@ -11,22 +11,22 @@ RUN: %clang %clangopts -o %t.tmpdir/1.o %p/Inputs/1.c -c
 RUN: %clang %clangopts -o %t.tmpdir/2.o %p/Inputs/2.c -c
 RUN: %ar cr %t.tmpdir/lib2.a %t.tmpdir/2.o
 
-RUN: %link -MapStyle txt %linkopts -o %t.tmpdir/out %t.tmpdir/1.o %t.tmpdir/lib2.a -MapDetail relative-path=%t.tmpdir -Map %t.tmpdir/map.txt --verbose 2>&1 | %filecheck %s --check-prefix=VERBOSE
+RUN: %link -MapStyle txt %linkopts -o %t.tmpdir/out %t.tmpdir/1.o %t.tmpdir/lib2.a --MapDetail relative-path=%t.tmpdir -Map %t.tmpdir/map.txt --verbose 2>&1 | %filecheck %s --check-prefix=VERBOSE
 RUN: %filecheck %s < %t.tmpdir/map.txt
 
-RUN: %link -MapStyle txt %linkopts -o %t.tmpdir/out %t.tmpdir/1.o %t.tmpdir/lib2.a -MapDetail relative-path=. -Map %t.tmpdir/map.txt.dot
+RUN: %link -MapStyle txt %linkopts -o %t.tmpdir/out %t.tmpdir/1.o %t.tmpdir/lib2.a --MapDetail relative-path=. -Map %t.tmpdir/map.txt.dot
 RUN: %filecheck %s --check-prefix=DOT < %t.tmpdir/map.txt.dot
 
-RUN: %link -MapStyle txt %linkopts -o %t.tmpdir/out %t.tmpdir/1.o %t.tmpdir/lib2.a -MapDetail relative-path -Map %t.tmpdir/map.txt.default
+RUN: %link -MapStyle txt %linkopts -o %t.tmpdir/out %t.tmpdir/1.o %t.tmpdir/lib2.a --MapDetail relative-path -Map %t.tmpdir/map.txt.default
 RUN: %filecheck %s --check-prefix=DEFAULT < %t.tmpdir/map.txt.default
 
 RUN: %rm -f %t.tmpdir/lib2.a
 RUN: %ar --thin cr %t.tmpdir/lib2.a %t.tmpdir/2.o
-RUN: %link -MapStyle txt %linkopts -o %t.tmpdir/out %t.tmpdir/1.o %t.tmpdir/lib2.a -MapDetail relative-path=%t.tmpdir -Map %t.tmpdir/map.txt --verbose 2>&1 | %filecheck %s --check-prefix=VERBOSE
+RUN: %link -MapStyle txt %linkopts -o %t.tmpdir/out %t.tmpdir/1.o %t.tmpdir/lib2.a --MapDetail relative-path=%t.tmpdir -Map %t.tmpdir/map.txt --verbose 2>&1 | %filecheck %s --check-prefix=VERBOSE
 RUN: %filecheck %s --check-prefix=CHECK_THIN < %t.tmpdir/map.txt
-RUN: %link -MapStyle txt %linkopts -o %t.tmpdir/out %t.tmpdir/1.o %t.tmpdir/lib2.a -MapDetail relative-path=. -Map %t.tmpdir/map.txt.dot
+RUN: %link -MapStyle txt %linkopts -o %t.tmpdir/out %t.tmpdir/1.o %t.tmpdir/lib2.a --MapDetail relative-path=. -Map %t.tmpdir/map.txt.dot
 RUN: %filecheck %s --check-prefix=DOT_THIN < %t.tmpdir/map.txt.dot
-RUN: %link -MapStyle txt %linkopts -o %t.tmpdir/out %t.tmpdir/1.o %t.tmpdir/lib2.a -MapDetail relative-path -Map %t.tmpdir/map.txt.default
+RUN: %link -MapStyle txt %linkopts -o %t.tmpdir/out %t.tmpdir/1.o %t.tmpdir/lib2.a --MapDetail relative-path -Map %t.tmpdir/map.txt.default
 RUN: %filecheck %s --check-prefix=DEFAULT_THIN < %t.tmpdir/map.txt.default
 #END_TEST
 VERBOSE: Verbose: Using '{{.*}}' for computing relative paths in map files

--- a/test/Common/standalone/Map/RuleOrigin/RuleOrigin.test
+++ b/test/Common/standalone/Map/RuleOrigin/RuleOrigin.test
@@ -9,7 +9,7 @@ RUN: %clang %clangopts -c %p/Inputs/1.c -ffunction-sections -fdata-sections -o %
 RUN: %clang %clangopts -c %p/Inputs/2.c -ffunction-sections -fdata-sections -o %t1.2.o
 RUN: %link -MapStyle txt %linkopts %t1.1.o %t1.2.o -Map %t2.map.withtiming -L %p/Inputs/ -o %t2.out -T %p/Inputs/script.t
 RUN: %filecheck %s < %t2.map.withtiming
-RUN: %link -MapStyle txt %linkopts %t1.1.o %t1.2.o -Map %t2.map.notiming -L %p/Inputs/ -o %t2.out -T %p/Inputs/script.t -MapDetail no-timing
+RUN: %link -MapStyle txt %linkopts %t1.1.o %t1.2.o -Map %t2.map.notiming -L %p/Inputs/ -o %t2.out -T %p/Inputs/script.t --MapDetail no-timing
 RUN: %filecheck %s < %t2.map.notiming
 
 #CHECK: mytext{{.*}}text.t

--- a/test/Common/standalone/Map/Timing/Timing.test
+++ b/test/Common/standalone/Map/Timing/Timing.test
@@ -7,7 +7,7 @@ UNSUPPORTED: true
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/main.c -o %t1.main.o
 RUN: %clang %clangopts -c %p/Inputs/foo.c -o %t1.foo.o
-RUN: %link %linkopts %t1.main.o %t1.foo.o -M -MapDetail show-timing -o %t2.out 2>&1 | %filecheck %s
+RUN: %link %linkopts %t1.main.o %t1.foo.o -M --MapDetail show-timing -o %t2.out 2>&1 | %filecheck %s
 
 #CHECK: LinkStats
 #CHECK: Common symbol	size	file

--- a/test/Common/standalone/Map/WholeArchive/mapfilewholearchive.test
+++ b/test/Common/standalone/Map/WholeArchive/mapfilewholearchive.test
@@ -11,9 +11,9 @@ RUN: %link %linkopts %t1.main.o --whole-archive %t1.library.a -M -o %t2.out 2>&1
 
 #CHECK: Archive member included because of file (symbol)
 #CHECK: {{[ -\(\)_A-Za-z0-9.\\/:]+}}foo.o
-#CHECK: 		-whole-archive
+#CHECK: 		--whole-archive
 #CHECK: {{[ -\(\)_A-Za-z0-9.\\/:]+}}bar.o
-#CHECK: 		-whole-archive
+#CHECK: 		--whole-archive
 #CHECK: Common symbol	size	file
 #CHECK: common_array	0x50	{{[ -\(\)_A-Za-z0-9.\\/:]+}}main.o
 #CHECK: Linker Script and memory map

--- a/test/Common/standalone/Map/YamlMap/AbsolutePath/AbsolutePath.test
+++ b/test/Common/standalone/Map/YamlMap/AbsolutePath/AbsolutePath.test
@@ -6,7 +6,7 @@
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -ffunction-sections -o %t1.1.o
 RUN: %clang %clangopts -c %p/Inputs/2.c -ffunction-sections -o %t1.2.o
-RUN: %link -MapStyle yaml %linkopts %t1.1.o %t1.2.o -Map %t2.map -MapDetail absolute-path -o %t2.out -T %p/Inputs/script.t
+RUN: %link -MapStyle yaml %linkopts %t1.1.o %t1.2.o -Map %t2.map --MapDetail absolute-path -o %t2.out -T %p/Inputs/script.t
 RUN: %filecheck %s < %t2.map
 #END_TEST
 

--- a/test/Common/standalone/OrphanSectionDiagnostic/OrphanEmptySections.test
+++ b/test/Common/standalone/OrphanSectionDiagnostic/OrphanEmptySections.test
@@ -6,7 +6,7 @@
 #START_TEST
 
 RUN: %clang %clangopts -c %p/Inputs/4.c -o %t1.1.o -ffunction-sections
-RUN: %not %link %linkopts -orphan-handling=error %t1.1.o -T %p/Inputs/script_empty.t -o %t2.out 2>&1 | %filecheck %s
+RUN: %not %link %linkopts --orphan-handling=error %t1.1.o -T %p/Inputs/script_empty.t -o %t2.out 2>&1 | %filecheck %s
 #CHECK:Error: no linker script rule for section .text.bar
 #CHECK-NOT:Error: no linker script rule for section .bss.str
 #END_TEST

--- a/test/Common/standalone/OrphanSectionDiagnostic/OrphanNoteGNUStack.test
+++ b/test/Common/standalone/OrphanSectionDiagnostic/OrphanNoteGNUStack.test
@@ -6,7 +6,7 @@ UNSUPPORTED: x86
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -ffunction-sections
-RUN: %link %linkopts -orphan-handling=warn %t1.1.o -T %p/Inputs/script.t -o %t2.out 2>&1 | %filecheck %s
+RUN: %link %linkopts --orphan-handling=warn %t1.1.o -T %p/Inputs/script.t -o %t2.out 2>&1 | %filecheck %s
 
 #CHECK-NOT: Warning: no linker script rule for section .note.GNU-stack
 

--- a/test/Common/standalone/OrphanSectionDiagnostic/OrphanSectionError.test
+++ b/test/Common/standalone/OrphanSectionDiagnostic/OrphanSectionError.test
@@ -6,7 +6,7 @@ UNSUPPORTED: x86
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -ffunction-sections
-RUN: %not %link %linkopts -orphan-handling=error %t1.1.o -T %p/Inputs/script.t -o %t2.out 2>&1 | %filecheck %s
+RUN: %not %link %linkopts --orphan-handling=error %t1.1.o -T %p/Inputs/script.t -o %t2.out 2>&1 | %filecheck %s
 
 #CHECK:Error: no linker script rule for section .text.bar
 

--- a/test/Common/standalone/OrphanSectionDiagnostic/OrphanSectionPlace.test
+++ b/test/Common/standalone/OrphanSectionDiagnostic/OrphanSectionPlace.test
@@ -7,7 +7,7 @@ UNSUPPORTED: x86
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -ffunction-sections
-RUN: %link -MapStyle txt %linkopts -orphan-handling=place %t1.1.o -T %p/Inputs/script.t -o %t2.out -Map %t2.map
+RUN: %link -MapStyle txt %linkopts --orphan-handling=place %t1.1.o -T %p/Inputs/script.t -o %t2.out -Map %t2.map
 RUN: %filecheck %s < %t2.map
 
 #CHECK: .text.bar

--- a/test/Common/standalone/OrphanSectionDiagnostic/OrphanSectionReproduce.test
+++ b/test/Common/standalone/OrphanSectionDiagnostic/OrphanSectionReproduce.test
@@ -6,7 +6,7 @@ UNSUPPORTED: x86
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -ffunction-sections
-RUN: %not %link %linkopts -orphan-handling=error --reproduce %t.1.tar %t1.1.o -T %p/Inputs/script.t -o %t2.out 2>&1 | %filecheck %s
+RUN: %not %link %linkopts --orphan-handling=error --reproduce %t.1.tar %t1.1.o -T %p/Inputs/script.t -o %t2.out 2>&1 | %filecheck %s
 
 #CHECK:Error: no linker script rule for section .text.bar
 #CHECK:Note: Creating tarball {{.*}}.tar

--- a/test/Common/standalone/OrphanSectionDiagnostic/OrphanSectionWarning.test
+++ b/test/Common/standalone/OrphanSectionDiagnostic/OrphanSectionWarning.test
@@ -6,6 +6,6 @@ UNSUPPORTED: x86
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -ffunction-sections
-RUN: %link %linkopts -orphan-handling=warn %t1.1.o -T %p/Inputs/script.t -o %t2.out 2>&1 | %filecheck %s
+RUN: %link %linkopts --orphan-handling=warn %t1.1.o -T %p/Inputs/script.t -o %t2.out 2>&1 | %filecheck %s
 
 #CHECK:Warning: no linker script rule for section .text.bar

--- a/test/Common/standalone/OrphanSectionDiagnostic/OrphanSectionsDynamic.test
+++ b/test/Common/standalone/OrphanSectionDiagnostic/OrphanSectionsDynamic.test
@@ -8,7 +8,7 @@
 RUN: %clang %clangopts -c %p/Inputs/2.c -o %t1.2.o -ffunction-sections
 RUN: %clang %clangopts -c %p/Inputs/3.c -o %t1.3.o -ffunction-sections
 RUN: %link %linkopts -shared %t1.2.o -o %t1.lib2.so
-RUN: %link %linkopts -Bdynamic -orphan-handling=warn %t1.3.o %t1.lib2.so -T %p/Inputs/scriptdyn.t -o %t2.out 2>&1 | %filecheck %s
+RUN: %link %linkopts -Bdynamic --orphan-handling=warn %t1.3.o %t1.lib2.so -T %p/Inputs/scriptdyn.t -o %t2.out 2>&1 | %filecheck %s
 
 #CHECK: Warning: no linker script rule for section .dynsym
 #CHECK: Warning: no linker script rule for section .dynstr

--- a/test/Common/standalone/OrphanSectionDiagnostic/OrphanSymTab.test
+++ b/test/Common/standalone/OrphanSectionDiagnostic/OrphanSymTab.test
@@ -6,7 +6,7 @@ UNSUPPORTED: x86
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -ffunction-sections
-RUN: %link %linkopts -orphan-handling=warn %t1.1.o -T %p/Inputs/script.t -o %t2.out 2>&1 | %filecheck %s
+RUN: %link %linkopts --orphan-handling=warn %t1.1.o -T %p/Inputs/script.t -o %t2.out 2>&1 | %filecheck %s
 
 #CHECK-NOT:Warning: no linker script rule for section .shstrtab
 #CHECK-NOT:Warning: no linker script rule for section .symtab

--- a/test/Common/standalone/SearchDiagnostics/SearchDiagnostics.test
+++ b/test/Common/standalone/SearchDiagnostics/SearchDiagnostics.test
@@ -15,7 +15,7 @@ NOT-FOUND: Trying to open input `{{.+}}libblablabla.a' of type `archive' for nam
 RUN: %link %linkopts -static --verbose -o %t2.out %t1.o -L%t-lib -la 2>&1 | %filecheck %s --check-prefix=FOUND-STATIC
 FOUND-STATIC: Trying to open input `{{.+}}-lib/liba.a' of type `archive' for namespec `a': found
 
-RUN: %link %linkopts -dynamic --verbose -o %t3.out %t1.o -L%t-lib -la 2>&1 | %filecheck %s --check-prefix=FOUND-DYNOBJ
+RUN: %link %linkopts --dynamic --verbose -o %t3.out %t1.o -L%t-lib -la 2>&1 | %filecheck %s --check-prefix=FOUND-DYNOBJ
 FOUND-DYNOBJ: Trying to open input `{{.+}}-lib/liba.so' of type `dynamic object' for namespec `a': found
 
 RUN: %link %linkopts --verbose -o %t1.out %t1.o -L%p/Inputs/ -T 1.t 2>&1 | %filecheck %s --check-prefix=FOUND-SCRIPT

--- a/test/Common/standalone/SharedLibrarySegmentPermissions/SharedLibrarySegmentPermissions.test
+++ b/test/Common/standalone/SharedLibrarySegmentPermissions/SharedLibrarySegmentPermissions.test
@@ -2,7 +2,7 @@
 # building a shared object
 RUN: %clang %clangopts -c -fPIC %p/Inputs/blah.c -o %t1.1.o
 RUN: %link %linkopts -shared %t1.1.o -o %t2.so
-RUN: %link %linkopts -rosegment -shared %t1.1.o -o %t2.rosegment.so
+RUN: %link %linkopts --rosegment -shared %t1.1.o -o %t2.rosegment.so
 RUN: %readelf -l -W %t2.so | %filecheck %s -check-prefix='NOROSEGMENT'
 RUN: %readelf -l -W %t2.rosegment.so | %filecheck %s -check-prefix='ROSEGMENT'
 

--- a/test/Common/standalone/SymDef/WriteSymDef/WriteSymDefStyleInvalid.test
+++ b/test/Common/standalone/SymDef/WriteSymDef/WriteSymDefStyleInvalid.test
@@ -6,5 +6,5 @@
 RUN: %clang %clangopts %p/Inputs/1.c -o %t1.1.o -c
 RUN: %not %link %linkopts %t1.1.o -o %t2.out.1 -T %p/Inputs/script.t --symdef --symdef-style abdc11@ 2>&1 | %filecheck %s
 RUN: %not %link %linkopts %t1.1.o -o %t2.out.2 -T %p/Inputs/script.t --symdef-file %t2.x.symdef --symdef-style abdc11@ 2>&1 | %filecheck %s
-#CHECK: Invalid options specified for -symdef-style=abdc11@ valid values are default/provide
+#CHECK: Invalid options specified for --symdef-style=abdc11@ valid values are default/provide
 #END_TEST

--- a/test/Common/standalone/SymbolResolutionReport/ArchiveSymbols/ArchiveSymbols.test
+++ b/test/Common/standalone/SymbolResolutionReport/ArchiveSymbols/ArchiveSymbols.test
@@ -7,9 +7,9 @@ RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c
 RUN: %clang %clangopts -o %t1.2.o %p/Inputs/2.c -c
 RUN: %clang %clangopts -o %t1.3.o %p/Inputs/3.c -c
 RUN: %ar cr %aropts %t1.lib2.a %t1.2.o
-RUN: %link -MapStyle txt %linkopts -o %t1.a.out %t1.1.o %t1.lib2.a %t1.3.o -Map %t1.a.map.txt -MapDetail show-symbol-resolution
+RUN: %link -MapStyle txt %linkopts -o %t1.a.out %t1.1.o %t1.lib2.a %t1.3.o -Map %t1.a.map.txt --MapDetail show-symbol-resolution
 RUN: %filecheck %s --check-prefix ARCHIVE_FIRST < %t1.a.map.txt
-RUN: %link -MapStyle txt %linkopts -o %t1.b.out %t1.1.o %t1.3.o %t1.lib2.a -Map %t1.b.map.txt -MapDetail show-symbol-resolution
+RUN: %link -MapStyle txt %linkopts -o %t1.b.out %t1.1.o %t1.3.o %t1.lib2.a -Map %t1.b.map.txt --MapDetail show-symbol-resolution
 RUN: %filecheck %s --check-prefix ARCHIVE_LATER < %t1.b.map.txt
 
 ARCHIVE_FIRST: # Symbol Resolution:

--- a/test/Common/standalone/SymbolResolutionReport/CommonSymbols/CommonSymbols.test
+++ b/test/Common/standalone/SymbolResolutionReport/CommonSymbols/CommonSymbols.test
@@ -8,7 +8,7 @@ RUN: %clang %clangopts -fcommon -o %t1.1.o %p/Inputs/1.c -c
 RUN: %clang %clangopts -fcommon -o %t1.2.o %p/Inputs/2.c -c
 RUN: %clang %clangopts -fcommon -o %t1.3.o %p/Inputs/3.c -c
 RUN: %clang %clangopts -fcommon -o %t1.4.o %p/Inputs/4.c -c
-RUN: %link -MapStyle txt %linkopts -o %t1.var.out %t1.1.o %t1.2.o %t1.3.o %t1.4.o -Map %t1.var.map.txt -MapDetail show-symbol-resolution
+RUN: %link -MapStyle txt %linkopts -o %t1.var.out %t1.1.o %t1.2.o %t1.3.o %t1.4.o -Map %t1.var.map.txt --MapDetail show-symbol-resolution
 RUN: %filecheck %s < %t1.var.map.txt
 
 CHECK: # Symbol Resolution:

--- a/test/Common/standalone/SymbolResolutionReport/LinkerScriptSymbols/LinkerScriptSymbols.test
+++ b/test/Common/standalone/SymbolResolutionReport/LinkerScriptSymbols/LinkerScriptSymbols.test
@@ -5,7 +5,7 @@
 #END_COMMENT
 RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c
 RUN: %clang %clangopts -o %t1.2.o %p/Inputs/2.c -c
-RUN: %link -MapStyle txt %linkopts -o %t1.a.out %t1.1.o %t1.2.o %p/Inputs/script1.t %p/Inputs/script2.t -Map %t1.a.map.txt -MapDetail show-symbol-resolution
+RUN: %link -MapStyle txt %linkopts -o %t1.a.out %t1.1.o %t1.2.o %p/Inputs/script1.t %p/Inputs/script2.t -Map %t1.a.map.txt --MapDetail show-symbol-resolution
 RUN: %filecheck %s < %t1.a.map.txt
 
 CHECK: # Symbol Resolution:

--- a/test/Common/standalone/SymbolResolutionReport/PluginSymbols/PluginSymbols.test
+++ b/test/Common/standalone/SymbolResolutionReport/PluginSymbols/PluginSymbols.test
@@ -3,7 +3,7 @@
 # This test checks the symbol resolution report when there are
 # plugin-inserted symbols.
 RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -ffunction-sections
-RUN: %link -MapStyle txt %linkopts -o %t1.1.out %t1.1.o -L%libsdir/test -T %p/Inputs/script.t -Map %t1.1.map.txt -MapDetail show-symbol-resolution
+RUN: %link -MapStyle txt %linkopts -o %t1.1.out %t1.1.o -L%libsdir/test -T %p/Inputs/script.t -Map %t1.1.map.txt --MapDetail show-symbol-resolution
 RUN: %filecheck %s < %t1.1.map.txt
 
 CHECK: Symbol Resolution:

--- a/test/Common/standalone/SymbolResolutionReport/SharedLib/SharedLibs.test
+++ b/test/Common/standalone/SymbolResolutionReport/SharedLib/SharedLibs.test
@@ -5,11 +5,11 @@
 RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -fPIC
 RUN: %clang %clangopts -o %t1.2.o %p/Inputs/2.c -c -fPIC
 RUN: %clang %clangopts -o %t1.3.o %p/Inputs/3.c -c
-RUN: %link -MapStyle txt %linkopts -o %t1.lib1.so %t1.1.o -shared -Map %t1.lib1.map.txt -MapDetail show-symbol-resolution
+RUN: %link -MapStyle txt %linkopts -o %t1.lib1.so %t1.1.o -shared -Map %t1.lib1.map.txt --MapDetail show-symbol-resolution
 RUN: %filecheck %s --check-prefix=LIB1 < %t1.lib1.map.txt
-RUN: %link -MapStyle txt %linkopts -o %t1.lib2.so %t1.2.o -shared -Map %t1.lib2.map.txt -MapDetail show-symbol-resolution
+RUN: %link -MapStyle txt %linkopts -o %t1.lib2.so %t1.2.o -shared -Map %t1.lib2.map.txt --MapDetail show-symbol-resolution
 RUN: %filecheck %s --check-prefix=LIB2 < %t1.lib2.map.txt
-RUN: %link -MapStyle txt %linkopts -dy -o %t1.3.out %t1.3.o %t1.lib1.so %t1.lib2.so -Map %t1.3.map.txt -MapDetail show-symbol-resolution
+RUN: %link -MapStyle txt %linkopts -dy -o %t1.3.out %t1.3.o %t1.lib1.so %t1.lib2.so -Map %t1.3.map.txt --MapDetail show-symbol-resolution
 RUN: %filecheck %s < %t1.3.map.txt
 
 LIB1: # Symbol Resolution:

--- a/test/Common/standalone/SymbolResolutionReport/WeakVsCommonVsGlobal/WeakVsCommonVsGlobal.test
+++ b/test/Common/standalone/SymbolResolutionReport/WeakVsCommonVsGlobal/WeakVsCommonVsGlobal.test
@@ -9,7 +9,7 @@ RUN: %clang %clangopts -fcommon -o %t1.1.o %p/Inputs/1.c -c
 RUN: %clang %clangopts -fcommon -o %t1.2.o %p/Inputs/2.c -c
 RUN: %clang %clangopts -fcommon -o %t1.3.o %p/Inputs/3.c -c
 RUN: %clang %clangopts -fcommon -o %t1.4.o %p/Inputs/4.c -c
-RUN: %link -MapStyle txt %linkopts -o %t1.foo.out %t1.0.o %t1.1.o %t1.2.o %t1.3.o %t1.4.o -Map %t1.foo.map.txt -MapDetail show-symbol-resolution
+RUN: %link -MapStyle txt %linkopts -o %t1.foo.out %t1.0.o %t1.1.o %t1.2.o %t1.3.o %t1.4.o -Map %t1.foo.map.txt --MapDetail show-symbol-resolution
 RUN: %filecheck %s < %t1.foo.map.txt
 
 CHECK: # Symbol Resolution:

--- a/test/Common/standalone/SymbolResolutionReport/WrapSymbol/WrapSymbol.test
+++ b/test/Common/standalone/SymbolResolutionReport/WrapSymbol/WrapSymbol.test
@@ -5,7 +5,7 @@ UNSUPPORTED: x86
 #END_COMMENT
 RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c
 RUN: %clang %clangopts -o %t1.2.o %p/Inputs/2.c -c
-RUN: %link -MapStyle txt %linkopts -o %t1.a.out %t1.1.o %t1.2.o -Map %t1.a.map.txt -MapDetail show-symbol-resolution --wrap=foo
+RUN: %link -MapStyle txt %linkopts -o %t1.a.out %t1.1.o %t1.2.o -Map %t1.a.map.txt --MapDetail show-symbol-resolution --wrap=foo
 RUN: %filecheck %s < %t1.a.map.txt
 
 CHECK: # Symbol Resolution:

--- a/test/Common/standalone/linkerscript/AlignWithInput/LoadPhdrs/LoadHeaders32bit.test
+++ b/test/Common/standalone/linkerscript/AlignWithInput/LoadPhdrs/LoadHeaders32bit.test
@@ -6,7 +6,7 @@
 # when it includes SIZEOF_HEADERS
 #END_COMMENT
 RUN: %clang %clangopts -c %p/Inputs/test.c -o %t1.1.o.nophdr
-RUN: %link %linkopts -z max-page-size=0x1000 %t1.1.o.nophdr -T %p/Inputs/scriptnophdrs.t -Map %t2.map.nophdr -MapDetail show-header-details -o %t2.out.nophdr 2>&1
+RUN: %link %linkopts -z max-page-size=0x1000 %t1.1.o.nophdr -T %p/Inputs/scriptnophdrs.t -Map %t2.map.nophdr --MapDetail show-header-details -o %t2.out.nophdr 2>&1
 RUN: %filecheck %s < %t2.map.nophdr
 
 #CHECK: __ehdr__	0x0	0x34 # Offset: 0x0, LMA: 0x2fc0

--- a/test/Common/standalone/linkerscript/AlignWithInput/LoadPhdrs/LoadHeadersPHDRS32bit.test
+++ b/test/Common/standalone/linkerscript/AlignWithInput/LoadPhdrs/LoadHeadersPHDRS32bit.test
@@ -6,7 +6,7 @@
 # when it includes PHDRS and FILEHDRS to be loaded
 #END_COMMENT
 RUN: %clang %clangopts -c %p/Inputs/test.c -o %t1.1.o
-RUN: %link %linkopts -z max-page-size=0x1000 %t1.1.o -T %p/Inputs/script.t -Map %t2.map -MapDetail show-header-details -o %t2.out 2>&1
+RUN: %link %linkopts -z max-page-size=0x1000 %t1.1.o -T %p/Inputs/script.t -Map %t2.map --MapDetail show-header-details -o %t2.out 2>&1
 RUN: %filecheck %s < %t2.map
 
 #CHECK: __ehdr__	0x0	0x34 # Offset: 0x0, LMA: 0x2fc0

--- a/test/Common/standalone/linkerscript/ForceDynPerm/ForceDynPerm.test
+++ b/test/Common/standalone/linkerscript/ForceDynPerm/ForceDynPerm.test
@@ -1,6 +1,6 @@
 # Test that hidden symbols are not exported.
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o
-RUN: %link %linkopts --rosegment -force-dynamic -T %p/Inputs/script.t %t1.o -o %t.out 2>&1
+RUN: %link %linkopts --rosegment --force-dynamic -T %p/Inputs/script.t %t1.o -o %t.out 2>&1
 RUN: %readelf -l -W %t.out |   %filecheck %s
 
 # CHECK:  PHDR            {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  R E {{[x0-9a-z]+}}

--- a/test/Common/standalone/linkerscript/GarbageCollection/GarbageCollection.test
+++ b/test/Common/standalone/linkerscript/GarbageCollection/GarbageCollection.test
@@ -9,7 +9,7 @@ RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
 RUN: %clang %clangopts -c %p/Inputs/2.c -o %t1.2.o
 RUN: %ar cr %aropts %t1.lib2.a %t1.2.o
 RUN: %link -MapStyle txt %linkopts %t1.1.o %t1.lib2.a -T %p/Inputs/s.t --noinhibit-exec \
-RUN: -MapDetail show-timing -Map %t1.map  -o %t2.out --gc-sections 2>&1 | %filecheck %s
+RUN: --MapDetail show-timing -Map %t1.map  -o %t2.out --gc-sections 2>&1 | %filecheck %s
 RUN_UNSUPPORTED %filecheck %s -check-prefix=GCTIMER < %t1.map
 
 #CHECK: undefined reference to `baz'

--- a/test/Hexagon/Plugin/FileSize/FileSizeEmitAllUserPluginStats.test
+++ b/test/Hexagon/Plugin/FileSize/FileSizeEmitAllUserPluginStats.test
@@ -4,7 +4,7 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -ffunction-sections
-RUN: %link %linkopts %t1.1.o -T %p/Inputs/script.t -o %t2.out -print-timing-stats --time-region=all-user-plugins 2>&1 | %filecheck %s
+RUN: %link %linkopts %t1.1.o -T %p/Inputs/script.t -o %t2.out --print-timing-stats --time-region=all-user-plugins 2>&1 | %filecheck %s
 
 #CHECK-NOT: Diagnostics
 #CHECK-NOT:  Emit Output File

--- a/test/Hexagon/Plugin/FileSize/FileSizeEmitOnlyPluginStats.test
+++ b/test/Hexagon/Plugin/FileSize/FileSizeEmitOnlyPluginStats.test
@@ -4,7 +4,7 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -ffunction-sections
-RUN: %link %linkopts %t1.1.o -T %p/Inputs/script.t -o %t2.out -print-timing-stats --time-region=plugin 2>&1 | %filecheck %s
+RUN: %link %linkopts %t1.1.o -T %p/Inputs/script.t -o %t2.out --print-timing-stats --time-region=plugin 2>&1 | %filecheck %s
 
 #CHECK-NOT: Diagnostics
 #CHECK-NOT:  Emit Output File

--- a/test/Hexagon/Plugin/FileSize/FileSizeEmitOnlyUserPluginStats.test
+++ b/test/Hexagon/Plugin/FileSize/FileSizeEmitOnlyUserPluginStats.test
@@ -4,7 +4,7 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -ffunction-sections
-RUN: %link %linkopts %t1.1.o -T %p/Inputs/script.t -o %t2.out -print-timing-stats --time-region=plugin=filesize 2>&1 | %filecheck %s
+RUN: %link %linkopts %t1.1.o -T %p/Inputs/script.t -o %t2.out --print-timing-stats --time-region=plugin=filesize 2>&1 | %filecheck %s
 
 #CHECK-NOT: Diagnostics
 #CHECK-NOT:  Emit Output File

--- a/test/Hexagon/Plugin/FileSize/InvalidTimeRegionValue.test
+++ b/test/Hexagon/Plugin/FileSize/InvalidTimeRegionValue.test
@@ -4,7 +4,7 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -ffunction-sections
-RUN: %not %link %linkopts %t1.1.o -T %p/Inputs/script.t -o %t2.out -print-timing-stats --time-region=abcd 2>&1 | %filecheck %s
+RUN: %not %link %linkopts %t1.1.o -T %p/Inputs/script.t -o %t2.out --print-timing-stats --time-region=abcd 2>&1 | %filecheck %s
 
 #CHECK: Invalid value for --time-region: abcd
 #END_TEST

--- a/test/Hexagon/linux/CommonsGnuHash/CommonsGnuHash.test
+++ b/test/Hexagon/linux/CommonsGnuHash/CommonsGnuHash.test
@@ -9,7 +9,7 @@
 #START_TEST
 
 RUN: %clang %clangopts -c -fpic %p/Inputs/1.c -o %t.o
-RUN: %link %linkopts -shared -hash-style=gnu -o %t.so %t.o
+RUN: %link %linkopts -shared --hash-style=gnu -o %t.so %t.o
 RUN: %readelf -I %t.so
 
 CHECK: Histogram for `.gnu.hash' bucket list length (total of 3 buckets):

--- a/test/Hexagon/linux/ForceDynPerm/ForceDynPerm.test
+++ b/test/Hexagon/linux/ForceDynPerm/ForceDynPerm.test
@@ -1,6 +1,6 @@
 # Test that hidden symbols are not exported.
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o
-RUN: %link %linkopts --rosegment -force-dynamic %t1.o -o %t.out -z max-page-size=4096 2>&1
+RUN: %link %linkopts --rosegment --force-dynamic %t1.o -o %t.out -z max-page-size=4096 2>&1
 RUN: %readelf -l -W %t.out |   %filecheck %s
 
 # CHECK:  PHDR            {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  R E {{[x0-9a-z]+}}

--- a/test/Hexagon/linux/LTO/GetSetSectionName/GetSetSectionName.test
+++ b/test/Hexagon/linux/LTO/GetSetSectionName/GetSetSectionName.test
@@ -7,7 +7,7 @@ RUN: %clang %clangopts -c  %p/Inputs/c.c -o %t4
 RUN: %ar cr %aropts %t5 %t2
 RUN: %ar cr %aropts %t6 %t3
 RUN: %ar cr %aropts %t7 %t4
-RUN: %link %linkopts -M  -flto-options=preserveall %t1 --start-group %t5 %t7 %t6 --end-group -o %t8
+RUN: %link %linkopts -M  --flto-options=preserveall %t1 --start-group %t5 %t7 %t6 --end-group -o %t8
 RUN: %readelf -s %t8 | %grep "foo" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "bar" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "baz" | %filecheck %s -check-prefix YES

--- a/test/Hexagon/linux/LTO/LTOCommonSymbols/ltocommonsymbols.test
+++ b/test/Hexagon/linux/LTO/LTOCommonSymbols/ltocommonsymbols.test
@@ -1,7 +1,7 @@
 # Checks that commons are selected from the right files even after LTO.
 RUN: %clang %clangopts -fcommon -c -flto -ffunction-sections -fdata-sections %p/Inputs/1.c -o %t1.1.o
 RUN: %clang %clangopts -fcommon -c -flto -ffunction-sections -fdata-sections %p/Inputs/2.c -o %t1.2.o
-RUN: %link %linkopts  %t1.1.o %t1.2.o -flto-options=codegen="-function-sections -data-sections"  -T %p/Inputs/script.t -o %t2.out
+RUN: %link %linkopts  %t1.1.o %t1.2.o --flto-options=codegen="-function-sections -data-sections"  -T %p/Inputs/script.t -o %t2.out
 RUN: %readelf -S -W %t2.out | %filecheck %s
 
 #CHECK-NOT: mysmallcommons1 PROGBITS

--- a/test/Hexagon/linux/LTO/LTOGroups/ltogroups.test
+++ b/test/Hexagon/linux/LTO/LTOGroups/ltogroups.test
@@ -7,7 +7,7 @@ RUN: %clang %clangopts -c  %p/Inputs/c.c -o %t4
 RUN: %ar cr %aropts %t5 %t2
 RUN: %ar cr %aropts %t6 %t3
 RUN: %ar cr %aropts %t7 %t4
-RUN: %link %linkopts -M  -flto-options=preserveall %t1 --start-group %t5 %t7 %t6 --end-group -o %t8
+RUN: %link %linkopts -M  --flto-options=preserveall %t1 --start-group %t5 %t7 %t6 --end-group -o %t8
 RUN: %readelf -s %t8 | %grep "foo" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "bar" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "baz" | %filecheck %s -check-prefix YES

--- a/test/Hexagon/linux/LTO/LTOGroupsNoMerge/ltogroupsnomerge.test
+++ b/test/Hexagon/linux/LTO/LTOGroupsNoMerge/ltogroupsnomerge.test
@@ -8,7 +8,7 @@ RUN: %clang %clangopts -c  %p/Inputs/crap.c -o %t1.crap.o
 RUN: %ar cr %t2.libb1.a %t1.b1.o
 RUN: %ar cr %aropts %t2.libb2.a %t1.b2.o
 RUN: %ar cr %aropts %t2.libc.a %t1.c.o
-RUN: %link %linkopts -flto-options=no-merge-modules  -M  %t1.a.o --start-group %t2.libb1.a %t2.libb2.a %t2.libc.a %t1.crap.o --end-group --trace=lto -t 2>&1 | %filecheck %s
+RUN: %link %linkopts --flto-options=no-merge-modules  -M  %t1.a.o --start-group %t2.libb1.a %t2.libb2.a %t2.libc.a %t1.crap.o --end-group --trace=lto -t 2>&1 | %filecheck %s
 
 #CHECK: {{[ -\(\)_A-Za-z0-9.\\/:]+}}crap
 

--- a/test/Hexagon/linux/LTO/LTONoGroupArchives/ltonogrouparchives.test
+++ b/test/Hexagon/linux/LTO/LTONoGroupArchives/ltonogrouparchives.test
@@ -7,7 +7,7 @@ RUN: %clang %clangopts -c  %p/Inputs/c.c -o %t4
 RUN: %ar cr %aropts %t5 %t2
 RUN: %ar cr %aropts %t6 %t3
 RUN: %ar cr %aropts %t7 %t4
-RUN: %link %linkopts -M -flto-options=preserveall %t1 %t5 %t7 %t6 -o %t8
+RUN: %link %linkopts -M --flto-options=preserveall %t1 %t5 %t7 %t6 -o %t8
 RUN: %readelf -s %t8 | %grep "foo" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "bar" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "baz" | %filecheck %s -check-prefix YES

--- a/test/Hexagon/linux/LTO/LTONoGroupObjs/ltonogroupobjs.test
+++ b/test/Hexagon/linux/LTO/LTONoGroupObjs/ltonogroupobjs.test
@@ -3,7 +3,7 @@ RUN: %clang %clangopts -c  %p/Inputs/a.c -flto -o %t1
 RUN: %clang %clangopts -c  %p/Inputs/b1.c -o %t2
 RUN: %clang %clangopts -c  %p/Inputs/b2.c -o %t3
 RUN: %clang %clangopts -c  %p/Inputs/c.c -o %t4
-RUN: %link %linkopts -M -flto-options=preserveall %t1 %t2 %t4 %t3 -o %t5
+RUN: %link %linkopts -M --flto-options=preserveall %t1 %t2 %t4 %t3 -o %t5
 RUN: %readelf -s %t5 | %grep "foo" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t5 | %grep "bar" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t5 | %grep "baz" | %filecheck %s -check-prefix YES

--- a/test/Hexagon/linux/LTO/PreserveFile/preservefile.test
+++ b/test/Hexagon/linux/LTO/PreserveFile/preservefile.test
@@ -1,7 +1,7 @@
 # Check if LTO works for no groups and only archives and bitcodes
 RUN: %clang %clangopts -c  %p/Inputs/a.c -flto -o %t1
 RUN: %clang %clangopts -c  %p/Inputs/b.c -flto -o %t2
-RUN: %link %linkopts -M -flto-options preserve-file=%p/Inputs/preserve1 %t1 %t2 -o %t3
+RUN: %link %linkopts -M --flto-options preserve-file=%p/Inputs/preserve1 %t1 %t2 -o %t3
 RUN: %readelf -s %t3 | %grep "boo" | wc -l | %filecheck %s -check-prefix YES
 
 YES: 1

--- a/test/Hexagon/linux/LTO/PreserveSym/preservesym.test
+++ b/test/Hexagon/linux/LTO/PreserveSym/preservesym.test
@@ -7,7 +7,7 @@ RUN: %clang %clangopts -c  %p/Inputs/c.c -o %t4
 RUN: %ar cr %aropts %t5 %t2
 RUN: %ar cr %aropts %t6 %t3
 RUN: %ar cr %aropts %t7 %t4
-RUN: %link %linkopts -M -flto-options preserve-sym=foo %t1 %t5 %t7 %t6 -o %t8
+RUN: %link %linkopts -M --flto-options preserve-sym=foo %t1 %t5 %t7 %t6 -o %t8
 RUN: %readelf -s %t8 | %grep "foo" | %filecheck %s -check-prefix YES
 
 YES: 1

--- a/test/Hexagon/linux/LTO/Verbose/verbose.test
+++ b/test/Hexagon/linux/LTO/Verbose/verbose.test
@@ -1,7 +1,7 @@
 # Check if LTO works for no groups and only archives and bitcodes
 RUN: %clang %clangopts -c  %p/Inputs/a.c -flto -o %t1
 RUN: %clang %clangopts -c  %p/Inputs/b.c -flto -o %t2
-RUN: %link %linkopts --save-temps -M -flto-options verbose %t1 %t2 -o %t3 2>&1\
+RUN: %link %linkopts --save-temps -M --flto-options verbose %t1 %t2 -o %t3 2>&1\
 RUN:  | %filecheck %s -check-prefix YES
 
 YES: Note: Beginning LTO Phase 1

--- a/test/Hexagon/linux/PageSize/PageSize.test
+++ b/test/Hexagon/linux/PageSize/PageSize.test
@@ -1,6 +1,6 @@
 # Test ABI page size value
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o
-RUN: %link %emulation %linkopts -mtriple hexagon-unknown-linux-elf %t1.o -o %t.out -trace=command-line | %filecheck %s
+RUN: %link %emulation %linkopts -mtriple hexagon-unknown-linux-elf %t1.o -o %t.out --trace=command-line | %filecheck %s
 
 # CHECK:  ABI Page Size: 0x10000
 

--- a/test/Hexagon/linux/linkerscript/ForceDynPerm/ForceDynPerm.test
+++ b/test/Hexagon/linux/linkerscript/ForceDynPerm/ForceDynPerm.test
@@ -1,6 +1,6 @@
 # Test that hidden symbols are not exported.
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o
-RUN: %link %linkopts --rosegment -force-dynamic -T %p/Inputs/script.t %t1.o -o %t.out 2>&1
+RUN: %link %linkopts --rosegment --force-dynamic -T %p/Inputs/script.t %t1.o -o %t.out 2>&1
 RUN: %readelf -l -W %t.out |   %filecheck %s
 
 # CHECK:  PHDR            {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  {{[x0-9a-z]+}}  R E {{[x0-9a-z]+}}

--- a/test/Hexagon/linux/trampolinesCopy/copy-instead-of-trampolines.test
+++ b/test/Hexagon/linux/trampolinesCopy/copy-instead-of-trampolines.test
@@ -2,7 +2,7 @@
 # reuse them.
 RUN: %clang %clangopts -c %p/Inputs/trampoline.s -o %t1.o
 RUN: %clang %clangopts -c %p/Inputs/myfn.s -o %t2.o
-RUN: %link %linkopts %t1.o %t2.o -o %t.out  --section-start .boo=0x80000000 -copy-farcalls-from-file=%p/Inputs/dup --trace=trampolines 2>&1 | %filecheck %s -check-prefix=CLONES
+RUN: %link %linkopts %t1.o %t2.o -o %t.out  --section-start .boo=0x80000000 --copy-farcalls-from-file=%p/Inputs/dup --trace=trampolines 2>&1 | %filecheck %s -check-prefix=CLONES
 RUN: %readelf -s -W %t.out | %filecheck %s -check-prefix=CLONESYMS
 
 #CLONES: Creating Stub clone_1_for_myfn

--- a/test/Hexagon/standalone/CommonSymbolTimer/CommonSymbolTimer.test
+++ b/test/Hexagon/standalone/CommonSymbolTimer/CommonSymbolTimer.test
@@ -2,7 +2,7 @@
 RUN: %clang %clangopts -fcommon -c %p/Inputs/1.c -o %t1.o
 RUN: %clang %clangopts -fcommon -c %p/Inputs/2.c -o %t2.o
 RUN: %ar cr %aropts  %tlib2.a %t2.o
-RUN: %link %linkopts %t1.o %tlib2.a -o %t.out -print-timing-stats 2>&1 | %filecheck %s
+RUN: %link %linkopts %t1.o %tlib2.a -o %t.out --print-timing-stats 2>&1 | %filecheck %s
 
 CHECK: Hexagon Allocate Common Symbols
 

--- a/test/Hexagon/standalone/EndOfImageSymbolGC/EndOfImageSymbolGC.test
+++ b/test/Hexagon/standalone/EndOfImageSymbolGC/EndOfImageSymbolGC.test
@@ -8,7 +8,7 @@
 RUN: %clang %clangopts -c %p/Inputs/fb.s -o %t1.o
 RUN: %link %linkopts %t1.o -e main --gc-sections -o %t2.out
 RUN: %dwarfdump -debug-frame %t2.out | %filecheck %s -check-prefix=EOI
-RUN: %link %linkopts %t1.o -e main --gc-sections -defsym ___end=0 -o %t2.out.noeoi
+RUN: %link %linkopts %t1.o -e main --gc-sections --defsym ___end=0 -o %t2.out.noeoi
 RUN: %dwarfdump -debug-frame %t2.out.noeoi | %filecheck %s -check-prefix=NOEOI
 
 #EOI: 00000014 0000000c 00000000 FDE cie=00000000 pc=00000000...00000004

--- a/test/Hexagon/standalone/ExcludeLibs/ExcludeLibs.test
+++ b/test/Hexagon/standalone/ExcludeLibs/ExcludeLibs.test
@@ -17,7 +17,7 @@ RUN: %rm -rf %t.tmpdir
 
 ONE-NOT: foo
 
-RUN: %link %linkopts -dy -dynamic-list %p/Inputs/list %t1.o %tlib.a --exclude-libs %tlib.a %t3.so -o %t2.out
+RUN: %link %linkopts -dy --dynamic-list %p/Inputs/list %t1.o %tlib.a --exclude-libs %tlib.a %t3.so -o %t2.out
 RUN: %readelf --dyn-symbols %t2.out |%filecheck --check-prefix="TWO" %s
 TWO-NOT: foo
 
@@ -53,6 +53,6 @@ RUN: %link %linkopts -shared %tpic1.o %tlib2.a --exclude-libs %tlib2.a %t3.o -o 
 RUN: %readelf --dyn-symbols %t4.out.so |%filecheck --check-prefix="FOUR" %s
 FOUR-NOT: foo
 
-RUN: %link %linkopts -shared %tpic1.o %tlib2.a --exclude-libs %tlib2.a %t3.o -version-script %p/Inputs/script -o %t5.out.so
+RUN: %link %linkopts -shared %tpic1.o %tlib2.a --exclude-libs %tlib2.a %t3.o --version-script %p/Inputs/script -o %t5.out.so
 RUN: %readelf --dyn-symbols %t5.out.so |%filecheck --check-prefix="FIVE" %s
 FIVE-NOT: foo

--- a/test/Hexagon/standalone/LTO/ApplySameNameSectionGC/applysamenamesectiongc.test
+++ b/test/Hexagon/standalone/LTO/ApplySameNameSectionGC/applysamenamesectiongc.test
@@ -5,6 +5,6 @@ RUN: %clang %clangopts -c %p/Inputs/2.c -o %t1.2.o -flto -ffunction-sections
 RUN: %clang %clangopts -c %p/Inputs/3.c -o %t1.3.o -flto -ffunction-sections
 RUN: %clang %clangopts -c %p/Inputs/4.c -o %t1.4.o -flto -ffunction-sections
 RUN: %clang %clangopts -c %p/Inputs/override.s -o %t1.override.o
-RUN: %link %linkopts %t1.1.o %t1.2.o %t1.3.o %t1.4.o -flto-options=codegen="-function-sections -data-sections"  -flto-options=lto-output-file=%t1.override.o -o %t2.out -T %p/Inputs/script.t --save-temps --gc-sections -e main
+RUN: %link %linkopts %t1.1.o %t1.2.o %t1.3.o %t1.4.o --flto-options=codegen="-function-sections -data-sections"  --flto-options=lto-output-file=%t1.override.o -o %t2.out -T %p/Inputs/script.t --save-temps --gc-sections -e main
 RUN: %readelf -s %t2.out | %filecheck %s
 #CHECK-NOT: baz

--- a/test/Hexagon/standalone/LTO/GetSetSectionName/GetSetSectionName.test
+++ b/test/Hexagon/standalone/LTO/GetSetSectionName/GetSetSectionName.test
@@ -7,7 +7,7 @@ RUN: %clang %clangopts -c  %p/Inputs/c.c -o %t4
 RUN: %ar cr %aropts %t5 %t2
 RUN: %ar cr %aropts %t6 %t3
 RUN: %ar cr %aropts %t7 %t4
-RUN: %link %linkopts -M  -flto-options=preserveall %t1 --start-group %t5 %t7 %t6 --end-group -o %t8
+RUN: %link %linkopts -M  --flto-options=preserveall %t1 --start-group %t5 %t7 %t6 --end-group -o %t8
 RUN: %readelf -s %t8 | %grep "foo" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "bar" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "baz" | %filecheck %s -check-prefix YES

--- a/test/Hexagon/standalone/LTO/LTOAsmOpts/ltoasmopts.test
+++ b/test/Hexagon/standalone/LTO/LTOAsmOpts/ltoasmopts.test
@@ -1,7 +1,7 @@
 # Check that LTO passes on assembler options
 RUN: %clang %clangopts -fcommon -c %clangg0opts  %p/Inputs/main.c -o %t1.main.o
 RUN: %clang %clangopts -fcommon -c %clangg0opts -flto %p/Inputs/foo.c -o %t1.foo.o
-RUN: %link %linkopts %t1.main.o %t1.foo.o -flto-options=asmopts="-gpsize=0" -o %t2.out.nosdata --trace=lto  %linkg0opts  2>&1
+RUN: %link %linkopts %t1.main.o %t1.foo.o --flto-options=asmopts="-gpsize=0" -o %t2.out.nosdata --trace=lto  %linkg0opts  2>&1
 RUN: %readelf -S %t2.out.nosdata | %filecheck %s -check-prefix=ASMOPTS
 
 #ASMOPTS-NOT: sdata

--- a/test/Hexagon/standalone/LTO/LTOCommonSymbols/ltocommonsymbols.test
+++ b/test/Hexagon/standalone/LTO/LTOCommonSymbols/ltocommonsymbols.test
@@ -1,7 +1,7 @@
 # Checks that commons are selected from the right files even after LTO.
 RUN: %clang %clangopts -fcommon -c -flto -ffunction-sections -fdata-sections %p/Inputs/1.c -o %t1.1.o
 RUN: %clang %clangopts -fcommon -c -flto -ffunction-sections -fdata-sections %p/Inputs/2.c -o %t1.2.o
-RUN: %link %linkopts  %t1.1.o %t1.2.o -flto-options=codegen="-function-sections -data-sections" -T %p/Inputs/script.t -o %t2.out
+RUN: %link %linkopts  %t1.1.o %t1.2.o --flto-options=codegen="-function-sections -data-sections" -T %p/Inputs/script.t -o %t2.out
 RUN: %readelf -S -W %t2.out | %filecheck %s
 
 #CHECK-NOT: mysmallcommons1 PROGBITS

--- a/test/Hexagon/standalone/LTO/LTOCommonSymbolsGC/LTOCommonSymbolsGC.test
+++ b/test/Hexagon/standalone/LTO/LTOCommonSymbolsGC/LTOCommonSymbolsGC.test
@@ -4,5 +4,5 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c -flto -ffunction-sections -fdata-sections %p/Inputs/common.c -o %t1.1.o
-RUN: %link %linkopts --gc-sections %t1.1.o -flto-options=codegen="-function-sections -data-sections" -o %t2.out -e foo
+RUN: %link %linkopts --gc-sections %t1.1.o --flto-options=codegen="-function-sections -data-sections" -o %t2.out -e foo
 #END_TEST

--- a/test/Hexagon/standalone/LTO/LTOConstructors/ltoconstructors.test
+++ b/test/Hexagon/standalone/LTO/LTOConstructors/ltoconstructors.test
@@ -2,7 +2,7 @@
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
 RUN: %clang %clangopts -c %p/Inputs/2.c -flto -o %t1.2.o
 RUN: %clang %clangopts -c %p/Inputs/3.c  -o %t1.3.o
-RUN: %link -MapStyle txt %linkopts %t1.1.o %t1.2.o %t1.3.o  -T %p/Inputs/script.t -Map %t2.out.map --trace=lto -flto-options=codegen="-use-ctors"
+RUN: %link -MapStyle txt %linkopts %t1.1.o %t1.2.o %t1.3.o  -T %p/Inputs/script.t -Map %t2.out.map --trace=lto --flto-options=codegen="-use-ctors"
 RUN: %filecheck %s < %t2.out.map
 
 #CHECK: .ctors  {{[0-9xa-f]+}}    {{[0-9xa-f]+}}     {{[ -\(\)_A-Za-z0-9.~\\/:]+}}1.o

--- a/test/Hexagon/standalone/LTO/LTOForceDynamic/ltoforcedynamic.test
+++ b/test/Hexagon/standalone/LTO/LTOForceDynamic/ltoforcedynamic.test
@@ -1,4 +1,4 @@
 # Test that LTO sets the mode to static when --force-dynamic is used.
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -flto
-RUN: %link %linkopts  %t1.1.o --force-dynamic -flto-options=preserve-sym=foo -o %t2.out --trace=lto 2>&1 | %filecheck %s
+RUN: %link %linkopts  %t1.1.o --force-dynamic --flto-options=preserve-sym=foo -o %t2.out --trace=lto 2>&1 | %filecheck %s
 #CHECK: Note: LTO Set codemodel to Auto Detect

--- a/test/Hexagon/standalone/LTO/LTOGroups/ltogroups.test
+++ b/test/Hexagon/standalone/LTO/LTOGroups/ltogroups.test
@@ -7,7 +7,7 @@ RUN: %clang %clangopts -c  %p/Inputs/c.c -o %t4
 RUN: %ar cr %aropts %t5 %t2
 RUN: %ar cr %aropts %t6 %t3
 RUN: %ar cr %aropts %t7 %t4
-RUN: %link %linkopts -M  -flto-options=preserveall %t1 --start-group %t5 %t7 %t6 --end-group -o %t8
+RUN: %link %linkopts -M  --flto-options=preserveall %t1 --start-group %t5 %t7 %t6 --end-group -o %t8
 RUN: %readelf -s %t8 | %grep "foo" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "bar" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "baz" | %filecheck %s -check-prefix YES

--- a/test/Hexagon/standalone/LTO/LTOGroupsNoMerge/ltogroupsnomerge.test
+++ b/test/Hexagon/standalone/LTO/LTOGroupsNoMerge/ltogroupsnomerge.test
@@ -8,7 +8,7 @@ RUN: %clang %clangopts -c  %p/Inputs/crap.c -o %t1.crap.o
 RUN: %ar cr %t2.libb1.a %t1.b1.o
 RUN: %ar cr %aropts %t2.libb2.a %t1.b2.o
 RUN: %ar cr %aropts %t2.libc.a %t1.c.o
-RUN: %link %linkopts -flto-options=no-merge-modules  -M %t1.a.o --start-group %t2.libb1.a %t2.libb2.a %t2.libc.a %t1.crap.o --end-group --trace=lto -t 2>&1 | %filecheck %s
+RUN: %link %linkopts --flto-options=no-merge-modules  -M %t1.a.o --start-group %t2.libb1.a %t2.libb2.a %t2.libc.a %t1.crap.o --end-group --trace=lto -t 2>&1 | %filecheck %s
 
 #CHECK: {{[ -\(\)_A-Za-z0-9.\\/:]+}}crap
 

--- a/test/Hexagon/standalone/LTO/LTONoGroupArchives/ltonogrouparchives.test
+++ b/test/Hexagon/standalone/LTO/LTONoGroupArchives/ltonogrouparchives.test
@@ -7,7 +7,7 @@ RUN: %clang %clangopts -c  %p/Inputs/c.c -o %t4
 RUN: %ar cr %aropts %t5 %t2
 RUN: %ar cr %aropts %t6 %t3
 RUN: %ar cr %aropts %t7 %t4
-RUN: %link %linkopts -M -flto-options=preserveall %t1 %t5 %t7 %t6 -o %t8
+RUN: %link %linkopts -M --flto-options=preserveall %t1 %t5 %t7 %t6 -o %t8
 RUN: %readelf -s %t8 | %grep "foo" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "bar" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t8 | %grep "baz" | %filecheck %s -check-prefix YES

--- a/test/Hexagon/standalone/LTO/LTONoGroupObjs/ltonogroupobjs.test
+++ b/test/Hexagon/standalone/LTO/LTONoGroupObjs/ltonogroupobjs.test
@@ -3,7 +3,7 @@ RUN: %clang %clangopts -c  %p/Inputs/a.c -flto -o %t1
 RUN: %clang %clangopts -c  %p/Inputs/b1.c -o %t2
 RUN: %clang %clangopts -c  %p/Inputs/b2.c -o %t3
 RUN: %clang %clangopts -c  %p/Inputs/c.c -o %t4
-RUN: %link %linkopts -M -flto-options=preserveall %t1 %t2 %t4 %t3 -o %t5
+RUN: %link %linkopts -M --flto-options=preserveall %t1 %t2 %t4 %t3 -o %t5
 RUN: %readelf -s %t5 | %grep "foo" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t5 | %grep "bar" | %filecheck %s -check-prefix YES
 RUN: %readelf -s %t5 | %grep "baz" | %filecheck %s -check-prefix YES

--- a/test/Hexagon/standalone/LTO/LTOPartition/LTOPartitionWithUndef/ltopartitionwithundef.test
+++ b/test/Hexagon/standalone/LTO/LTOPartition/LTOPartitionWithUndef/ltopartitionwithundef.test
@@ -5,6 +5,6 @@ RUN: %clang %clangopts -c %p/Inputs/2.c -o %t1.2.o.bc
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o
 RUN: %clang %clangopts -c %p/Inputs/2.c -o %t1.2.o
 RUN: %clang %clangopts -c %p/Inputs/3.c -o %t1.3.o
-RUN: %link %linkopts -flto-options=lto-output-file=%t1.1.o,%t1.2.o %t1.1.o.bc %t1.2.o.bc %t1.3.o -o %t2.out --section-start .text=0xF0000000
+RUN: %link %linkopts --flto-options=lto-output-file=%t1.1.o,%t1.2.o %t1.1.o.bc %t1.2.o.bc %t1.3.o -o %t2.out --section-start .text=0xF0000000
 RUN: %readelf -s %t2.out | %filecheck %s
 #CHECK: f0000000    12 FUNC    GLOBAL DEFAULT    1 foo

--- a/test/Hexagon/standalone/LTO/LTOPartition/SimpleLTOPartition/ltopartition.disable
+++ b/test/Hexagon/standalone/LTO/LTOPartition/SimpleLTOPartition/ltopartition.disable
@@ -1,5 +1,5 @@
 # Module partitioning can currently only produce assembly files so it won't
-# work without -save-temps; however, after the recent re-externalization
+# work without --save-temps; however, after the recent re-externalization
 # changes, it is no longer working correctly anyway. So XFAIL it for now.
 #
 # This tests that partitioning with LTO works.
@@ -7,7 +7,7 @@ RUN: %clang -c %p/Inputs/main.c -ffunction-sections -fdata-sections -o %t1.main.
 RUN: %clang -c %p/Inputs/3.c -ffunction-sections -fdata-sections -o %t1.3.o
 RUN: %clang -c %p/Inputs/1.c -ffunction-sections -fdata-sections -o %t1.1.o -flto
 RUN: %clang -c %p/Inputs/2.c -ffunction-sections -fdata-sections -o %t1.2.o -flto
-RUN: %link -T %p/Inputs/script.t %t1.main.o %t1.1.o %t1.2.o %t1.3.o -flto-options=no-merge-modules -flto-options=codegen="-resolved-sections-conservatively=false -Os -split-lto-cg   -data-sections -function-sections" --gc-sections --print-gc-sections 2>&1 | %filecheck %s
-RUN: %link  %t1.main.o %t1.1.o %t1.2.o %t1.3.o -flto-options=no-merge-modules -flto-options=codegen="-resolved-sections-conservatively=false -Os -split-lto-cg   -data-sections -function-sections"  --gc-sections --print-gc-sections 2>&1 | %filecheck %s
+RUN: %link -T %p/Inputs/script.t %t1.main.o %t1.1.o %t1.2.o %t1.3.o --flto-options=no-merge-modules --flto-options=codegen="-resolved-sections-conservatively=false -Os -split-lto-cg   -data-sections -function-sections" --gc-sections --print-gc-sections 2>&1 | %filecheck %s
+RUN: %link  %t1.main.o %t1.1.o %t1.2.o %t1.3.o --flto-options=no-merge-modules --flto-options=codegen="-resolved-sections-conservatively=false -Os -split-lto-cg   -data-sections -function-sections"  --gc-sections --print-gc-sections 2>&1 | %filecheck %s
 #CHECK-NOT: foostr
 #CHECK-NOT: barstr

--- a/test/Hexagon/standalone/LTO/LTORaiseUndef/LTORaiseUndef.test
+++ b/test/Hexagon/standalone/LTO/LTORaiseUndef/LTORaiseUndef.test
@@ -8,6 +8,6 @@
 RUN: %clang %clangopts -c %p/Inputs/lto.c -o %t1.lto.o -flto
 RUN: %clang %clangopts -c %p/Inputs/main.c -o %t1.main.o
 # Replace asm files.
-RUN: %not %link %emulation %linkopts  %t1.lto.o %t1.main.o -flto-options=lto-asm-file=%p/Inputs/lto.s -o %t2.out.asmoverride 2>&1 | %filecheck %s -check-prefix=UNDEF
+RUN: %not %link %emulation %linkopts  %t1.lto.o %t1.main.o --flto-options=lto-asm-file=%p/Inputs/lto.s -o %t2.out.asmoverride 2>&1 | %filecheck %s -check-prefix=UNDEF
 #UNDEF: function main: undefined reference to `bar'
 #END_TEST

--- a/test/Hexagon/standalone/LTO/LTOReuseFiles/ltoreusefiles.test
+++ b/test/Hexagon/standalone/LTO/LTOReuseFiles/ltoreusefiles.test
@@ -6,13 +6,13 @@ RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o -flto
 RUN: %clang %clangopts -c %p/Inputs/lto1.s -o %t1.lto1.o
 RUN: %clang %clangopts -c %p/Inputs/lto2.s -o %t1.lto2.o
 # Replace asm files.
-RUN: %link %emulation %linkopts -flto-options=preserve-sym=foo %t1.o --trace=lto -flto-options=lto-asm-file=%p/Inputs/lto1.s,%p/Inputs/lto2.s -o %t2.out.asmoverride 2>&1 | %filecheck %s -check-prefix=ASMOVERRIDE
+RUN: %link %emulation %linkopts --flto-options=preserve-sym=foo %t1.o --trace=lto --flto-options=lto-asm-file=%p/Inputs/lto1.s,%p/Inputs/lto2.s -o %t2.out.asmoverride 2>&1 | %filecheck %s -check-prefix=ASMOVERRIDE
 RUN: %readelf -s -W %t2.out.asmoverride | %filecheck %s -check-prefix=ASMOVERRIDESYMS
 # Reuse output files only.
-RUN: %link %emulation %linkopts -flto-options=preserve-sym=foo %t1.o --trace=lto -flto-options=lto-output-file=%t1.lto1.o,%t1.lto2.o -o %t2.out.outputoverride 2>&1 | %filecheck %s -check-prefix=OUTPUTOVERRIDE
+RUN: %link %emulation %linkopts --flto-options=preserve-sym=foo %t1.o --trace=lto --flto-options=lto-output-file=%t1.lto1.o,%t1.lto2.o -o %t2.out.outputoverride 2>&1 | %filecheck %s -check-prefix=OUTPUTOVERRIDE
 RUN: %readelf -s -W %t2.out.outputoverride | %filecheck %s -check-prefix=OUTPUTOVERRIDESYMS
 # Reuse output files and asm files.
-RUN: %link %emulation %linkopts -flto-options=preserve-sym=foo %t1.o --trace=lto -flto-options=lto-asm-file=%p/Inputs/lto1.s,%p/Inputs/lto2.s -flto-options=lto-output-file=%t1.lto1.o,%t1.lto2.o -o %t2.out.asmoutputoverride 2>&1 | %filecheck %s -check-prefix=ASMOUTPUTOVERRIDE
+RUN: %link %emulation %linkopts --flto-options=preserve-sym=foo %t1.o --trace=lto --flto-options=lto-asm-file=%p/Inputs/lto1.s,%p/Inputs/lto2.s --flto-options=lto-output-file=%t1.lto1.o,%t1.lto2.o -o %t2.out.asmoutputoverride 2>&1 | %filecheck %s -check-prefix=ASMOUTPUTOVERRIDE
 RUN: %readelf -s -W %t2.out.asmoutputoverride | %filecheck %s -check-prefix=ASMOUTPUTOVERRIDESYMS
 
 #ASMOVERRIDE: Using LTO assembly file : {{[ -\(\)_A-Za-z0-9.\\/:]+}}lto1.s

--- a/test/Hexagon/standalone/LTO/LTOSortByOrdinal/ltosortbyordinal.test
+++ b/test/Hexagon/standalone/LTO/LTOSortByOrdinal/ltosortbyordinal.test
@@ -3,7 +3,7 @@ RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -ffunction-sections
 RUN: %clang %clangopts -c %p/Inputs/2.c -o %t1.2.o -flto -ffunction-sections
 RUN: %clang %clangopts -c %p/Inputs/3.c -o %t1.3.o -flto -ffunction-sections
 RUN: %clang %clangopts -c %p/Inputs/4.c -o %t1.4.o -flto -ffunction-sections
-RUN: %link -o %t1.out.1 %linkopts %t1.1.o %t1.2.o %t1.3.o %t1.4.o -flto-options=codegen="-function-sections -data-sections"  -o %t2.out.sort -T %p/Inputs/script.t --save-temps
+RUN: %link -o %t1.out.1 %linkopts %t1.1.o %t1.2.o %t1.3.o %t1.4.o --flto-options=codegen="-function-sections -data-sections"  -o %t2.out.sort -T %p/Inputs/script.t --save-temps
 RUN: %nm -n %t2.out.sort | %filecheck %s -check-prefix=SORT
 
 #SORT: main

--- a/test/Hexagon/standalone/LTO/Map/LTO/Cref/cref.test
+++ b/test/Hexagon/standalone/LTO/Map/LTO/Cref/cref.test
@@ -3,7 +3,7 @@ RUN: %clang %clangopts -c %p/Inputs/main.c -o %t1.main.o
 RUN: %clang %clangopts -c %p/Inputs/foo.c -o %t1.foo.o -flto
 RUN: %clang %clangopts -c %p/Inputs/bar.c -o %t1.bar.o -flto
 RUN: %ar cr %t1.library.a %t1.foo.o %t1.bar.o
-RUN: %link %linkopts --cref -flto-options=codegen="-Os -relocation-model=static -function-sections -data-sections" %t1.main.o %t1.library.a -o %t2.out 2>&1 | %filecheck %s
+RUN: %link %linkopts --cref --flto-options=codegen="-Os -relocation-model=static -function-sections -data-sections" %t1.main.o %t1.library.a -o %t2.out 2>&1 | %filecheck %s
 
 #CHECK: Cross Reference Table - Pre LTO phase
 #CHECK: Symbol                                                File

--- a/test/Hexagon/standalone/LTO/Map/LTO/Map/mapfileltoarchive.test
+++ b/test/Hexagon/standalone/LTO/Map/LTO/Map/mapfileltoarchive.test
@@ -3,8 +3,8 @@ RUN: %clang %clangopts -fcommon -c %p/Inputs/main.c -o %t1.main.o
 RUN: %clang %clangopts -fcommon -c %p/Inputs/foo.c -o %t1.foo.o -flto -ffunction-sections -fdata-sections
 RUN: %clang %clangopts -fcommon -c %p/Inputs/bar.c -o %t1.bar.o -flto -ffunction-sections -fdata-sections
 RUN: %ar cr %t1.library.a %t1.foo.o %t1.bar.o
-RUN: %link %linkopts -flto-options=codegen="-Os -relocation-model=static -function-sections -data-sections" %t1.main.o %t1.library.a -M -o %t2.out 2>&1 | %filecheck %s
-RUN: %link %linkopts -flto-options=codegen="-Os -relocation-model=static -function-sections -data-sections" %t1.main.o %t1.library.a -M -MapStyle=yaml -o %t2.out 2>&1 | %filecheck %s --check-prefix=YAML
+RUN: %link %linkopts --flto-options=codegen="-Os -relocation-model=static -function-sections -data-sections" %t1.main.o %t1.library.a -M -o %t2.out 2>&1 | %filecheck %s
+RUN: %link %linkopts --flto-options=codegen="-Os -relocation-model=static -function-sections -data-sections" %t1.main.o %t1.library.a -M -MapStyle=yaml -o %t2.out 2>&1 | %filecheck %s --check-prefix=YAML
 
 
 #CHECK: =======================================

--- a/test/Hexagon/standalone/LTO/PreserveFile/preservefile.test
+++ b/test/Hexagon/standalone/LTO/PreserveFile/preservefile.test
@@ -1,7 +1,7 @@
 # Check if LTO works for no groups and only archives and bitcodes
 RUN: %clang %clangopts -c  %p/Inputs/a.c -flto -o %t1
 RUN: %clang %clangopts -c  %p/Inputs/b.c -flto -o %t2
-RUN: %link %linkopts -flto-options=preserve-file=%p/Inputs/preserve1 %t1 %t2 -o %t3
+RUN: %link %linkopts --flto-options=preserve-file=%p/Inputs/preserve1 %t1 %t2 -o %t3
 RUN: %readelf -s %t3 | %filecheck %s
 
 #CHECK: boo

--- a/test/Hexagon/standalone/LTO/PreserveFileDOS/PreserveFileDOS.test
+++ b/test/Hexagon/standalone/LTO/PreserveFileDOS/PreserveFileDOS.test
@@ -5,7 +5,7 @@
 #START_TEST
 RUN: %clang %clangopts -c  %p/Inputs/a.c -flto -o %t1
 RUN: %clang %clangopts -c  %p/Inputs/b.c -flto -o %t2
-RUN: %link %linkopts -flto-options=preserve-file=%p/Inputs/preserve1 %t1 %t2 -o %t3
+RUN: %link %linkopts --flto-options=preserve-file=%p/Inputs/preserve1 %t1 %t2 -o %t3
 RUN: %readelf -s %t3 | %filecheck %s
 #CHECK: boo
 #END_TEST

--- a/test/Hexagon/standalone/LTO/PreserveSym/preservesym.test
+++ b/test/Hexagon/standalone/LTO/PreserveSym/preservesym.test
@@ -7,7 +7,7 @@ RUN: %clang %clangopts -c  %p/Inputs/c.c -o %t4
 RUN: %ar cr %aropts %t5 %t2
 RUN: %ar cr %aropts %t6 %t3
 RUN: %ar cr %aropts %t7 %t4
-RUN: %link %linkopts -M -flto-options=preserve-sym=foo %t1 %t5 %t7 %t6 -o %t8
+RUN: %link %linkopts -M --flto-options=preserve-sym=foo %t1 %t5 %t7 %t6 -o %t8
 RUN: %readelf -s %t8 | %filecheck %s
 
 #CHECK: foo

--- a/test/Hexagon/standalone/LTO/Verbose/verbose.test
+++ b/test/Hexagon/standalone/LTO/Verbose/verbose.test
@@ -1,7 +1,7 @@
 # Check if LTO works for no groups and only archives and bitcodes
 RUN: %clang %clangopts -c  %p/Inputs/a.c -flto -o %t1
 RUN: %clang %clangopts -c  %p/Inputs/b.c -flto -o %t2
-RUN: %link %linkopts --save-temps -M -flto-options verbose %t1 %t2 -o %t3 2>&1\
+RUN: %link %linkopts --save-temps -M --flto-options verbose %t1 %t2 -o %t3 2>&1\
 RUN:  | %filecheck %s -check-prefix YES
 
 YES: Note: Beginning LTO Phase 1

--- a/test/Hexagon/standalone/Map/Expressions/expression.test
+++ b/test/Hexagon/standalone/Map/Expressions/expression.test
@@ -1,7 +1,7 @@
 # Test that shows that Map file displays information in the right way.
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o
 RUN: %link %linkopts %t1.o -T %p/Inputs/script.t -o %t2.out -M 2>&1 | %filecheck %s
-RUN: %link %linkopts %t1.o -T %p/Inputs/script.t -o %t2.out -MapDetail only-layout -M 2>&1
+RUN: %link %linkopts %t1.o -T %p/Inputs/script.t -o %t2.out --MapDetail only-layout -M 2>&1
 
 #CHECK: 	.({{[0-9a-fx]+}}) = .({{[0-9a-fx]+}}) + 0xa;
 #CHECK: *(.text.foo)

--- a/test/Hexagon/standalone/Map/WholeArchive/mapfilewholearchive.test
+++ b/test/Hexagon/standalone/Map/WholeArchive/mapfilewholearchive.test
@@ -10,9 +10,9 @@ RUN: %link %linkopts %t1.main.o --whole-archive %t1.library.a -M -o %t2.out 2>&1
 
 #CHECK: Archive member included because of file (symbol)
 #CHECK: {{[ -\(\)_A-Za-z0-9.\\/:]+}}foo.o
-#CHECK: 		-whole-archive
+#CHECK: 		--whole-archive
 #CHECK: {{[ -\(\)_A-Za-z0-9.\\/:]+}}bar.o
-#CHECK: 		-whole-archive
+#CHECK: 		--whole-archive
 #CHECK: Common symbol	size	file
 #CHECK: common_array	0x50	{{[ -\(\)_A-Za-z0-9.\\/:]+}}main.o
 #CHECK: Linker Script and memory map

--- a/test/Hexagon/standalone/OrphanSectionDiagnostic/OrphanInternalSectionWarn.test
+++ b/test/Hexagon/standalone/OrphanSectionDiagnostic/OrphanInternalSectionWarn.test
@@ -5,7 +5,7 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -ffunction-sections
-RUN: %link %linkopts -orphan-handling=warn -emit-timing-stats-in-output %t1.1.o -T %p/Inputs/script.t -o %t2.out 2>&1 | %filecheck %s
+RUN: %link %linkopts --orphan-handling=warn --emit-timing-stats-in-output %t1.1.o -T %p/Inputs/script.t -o %t2.out 2>&1 | %filecheck %s
 
 #CHECK:Warning: no linker script rule for section .text.bar
 #CHECK:Warning: no linker script rule for section .note.qc.timing

--- a/test/Hexagon/standalone/OrphanSectionDiagnostic/OrphanSectionPartialLinking.test
+++ b/test/Hexagon/standalone/OrphanSectionDiagnostic/OrphanSectionPartialLinking.test
@@ -6,7 +6,7 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.1.o -ffunction-sections
-RUN: %link %linkopts -orphan-handling=warn -r %t1.1.o -o %t2.r.o.script -T %p/Inputs/script.t 2>&1 | %filecheck %s
+RUN: %link %linkopts --orphan-handling=warn -r %t1.1.o -o %t2.r.o.script -T %p/Inputs/script.t 2>&1 | %filecheck %s
 
 #CHECK:Warning: no linker script rule for section .text.bar
 #CHECK:Warning: no linker script rule for section .rela.foobar

--- a/test/Hexagon/standalone/TraceSection/TraceSectionsLTO.test
+++ b/test/Hexagon/standalone/TraceSection/TraceSectionsLTO.test
@@ -4,5 +4,5 @@
 #--------------------------------------------------------------------------------------
 #END_COMMENT
 RUN: %clang %clangopts -ffunction-sections -c %p/Inputs/1.c -emit-llvm -o %t1.bc
-RUN: %link %linkopts -o %t.out %t1.bc -e foo -flto-options="codegen=-function-sections" --trace=section=.text.foo 2>&1 | %filecheck %s
+RUN: %link %linkopts -o %t.out %t1.bc -e foo --flto-options="codegen=-function-sections" --trace=section=.text.foo 2>&1 | %filecheck %s
 CHECK: Note: Input Section : .text.foo InputFile :

--- a/test/Hexagon/standalone/TrampolinesCopyWithRelocs/TrampolinesCopyWithRelocs.test
+++ b/test/Hexagon/standalone/TrampolinesCopyWithRelocs/TrampolinesCopyWithRelocs.test
@@ -8,10 +8,10 @@
 RUN: %clang %clangopts -c %p/Inputs/trampoline.s -o %t1.o
 RUN: %clang %clangopts -c %p/Inputs/myfn.s -o %t2.o
 RUN: %link %linkopts %t1.o %t2.o -o %t.out.1  --section-start .boo=0x80000000  \
-RUN: -copy-farcalls-from-file=%p/Inputs/dup --trace=trampolines 2>&1 | %filecheck %s
+RUN: --copy-farcalls-from-file=%p/Inputs/dup --trace=trampolines 2>&1 | %filecheck %s
 # Use search path to find file dup
 RUN: %link %linkopts %t1.o %t2.o -o %t.out.2 -L %p/Inputs/ --section-start .boo=0x80000000 \
-RUN: -copy-farcalls-from-file dup --trace=trampolines 2>&1 | %filecheck %s
+RUN: --copy-farcalls-from-file dup --trace=trampolines 2>&1 | %filecheck %s
 #CHECK: Unable to clone fragment for symbol myfn from file
 #CHECK: Creating Stub trampoline_for_myfn_from_.text.main_{{[0-9]+}}
 #CHECK: Reusing Stub trampoline_for_myfn_from_.text.main_{{[0-9]+}}

--- a/test/Hexagon/standalone/commonsInMap/commonsInMap.test
+++ b/test/Hexagon/standalone/commonsInMap/commonsInMap.test
@@ -17,7 +17,7 @@ RUN: %link %linkopts -o %t1.1.r.elf %t1.o -r -d -M 2>&1 | %filecheck %s --check-
 
 # Test for common symbols with LTO
 RUN: %clang %clangopts -fcommon -o %t1.1.lto.o %p/Inputs/1.c -c -flto -ffunction-sections -fdata-sections
-RUN: %link %linkopts -o %t1.1.lto.elf %t1.1.lto.o -flto-options=codegen="-function-sections -data-sections" -T %p/Inputs/1.linker.script -M 2>&1 | %filecheck %s --check-prefix=COMMON_LTO
+RUN: %link %linkopts -o %t1.1.lto.elf %t1.1.lto.o --flto-options=codegen="-function-sections -data-sections" -T %p/Inputs/1.linker.script -M 2>&1 | %filecheck %s --check-prefix=COMMON_LTO
 
 RUN: %clang %clangopts -fcommon -o %t1.2.o %p/Inputs/2.c -c -fPIC -ffunction-sections -fdata-sections
 RUN: %link %linkopts -o %t1.lib2.so %t1.2.o -shared -M 2>&1 | %filecheck %s --check-prefix=COMMON_SHARED_LIB

--- a/test/Hexagon/standalone/linkerscript/OrphanSections/orphansections.test
+++ b/test/Hexagon/standalone/linkerscript/OrphanSections/orphansections.test
@@ -1,7 +1,7 @@
 # This tests that orphan sections are placed properly and virtual addresses
 # assigned.
 RUN: %clang %clangopts -c   %clangg0opts %p/Inputs/1.c -o %t1.o
-RUN: %link %linkopts -orphan-handling=warn %t1.o -T %p/Inputs/script.t -o %t2.out 2>&1 | %filecheck %s -check-prefix=ORPHAN
+RUN: %link %linkopts --orphan-handling=warn %t1.o -T %p/Inputs/script.t -o %t2.out 2>&1 | %filecheck %s -check-prefix=ORPHAN
 RUN: %readelf -h -l -S %t2.out | %filecheck %s
 
 #ORPHAN: no linker script rule for section .text.bar

--- a/test/Hexagon/standalone/trampolinesCopy/copy-instead-of-trampolines.test
+++ b/test/Hexagon/standalone/trampolinesCopy/copy-instead-of-trampolines.test
@@ -2,7 +2,7 @@
 # reuse them.
 RUN: %clang %clangopts -c %p/Inputs/trampoline.s -o %t1.o
 RUN: %clang %clangopts -c %p/Inputs/myfn.s -o %t2.o
-RUN: %link %linkopts %t1.o %t2.o -o %t.out  --section-start .boo=0x80000000 -copy-farcalls-from-file=%p/Inputs/dup --trace=trampolines 2>&1 | %filecheck %s -check-prefix=CLONES
+RUN: %link %linkopts %t1.o %t2.o -o %t.out  --section-start .boo=0x80000000 --copy-farcalls-from-file=%p/Inputs/dup --trace=trampolines 2>&1 | %filecheck %s -check-prefix=CLONES
 RUN: %readelf -s -W %t.out | %filecheck %s -check-prefix=CLONESYMS
 
 #CLONES: Creating Stub clone_1_for_myfn

--- a/test/RISCV/standalone/JustSymbols/JustSymbolsOptionsForSharedObjectFiles.test
+++ b/test/RISCV/standalone/JustSymbols/JustSymbolsOptionsForSharedObjectFiles.test
@@ -7,7 +7,7 @@ RUN: %clang %clangopts %p/Inputs/1.c -o %t1.1.o -c -ffunction-sections -fdata-se
 RUN: %clang %clangopts %p/Inputs/2.c -o %t1.2.o -c -ffunction-sections -fdata-sections
 RUN: %clang %clangopts %p/Inputs/3.c -o %t1.3.o -c -ffunction-sections -fdata-sections
 RUN: %link %linkopts -shared %t1.3.o -o %t3.so
-RUN: %link -dynamic -MapStyle txt %linkopts %t1.1.o %t1.2.o --just-symbols=%t3.so -T %p/Inputs/script.t -o %t.out.sharedlibrary -Map %t.map --trace=symbol=bar --verbose 2>&1 | %filecheck %s
+RUN: %link --dynamic -MapStyle txt %linkopts %t1.1.o %t1.2.o --just-symbols=%t3.so -T %p/Inputs/script.t -o %t.out.sharedlibrary -Map %t.map --trace=symbol=bar --verbose 2>&1 | %filecheck %s
 RUN: %filecheck %s --check-prefix=MAPCHECK < %t.map
 RUN: %readelf -s %t.out.sharedlibrary 2>&1 | %filecheck %s --check-prefix=ELFCHECK
 #CHECK-COUNT-1: Using just symbols for input

--- a/test/RISCV/standalone/JustSymbols/MultipleJustSymbolsUsageForSharedObject.test
+++ b/test/RISCV/standalone/JustSymbols/MultipleJustSymbolsUsageForSharedObject.test
@@ -9,7 +9,7 @@ RUN: %clang %clangopts %p/Inputs/3.c -o %t1.3.o -c -ffunction-sections
 RUN: %clang %clangopts %p/Inputs/4.c -o %t1.4.o -c -ffunction-sections
 RUN: %link %linkopts -shared %t1.3.o -T %p/Inputs/image.t -o %t3.so
 RUN: %link %linkopts -shared %t1.4.o -T %p/Inputs/image.t -o %t4.so
-RUN: %link -MapStyle txt %linkopts -dynamic %t1.1.o %t1.2.o --just-symbols=%t3.so --just-symbols=%t4.so -T %p/Inputs/script.t -o %t.out.sharedlibrary -Map %t.map --trace=symbol=baz --verbose 2>&1 | %filecheck %s
+RUN: %link -MapStyle txt %linkopts --dynamic %t1.1.o %t1.2.o --just-symbols=%t3.so --just-symbols=%t4.so -T %p/Inputs/script.t -o %t.out.sharedlibrary -Map %t.map --trace=symbol=baz --verbose 2>&1 | %filecheck %s
 RUN: %readelf -s %t.out.sharedlibrary 2>&1 | %filecheck %s --check-prefix=ELFCHECK
 RUN: %filecheck %s --check-prefix=MAPCHECK < %t.map
 #CHECK-COUNT-2: Using just symbols for input

--- a/test/RISCV/standalone/JustSymbols/UseSymbolFromLinkerScriptForSharedObject.test
+++ b/test/RISCV/standalone/JustSymbols/UseSymbolFromLinkerScriptForSharedObject.test
@@ -8,7 +8,7 @@ RUN: %clang %clangopts %p/Inputs/1.c -o %t1.1.o -c -ffunction-sections -fdata-se
 RUN: %clang %clangopts %p/Inputs/2.c -o %t1.2.o -c -ffunction-sections -fdata-sections
 RUN: %clang %clangopts %p/Inputs/3.c -o %t1.3.o -c -ffunction-sections -fdata-sections
 RUN: %link %linkopts -shared %t1.3.o -T %p/Inputs/image.t -o %t3.so
-RUN: %link -MapStyle txt %linkopts -dynamic %t1.1.o %t1.2.o --just-symbols=%t3.so -T %p/Inputs/script.t -o %t.out.sharedlibrary -Map %t.map --trace=symbol=a1 2>&1 | %filecheck %s
+RUN: %link -MapStyle txt %linkopts --dynamic %t1.1.o %t1.2.o --just-symbols=%t3.so -T %p/Inputs/script.t -o %t.out.sharedlibrary -Map %t.map --trace=symbol=a1 2>&1 | %filecheck %s
 RUN: %readelf -s %t.out.sharedlibrary 2>&1 | %filecheck %s --check-prefix=ELFCHECK
 RUN: %filecheck %s --check-prefix=MAPCHECK < %t.map
 #CHECK: Resolving symbol 'a1' from provide style sym def file '{{.*}}/Inputs/script.t'

--- a/test/RISCV/standalone/options/shared/shared.test
+++ b/test/RISCV/standalone/options/shared/shared.test
@@ -14,17 +14,12 @@ RUN: %not %link -o %t1.out.1 %linkopts -Bsymbolic-functions 2>&1 | %filecheck %s
 RUN: %not %link -o %t1.out.1 %linkopts -Bsymbolic 2>&1 | %filecheck %s
 RUN: %not %link -o %t1.out.1 %linkopts -call_shared 2>&1 | %filecheck %s
 RUN: %not %link -o %t1.out.1 %linkopts --copy-dt-needed-entries null 2>&1 | %filecheck %s
-RUN: %not %link -o %t1.out.1 %linkopts -dynamic-linker=null 2>&1 | %filecheck %s
 RUN: %not %link -o %t1.out.1 %linkopts --dynamic-linker=null 2>&1 | %filecheck %s
-RUN: %not %link -o %t1.out.1 %linkopts -dynamic-linker null 2>&1 | %filecheck %s
 RUN: %not %link -o %t1.out.1 %linkopts --dynamic-linker null 2>&1 | %filecheck %s
-RUN: %not %link -o %t1.out.1 %linkopts -dynamic-list=null 2>&1 | %filecheck %s
 RUN: %not %link -o %t1.out.1 %linkopts --dynamic-list=null 2>&1 | %filecheck %s
-RUN: %not %link -o %t1.out.1 %linkopts -dynamic-list null 2>&1 | %filecheck %s
 RUN: %not %link -o %t1.out.1 %linkopts --dynamic-list null 2>&1 | %filecheck %s
-RUN: %not %link -o %t1.out.1 %linkopts -dynamic 2>&1 | %filecheck %s
+RUN: %not %link -o %t1.out.1 %linkopts --dynamic 2>&1 | %filecheck %s
 RUN: %not %link -o %t1.out.1 %linkopts -dy 2>&1 | %filecheck %s
-RUN: %not %link -o %t1.out.1 %linkopts -force-dynamic 2>&1 | %filecheck %s
 RUN: %not %link -o %t1.out.1 %linkopts --force-dynamic 2>&1 | %filecheck %s
 RUN: %not %link -o %t1.out.1 %linkopts -g 2>&1 | %filecheck %s
 RUN: %not %link -o %t1.out.1 %linkopts --hash-size=0 2>&1 | %filecheck %s
@@ -47,9 +42,9 @@ RUN: %not %link -o %t1.out.1 %linkopts --warn-shared-textrel 2>&1 | %filecheck %
 
 RUN: %link -o %t1.out.2 %linkopts --disable-new-dtags %t1.o 2>&1 | %filecheck %s -allow-empty
 RUN: %link -o %t1.out.3 %linkopts --enable-new-dtags %t1.o 2>&1 | %filecheck %s -allow-empty
-RUN: %link -o %t1.out.4 %linkopts -hash-style=gnu %t1.o 2>&1 | %filecheck %s -allow-empty
+RUN: %link -o %t1.out.4 %linkopts --hash-style=gnu %t1.o 2>&1 | %filecheck %s -allow-empty
 RUN: %link -o %t1.out.5 %linkopts --hash-style=gnu %t1.o 2>&1 | %filecheck %s -allow-empty
-RUN: %link -o %t1.out.6 %linkopts -hash-style gnu %t1.o 2>&1 | %filecheck %s -allow-empty
+RUN: %link -o %t1.out.6 %linkopts --hash-style gnu %t1.o 2>&1 | %filecheck %s -allow-empty
 RUN: %link -o %t1.out.7 %linkopts --hash-style gnu %t1.o 2>&1 | %filecheck %s -allow-empty
 RUN: %link -o %t1.out.8 %linkopts --hash-style gnu %t1.o \
 RUN: -static 2>&1 | %filecheck %s -allow-empty -check-prefix=STATIC

--- a/test/lld/ELF/opt-remarks.ll
+++ b/test/lld/ELF/opt-remarks.ll
@@ -2,7 +2,7 @@
 ; RUN: %opt --mtriple=%triple --data-layout=%datalayout %s -o %t.o
 ; RUN: %rm -f %t.yaml %t1.yaml %t.hot.yaml %t.t300.yaml %t.t301.yaml
 
-; RUN: %link %linkopts --opt-remarks-filename %t.yaml %t.o -o %t -shared -save-temps
+; RUN: %link %linkopts --opt-remarks-filename %t.yaml %t.o -o %t -shared --save-temps
 ; RUN: %llvm-dis %t.llvm-lto.0.4.opt.bc -o - | FileCheck %s
 ; RUN: %link %linkopts --opt-remarks-with-hotness --opt-remarks-filename %t.hot.yaml \
 ; RUN:   %t.o -o %t -shared

--- a/test/lld/ELF/thinlto.test
+++ b/test/lld/ELF/thinlto.test
@@ -7,60 +7,60 @@ RUN: %clang %clangopts -c -flto=thin %p/Inputs/b.c -o %t.b.o
 
 ## First force single-threaded mode
 RUN: %rm -f %t.out*
-RUN: %link %linkopts -save-temps --thinlto-jobs=1 -shared %t.a.o %t.b.o -o %t.out 2>&1 | %filecheck %s --check-prefix=CHECK-ONE
+RUN: %link %linkopts --save-temps --thinlto-jobs=1 -shared %t.a.o %t.b.o -o %t.out 2>&1 | %filecheck %s --check-prefix=CHECK-ONE
 CHECK-ONE: Note: Using 1 threads for LTO code generation
 RUN: %nm %t.out.llvm-lto.1.o | %filecheck %s --check-prefix=NM1
 RUN: %nm %t.out.llvm-lto.2.o | %filecheck %s --check-prefix=NM2
 
 ## Next force multi-threaded mode
 RUN: %rm -f %t.out*
-RUN: %link %linkopts -save-temps --thinlto-jobs=2 -shared %t.a.o %t.b.o -o %t.out 2>&1 | %filecheck %s --check-prefix=CHECK-TWO
+RUN: %link %linkopts --save-temps --thinlto-jobs=2 -shared %t.a.o %t.b.o -o %t.out 2>&1 | %filecheck %s --check-prefix=CHECK-TWO
 CHECK-TWO: Note: Using 2 threads for LTO code generation
 RUN: %nm %t.out.llvm-lto.1.o | %filecheck %s --check-prefix=NM1
 RUN: %nm %t.out.llvm-lto.2.o | %filecheck %s --check-prefix=NM2
 
 ## --plugin-opt=jobs= is an alias.
 RUN: %rm -f %t.out*
-RUN: %link %linkopts -save-temps --plugin-opt=jobs=2 -shared %t.a.o %t.b.o -o %t.out 2>&1 | %filecheck %s --check-prefix=CHECK-TWO
+RUN: %link %linkopts --save-temps --plugin-opt=jobs=2 -shared %t.a.o %t.b.o -o %t.out 2>&1 | %filecheck %s --check-prefix=CHECK-TWO
 RUN: %nm %t.out.llvm-lto.1.o | %filecheck %s --check-prefix=NM1
 RUN: %nm %t.out.llvm-lto.2.o | %filecheck %s --check-prefix=NM2
 
 ## --thinlto-jobs= defaults to --threads=.
 RUN: %rm -f %t.out*
-RUN: %link %linkopts -save-temps --thread-count=2 -shared %t.a.o %t.b.o -o %t.out 2>&1 | %filecheck %s --check-prefix=CHECK-TWO
+RUN: %link %linkopts --save-temps --thread-count=2 -shared %t.a.o %t.b.o -o %t.out 2>&1 | %filecheck %s --check-prefix=CHECK-TWO
 RUN: %nm %t.out.llvm-lto.1.o | %filecheck %s --check-prefix=NM1
 RUN: %nm %t.out.llvm-lto.2.o | %filecheck %s --check-prefix=NM2
 
 ## --thinlto-jobs= overrides --threads=.
 RUN: %rm -f %t.out*
-RUN: %link %linkopts -save-temps --thread-count=1 --plugin-opt=jobs=2 -shared %t.a.o %t.b.o -o %t.out 2>&1 | %filecheck %s --check-prefix=CHECK-TWO
+RUN: %link %linkopts --save-temps --thread-count=1 --plugin-opt=jobs=2 -shared %t.a.o %t.b.o -o %t.out 2>&1 | %filecheck %s --check-prefix=CHECK-TWO
 RUN: %nm %t.out.llvm-lto.1.o | %filecheck %s --check-prefix=NM1
 RUN: %nm %t.out.llvm-lto.2.o | %filecheck %s --check-prefix=NM2
 
 # Test with all threads, on all cores, on all CPU sockets
 RUN: %rm -f %t.out*
-RUN: %link %linkopts -save-temps --thinlto-jobs=all -shared %t.a.o %t.b.o -o %t.out 2>&1 | %filecheck %s --check-prefix=CHECK-ALL
+RUN: %link %linkopts --save-temps --thinlto-jobs=all -shared %t.a.o %t.b.o -o %t.out 2>&1 | %filecheck %s --check-prefix=CHECK-ALL
 CHECK-ALL: Note: Using all threads for LTO code generation
 RUN: %nm %t.out.llvm-lto.1.o | %filecheck %s --check-prefix=NM1
 RUN: %nm %t.out.llvm-lto.2.o | %filecheck %s --check-prefix=NM2
 
 ## Test with many more threads than the system has
 RUN: %rm -f %t.out*
-RUN: %link %linkopts -save-temps --thinlto-jobs=100 -shared %t.a.o %t.b.o -o %t.out 2>&1 | %filecheck %s --check-prefix=CHECK-HUNDRED
+RUN: %link %linkopts --save-temps --thinlto-jobs=100 -shared %t.a.o %t.b.o -o %t.out 2>&1 | %filecheck %s --check-prefix=CHECK-HUNDRED
 CHECK-HUNDRED: Note: Using 100 threads for LTO code generation
 RUN: %nm %t.out.llvm-lto.1.o | %filecheck %s --check-prefix=NM1
 RUN: %nm %t.out.llvm-lto.2.o | %filecheck %s --check-prefix=NM2
 
 ## Test with a bad value
 RUN: %rm -f %t.out*
-RUN: %not %link %linkopts -save-temps --thinlto-jobs=foo -shared %t.a.o %t.b.o -o %t.out 2>&1 | %filecheck %s --check-prefix=BAD-JOBS
+RUN: %not %link %linkopts --save-temps --thinlto-jobs=foo -shared %t.a.o %t.b.o -o %t.out 2>&1 | %filecheck %s --check-prefix=BAD-JOBS
 BAD-JOBS: Error: Invalid value for --thinlto-jobs=: foo
 
-## Check that -save-temps is usable with thin archives
+## Check that --save-temps is usable with thin archives
 RUN: mkdir -p %t.dir
 RUN: cp %t.b.o %t.dir/t.o
 RUN: %ar rcsT %t.a %t.dir/t.o
-RUN: %link %linkopts -save-temps %t.a.o %t.a -o %t.thin.out 2>&1 | %filecheck %s --check-prefix=CHECK-THIN
+RUN: %link %linkopts --save-temps %t.a.o %t.a -o %t.thin.out 2>&1 | %filecheck %s --check-prefix=CHECK-THIN
 CHECK-THIN: Note: LTO generated native object: {{.+}}.thin.out.llvm-lto.{{.*}}.o
 
 NM1: T f

--- a/test/x86_64/linux/DynamicDataCall/DynamicDataCall.test
+++ b/test/x86_64/linux/DynamicDataCall/DynamicDataCall.test
@@ -12,7 +12,7 @@
 RUN: %clang %clangopts -c %p/Inputs/1.c -fPIC -o %t.1.o
 RUN: %clang %clangopts -c %p/Inputs/2.c -o %t.2.o
 RUN: %link %linkopts -shared -o %t.lib2.so %t.2.o
-RUN: %link %linkopts  -dynamic-linker /lib64/ld-linux-x86-64.so.2 -o %t.out %t.1.o %t.lib2.so
+RUN: %link %linkopts  --dynamic-linker /lib64/ld-linux-x86-64.so.2 -o %t.out %t.1.o %t.lib2.so
 RUN: %run_and_print_exit %t.out | %filecheck %s --check-prefix=EXITCODE
 RUN: %readelf -Sdr %t.out > %t.check.txt
 RUN: %filecheck %s < %t.check.txt

--- a/test/x86_64/linux/DynamicRelocsForAbs64/DynamicRelocsforAbs64.test
+++ b/test/x86_64/linux/DynamicRelocsForAbs64/DynamicRelocsforAbs64.test
@@ -15,7 +15,7 @@
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.1.o
 RUN: %clang %clangopts -c %p/Inputs/2.c -fPIC -o %t.2.o
 RUN: %link %linkopts -shared -o %t.lib2.so %t.2.o
-RUN: %link %linkopts  -dynamic-linker /lib64/ld-linux-x86-64.so.2 -o %t.out %t.1.o %t.lib2.so
+RUN: %link %linkopts  --dynamic-linker /lib64/ld-linux-x86-64.so.2 -o %t.out %t.1.o %t.lib2.so
 # TODO: ELD emits R_X86_64_GLOB_DAT outside .data instead of in .got, causing
 # a runtime segfault. Re-enable execution once the R_X86_64_64 GOT allocation
 # bug is fixed.

--- a/test/x86_64/linux/relocPLT32dynamic/relocPLT32dynamic.test
+++ b/test/x86_64/linux/relocPLT32dynamic/relocPLT32dynamic.test
@@ -8,6 +8,6 @@
 RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.1.o
 RUN: %clang %clangopts -c %p/Inputs/2.c -o %t.2.o
 RUN: %link %linkopts -shared -o %t.lib2.so %t.2.o
-RUN: %link %linkopts  -dynamic-linker /lib64/ld-linux-x86-64.so.2 -o %t.out %t.1.o %t.lib2.so
+RUN: %link %linkopts  --dynamic-linker /lib64/ld-linux-x86-64.so.2 -o %t.out %t.1.o %t.lib2.so
 RUN: %run_and_print_exit %t.out | %filecheck %s --check-prefix=EXITCODE
 EXITCODE: 3

--- a/utils/archive_member_report/archive_member_trace.py
+++ b/utils/archive_member_report/archive_member_trace.py
@@ -17,7 +17,7 @@ def get_referrer_path(record: dict) -> str:
     if obj:
         return obj
     if record.get("WholeArchive"):
-        return "-whole-archive"
+        return "--whole-archive"
     ref = record.get("Referrer")
     if ref:
         return ref


### PR DESCRIPTION
Update the codebase to stop using deprecated command-line flags and switch entirely to their canonical forms. This removes internal reliance on deprecated flags and ensures no further changes are needed when they are eventually removed.

Fix: qualcomm#1221