### PR TITLE
[Diagnostics] Emit mismatch diagnostics as notes with --no-warn-mismatch

### DIFF
--- a/include/eld/Diagnostics/DiagnosticEngine.h
+++ b/include/eld/Diagnostics/DiagnosticEngine.h
@@ -260,6 +260,10 @@ public:
 
   static void ignoreLLVMError(llvm::Error E);
 
+  static bool isWarnMismatch(DiagIDType Id);
+
+  static bool isErrorMismatch(DiagIDType Id);
+
 private:
   // -----  emission  ----- //
   // emit - process the message to printer

--- a/lib/Diagnostics/DiagnosticEngine.cpp
+++ b/lib/Diagnostics/DiagnosticEngine.cpp
@@ -230,6 +230,25 @@ void DiagnosticEngine::ignoreLLVMError(llvm::Error E) {
     ASSERT(!IgnoreErr, "ignoreErr must always be false");
 }
 
+bool DiagnosticEngine::isWarnMismatch(DiagIDType Id) {
+  if (Id == Diag::warn_mismatch_enum_size ||
+      Id == Diag::incompatible_architecture ||
+      Id == Diag::incompatible_input_architecture)
+    return true;
+
+  return false;
+}
+
+bool DiagnosticEngine::isErrorMismatch(DiagIDType Id) {
+  if (Id == Diag::err_mismatch_r9_use ||
+      Id == Diag::incompatible_architecture_versions ||
+      Id == Diag::attribute_parsing_error ||
+      Id == Diag::err_unrecognized_input_file || Id == Diag::invalid_elf_class)
+    return true;
+
+  return false;
+}
+
 // Initializes the default diagnostic IDs.
 // Diagnostic IDs are formed of 2 components: diagnostic severity and base ID.
 // Both diagnostic severity and the base diagnostic ID can be extract out of the

--- a/lib/Diagnostics/DiagnosticInfos.cpp
+++ b/lib/Diagnostics/DiagnosticInfos.cpp
@@ -197,6 +197,13 @@ eld::Expected<void> DiagnosticInfos::process(DiagnosticEngine &PEngine) const {
       Severity = DiagnosticEngine::Fatal;
   }
 
+  // If --no-warn-mismatch is used, then switch errors and warning affected by
+  // --no-warn-mismatch to notes
+  if (!Config.options().warnMismatch() &&
+      (DiagnosticEngine::isWarnMismatch(ID) ||
+       DiagnosticEngine::isErrorMismatch(ID)))
+    Severity = DiagnosticEngine::Note;
+
   // finally, report it.
   eld::Expected<void> ExpReportRes =
       PEngine.getPrinter()->handleDiagnostic(Severity, Info);

