### PR TITLE
[GNULDBackend] Replace std::move with std::copy in sizeDynNamePools

### DIFF
--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -816,9 +816,8 @@ void GNULDBackend::sizeDynNamePools() {
 
     DynamicSymbols.push_back(LDSymbol::null()->resolveInfo());
 
-    // Move all the DynamicSymbols.
-    // FIXME: Is it really moving?
-    std::move(PartitionBegin, RVect.end(), std::back_inserter(DynamicSymbols));
+    // Copy all the DynamicSymbols.
+    std::copy(PartitionBegin, RVect.end(), std::back_inserter(DynamicSymbols));
   }
 
   {


### PR DESCRIPTION
std::move on a range of raw pointers (ResolveInfo *) is identical to std::copy — raw pointers are trivially copyable and moving them does not null the source. Using std::move here is misleading.
Resolves #1301 . 