### PR TITLE
Fix dc and dp flag definitions to match GNU

### DIFF
--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -815,10 +815,14 @@ defm portable : mDashDeprEq<"portable",
 def d : Flag<["-"], "d">,
         HelpText<"Assign space to common symbols">,
         Group<grp_symbolopts>;
-defm dc : mDashDeprWithOpt<"dc", "d", "Assign space to common symbols">,
-          Group<grp_symbolopts>;
-defm dp : mDashDeprWithOpt<"dp", "d", "Assign space to common symbols">,
-          Group<grp_symbolopts>;
+def dc : Flag<["-"], "dc">,
+         HelpText<"Assign space to common symbols">,
+         Alias<d>,
+         Group<grp_symbolopts>;
+def dp : Flag<["-"], "dp">,
+         HelpText<"Assign space to common symbols">,
+         Alias<d>,
+         Group<grp_symbolopts>;
 def sort_common : FF<"sort-common">,
                   HelpText<"sort common symbols by alignment">,
                   Group<grp_symbolopts>;

--- a/test/Common/standalone/CommandLine/PrintHelp/PrintModHelp.test
+++ b/test/Common/standalone/CommandLine/PrintHelp/PrintModHelp.test
@@ -485,14 +485,12 @@ RUN: %link --help 2>&1 | %filecheck %s
 #CHECK:   -version-script=<linkersciptfile>
 #CHECK:   --version-script <linkersciptfile>
 #CHECK:   -version-script <linkersciptfile>
-#CHECK:   --dc
 #CHECK:   -dc
 #CHECK:   --demangle-style=<value>
 #CHECK:   --demangle-style <value>
 #CHECK:   --demangle
 #CHECK:   --discard-all
 #CHECK:   --discard-locals
-#CHECK:   --dp
 #CHECK:   -dp
 #CHECK:   -d
 #CHECK:   --no-demangle


### PR DESCRIPTION
Replace incorrect "--dc" and "--dp" flags with GNU-standard "-dc" and "-dp".

Fix: qualcomm#1310