--- a/lib/Readers/ELFReader.cpp
+++ b/lib/Readers/ELFReader.cpp
@@ -424,22 +424,35 @@ template <class ELFT>
 eld::Expected<bool> ELFReader<ELFT>::isCompatible() const {
   const InputFile &inputFile = this->m_InputFile;
   LinkerConfig &config = this->m_Module.getConfig();
+  bool WarnMismatch = config.options().warnMismatch();
 
-  if (config.options().warnMismatch() && !checkMachine())
-    return std::make_unique<plugin::DiagnosticEntry>(plugin::DiagnosticEntry(
+  if (!checkMachine()) {
+    auto DE = std::make_unique<DiagnosticEntry>(
         Diag::err_unrecognized_input_file,
-        {inputFile.getInput()->getResolvedPath().native(),
-         config.targets().getArch()}));
+        std::vector<std::string>{
+            inputFile.getInput()->getResolvedPath().native(),
+            config.targets().getArch()});
+    if (!WarnMismatch)
+      config.raiseDiagEntry(std::move(DE));
+    else
+      return std::move(DE);
+  }
 
   eld::Expected<bool> expCheckFlags = checkFlags();
   ELDEXP_RETURN_DIAGENTRY_IF_ERROR(expCheckFlags);
   if (!expCheckFlags.value())
     return false;
 
-  if (config.options().warnMismatch() && !checkClass())
-    return std::make_unique<plugin::DiagnosticEntry>(plugin::DiagnosticEntry(
+  if (!checkClass()) {
+    auto DE = std::make_unique<DiagnosticEntry>(
         Diag::invalid_elf_class,
-        {inputFile.getInput()->decoratedPath(), config.targets().getArch()}));
+        std::vector<std::string>{inputFile.getInput()->decoratedPath(),
+                                 config.targets().getArch()});
+    if (!WarnMismatch)
+      config.raiseDiagEntry(std::move(DE));
+    else
+      return std::move(DE);
+  }
 
   checkOSABI();
 

--- a/lib/Target/ARM/ARMAttributeFragment.cpp
+++ b/lib/Target/ARM/ARMAttributeFragment.cpp
@@ -182,8 +182,9 @@ bool ARMAttributeFragment::updateARMVFPArgs(
     // as a clash.
     return true;
 
+  bool WarnMismatch = Config.options().warnMismatch();
   unsigned vfpArgs = attr.value();
-  ARMVFPArgKind arg;
+  ARMVFPArgKind arg = ARMVFPArgKind::Default;
   switch (vfpArgs) {
   case llvm::ARMBuildAttrs::BaseAAPCS:
     arg = ARMVFPArgKind::Base;
@@ -199,22 +200,22 @@ bool ARMAttributeFragment::updateARMVFPArgs(
     // Object compatible with all conventions.
     return true;
   default: {
-    if (Config.options().warnMismatch()) {
-      std::string ErrorMsg =
-          "unknown Tag_ABI_VFP_args value: " + std::to_string(vfpArgs);
-      DiagEngine->raise(Diag::attribute_parsing_error)
-          << f->getInput()->decoratedPath() << ErrorMsg;
+    std::string ErrorMsg =
+        "unknown Tag_ABI_VFP_args value: " + std::to_string(vfpArgs);
+    DiagEngine->raise(Diag::attribute_parsing_error)
+        << f->getInput()->decoratedPath() << ErrorMsg;
+    if (WarnMismatch)
       return false;
-    }
+    break;
   }
   }
   // Follow ld.bfd and error if there is a mix of calling conventions.
-  if (Config.options().warnMismatch() &&
-      (OutputAttributes.armVFPArgs != arg &&
-       OutputAttributes.armVFPArgs != ARMVFPArgKind::Default)) {
+  if (OutputAttributes.armVFPArgs != arg &&
+      OutputAttributes.armVFPArgs != ARMVFPArgKind::Default) {
     DiagEngine->raise(Diag::attribute_parsing_error)
         << f->getInput()->decoratedPath() << "incompatible Tag_ABI_VFP_args";
-    return false;
+    if (WarnMismatch)
+      return false;
   }
   std::string VFPStr = "ARM VFP " + std::to_string((uint32_t)arg);
   f->recordFeature(VFPStr);
@@ -245,12 +246,12 @@ bool ARMAttributeFragment::updatePCS(const llvm::ARMAttributeParser &attributes,
     OutputAttributes.armR9Args = r9args;
     return true;
   }
-  if (Config.options().warnMismatch() &&
-      (OutputAttributes.armR9Args != r9args)) {
+  if (OutputAttributes.armR9Args != r9args) {
     DiagEngine->raise(Diag::err_mismatch_r9_use)
         << R9Str(*OutputAttributes.armR9Args) << R9Str(r9args)
         << f->getInput()->decoratedPath();
-    return false;
+    if (Config.options().warnMismatch())
+      return false;
   }
   return true;
 }
@@ -273,12 +274,12 @@ bool ARMAttributeFragment::updatePCSRO(
     OutputAttributes.ABI_PCS_RO_data = ABI_PCS_RO_data_val;
     return true;
   }
-  if (Config.options().warnMismatch() &&
-      (OutputAttributes.ABI_PCS_RO_data != ABI_PCS_RO_data_val)) {
+  if (OutputAttributes.ABI_PCS_RO_data != ABI_PCS_RO_data_val) {
     Config.raise(Diag::err_mismatch_r9_use)
         << PCS_ROStr(*OutputAttributes.ABI_PCS_RO_data)
         << PCS_ROStr(ABI_PCS_RO_data_val) << f->getInput()->decoratedPath();
-    return false;
+    if (Config.options().warnMismatch())
+      return false;
   }
   return true;
 }
@@ -302,12 +303,12 @@ bool ARMAttributeFragment::updatePCSRW(
     OutputAttributes.ABI_PCS_RW_data = ABI_PCS_RW_data_val;
     return true;
   }
-  if (Config.options().warnMismatch() &&
-      (OutputAttributes.ABI_PCS_RW_data != ABI_PCS_RW_data_val)) {
+  if (OutputAttributes.ABI_PCS_RW_data != ABI_PCS_RW_data_val) {
     DiagEngine->raise(Diag::err_mismatch_r9_use)
         << PCS_RWStr(*OutputAttributes.ABI_PCS_RW_data)
         << PCS_RWStr(ABI_PCS_RW_data_val) << f->getInput()->decoratedPath();
-    return false;
+    if (Config.options().warnMismatch())
+      return false;
   }
   return true;
 }
@@ -331,12 +332,12 @@ bool ARMAttributeFragment::updateEnumSize(
     OutputAttributes.armEnumSize = enumSize;
     return true;
   }
-  if (Config.options().warnMismatch() &&
-      (OutputAttributes.armEnumSize != enumSize)) {
+  if (OutputAttributes.armEnumSize != enumSize) {
     DiagEngine->raise(Diag::warn_mismatch_enum_size)
         << f->getInput()->decoratedPath() << enumSize
         << *OutputAttributes.armEnumSize;
-    return false;
+    if (Config.options().warnMismatch())
+      return false;
   }
   return true;
 }

--- a/lib/Target/Hexagon/HexagonInfo.cpp
+++ b/lib/Target/Hexagon/HexagonInfo.cpp
@@ -298,10 +298,9 @@ bool HexagonInfo::checkFlags(uint64_t pFlag, const InputFile *pInputFile,
         << ISAs[translateFlag(pFlag)];
     return false;
   case WA:
-    if (m_Config.options().warnMismatch())
-      m_Config.raise(Diag::incompatible_input_architecture)
-          << pInputFile->getInput()->decoratedPath() << getArchStr(pFlag)
-          << getArchStr(m_OutputFlag);
+    m_Config.raise(Diag::incompatible_input_architecture)
+        << pInputFile->getInput()->decoratedPath() << getArchStr(pFlag)
+        << getArchStr(m_OutputFlag);
     LLVM_FALLTHROUGH;
   case OK:
     if (m_OutputFlag < (int64_t)pFlag)
@@ -329,9 +328,8 @@ uint64_t HexagonInfo::flags() const {
           << targetOptions().getTargetCPU() << ISAs[translateFlag(OutputFlag)];
       LLVM_FALLTHROUGH;
     case WA:
-      if (m_Config.options().warnMismatch())
-        m_Config.raise(Diag::incompatible_architecture)
-            << targetOptions().getTargetCPU();
+      m_Config.raise(Diag::incompatible_architecture)
+          << targetOptions().getTargetCPU();
       LLVM_FALLTHROUGH;
     case OK:
       if (OutputFlag < m_CmdLineFlag)

--- a/lib/Target/RISCV/RISCVInfo.cpp
+++ b/lib/Target/RISCV/RISCVInfo.cpp
@@ -45,41 +45,41 @@ bool RISCVInfo::isABIFlagSet(uint64_t inputFlag, uint32_t ABIFlag) const {
 }
 
 bool RISCVInfo::isCompatible(uint64_t pFlag, const std::string &pFile) const {
-  if (!m_Config.options().warnMismatch())
-    return true;
-
+  bool WarnMismatch = m_Config.options().warnMismatch();
+  bool Result = true;
   assert(m_OutputFlag);
   if (isABIFlagSet(pFlag, llvm::ELF::EF_RISCV_FLOAT_ABI_SOFT) ^
       isABIFlagSet(*m_OutputFlag, llvm::ELF::EF_RISCV_FLOAT_ABI_SOFT)) {
     m_Config.raise(Diag::incompatible_architecture_versions)
         << flagString(pFlag) << pFile << flagString(*m_OutputFlag);
-    return false;
+    Result = !WarnMismatch;
   }
   if (isABIFlagSet(pFlag, llvm::ELF::EF_RISCV_FLOAT_ABI_SINGLE) ^
       isABIFlagSet(*m_OutputFlag, llvm::ELF::EF_RISCV_FLOAT_ABI_SINGLE)) {
     m_Config.raise(Diag::incompatible_architecture_versions)
         << flagString(pFlag) << pFile << flagString(*m_OutputFlag);
-    return false;
+    Result = !WarnMismatch;
   }
   if (isABIFlagSet(pFlag, llvm::ELF::EF_RISCV_FLOAT_ABI_DOUBLE) ^
       isABIFlagSet(*m_OutputFlag, llvm::ELF::EF_RISCV_FLOAT_ABI_DOUBLE)) {
     m_Config.raise(Diag::incompatible_architecture_versions)
         << flagString(pFlag) << pFile << flagString(*m_OutputFlag);
-    return false;
+    Result = !WarnMismatch;
   }
   if (isABIFlagSet(pFlag, llvm::ELF::EF_RISCV_FLOAT_ABI_QUAD) ^
       isABIFlagSet(*m_OutputFlag, llvm::ELF::EF_RISCV_FLOAT_ABI_QUAD)) {
     m_Config.raise(Diag::incompatible_architecture_versions)
         << flagString(pFlag) << pFile << flagString(*m_OutputFlag);
-    return false;
+    Result = !WarnMismatch;
   }
   if ((pFlag & llvm::ELF::EF_RISCV_RVE) ^
       (*m_OutputFlag & llvm::ELF::EF_RISCV_RVE)) {
     m_Config.raise(Diag::incompatible_architecture_versions)
         << flagString(pFlag) << pFile << flagString(*m_OutputFlag);
-    return false;
+    Result = !WarnMismatch;
   }
-  return true;
+
+  return Result;
 }
 
 bool RISCVInfo::checkFlags(uint64_t flag, const InputFile *pInputFile,

--- a/test/ARM/standalone/AttributesWarn/AttributesWarn.test
+++ b/test/ARM/standalone/AttributesWarn/AttributesWarn.test
@@ -10,4 +10,4 @@
 #RUN: %link --no-warn-mismatch -o %t1.out %linkopts %t1.o %t2.o 2>&1 | %filecheck %s --check-prefix="ENUM_NOERR" --allow-empty
 #
 #ENUM:  Warning: the size of enumerated data item
-#ENUM_NOERR-NOT:  Warning: the size of enumerated data item
+#ENUM_NOERR:  Note: the size of enumerated data item

--- a/test/ARM/standalone/PCSAttrs/PCSAttr.test
+++ b/test/ARM/standalone/PCSAttrs/PCSAttr.test
@@ -14,8 +14,8 @@ RUN: %not %link --warn-mismatch -MapStyle yaml %linkopts -Map %t1.yaml.map -marc
 RUN: %link --no-warn-mismatch -MapStyle yaml %linkopts -Map %t1.yaml.map -march armv7 %t1.o %t2.o -o %t2.out.2 2>&1 | %filecheck %s -check-prefix=NOERR --allow-empty
 RUN: %filecheck %s -check-prefix MAP < %t1.yaml.map
 
-CHECK: conflicting way to use R9. {{[ -\(\)_A-Za-z0-9.\\/:]+}}: `SB', previously seen: `GPR'
-NOERR-NOT: conflicting way to use R9. {{.*}}: `SB', previously seen: `GPR'
+CHECK: Error: conflicting way to use R9. {{.*}}: `SB', previously seen: `GPR'
+NOERR: Note: conflicting way to use R9. {{.*}}: `SB', previously seen: `GPR'
 
 #MAP: LOAD {{.*}}1.o[arm][blx,j1j2,movtmovw,GPR,PCRel,EnumSize 2,Application]
 #MAP: LOAD {{.*}}2.o[arm][blx,j1j2,movtmovw,SB,SBRel,EnumSize 2,Application]

--- a/test/Common/standalone/WrongArchObject/WrongArchInput.test
+++ b/test/Common/standalone/WrongArchObject/WrongArchInput.test
@@ -16,6 +16,6 @@ RUN: %not %link %emulation -Bdynamic --warn-mismatch %t.2.o -L%p/Inputs %t.lib.s
 RUN: %link %emulation -Bdynamic --no-warn-mismatch %t.2.o -L%p/Inputs %t.lib.so 2>&1 | %filecheck %s -check-prefix=NOERR --allow-empty
 
 CHECK: Error: cannot recognize the format of file {{[` -\(\)_A-Za-z0-9.\\/:]+}}.3.o'. object format or given target machine ({{[` -\(\)_A-Za-z0-9.\\/:]+}}) is incompatible.
-NOERR-NOT: Error: cannot recognize the format of file
+NOERR: Note: cannot recognize the format of file {{.*}}. object format or given target machine ({{.*}}) is incompatible.
 ARCHIVE: Error: cannot recognize the format of file {{[` -\(\)_A-Za-z0-9.\\/:]+}}.a'. object format or given target machine ({{[` -\(\)_A-Za-z0-9.\\/:]+}}) is incompatible.
 DYNAMIC: Error: cannot recognize the format of file {{[` -\(\)_A-Za-z0-9.\\/:]+}}.lib.so'. object format or given target machine ({{[` -\(\)_A-Za-z0-9.\\/:]+}}) is incompatible.

--- a/test/Hexagon/standalone/Diagnostics/MixedISA/MixedISA.s
+++ b/test/Hexagon/standalone/Diagnostics/MixedISA/MixedISA.s
@@ -10,8 +10,12 @@ nop
 // RUN: %link %linkopts %t2.o %t.o -o %t2.out 2>&1 | %filecheck %s --check-prefix=WA7371
 
 // RUN: %link %linkopts --no-warn-mismatch %t.o %t2.o -o %t3.out 2>&1 \
-// RUN:  | %filecheck --allow-empty %s --check-prefix=NOWARN
+// RUN:  | %filecheck %s --check-prefix=WA7173_NOTE
+
+// RUN: %link %linkopts --no-warn-mismatch %t2.o %t.o -o %t4.out 2>&1 \
+// RUN:  | %filecheck %s --check-prefix=WA7371_NOTE
 
 // WA7173: Warning: Mixing incompatible object file {{.*}} object file arch is hexagonv73, {{.*}}hexagonv71t
 // WA7371: Warning: Mixing incompatible object file {{.*}} object file arch is hexagonv71t, {{.*}} hexagonv73
-// NOWARN-NOT: Mixing incompatible object file
+// WA7173_NOTE: Note: Mixing incompatible object file {{.*}} object file arch is hexagonv73, {{.*}}hexagonv71t
+// WA7371_NOTE: Note: Mixing incompatible object file {{.*}} object file arch is hexagonv71t, {{.*}} hexagonv73

--- a/test/RISCV/FromLLD/riscv-attributes.s
+++ b/test/RISCV/FromLLD/riscv-attributes.s
@@ -31,11 +31,9 @@
 
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 invalid_arch1.s -o invalid_arch1.o
 # RUN: %not %link %linkopts --warn-mismatch invalid_arch1.o -o /dev/null 2>&1 | FileCheck %s --check-prefix=INVALID_ARCH1 --implicit-check-not=error:
-#TODO: Why this does not link with eld but does with gnu ld?
-# RUN: %not %link %linkopts --no-warn-mismatch invalid_arch1.o -o /dev/null 2>&1 | FileCheck %s --check-prefix=INVALID_ARCH1_NOERR
+# RUN: %link %linkopts --no-warn-mismatch invalid_arch1.o -o /dev/null 2>&1 | FileCheck %s --check-prefix=INVALID_ARCH1_NOERR
 # INVALID_ARCH1: Reading attributes failed for file invalid_arch1.o, Error : extension lacks version in expected format
-# INVALID_ARCH1_NOERR-NOT: Warning: Reading attributes failed for file invalid_arch1.o, Error : extension lacks version in expected format
-# INVALID_ARCH1_NOERR: Fatal: Linking had errors ({{/dev/null|NUL}})
+# INVALID_ARCH1_NOERR: Note: Reading attributes failed for file invalid_arch1.o, Error : extension lacks version in expected format
 
 ## A zero value attribute is not printed.
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 unaligned_access_0.s -o unaligned_access_0.o
@@ -57,20 +55,16 @@
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 unknown13.s -o unknown13.o
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 unknown13a.s -o unknown13a.o
 # RUN: %not %link %linkopts --warn-mismatch -e 0 unknown13.o unknown13.o unknown13a.o -o unknown13 2>&1 | FileCheck %s --check-prefix=UNKNOWN13 --implicit-check-not=warning:
-#TODO: Why this does not link with eld but does with gnu ld?
-# RUN: %not %link %linkopts --no-warn-mismatch -e 0 unknown13.o unknown13.o unknown13a.o -o unknown13 2>&1 | FileCheck %s --check-prefix=UNKNOWN13_NOERR
+# RUN: %link %linkopts --no-warn-mismatch -e 0 unknown13.o unknown13.o unknown13a.o -o unknown13 2>&1 | FileCheck %s --check-prefix=UNKNOWN13_NOERR
 # UNKNOWN13: Reading attributes failed for file unknown13.o, Error : invalid tag 0xd at offset 0x10
-# UNKNOWN13_NOERR-NOT: Warning: Reading attributes failed for file unknown13.o, Error : invalid tag
-# UNKNOWN13_NOERR: Fatal: Linking had errors (unknown13)
+# UNKNOWN13_NOERR: Note: Reading attributes failed for file unknown13.o, Error : invalid tag 0xd at offset 0x10
 
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 unknown22.s -o unknown22.o
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 unknown22a.s -o unknown22a.o
 # RUN: %not %link %linkopts --warn-mismatch -e 0 unknown22.o unknown22.o unknown22a.o -o unknown22 2>&1 | FileCheck %s --check-prefix=UNKNOWN22 --implicit-check-not=warning:
-#TODO: Why this does not link with eld but does with gnu ld?
-# RUN: %not %link %linkopts --no-warn-mismatch -e 0 unknown22.o unknown22.o unknown22a.o -o unknown22 2>&1 | FileCheck %s --check-prefix=UNKNOWN22_NOERR
+# RUN: %link %linkopts --no-warn-mismatch -e 0 unknown22.o unknown22.o unknown22a.o -o unknown22 2>&1 | FileCheck %s --check-prefix=UNKNOWN22_NOERR
 # UNKNOWN22: Reading attributes failed for file unknown22.o, Error : invalid tag 0x16 at offset 0x10
-# UNKNOWN22_NOERR-NOT: Warning: Reading attributes failed for file unknown22.o, Error : invalid tag
-# UNKNOWN22_NOERR: Fatal: Linking had errors (unknown22)
+# UNKNOWN22_NOERR: Note: Reading attributes failed for file unknown22.o, Error : invalid tag 0x16 at offset 0x10
 
 # HDR:      Name              Type             Address          Off    Size   ES Flg Lk Inf Al
 # HDR:      .riscv.attributes RISCV_ATTRIBUTES 0000000000000000 {{.*}} {{.*}} 00      0   0  1{{$}}

--- a/test/RISCV/standalone/Attributes/riscv-attributes.s
+++ b/test/RISCV/standalone/Attributes/riscv-attributes.s
@@ -34,11 +34,9 @@ UNSUPPORTED: riscv32, windows
 
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 invalid_arch1.s -o invalid_arch1.o
 # RUN: %not %link --warn-mismatch -march riscv64 invalid_arch1.o -o /dev/null 2>&1 | FileCheck %s --check-prefix=INVALID_ARCH1 --implicit-check-not=error:
-#TODO: Why this does not link with eld but does with gnu ld?
-# RUN: %not %link --no-warn-mismatch -march riscv64 invalid_arch1.o -o /dev/null 2>&1 | FileCheck %s --check-prefix=INVALID_ARCH1_NOERR
+# RUN: %link --no-warn-mismatch -march riscv64 invalid_arch1.o -o /dev/null 2>&1 | FileCheck %s --check-prefix=INVALID_ARCH1_NOERR
 # INVALID_ARCH1: Reading attributes failed for file invalid_arch1.o, Error : extension lacks version in expected format
-# INVALID_ARCH1_NOERR-NOT: Warning: Reading attributes failed for file invalid_arch1.o, Error : extension lacks version in expected format
-# INVALID_ARCH1_NOERR: Fatal: Linking had errors (/dev/null)
+# INVALID_ARCH1_NOERR: Note: Reading attributes failed for file invalid_arch1.o, Error : extension lacks version in expected format
 
 ## A zero value attribute is not printed.
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 unaligned_access_0.s -o unaligned_access_0.o
@@ -60,20 +58,16 @@ UNSUPPORTED: riscv32, windows
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 unknown13.s -o unknown13.o
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 unknown13a.s -o unknown13a.o
 # RUN: not %link --warn-mismatch -march riscv64 -e 0 unknown13.o unknown13.o unknown13a.o -o unknown13 2>&1 | FileCheck %s --check-prefix=UNKNOWN13 --implicit-check-not=warning:
-#TODO: Why this does not link with eld but does with gnu ld?
-# RUN: not %link --no-warn-mismatch -march riscv64 -e 0 unknown13.o unknown13.o unknown13a.o -o unknown13 2>&1 | FileCheck %s --check-prefix=UNKNOWN13_NOERR
+# RUN: %link --no-warn-mismatch -march riscv64 -e 0 unknown13.o unknown13.o unknown13a.o -o unknown13 2>&1 | FileCheck %s --check-prefix=UNKNOWN13_NOERR
 # UNKNOWN13: Reading attributes failed for file unknown13.o, Error : invalid tag 0xd at offset 0x10
-# UNKNOWN13_NOERR-NOT: Warning: Reading attributes failed for file unknown13.o, Error : invalid tag
-# UNKNOWN13_NOERR: Fatal: Linking had errors (unknown13)
+# UNKNOWN13_NOERR: Note: Reading attributes failed for file unknown13.o, Error : invalid tag 0xd at offset 0x10
 
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 unknown22.s -o unknown22.o
 # RUN: %llvm-mc -filetype=obj -triple=riscv64 unknown22a.s -o unknown22a.o
 # RUN: not %link --warn-mismatch -march riscv64 -e 0 unknown22.o unknown22.o unknown22a.o -o unknown22 2>&1 | FileCheck %s --check-prefix=UNKNOWN22 --implicit-check-not=warning:
-#TODO: Why this does not link with eld but does with gnu ld?
-# RUN: not %link --no-warn-mismatch -march riscv64 -e 0 unknown22.o unknown22.o unknown22a.o -o unknown22 2>&1 | FileCheck %s --check-prefix=UNKNOWN22_NOERR
+# RUN: %link --no-warn-mismatch -march riscv64 -e 0 unknown22.o unknown22.o unknown22a.o -o unknown22 2>&1 | FileCheck %s --check-prefix=UNKNOWN22_NOERR
 # UNKNOWN22: Reading attributes failed for file unknown22a.o
-# UNKNOWN22_NOERR-NOT: Warning: Reading attributes failed for file
-# UNKNOWN22_NOERR: Fatal: Linking had errors (unknown22)
+# UNKNOWN22_NOERR: Note: Reading attributes failed for file
 
 # HDR:      Name              Type             Address          Off    Size   ES Flg Lk Inf Al
 # HDR:      .riscv.attributes RISCV_ATTRIBUTES 0000000000000000 0000b0 {{.*}} 00      0   0  1{{$}}

--- a/test/RISCV/standalone/EFlags/EFlags.test
+++ b/test/RISCV/standalone/EFlags/EFlags.test
@@ -16,4 +16,4 @@ RUN: %eld --no-warn-mismatch %t.f.o %t.1.o -o %t1.out 2>&1 | %filecheck %s --che
 
 EFLAGS: Flags: 0x3
 CHECK: Error: Incompatible object files when reading {{.*}}1.o
-NOERR-NOT: Error: Incompatible object files when reading
+NOERR: Note: Incompatible object files when reading {{.*}}1.o

--- a/test/RISCV/standalone/Emulation/Emulation.test
+++ b/test/RISCV/standalone/Emulation/Emulation.test
@@ -16,7 +16,7 @@ RISCV32: ELF32
 RISCV32: RISC-V
 
 RISCV64ERR: Error: Invalid ELF file {{.*}}1.64.o for target riscv32
-RISCV64NOERR-NOT: Error: Invalid ELF file
+RISCV64NOERR: Note: Invalid ELF file {{.*}}1.64.o for target riscv32
 
 RISCV64: ELF64
 RISCV64: RISC-V


### PR DESCRIPTION
Diagnostics affected by --no-warn-mismatch
(e.g., incompatible_architecture_versions) are no longer suppressed entirely.

Instead, downgrade them to notes and always emit them, ensuring users have visibility into mismatch information without treating it as actionable warnings or errors.

Fix: #1264