### PR TITLE
Unify default behavior for --warn-mismatch flags

### DIFF
--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -58,8 +58,6 @@ public:
     StripAllSymbols
   };
 
-  enum class WarnMismatchMode { None, WarnMismatch, NoWarnMismatch };
-
   enum OrphanMode { Place, Warn, Error, Invalid };
 
   enum ErrorStyleType { gnu, llvm };
@@ -481,25 +479,9 @@ public:
 
   bool printMap() const { return BPrintMap; }
 
-  void setWarnMismatch(bool PEnable) {
-    if (PEnable) {
-      WarnMismatch = WarnMismatchMode::WarnMismatch;
-      return;
-    }
-    WarnMismatch = WarnMismatchMode::NoWarnMismatch;
-  }
+  void setWarnMismatch(bool Enable) { WarnMismatch = Enable; }
 
-  bool hasOptionWarnNoWarnMismatch() const {
-    return (WarnMismatch != WarnMismatchMode::None);
-  }
-
-  bool noWarnMismatch() const {
-    return (WarnMismatch == WarnMismatchMode::NoWarnMismatch);
-  }
-
-  bool warnMismatch() const {
-    return (WarnMismatch == WarnMismatchMode::WarnMismatch);
-  }
+  bool warnMismatch() const { return WarnMismatch; }
 
   // --gc-sections
   void setGCSections(bool PEnable = true) { BGCSections = PEnable; }
@@ -1247,8 +1229,7 @@ private:
   bool BLTOOptRemarksDisplayHotness = false; // --display-hotness-remarks
   bool BNoStdlib = false;                    // -nostdlib
   bool BPrintMap = false;                    // --print-map
-  WarnMismatchMode WarnMismatch =
-      WarnMismatchMode::None;        // --no{-warn}-mismatch
+  bool WarnMismatch = true;                  // --[no-]warn-mismatch
   bool BGCSections = false;          // --gc-sections
   bool BPrintGCSections = false;     // --print-gc-sections
   bool BGenUnwindInfo = true;        // --ld-generated-unwind-info

