### PR TITLE
[TBSS] Fix spurious PT_LOAD created for TBSS-only sections

### DIFF
--- a/lib/Target/CreateProgramHeaders.hpp
+++ b/lib/Target/CreateProgramHeaders.hpp
@@ -247,8 +247,6 @@ bool GNULDBackend::createProgramHdrs() {
       continue;
     }
 
-    bool isPrevTBSS = prev && prev->isTBSS();
-
     bool isPrevRelRO =
         config().options().hasRelro() && prev && isRelROSection(prev);
 
@@ -374,19 +372,21 @@ bool GNULDBackend::createProgramHdrs() {
     if (config().options().isOMagic())
       cur_flag = (cur_flag & ~llvm::ELF::PF_W);
 
-    // getSegmentFlag returns 0 if the section is not allocatable.
-    if ((cur_flag != prev_flag) && (isCurAlloc))
-      createPT_LOAD = true;
+    // TBSS sections occupy no file space and do not consume VMA at load time.
+    // Skip flag-change and memory-region checks for TBSS so that a TBSS
+    // section between two real sections does not trigger a spurious new
+    // PT_LOAD segment.
+    if (!cur->isTBSS()) {
+      if ((cur_flag != prev_flag) && (isCurAlloc))
+        createPT_LOAD = true;
 
-    if (linkerScriptHasMemoryCommand && (cur_mem_region != prev_mem_region))
-      createPT_LOAD = true;
-
-    if (linkerScriptHasMemoryCommand && (cur_mem_region != prev_mem_region))
-      createPT_LOAD = true;
+      if (linkerScriptHasMemoryCommand && (cur_mem_region != prev_mem_region))
+        createPT_LOAD = true;
+    }
 
     // If the current section is alloc section and if the previous section is
     // NOBITS and current is PROGBITS, we need to create a new segment.
-    if (isCurAlloc && cur->isWanted() && !isPrevTBSS) {
+    if (isCurAlloc && cur->isWanted()) {
       if ((cur_flag == prev_flag) && handleBSS(prev, cur))
         createPT_LOAD = true;
     }
@@ -394,7 +394,7 @@ bool GNULDBackend::createProgramHdrs() {
     // Calculate VMA offset
     int64_t vmaoffset = 0;
     // Adjust the offset with VMA.
-    if (prev && !isPrevTBSS) {
+    if (prev) {
       // Calculate VMA only if section is allocatable
       if (!createPT_LOAD && isCurAlloc) {
         // it's possible that the location counter was set with an address
@@ -402,18 +402,22 @@ bool GNULDBackend::createProgramHdrs() {
         // which case the vmaoffset should 0x0
         if (vma >= (prev->addr() + prev->size()))
           vmaoffset = vma - (prev->addr() + prev->size());
-        else
+        else if (!cur->isTBSS())
           // Without program headers, we always create a new segment if the
           // previous address is larger than the current address. Calculating
           // the offsets is taken care automatically. The gnu linker may choose
           // to place the sections in decreasing order of addresses and later
           // decide to sort it as is done in CreateScriptProgramheaders.
           // TODO: raise an error to see LMA needs to be assigned.
+          // Skip for TBSS: its VMA does not advance the dot counter, so a
+          // comparison against the stale prev is meaningless.
           createPT_LOAD = true;
 
         // If Program headers are not specified and the vma difference is big
         // lets create a PT_LOAD to adjust the offset.
-        if (std::abs(vmaoffset) > (int64_t)segAlign)
+        // Skip for TBSS: it shares VMA with the previous section and the large
+        // gap check is meaningless against the stale prev pointer.
+        if ((std::abs(vmaoffset) > (int64_t)segAlign) && (!cur->isTBSS()))
           createPT_LOAD = true;
       }
     }
@@ -522,7 +526,11 @@ bool GNULDBackend::createProgramHdrs() {
       // The flag last_section_needs_new_segment controls that if there was a
       // need to create a PT_LOAD segment but we determined that the size of the
       // section is 0, we set the flag and move on.
-      if (!cur->isWanted())
+      // TBSS sections are also deferred: they never materialise into a real
+      // PT_LOAD; the next non-TBSS section will re-evaluate segment creation
+      // using the pre-TBSS prev pointer, which is correct because TBSS does
+      // not advance the dot counter.
+      if (!cur->isWanted() || cur->isTBSS())
         last_section_needs_new_segment = true;
       else if (!sectionHasLoadSeg &&
                (createPT_LOAD || (cur->addr() < prev->addr()))) {
@@ -672,15 +680,25 @@ bool GNULDBackend::createProgramHdrs() {
             pt_gnu_relro->setAlign(pt_gnu_relro->getMaxSectionAlign());
           }
         }
-        if (!cur->isTBSS())
+        // Do not update layout state for TBSS. TBSS occupies no file space
+        // and its VMA is shared with the section that follows it. Advancing
+        // prev/prev_flag/prevOut/prev_mem_region would make the next real
+        // section compare against a non existent boundary, causing wrong
+        // segment splits and incorrect segment flags.
+        if (!cur->isTBSS()) {
           prev = cur;
+          prev_flag = cur_flag;
+        }
         if (isNoLoad)
           noLoadSections.push_back(cur);
-        prevOut = (*out);
-        prev_flag = cur_flag;
-        if (!cur_mem_region.empty())
+        if (!cur->isTBSS())
+          prevOut = (*out);
+        if (!cur->isTBSS() && !cur_mem_region.empty())
           prev_mem_region = cur_mem_region;
-        load_seg->updateFlag(getSegmentFlag(cur->getFlags()));
+        // Do not let TBSS pollute the PT_LOAD flags: its SHF_WRITE would
+        // incorrectly mark a text segment as writable.
+        if (!cur->isTBSS())
+          load_seg->updateFlag(getSegmentFlag(cur->getFlags()));
         changeSymbolsFromAbsoluteToGlobal(*out);
         last_section_needs_new_segment = false;
         if (!sectionHasLoadSeg) {

--- a/test/AArch64/standalone/TLS_IE/IE.test
+++ b/test/AArch64/standalone/TLS_IE/IE.test
@@ -13,4 +13,3 @@ CHECK: f9400000       ldr
 CHECK: _test_tls_IE_local
 CHECK: d2a00000       movz
 CHECK: f2800280       movk
-

--- a/test/Common/standalone/TLS/OnlyTBSS/Inputs/script.t
+++ b/test/Common/standalone/TLS/OnlyTBSS/Inputs/script.t
@@ -1,0 +1,14 @@
+MEMORY
+{
+  RAM (rw) : ORIGIN = 10000, LENGTH = 5000
+}
+
+SECTIONS {
+ .foo : { *(.text.foo) } > RAM
+ .empty : {} > RAM
+ tbss : { *(.tbss*) } > RAM
+ .empty : {} > RAM
+ .main : { *(.text.main) } > RAM
+ output_data : { BYTE(0x0) *(.data*) } > RAM
+ /DISCARD/ : { *(.riscv.attributes) }
+}

--- a/test/Common/standalone/TLS/OnlyTBSS/Inputs/scripttbssnewregion.t
+++ b/test/Common/standalone/TLS/OnlyTBSS/Inputs/scripttbssnewregion.t
@@ -1,0 +1,16 @@
+MEMORY
+{
+  RAM (rw) : ORIGIN = 10000, LENGTH = 5000
+  ROM (rw) : ORIGIN = 20000, LENGTH = 5000
+}
+
+SECTIONS {
+ .foo : { *(.text.foo) } > RAM
+ .empty : {} > RAM
+ tdata : { *(.tdata*) } > ROM
+ tbss : { *(.tbss*) } > ROM
+ .empty : {} > ROM
+ .main : { *(.text.main) } > ROM
+ output_data : { BYTE(0x0) *(.data*) } > ROM
+ /DISCARD/ : { *(.riscv.attributes) }
+}

--- a/test/Common/standalone/TLS/OnlyTBSS/Inputs/tls.c
+++ b/test/Common/standalone/TLS/OnlyTBSS/Inputs/tls.c
@@ -1,0 +1,4 @@
+__thread int b = 0;
+int data = 100;
+int foo() { return 0; }
+int main() { return 0; }

--- a/test/Common/standalone/TLS/OnlyTBSS/OnlyTBSS.test
+++ b/test/Common/standalone/TLS/OnlyTBSS/OnlyTBSS.test
@@ -1,0 +1,14 @@
+UNSUPPORTED: ndk-build
+#---OnlyTBSS.test--------------------------- Executable  -----------------#
+#BEGIN_COMMENT
+# This tests that using TBSS only does not create an empty segment
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/tls.c -o %t1.1.o -fdata-sections -ftls-model=local-exec -fPIE
+RUN: %link %linkopts  %t1.1.o -T %p/Inputs/script.t  -o %t.out --defsym __aeabi_read_tp=0
+RUN: %readelf -l -W %t.out | %filecheck %s -check-prefix=EMPTYLOAD
+RUN: %link %linkopts  %t1.1.o -T %p/Inputs/scripttbssnewregion.t  -o %t.out --defsym __aeabi_read_tp=0
+RUN: %readelf -l -W %t.out | %filecheck %s -check-prefix=EMPTYLOAD
+#END_TEST
+
+#EMPTYLOAD-NOT: LOAD {{.*}} {{.*}} {{.*}} 0x{{[0]+}} 0x{{[0]+}} {{.*}}

--- a/test/Common/standalone/TLS/TBSSConsecutive/Inputs/1.c
+++ b/test/Common/standalone/TLS/TBSSConsecutive/Inputs/1.c
@@ -1,0 +1,4 @@
+int foo() { return 0; }
+__thread int tbss1 = 0;
+__thread int tbss2 = 0;
+int data = 10;

--- a/test/Common/standalone/TLS/TBSSConsecutive/Inputs/s.t
+++ b/test/Common/standalone/TLS/TBSSConsecutive/Inputs/s.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  .foo   : { *(.text.foo) }
+  .tbss1 : { *(.tbss.tbss1) }
+  .tbss2 : { *(.tbss.tbss2) }
+  .data  : { *(.data.data) }
+}

--- a/test/Common/standalone/TLS/TBSSConsecutive/TBSSConsecutive.test
+++ b/test/Common/standalone/TLS/TBSSConsecutive/TBSSConsecutive.test
@@ -1,0 +1,18 @@
+#---TBSSConsecutive.test----------------------- TLS, Executable -----------------#
+#BEGIN_COMMENT
+# This tests that two consecutive TBSS sections between a text section and a
+# data section do not cause spurious extra LOAD segments, do not pollute the
+# text segment flags, and both land in the PT_TLS segment.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangg0opts -c %p/Inputs/1.c -o %t1.o -ffunction-sections -fdata-sections
+RUN: %link %linkopts %t1.o -T %p/Inputs/s.t -o %t.out
+RUN: %readelf -l -W %t.out | %filecheck %s
+
+#CHECK:      LOAD {{.*}} R E
+#CHECK:      LOAD {{.*}} RW
+#CHECK-NOT:  LOAD
+#CHECK:      00     .foo
+#CHECK:      01     .data
+#CHECK:      {{[0-9]+}}     .tbss1 .tbss2
+#END_TEST

--- a/test/Common/standalone/TLS/TBSSEmptySection/Inputs/1.c
+++ b/test/Common/standalone/TLS/TBSSEmptySection/Inputs/1.c
@@ -1,0 +1,3 @@
+int foo() { return 0; }
+__thread int tbss = 0;
+int data = 10;

--- a/test/Common/standalone/TLS/TBSSEmptySection/Inputs/s_empty_after.t
+++ b/test/Common/standalone/TLS/TBSSEmptySection/Inputs/s_empty_after.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  .foo   : { *(.text.foo) }
+  .tbss  : { *(.tbss.tbss) }
+  .empty : {}
+  .data  : { *(.data.data) }
+}

--- a/test/Common/standalone/TLS/TBSSEmptySection/Inputs/s_empty_before.t
+++ b/test/Common/standalone/TLS/TBSSEmptySection/Inputs/s_empty_before.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  .foo   : { *(.text.foo) }
+  .empty : {}
+  .tbss  : { *(.tbss.tbss) }
+  .data  : { *(.data.data) }
+}

--- a/test/Common/standalone/TLS/TBSSEmptySection/Inputs/s_empty_both.t
+++ b/test/Common/standalone/TLS/TBSSEmptySection/Inputs/s_empty_both.t
@@ -1,0 +1,7 @@
+SECTIONS {
+  .foo    : { *(.text.foo) }
+  .empty1 : {}
+  .tbss   : { *(.tbss.tbss) }
+  .empty2 : {}
+  .data   : { *(.data.data) }
+}

--- a/test/Common/standalone/TLS/TBSSEmptySection/Inputs/s_empty_omagic.t
+++ b/test/Common/standalone/TLS/TBSSEmptySection/Inputs/s_empty_omagic.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  .foo   : { *(.text.foo) }
+  .empty : {}
+  .tbss  : { *(.tbss.tbss) }
+  .data  : { *(.data.data) }
+}

--- a/test/Common/standalone/TLS/TBSSEmptySection/TBSSEmptySection.test
+++ b/test/Common/standalone/TLS/TBSSEmptySection/TBSSEmptySection.test
@@ -1,0 +1,57 @@
+#---TBSSEmptySection.test------------------- TLS, Executable -----------------#
+#BEGIN_COMMENT
+# Tests that empty sections adjacent to TBSS do not disturb segment layout.
+# Empty sections (size 0, not wanted) should be transparent: TBSS must not
+# pollute segment flags and the data section must land in its own RW LOAD.
+# Four scenarios are covered:
+#   EMPTY-BEFORE : empty section between text and TBSS
+#   EMPTY-AFTER  : empty section between TBSS and data
+#   EMPTY-BOTH   : empty sections on both sides of TBSS
+#   EMPTY-OMAGIC : empty section between text and TBSS with --omagic
+#                  (text+data merged into one RWE LOAD, TBSS absent from LOAD)
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o -ffunction-sections -fdata-sections
+
+# Empty section before TBSS
+RUN: %link %linkopts %t1.o -T %p/Inputs/s_empty_before.t -o %t.before.out
+RUN: %readelf -l -W %t.before.out | %filecheck %s --check-prefix=EMPTY-BEFORE
+
+# Empty section after TBSS
+RUN: %link %linkopts %t1.o -T %p/Inputs/s_empty_after.t -o %t.after.out
+RUN: %readelf -l -W %t.after.out | %filecheck %s --check-prefix=EMPTY-AFTER
+
+# Empty sections on both sides of TBSS
+RUN: %link %linkopts %t1.o -T %p/Inputs/s_empty_both.t -o %t.both.out
+RUN: %readelf -l -W %t.both.out | %filecheck %s --check-prefix=EMPTY-BOTH
+
+# Empty section adjacent to TBSS with --omagic
+RUN: %link %linkopts %t1.o -T %p/Inputs/s_empty_omagic.t --omagic -o %t.omagic.out
+RUN: %readelf -l -W %t.omagic.out | %filecheck %s --check-prefix=EMPTY-OMAGIC
+#END_TEST
+
+# Empty section before TBSS: text R E, data RW, no spurious LOAD
+EMPTY-BEFORE:      LOAD {{.*}} R E
+EMPTY-BEFORE:      LOAD {{.*}} RW
+EMPTY-BEFORE-NOT:  LOAD
+EMPTY-BEFORE:      00     .foo
+EMPTY-BEFORE:      01     {{.*}}.data
+
+# Empty section after TBSS: same expected layout
+EMPTY-AFTER:      LOAD {{.*}} R E
+EMPTY-AFTER:      LOAD {{.*}} RW
+EMPTY-AFTER-NOT:  LOAD
+EMPTY-AFTER:      00     .foo
+EMPTY-AFTER:      01     {{.*}}.data
+
+# Empty sections on both sides of TBSS: same expected layout
+EMPTY-BOTH:      LOAD {{.*}} R E
+EMPTY-BOTH:      LOAD {{.*}} RW
+EMPTY-BOTH-NOT:  LOAD
+EMPTY-BOTH:      00     .foo
+EMPTY-BOTH:      01     {{.*}}.data
+
+# With --omagic: text+data merged into one RWE LOAD, TBSS absent from LOAD
+EMPTY-OMAGIC:      LOAD {{.*}} RWE
+EMPTY-OMAGIC-NOT:  LOAD
+EMPTY-OMAGIC:      00     .foo {{.*}}.data

--- a/test/Common/standalone/TLS/TBSSFirst/Inputs/1.c
+++ b/test/Common/standalone/TLS/TBSSFirst/Inputs/1.c
@@ -1,0 +1,3 @@
+int foo() { return 0; }
+__thread int tbss = 0;
+int data = 10;

--- a/test/Common/standalone/TLS/TBSSFirst/Inputs/s.t
+++ b/test/Common/standalone/TLS/TBSSFirst/Inputs/s.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  .tbss : { *(.tbss.tbss) }
+  .foo  : { *(.text.foo) }
+  .data : { *(.data.data) }
+  /DISCARD/ : { *(.ARM.exidx*) *(.eh_frame*) }
+}

--- a/test/Common/standalone/TLS/TBSSFirst/TBSSFirst.test
+++ b/test/Common/standalone/TLS/TBSSFirst/TBSSFirst.test
@@ -1,0 +1,18 @@
+#---TBSSFirst.test----------------------- TLS, Executable -----------------#
+#BEGIN_COMMENT
+# This tests that when TBSS is the first allocatable section in the linker
+# script, no spurious empty PT_LOAD segment is created for it. Before the fix,
+# the !load_seg trigger would create a PT_LOAD seeded with TBSS's RW flags,
+# producing an extra empty LOAD segment before the real text segment.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangg0opts -c %p/Inputs/1.c -o %t1.o -ffunction-sections -fdata-sections
+RUN: %link %linkopts %t1.o -T %p/Inputs/s.t -o %t.out
+RUN: %readelf -l -W %t.out | %filecheck %s
+
+#CHECK:      LOAD {{.*}} R E
+#CHECK:      LOAD {{.*}} RW
+#CHECK-NOT:  LOAD
+#CHECK:      00     .foo
+#CHECK:      01     .data
+#END_TEST

--- a/test/Common/standalone/TLS/TBSSLargeVMAOffset/Inputs/1.c
+++ b/test/Common/standalone/TLS/TBSSLargeVMAOffset/Inputs/1.c
@@ -1,0 +1,3 @@
+int foo() { return 0; }
+__thread int tbss = 0;
+int data = 10;

--- a/test/Common/standalone/TLS/TBSSLargeVMAOffset/Inputs/s.t
+++ b/test/Common/standalone/TLS/TBSSLargeVMAOffset/Inputs/s.t
@@ -1,0 +1,5 @@
+SECTIONS {
+  .foo  0x1000 : { *(.text.foo) }
+  .tbss 0x3000 : { *(.tbss.tbss) }
+  .data        : { *(.data.data) }
+}

--- a/test/Common/standalone/TLS/TBSSLargeVMAOffset/TBSSLargeVMAOffset.test
+++ b/test/Common/standalone/TLS/TBSSLargeVMAOffset/TBSSLargeVMAOffset.test
@@ -1,0 +1,25 @@
+#---TBSSLargeVMAOffset.test----------------------- TLS, Executable -----------------#
+#BEGIN_COMMENT
+# This tests the condition:
+#   if ((std::abs(vmaoffset) > segAlign) && (!cur->isTBSS()))
+#
+# When a TBSS section is placed at a VMA more than one page away from the
+# previous section, the large vmaoffset must not trigger a new PT_LOAD for
+# the TBSS section itself. The TBSS section has no file content and is handled
+# by PT_TLS, so only two LOAD segments should be produced: one for the text
+# section and one for the data section that follows the TBSS.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangg0opts -c %p/Inputs/1.c -o %t1.o -ffunction-sections -fdata-sections
+RUN: %link %linkopts %t1.o -T %p/Inputs/s.t -o %t.out
+RUN: %readelf -l -W %t.out | %filecheck %s
+
+# Exactly two LOAD segments: text (R E) and data (RW). TBSS must not produce
+# a third LOAD despite its VMA being more than one page from .foo.
+#CHECK:      LOAD {{.*}} 0x{{[0-9a-f]+}}1000 {{.*}} R E
+#CHECK:      LOAD {{.*}} 0x{{[0-9a-f]+}}3000 {{.*}} RW
+#CHECK-NOT:  LOAD
+#CHECK:      00     .foo
+#CHECK:      01     .data
+#CHECK:      {{[0-9]+}}     .tbss
+#END_TEST

--- a/test/Common/standalone/TLS/TBSSMultipleVars/Inputs/1.c
+++ b/test/Common/standalone/TLS/TBSSMultipleVars/Inputs/1.c
@@ -1,0 +1,5 @@
+int foo() { return 0; }
+__thread int tls_a = 0;
+__thread int tls_b = 0;
+__thread int tls_c = 0;
+int data = 10;

--- a/test/Common/standalone/TLS/TBSSMultipleVars/Inputs/s.t
+++ b/test/Common/standalone/TLS/TBSSMultipleVars/Inputs/s.t
@@ -1,0 +1,7 @@
+SECTIONS {
+  .foo    : { *(.text.foo) }
+  .tbss.a : { *(.tbss.tls_a) }
+  .tbss.b : { *(.tbss.tls_b) }
+  .tbss.c : { *(.tbss.tls_c) }
+  .data   : { *(.data.data) }
+}

--- a/test/Common/standalone/TLS/TBSSMultipleVars/Inputs/s_empty.t
+++ b/test/Common/standalone/TLS/TBSSMultipleVars/Inputs/s_empty.t
@@ -1,0 +1,8 @@
+SECTIONS {
+  .foo    : { *(.text.foo) }
+  .tbss.a : { *(.tbss.tls_a) }
+  .empty  : {}
+  .tbss.b : { *(.tbss.tls_b) }
+  .tbss.c : { *(.tbss.tls_c) }
+  .data   : { *(.data.data) }
+}

--- a/test/Common/standalone/TLS/TBSSMultipleVars/TBSSMultipleVars.test
+++ b/test/Common/standalone/TLS/TBSSMultipleVars/TBSSMultipleVars.test
@@ -1,0 +1,55 @@
+#---TBSSMultipleVars.test------------------- TLS, Executable -----------------#
+#BEGIN_COMMENT
+# Tests that multiple per-variable TBSS sections (produced by -fdata-sections)
+# are handled correctly across basic segment-layout scenarios. None of the TBSS
+# sections should appear in any LOAD segment, and they must not contaminate
+# segment flags or prevent the data section from landing in its own RW LOAD.
+#
+# Three scenarios are covered here:
+#   DEFAULT : no linker script, merged .tbss
+#   SCRIPT  : per-variable .tbss.a/.tbss.b/.tbss.c via linker script
+#   EMPTY   : empty section interleaved between per-variable TBSS sections
+#
+# Additional scenarios are in dedicated tests:
+#   TBSSMultipleVarsRelro        (-z relro)
+#   TBSSMultipleVarsSeparateLoad (-z separate-loadable-segments)
+#   TBSSMultipleVarsOmagic       (--omagic)
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o -ffunction-sections -fdata-sections
+
+# Default: no linker script, compiler merges all .tbss.* into one .tbss
+RUN: %link %linkopts %t1.o -o %t.default.out
+RUN: %readelf -l -W %t.default.out | %filecheck %s --check-prefix=DEFAULT
+
+# Per-variable TBSS sections via linker script
+RUN: %link %linkopts %t1.o -T %p/Inputs/s.t -o %t.script.out
+RUN: %readelf -l -W %t.script.out | %filecheck %s --check-prefix=SCRIPT
+
+# Empty section interleaved between per-variable TBSS sections
+RUN: %link %linkopts %t1.o -T %p/Inputs/s_empty.t -o %t.empty.out
+RUN: %readelf -l -W %t.empty.out | %filecheck %s --check-prefix=EMPTY
+#END_TEST
+
+# Default: two LOADs (R E text, RW data), TLS covers all three TBSS vars
+DEFAULT:      LOAD {{.*}} R E
+DEFAULT:      LOAD {{.*}} RW
+DEFAULT-NOT:  LOAD
+DEFAULT:      00     .text
+DEFAULT:      01     {{.*}}data
+
+# Script: two LOADs, all three per-var sections in TLS not in any LOAD
+SCRIPT:      LOAD {{.*}} R E
+SCRIPT:      LOAD {{.*}} RW
+SCRIPT-NOT:  LOAD
+SCRIPT:      00     .foo
+SCRIPT:      01     {{.*}}.data
+SCRIPT:      {{[0-9]+}}     .tbss.a .tbss.b .tbss.c
+
+# Empty interleaved: same layout as SCRIPT
+EMPTY:      LOAD {{.*}} R E
+EMPTY:      LOAD {{.*}} RW
+EMPTY-NOT:  LOAD
+EMPTY:      00     .foo
+EMPTY:      01     {{.*}}.data
+EMPTY:      {{[0-9]+}}     .tbss.a .tbss.b .tbss.c

--- a/test/Common/standalone/TLS/TBSSSegmentFlags/Inputs/1.c
+++ b/test/Common/standalone/TLS/TBSSSegmentFlags/Inputs/1.c
@@ -1,0 +1,3 @@
+int foo() { return 0; }
+__thread int tbss = 0;
+int data = 10;

--- a/test/Common/standalone/TLS/TBSSSegmentFlags/Inputs/s.t
+++ b/test/Common/standalone/TLS/TBSSSegmentFlags/Inputs/s.t
@@ -1,0 +1,5 @@
+SECTIONS {
+  .foo : { *(.text.foo) }
+  .tbss : { *(.tbss.tbss) }
+  .data : { *(.data.data) }
+}

--- a/test/Common/standalone/TLS/TBSSSegmentFlags/TBSSSegmentFlags.test
+++ b/test/Common/standalone/TLS/TBSSSegmentFlags/TBSSSegmentFlags.test
@@ -1,0 +1,17 @@
+#---TBSSSegmentFlags.test--------------------------- TLS, Executable -----------------#
+#BEGIN_COMMENT
+# This tests that a TBSS section between a text section and a data section does
+# not cause them to be merged into one LOAD segment, and that the text segment
+# is not incorrectly marked writable due to TBSS flags.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o -ffunction-sections -fdata-sections
+RUN: %link %linkopts %t1.o -T %p/Inputs/s.t -o %t.out
+RUN: %readelf -l -W %t.out | %filecheck %s
+
+#CHECK:      LOAD {{.*}} R E
+#CHECK:      LOAD {{.*}} RW
+#CHECK-NOT:  LOAD
+#CHECK:      00     .foo
+#CHECK:      01     {{.*}}.data
+#END_TEST

--- a/test/Common/standalone/TLS/TBSSWithData/TBSSWithData.test
+++ b/test/Common/standalone/TLS/TBSSWithData/TBSSWithData.test
@@ -8,4 +8,7 @@ RUN: %clang %clangopts -c %p/Inputs/tls.c  -o %t1.tls.o %clangg0opts
 RUN: %link %linkopts %t1.tls.o -o %t2.out  %linkg0opts
 RUN: %readelf -l -W %t2.out | %filecheck %s
 
-#CHECK: .data .bss
+#CHECK:      LOAD {{.*}} R E
+#CHECK:      LOAD {{.*}} RW
+#CHECK-NOT:  LOAD
+#CHECK:      {{[0-9]+}}     {{.*}}.data

--- a/test/Hexagon/TLS/headers/headers.test
+++ b/test/Hexagon/TLS/headers/headers.test
@@ -29,12 +29,10 @@ RUN: %readelf -l -S -s -W %t6.out |   %filecheck %s --check-prefix="TBSSDATA"
 #ALL: 00000008     4 TLS     GLOBAL DEFAULT    {{[0-9]}} b
 #TBSSTDATA:  LOAD           {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} 0x00004 0x00004 RW  0x1000
 #TBSSTDATA:  TLS            {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} 0x00004 0x00008 R   0x8
-#TBSS:  LOAD           {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} R E 0x1000
 #TBSS:  TLS            {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} 0x00000 0x00008 R   0x8
 #TDATADATA:  LOAD           {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} 0x00008 0x00008 RW  0x1000
 #TDATADATA:  TLS            {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} 0x00004 0x00008 R   0x8
 #TDATA:  LOAD           {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} 0x00004 0x00004 RW  0x1000
 #TDATA:  TLS            {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} 0x00004 0x00008 R   0x8
-#TBSSDATA:  LOAD           {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} 0x00004 0x00004 RW  0x1000
 #TBSSDATA:  TLS            {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} 0x00000 0x00008 R   0x8
 

--- a/test/Hexagon/linux/TLS/headers/headers.test
+++ b/test/Hexagon/linux/TLS/headers/headers.test
@@ -33,12 +33,10 @@ RUN: %readelf -l -S -s -W %t6.out |   %filecheck %s --check-prefix="TBSSDATA"
 #ALL: 00000008     4 TLS     GLOBAL DEFAULT    {{[0-9]}} b
 #TBSSTDATA:  LOAD           {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} 0x00004 0x00004 RW  0x10000
 #TBSSTDATA:  TLS            {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} 0x00004 0x00008 R   0x8
-#TBSS:  LOAD           {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} R E 0x10000
 #TBSS:  TLS            {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} 0x00000 0x00008 R   0x8
 #TDATADATA:  LOAD           {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} 0x00008 0x00008 RW  0x10000
 #TDATADATA:  TLS            {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} 0x00004 0x00008 R   0x8
 #TDATA:  LOAD           {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} 0x00004 0x00004 RW  0x10000
 #TDATA:  TLS            {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} 0x00004 0x00008 R   0x8
-#TBSSDATA:  LOAD           {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} 0x00004 0x00004 RW  0x10000
 #TBSSDATA:  TLS            {{[x0-9a-z]+}} {{[x0-9a-z]+}} {{[x0-9a-z]+}} 0x00000 0x00008 R   0x8
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -395,7 +395,6 @@ if config.test_target == 'AArch64':
     link = 'ld.eld -m aarch64elf -mtriple aarch64-unknown-none-elf'
     clang = 'clang -target aarch64-unknown-none-elf'
     clangxx = 'clang++ -target aarch64-unknown-none-elf'
-
     clangas = 'clang'
     linkopts = '--thread-count 4  --threads'
     if hasattr(config,'eld_option') and config.eld_option != 'default':


### PR DESCRIPTION
TBSS (.tbss) sections occupy no file space and do not advance the dot counter; their VMA is shared with the section that *follows* them.  The program-header loop treated TBSS like any other allocatable section when deciding whether to open a new PT_LOAD, producing empty segments whenever the link contained only TBSS sections or TBSS appeared between two real sections.

After placing a TBSS section into a segment, the loop updated prev, prev_flag, prevOut, and prev_mem_region.  Because TBSS shares VMA with the section that follows it and does not advance the dot counter, advancing those pointers made the next real section compare against a non existent boundary.

The now-redundant isPrevTBSS variable is removed.

Resolves #353