--- a/lib/Readers/ELFReader.cpp
+++ b/lib/Readers/ELFReader.cpp
@@ -425,7 +425,7 @@ eld::Expected<bool> ELFReader<ELFT>::isCompatible() const {
   const InputFile &inputFile = this->m_InputFile;
   LinkerConfig &config = this->m_Module.getConfig();
 
-  if (!config.options().noWarnMismatch() && !checkMachine())
+  if (config.options().warnMismatch() && !checkMachine())
     return std::make_unique<plugin::DiagnosticEntry>(plugin::DiagnosticEntry(
         Diag::err_unrecognized_input_file,
         {inputFile.getInput()->getResolvedPath().native(),
@@ -436,7 +436,7 @@ eld::Expected<bool> ELFReader<ELFT>::isCompatible() const {
   if (!expCheckFlags.value())
     return false;
 
-  if (!config.options().noWarnMismatch() && !checkClass())
+  if (config.options().warnMismatch() && !checkClass())
     return std::make_unique<plugin::DiagnosticEntry>(plugin::DiagnosticEntry(
         Diag::invalid_elf_class,
         {inputFile.getInput()->decoratedPath(), config.targets().getArch()}));

--- a/lib/Target/AArch64/AArch64Info.h
+++ b/lib/Target/AArch64/AArch64Info.h
@@ -62,12 +62,6 @@ public:
   bool InitializeDefaultMappings(Module &pModule) override;
 
   std::string flagString(uint64_t flag) const override;
-
-  void initializeAttributes(InputBuilder &pBuilder) override {
-    // Warn on mismatch.
-    if (!m_Config.options().hasOptionWarnNoWarnMismatch())
-      m_Config.options().setWarnMismatch(false);
-  }
 };
 
 } // namespace eld

--- a/lib/Target/ARM/ARMAttributeFragment.cpp
+++ b/lib/Target/ARM/ARMAttributeFragment.cpp
@@ -199,7 +199,7 @@ bool ARMAttributeFragment::updateARMVFPArgs(
     // Object compatible with all conventions.
     return true;
   default: {
-    if (!Config.options().noWarnMismatch()) {
+    if (Config.options().warnMismatch()) {
       std::string ErrorMsg =
           "unknown Tag_ABI_VFP_args value: " + std::to_string(vfpArgs);
       DiagEngine->raise(Diag::attribute_parsing_error)
@@ -209,7 +209,7 @@ bool ARMAttributeFragment::updateARMVFPArgs(
   }
   }
   // Follow ld.bfd and error if there is a mix of calling conventions.
-  if (!Config.options().noWarnMismatch() &&
+  if (Config.options().warnMismatch() &&
       (OutputAttributes.armVFPArgs != arg &&
        OutputAttributes.armVFPArgs != ARMVFPArgKind::Default)) {
     DiagEngine->raise(Diag::attribute_parsing_error)
@@ -245,7 +245,7 @@ bool ARMAttributeFragment::updatePCS(const llvm::ARMAttributeParser &attributes,
     OutputAttributes.armR9Args = r9args;
     return true;
   }
-  if (!Config.options().noWarnMismatch() &&
+  if (Config.options().warnMismatch() &&
       (OutputAttributes.armR9Args != r9args)) {
     DiagEngine->raise(Diag::err_mismatch_r9_use)
         << R9Str(*OutputAttributes.armR9Args) << R9Str(r9args)
@@ -273,7 +273,7 @@ bool ARMAttributeFragment::updatePCSRO(
     OutputAttributes.ABI_PCS_RO_data = ABI_PCS_RO_data_val;
     return true;
   }
-  if (!Config.options().noWarnMismatch() &&
+  if (Config.options().warnMismatch() &&
       (OutputAttributes.ABI_PCS_RO_data != ABI_PCS_RO_data_val)) {
     Config.raise(Diag::err_mismatch_r9_use)
         << PCS_ROStr(*OutputAttributes.ABI_PCS_RO_data)
@@ -302,7 +302,7 @@ bool ARMAttributeFragment::updatePCSRW(
     OutputAttributes.ABI_PCS_RW_data = ABI_PCS_RW_data_val;
     return true;
   }
-  if (!Config.options().noWarnMismatch() &&
+  if (Config.options().warnMismatch() &&
       (OutputAttributes.ABI_PCS_RW_data != ABI_PCS_RW_data_val)) {
     DiagEngine->raise(Diag::err_mismatch_r9_use)
         << PCS_RWStr(*OutputAttributes.ABI_PCS_RW_data)
@@ -331,7 +331,7 @@ bool ARMAttributeFragment::updateEnumSize(
     OutputAttributes.armEnumSize = enumSize;
     return true;
   }
-  if (!Config.options().noWarnMismatch() &&
+  if (Config.options().warnMismatch() &&
       (OutputAttributes.armEnumSize != enumSize)) {
     DiagEngine->raise(Diag::warn_mismatch_enum_size)
         << f->getInput()->decoratedPath() << enumSize

--- a/lib/Target/ARM/ARMInfo.h
+++ b/lib/Target/ARM/ARMInfo.h
@@ -75,13 +75,6 @@ public:
 
   std::string flagString(uint64_t flag) const override;
 
-  void initializeAttributes(InputBuilder &pBuilder) override {
-    // Do not warn on mismatch by default
-    if (!m_Config.options().hasOptionWarnNoWarnMismatch()) {
-      m_Config.options().setWarnMismatch(false);
-    }
-  }
-
   bool checkFlags(uint64_t Flag, const InputFile *I, bool) override;
 
 private:

--- a/lib/Target/Hexagon/HexagonInfo.cpp
+++ b/lib/Target/Hexagon/HexagonInfo.cpp
@@ -298,7 +298,7 @@ bool HexagonInfo::checkFlags(uint64_t pFlag, const InputFile *pInputFile,
         << ISAs[translateFlag(pFlag)];
     return false;
   case WA:
-    if (!m_Config.options().noWarnMismatch())
+    if (m_Config.options().warnMismatch())
       m_Config.raise(Diag::incompatible_input_architecture)
           << pInputFile->getInput()->decoratedPath() << getArchStr(pFlag)
           << getArchStr(m_OutputFlag);
@@ -329,7 +329,7 @@ uint64_t HexagonInfo::flags() const {
           << targetOptions().getTargetCPU() << ISAs[translateFlag(OutputFlag)];
       LLVM_FALLTHROUGH;
     case WA:
-      if (!m_Config.options().noWarnMismatch())
+      if (m_Config.options().warnMismatch())
         m_Config.raise(Diag::incompatible_architecture)
             << targetOptions().getTargetCPU();
       LLVM_FALLTHROUGH;

--- a/lib/Target/Hexagon/HexagonLinuxInfo.h
+++ b/lib/Target/Hexagon/HexagonLinuxInfo.h
@@ -46,9 +46,6 @@ public:
   void initializeAttributes(InputBuilder &pBuilder) override {
     if (!m_Config.options().isEhFrameHdrSet())
       m_Config.options().setEhFrameHdr(true);
-    // Warn on mismatch.
-    if (!m_Config.options().hasOptionWarnNoWarnMismatch())
-      m_Config.options().setWarnMismatch(true);
   }
 };
 

--- a/lib/Target/Hexagon/HexagonStandaloneInfo.h
+++ b/lib/Target/Hexagon/HexagonStandaloneInfo.h
@@ -25,9 +25,6 @@ public:
 
   void initializeAttributes(InputBuilder &pBuilder) override {
     pBuilder.makeBStatic();
-    // Warn on mismatch.
-    if (!m_Config.options().hasOptionWarnNoWarnMismatch())
-      m_Config.options().setWarnMismatch(true);
   }
 };
 

--- a/lib/Target/RISCV/RISCVInfo.cpp
+++ b/lib/Target/RISCV/RISCVInfo.cpp
@@ -45,7 +45,7 @@ bool RISCVInfo::isABIFlagSet(uint64_t inputFlag, uint32_t ABIFlag) const {
 }
 
 bool RISCVInfo::isCompatible(uint64_t pFlag, const std::string &pFile) const {
-  if (m_Config.options().noWarnMismatch())
+  if (!m_Config.options().warnMismatch())
     return true;
 
   assert(m_OutputFlag);

--- a/lib/Target/RISCV/RISCVStandaloneInfo.h
+++ b/lib/Target/RISCV/RISCVStandaloneInfo.h
@@ -37,12 +37,6 @@ public:
 
     return 0x0;
   }
-
-  void initializeAttributes(InputBuilder &pBuilder) override {
-    // Warn on mismatch is by default false.
-    if (!m_Config.options().hasOptionWarnNoWarnMismatch())
-      m_Config.options().setWarnMismatch(false);
-  }
 };
 
 } // namespace eld

--- a/test/Common/standalone/WrongArchObject/WrongArchInput.test
+++ b/test/Common/standalone/WrongArchObject/WrongArchInput.test
@@ -3,12 +3,15 @@
 #END_COMMENT
 RUN: %yaml2obj %p/Inputs/3.yaml -o %t.3.o
 RUN: %clang %clangopts -c %p/Inputs/2.c -o %t.2.o
+RUN: %not %link %emulation %linkopts %t.3.o %t.2.o 2>&1 | %filecheck %s
 RUN: %not %link %emulation %linkopts --warn-mismatch %t.3.o %t.2.o 2>&1 | %filecheck %s
 RUN: %link %emulation %linkopts --no-warn-mismatch %t.3.o %t.2.o 2>&1 | %filecheck %s -check-prefix=NOERR --allow-empty
 RUN: %ar cr %aropts %t.1.a %t.3.o
+RUN: %not %link %emulation %linkopts %t.2.o --whole-archive %t.1.a 2>&1 | %filecheck %s -check-prefix=ARCHIVE
 RUN: %not %link %emulation %linkopts --warn-mismatch %t.2.o --whole-archive %t.1.a 2>&1 | %filecheck %s -check-prefix=ARCHIVE
 RUN: %link %emulation %linkopts --no-warn-mismatch %t.2.o --whole-archive %t.1.a 2>&1 | %filecheck %s -check-prefix=NOERR --allow-empty
 RUN: %yaml2obj %p/Inputs/dyn.yaml -o %t.lib.so
+RUN: %not %link %emulation -Bdynamic %t.2.o -L%p/Inputs %t.lib.so 2>&1 | %filecheck %s -check-prefix=DYNAMIC
 RUN: %not %link %emulation -Bdynamic --warn-mismatch %t.2.o -L%p/Inputs %t.lib.so 2>&1 | %filecheck %s -check-prefix=DYNAMIC
 RUN: %link %emulation -Bdynamic --no-warn-mismatch %t.2.o -L%p/Inputs %t.lib.so 2>&1 | %filecheck %s -check-prefix=NOERR --allow-empty
 


### PR DESCRIPTION
Remove architecture-specific initialization of --[no-]warn-mismatch when not explicitly provided. Set the default behavior consistently to --warn-mismatch across all architectures.

Fix: qualcomm#1293