### PR TITLE
[RISCV] Implement the Xqccmt Qualcomm Vendor Extension

### DIFF
--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -66,6 +66,8 @@ public:
 
   enum HashStyle { SystemV = 0x1, GNU = 0x2, Both = 0x3 };
 
+  enum class RISCVRelaxTbljalMode { None, Zcmt, Xqccmt };
+
   enum TraceType { T_Files = 0x1, T_Trampolines = 0x2, T_Symbols = 0x4 };
 
   enum LTOOptionType {
@@ -934,9 +936,21 @@ public:
 
   bool getRISCVRelaxTLSDESC() const { return BRiscvRelaxTLSDESC; }
 
-  void setRISCVRelaxTbljal(bool Value) { BRiscvRelaxTbljal = Value; }
+  void setRISCVRelaxTbljal(RISCVRelaxTbljalMode Mode) {
+    RiscvRelaxTbljal = Mode;
+  }
 
-  bool getRISCVRelaxTbljal() const { return BRiscvRelaxTbljal; }
+  bool getRISCVRelaxTbljal() const {
+    return RiscvRelaxTbljal != RISCVRelaxTbljalMode::None;
+  }
+
+  RISCVRelaxTbljalMode getRISCVRelaxTbljalMode() const {
+    return RiscvRelaxTbljal;
+  }
+
+  bool getRISCVRelaxTbljalToXqccmt() const {
+    return RiscvRelaxTbljal == RISCVRelaxTbljalMode::Xqccmt;
+  }
 
   bool warnCommon() const { return BWarnCommon; }
 
@@ -1301,7 +1315,8 @@ private:
   bool BRiscvRelaxToC = true; // enable riscv relax to compressed code
   bool BRiscvRelaxXqci = false; // enable riscv relaxations for xqci
   bool BRiscvRelaxTLSDESC = true; // enable riscv relaxations for TLSDESC
-  bool BRiscvRelaxTbljal = false; // enable Zcmt table jump relaxation
+  RISCVRelaxTbljalMode RiscvRelaxTbljal =
+      RISCVRelaxTbljalMode::None; // enable Zcmt/Xqccmt table jump relaxation
   bool AllowIncompatibleSectionsMix = false; // Allow incompatibleSections;
   bool ProgressBar = false;                  // Show progressbar.
   bool RecordInputFiles = false;             // --reproduce

--- a/include/eld/Driver/RISCVLinkerOptions.td
+++ b/include/eld/Driver/RISCVLinkerOptions.td
@@ -63,9 +63,14 @@ def relax_tbljal
     : Flag<["--"], "relax-tbljal">,
       HelpText<"Enable conversion of call/jump instructions to Zcmt table jump instructions (cm.jt/cm.jalt)">,
       Group<grp_riscv_linker>;
+def relax_tbljal_eq
+    : Joined<["--"], "relax-tbljal=">,
+      HelpText<"Enable conversion of call/jump instructions to table jump instructions for zcmt or xqccmt (default: zcmt)">,
+      MetaVarName<"<zcmt|xqccmt>">,
+      Group<grp_riscv_linker>;
 def no_relax_tbljal
     : Flag<["--"], "no-relax-tbljal">,
-      HelpText<"Disable conversion of call/jump instructions to Zcmt table jump instructions (default behavior)">,
+      HelpText<"Disable conversion of call/jump instructions to table jump instructions (default behavior)">,
       Group<grp_riscv_linker>;
 def enable_bss_mixing : Flag<["--"], "enable-bss-mixing">,
                         HelpText<"Enable mixing BSS/NonBSS sections">,

--- a/lib/LinkerWrapper/RISCVLinkDriver.cpp
+++ b/lib/LinkerWrapper/RISCVLinkDriver.cpp
@@ -155,8 +155,8 @@ RISCVLinkDriver::parseOptions(ArrayRef<const char *> Args,
       TbljalMode =
           llvm::StringSwitch<GeneralOptions::RISCVRelaxTbljalMode>(
               Arg->getValue())
-              .Case("zcmt", GeneralOptions::RISCVRelaxTbljalMode::Zcmt)
-              .Case("xqccmt", GeneralOptions::RISCVRelaxTbljalMode::Xqccmt)
+              .CaseLower("zcmt", GeneralOptions::RISCVRelaxTbljalMode::Zcmt)
+              .CaseLower("xqccmt", GeneralOptions::RISCVRelaxTbljalMode::Xqccmt)
               .Default(GeneralOptions::RISCVRelaxTbljalMode::None);
       if (TbljalMode == GeneralOptions::RISCVRelaxTbljalMode::None) {
         Config.raise(Diag::invalid_value_for_option)

--- a/lib/LinkerWrapper/RISCVLinkDriver.cpp
+++ b/lib/LinkerWrapper/RISCVLinkDriver.cpp
@@ -140,19 +140,41 @@ RISCVLinkDriver::parseOptions(ArrayRef<const char *> Args,
   if (ArgList.hasArg(OPT_RISCVLinkOptTable::no_relax_tlsdesc))
     Config.options().setRISCVRelaxTLSDESC(false);
 
-  // --relax-tbljal, --no-relax-tbljal (default)
-  bool EnableTbljal =
-      ArgList.hasFlag(OPT_RISCVLinkOptTable::relax_tbljal,
-                      OPT_RISCVLinkOptTable::no_relax_tbljal, false);
-  if (EnableTbljal && (ArgList.hasArg(OPT_RISCVLinkOptTable::shared) ||
-                       ArgList.hasFlag(OPT_RISCVLinkOptTable::pie,
-                                       OPT_RISCVLinkOptTable::no_pie, false))) {
+  // --relax-tbljal[=zcmt|xqccmt], --no-relax-tbljal (default)
+  GeneralOptions::RISCVRelaxTbljalMode TbljalMode =
+      GeneralOptions::RISCVRelaxTbljalMode::None;
+  if (llvm::opt::Arg *Arg =
+          ArgList.getLastArg(OPT_RISCVLinkOptTable::relax_tbljal,
+                             OPT_RISCVLinkOptTable::relax_tbljal_eq,
+                             OPT_RISCVLinkOptTable::no_relax_tbljal)) {
+    if (Arg->getOption().matches(OPT_RISCVLinkOptTable::no_relax_tbljal)) {
+      TbljalMode = GeneralOptions::RISCVRelaxTbljalMode::None;
+    } else if (Arg->getOption().matches(OPT_RISCVLinkOptTable::relax_tbljal)) {
+      TbljalMode = GeneralOptions::RISCVRelaxTbljalMode::Zcmt;
+    } else {
+      TbljalMode =
+          llvm::StringSwitch<GeneralOptions::RISCVRelaxTbljalMode>(
+              Arg->getValue())
+              .Case("zcmt", GeneralOptions::RISCVRelaxTbljalMode::Zcmt)
+              .Case("xqccmt", GeneralOptions::RISCVRelaxTbljalMode::Xqccmt)
+              .Default(GeneralOptions::RISCVRelaxTbljalMode::None);
+      if (TbljalMode == GeneralOptions::RISCVRelaxTbljalMode::None) {
+        Config.raise(Diag::invalid_value_for_option)
+            << Arg->getOption().getPrefixedName() << Arg->getValue();
+        return LINK_FAIL;
+      }
+    }
+  }
+  if (TbljalMode != GeneralOptions::RISCVRelaxTbljalMode::None &&
+      (ArgList.hasArg(OPT_RISCVLinkOptTable::shared) ||
+       ArgList.hasFlag(OPT_RISCVLinkOptTable::pie,
+                       OPT_RISCVLinkOptTable::no_pie, false))) {
     Config.raise(Diag::not_supported)
-        << "Zcmt table jump relaxation"
+        << "Zcmt/Xqccmt table jump relaxation"
         << "shared libraries or position independent code";
     return LINK_FAIL;
   }
-  Config.options().setRISCVRelaxTbljal(EnableTbljal);
+  Config.options().setRISCVRelaxTbljal(TbljalMode);
 
   // --enable-bss-mixing
   if (ArgList.hasArg(OPT_RISCVLinkOptTable::enable_bss_mixing))

--- a/lib/Target/RISCV/RISCVAttributeFragment.h
+++ b/lib/Target/RISCV/RISCVAttributeFragment.h
@@ -61,6 +61,10 @@ public:
   bool updateInfo(llvm::StringRef Contents, InputFile *I,
                   DiagnosticEngine *DiagEngine, bool ShowAttributeMixWarnings);
 
+  bool hasExtension(llvm::StringRef Ext) const {
+    return exts.count(Ext.str()) != 0;
+  }
+
 private:
   bool getStringAttribute(llvm::RISCVAttributeParser &, uint32_t Tag,
                           std::string &Value);

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -545,6 +545,7 @@ bool RISCVLDBackend::doRelaxationQCCall(Relocation *reloc) {
   // extract instruction
   uint64_t qc_e_jump = reloc->target() & 0xffffffffffff;
   unsigned rd = getQCEJumpRd(qc_e_jump);
+  const bool IsValidRd = isValidQCEJumpRd(rd);
   bool isTailCall = rd == 0;
 
   Relocator::DWord S = getSymbolValuePLT(*reloc);
@@ -556,7 +557,7 @@ bool RISCVLDBackend::doRelaxationQCCall(Relocation *reloc) {
   bool DoCompressed = config().options().getRISCVRelaxToC();
   bool canRelaxXqci =
       config().targets().is32Bits() && config().options().getRISCVRelaxXqci();
-  bool canRelax = doRelax && canRelaxXqci && rd != 32;
+  bool canRelax = doRelax && canRelaxXqci && IsValidRd;
   bool canCompress =
       canRelax && DoCompressed && llvm::isInt<12>(X) && (rd == 0 || rd == 1);
   bool canRelaxTbljal = canRelax && DoCompressed &&

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -533,8 +533,8 @@ bool RISCVLDBackend::doRelaxationJal(Relocation *reloc) {
 }
 
 bool RISCVLDBackend::doRelaxationQCCall(Relocation *reloc) {
-  // This function performs the relaxation to replace QC.E.J, QC.E.JAL, or
-  // QC.E.JALT with one of CM.JT/CM.JALT, JAL, C.J, or C.JAL.
+  // This function performs the relaxation to replace QC.E.J or QC.E.JAL with
+  // one of CM.JT/CM.JALT, JAL, C.J, or C.JAL.
 
   Fragment *frag = reloc->targetRef()->frag();
   RegionFragmentEx *region = llvm::dyn_cast<RegionFragmentEx>(frag);
@@ -629,8 +629,6 @@ bool RISCVLDBackend::doRelaxationQCCall(Relocation *reloc) {
   const char *msg = "RISCV_QC_E_JAL";
   if (isTailCall)
     msg = "RISCV_QC_E_J";
-  else if (rd == 5)
-    msg = "RISCV_QC_E_JALT";
   relaxDeleteBytes(msg, *region, offset + 4, 2,
                    reloc->symInfo()->name());
 

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -165,7 +165,7 @@ void RISCVLDBackend::initTargetSymbols() {
     return;
 
   if (TableJumpFragment) {
-    // The __jvt_base$ symbol contains the Zcmt jump table base address.
+    // The __jvt_base$ symbol contains the Zcmt/Xqccmt jump table base address.
     std::string JvtName = "__jvt_base$";
     m_pJvtBase =
         m_Module.getIRBuilder()
@@ -321,15 +321,18 @@ void RISCVLDBackend::reportMissedRelaxation(StringRef Name,
   recordRelaxationStats(Section, 0, NumBytes);
 }
 
-// Select the matching JVT entry lookup for rd (x0 -> cm.jt, x1 -> cm.jalt).
+// Select the matching JVT entry lookup for rd.
+// x0 uses the jump-only table instruction.
+// x1 uses the normal link-register table instruction.
+// x5 is Xqccmt-only and uses bit 0 in the JVT entry to request t0 as link.
 // Returns the table entry index, or -1 when this relocation is not eligible.
 static int
 getTableJumpEntryIndex(const RISCVTableJumpFragment &TableJumpFragment,
                        const ResolveInfo *Sym, unsigned Rd) {
   if (Rd == 0)
     return TableJumpFragment.getCMJTEntryIndex(Sym);
-  if (Rd == 1)
-    return TableJumpFragment.getCMJALTEntryIndex(Sym);
+  if (Rd == 1 || Rd == 5)
+    return TableJumpFragment.getCMJALTEntryIndex(Sym, Rd);
   return -1;
 }
 
@@ -530,8 +533,8 @@ bool RISCVLDBackend::doRelaxationJal(Relocation *reloc) {
 }
 
 bool RISCVLDBackend::doRelaxationQCCall(Relocation *reloc) {
-  // This function performs the relaxation to replace: QC.E.JAL or QC.E.J with
-  // one of CM.JT/CM.JALT, JAL, C.J, or C.JAL.
+  // This function performs the relaxation to replace QC.E.J, QC.E.JAL, or
+  // QC.E.JALT with one of CM.JT/CM.JALT, JAL, C.J, or C.JAL.
 
   Fragment *frag = reloc->targetRef()->frag();
   RegionFragmentEx *region = llvm::dyn_cast<RegionFragmentEx>(frag);
@@ -541,7 +544,8 @@ bool RISCVLDBackend::doRelaxationQCCall(Relocation *reloc) {
 
   // extract instruction
   uint64_t qc_e_jump = reloc->target() & 0xffffffffffff;
-  bool isTailCall = (qc_e_jump & 0xf1f07f) == 0x00401f;
+  unsigned rd = getQCEJumpRd(qc_e_jump);
+  bool isTailCall = rd == 0;
 
   Relocator::DWord S = getSymbolValuePLT(*reloc);
   Relocator::DWord A = reloc->addend();
@@ -552,8 +556,9 @@ bool RISCVLDBackend::doRelaxationQCCall(Relocation *reloc) {
   bool DoCompressed = config().options().getRISCVRelaxToC();
   bool canRelaxXqci =
       config().targets().is32Bits() && config().options().getRISCVRelaxXqci();
-  bool canRelax = doRelax && canRelaxXqci;
-  bool canCompress = canRelax && DoCompressed && llvm::isInt<12>(X);
+  bool canRelax = doRelax && canRelaxXqci && rd != 32;
+  bool canCompress =
+      canRelax && DoCompressed && llvm::isInt<12>(X) && (rd == 0 || rd == 1);
   bool canRelaxTbljal = canRelax && DoCompressed &&
                         config().options().getRISCVRelaxTbljal() &&
                         llvm::isUInt<32>(S + A);
@@ -597,7 +602,6 @@ bool RISCVLDBackend::doRelaxationQCCall(Relocation *reloc) {
   if (canRelaxTbljal && TableJumpFragment && TableJumpFragment->size() &&
       m_pRISCVTableJumpSection && !m_pRISCVTableJumpSection->isIgnore() &&
       !m_pRISCVTableJumpSection->isDiscard()) {
-    unsigned rd = isTailCall ? /*x0*/ 0 : /*ra*/ 1;
     int EntryIndex =
         getTableJumpEntryIndex(*TableJumpFragment, reloc->symInfo(), rd);
     if (EntryIndex >= 0) {
@@ -615,7 +619,6 @@ bool RISCVLDBackend::doRelaxationQCCall(Relocation *reloc) {
   }
 
   // Replace the instruction to JAL
-  unsigned rd = isTailCall ? /*x0*/ 0 : /*ra*/ 1;
   uint32_t jal_instr = 0x6fu | rd << 7;
   region->replaceInstruction(offset, reloc,
                              reinterpret_cast<uint8_t *>(&jal_instr), 4);
@@ -623,7 +626,11 @@ bool RISCVLDBackend::doRelaxationQCCall(Relocation *reloc) {
   reloc->setType(llvm::ELF::R_RISCV_JAL);
   reloc->setTargetData(jal_instr);
   // Delete the next instruction
-  const char *msg = isTailCall ? "RISCV_QC_E_J" : "RISCV_QC_E_JAL";
+  const char *msg = "RISCV_QC_E_JAL";
+  if (isTailCall)
+    msg = "RISCV_QC_E_J";
+  else if (rd == 5)
+    msg = "RISCV_QC_E_JALT";
   relaxDeleteBytes(msg, *region, offset + 4, 2,
                    reloc->symInfo()->name());
 

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -545,7 +545,6 @@ bool RISCVLDBackend::doRelaxationQCCall(Relocation *reloc) {
   // extract instruction
   uint64_t qc_e_jump = reloc->target() & 0xffffffffffff;
   unsigned rd = getQCEJumpRd(qc_e_jump);
-  const bool IsValidRd = isValidQCEJumpRd(rd);
   bool isTailCall = rd == 0;
 
   Relocator::DWord S = getSymbolValuePLT(*reloc);
@@ -557,7 +556,7 @@ bool RISCVLDBackend::doRelaxationQCCall(Relocation *reloc) {
   bool DoCompressed = config().options().getRISCVRelaxToC();
   bool canRelaxXqci =
       config().targets().is32Bits() && config().options().getRISCVRelaxXqci();
-  bool canRelax = doRelax && canRelaxXqci && IsValidRd;
+  bool canRelax = doRelax && canRelaxXqci && isValidQCEJumpRd(rd);
   bool canCompress =
       canRelax && DoCompressed && llvm::isInt<12>(X) && (rd == 0 || rd == 1);
   bool canRelaxTbljal = canRelax && DoCompressed &&

--- a/lib/Target/RISCV/RISCVRelocationHelper.h
+++ b/lib/Target/RISCV/RISCVRelocationHelper.h
@@ -90,6 +90,19 @@ enum Reg {
   return inst;
 }
 
+[[maybe_unused]] unsigned getQCEJumpRd(uint64_t insn) {
+  switch ((insn >> 15) & 0x3) {
+  case 0:
+    return X_ZERO;
+  case 1:
+    return X_RA;
+  case 2:
+    return X_T0;
+  default:
+    return 32;
+  }
+}
+
 // Extract bits v[begin:end], where range is inclusive, and begin must be < 63.
 [[maybe_unused]] uint32_t extractBits(uint64_t v, uint32_t begin,
                                       uint32_t end) {

--- a/lib/Target/RISCV/RISCVRelocationHelper.h
+++ b/lib/Target/RISCV/RISCVRelocationHelper.h
@@ -96,8 +96,6 @@ enum Reg {
     return X_ZERO;
   case 1:
     return X_RA;
-  case 2:
-    return X_T0;
   default:
     return 32;
   }

--- a/lib/Target/RISCV/RISCVRelocationHelper.h
+++ b/lib/Target/RISCV/RISCVRelocationHelper.h
@@ -91,14 +91,11 @@ enum Reg {
 }
 
 [[maybe_unused]] unsigned getQCEJumpRd(uint64_t insn) {
-  switch ((insn >> 15) & 0x3) {
-  case 0:
-    return X_ZERO;
-  case 1:
-    return X_RA;
-  default:
-    return 32;
-  }
+  return (insn >> 15) & 0x3;
+}
+
+[[maybe_unused]] bool isValidQCEJumpRd(unsigned Rd) {
+  return Rd == X_ZERO || Rd == X_RA;
 }
 
 // Extract bits v[begin:end], where range is inclusive, and begin must be < 63.

--- a/lib/Target/RISCV/RISCVTableJump.cpp
+++ b/lib/Target/RISCV/RISCVTableJump.cpp
@@ -4,16 +4,23 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //===----------------------------------------------------------------------===//
 //
-// This file implements RISC-V Zcmt table-jump handling for linker relaxation:
-// - scans call/jal relocations and selects profitable cm.jt/cm.jalt entries
+// This file implements RISC-V table-jump handling for linker relaxation:
+// - scans call/jal relocations and selects profitable table entries
 // - materializes and emits the .riscv.jvt table
 // - provides map-dump support for selected table-jump entries
+//
+// Zcmt and Xqccmt use the same 16-bit instruction encoding. Zcmt calls the
+// instructions cm.jt/cm.jalt. Xqccmt calls them qc.cm.jt/qc.cm.jalt.
+// Xqccmt also lets qc.cm.jalt write the return address to t0 (x5). It does
+// that by storing bit 0 as metadata in the JVT entry. A clear bit means ra
+// (x1). A set bit means t0 (x5). The real jump target always has bit 0 clear.
 //
 // ABI reference:
 // https://riscv-non-isa.github.io/riscv-elf-psabi-doc/#_table_jump_relaxation
 
 #include "RISCVTableJump.h"
 #include "RISCVLDBackend.h"
+#include "RISCVRelocationHelper.h"
 #include "RISCVRelocationInternal.h"
 #include "eld/Core/Module.h"
 #include "eld/Readers/ELFSection.h"
@@ -61,8 +68,20 @@ static uint64_t getTableJumpTargetVA(RISCVLDBackend &Backend,
   return Backend.getSymbolValuePLT(const_cast<ResolveInfo &>(*Sym));
 }
 
+static unsigned getCallTableCandidateCount(
+    const llvm::DenseMap<const ResolveInfo *, RISCVTableJumpEntry>
+        &CMJALTCandidates,
+    const llvm::DenseMap<const ResolveInfo *, RISCVTableJumpEntry>
+        &QCCMJALTTCandidates) {
+  return CMJALTCandidates.size() + QCCMJALTTCandidates.size();
+}
+
 void RISCVTableJumpFragment::scanTableJumpEntries(ELFSection &Sec) {
   assert(Sec.isCode() && "table jump scan expects a code section");
+
+  const bool UseXqccmt =
+      Backend.config().options().getRISCVRelaxTbljalToXqccmt();
+  HasXqccmt |= UseXqccmt;
 
   auto RelocRange = Sec.getRelocations();
   llvm::SmallVector<const Relocation *, 0> Relocs(RelocRange.begin(),
@@ -94,9 +113,10 @@ void RISCVTableJumpFragment::scanTableJumpEntries(ELFSection &Sec) {
     if (R->type() == llvm::ELF::R_RISCV_JAL) {
       Rd = (R->target() >> 7) & 0x1f;
     } else if (R->type() == eld::ELF::riscv::internal::R_RISCV_QC_E_CALL_PLT) {
-      // QC.E.J has func2=0b00 and QC.E.JAL has func2=0b01. Use this as
-      // the rd-equivalent selector because QC.E.J does not write ra.
-      Rd = (R->target() >> 15) & 0x3;
+      // QC.E.J has func2=0b00, QC.E.JAL has func2=0b01, and QC.E.JALT
+      // has func2=0b10. Use this as the rd-equivalent selector because
+      // QC.E.J does not write a link register and QC.E.JALT writes t0.
+      Rd = getQCEJumpRd(R->target());
     } else {
       // CALL/CALL_PLT: read the following JALR to get rd.
       uint32_t Insn = 0;
@@ -104,8 +124,10 @@ void RISCVTableJumpFragment::scanTableJumpEntries(ELFSection &Sec) {
       Rd = (Insn >> 7) & 0x1f;
     }
 
-    // Only x0 (cm.jt) and ra (cm.jalt) are supported.
-    if (Rd != 0 && Rd != 1)
+    // x0 uses the jump-only instruction.
+    // ra uses the normal jump-and-link instruction.
+    // Xqccmt also supports t0 by setting bit 0 in the JVT entry.
+    if (Rd != 0 && Rd != 1 && !(UseXqccmt && Rd == 5))
       continue;
 
     const int64_t Displace = getCallDisplace(Backend, *R);
@@ -135,6 +157,8 @@ void RISCVTableJumpFragment::scanTableJumpEntries(ELFSection &Sec) {
 
     if (Rd == 0)
       addEntry(CMJTCandidates, Sym, Saved);
+    else if (Rd == 5)
+      addEntry(QCCMJALTTCandidates, Sym, Saved);
     else
       addEntry(CMJALTCandidates, Sym, Saved);
   }
@@ -175,14 +199,83 @@ static void selectEntries(
     Candidates.erase(Sym);
 }
 
-void RISCVTableJumpFragment::finalizeContents() {
-  selectEntries(Backend, CMJTCandidates, MaxCMJTEntrySize);
-  selectEntries(Backend, CMJALTCandidates, MaxCMJALTEntrySize);
+static void selectCallEntries(
+    RISCVLDBackend &Backend,
+    llvm::DenseMap<const ResolveInfo *, RISCVTableJumpEntry> &CMJALTCandidates,
+    llvm::DenseMap<const ResolveInfo *, RISCVTableJumpEntry>
+        &QCCMJALTTCandidates,
+    uint32_t MaxSize) {
+  struct CallEntry {
+    const ResolveInfo *Sym = nullptr;
+    RISCVTableJumpEntry Entry;
+    bool UseT0 = false;
+  };
+
+  llvm::SmallVector<CallEntry, 0> Entries;
+
+  // Add the normal ra entries. They are valid for both Zcmt and Xqccmt.
+  for (const auto &KV : CMJALTCandidates)
+    Entries.push_back({KV.first, KV.second, /*UseT0=*/false});
+
+  // Add the Xqccmt t0 entries. They need their own JVT slot even when the
+  // symbol is the same as an ra entry, because bit 0 in the slot is different.
+  for (const auto &KV : QCCMJALTTCandidates)
+    Entries.push_back({KV.first, KV.second, /*UseT0=*/true});
+
+  llvm::sort(Entries, [&Backend](const CallEntry &A, const CallEntry &B) {
+    if (A.Entry.Saved != B.Entry.Saved)
+      return A.Entry.Saved > B.Entry.Saved;
+    const uint64_t AVA = getTableJumpTargetVA(Backend, A.Sym);
+    const uint64_t BVA = getTableJumpTargetVA(Backend, B.Sym);
+    if (AVA != BVA)
+      return AVA < BVA;
+    if (A.Sym->name() != B.Sym->name())
+      return A.Sym->name() < B.Sym->name();
+    // Keep ra before t0 when every other key is the same. The order is only a
+    // tie-breaker, but stable output makes tests and maps easier to read.
+    return !A.UseT0 && B.UseT0;
+  });
+
+  if (Entries.size() > MaxSize)
+    Entries.resize(MaxSize);
 
   const int WordSize = Backend.config().targets().is32Bits() ? 4 : 8;
+  while (!Entries.empty() && Entries.back().Entry.Saved < WordSize)
+    Entries.pop_back();
 
-  int SavedBoth = -static_cast<int>(
-      (StartCMJALTEntryIdx + CMJALTCandidates.size()) * WordSize);
+  for (size_t I = 0; I < Entries.size(); ++I) {
+    if (Entries[I].UseT0)
+      QCCMJALTTCandidates[Entries[I].Sym].Index = static_cast<int>(I);
+    else
+      CMJALTCandidates[Entries[I].Sym].Index = static_cast<int>(I);
+  }
+
+  llvm::SmallVector<const ResolveInfo *, 0> ToErase;
+  for (const auto &KV : CMJALTCandidates)
+    if (KV.second.Index < 0)
+      ToErase.push_back(KV.first);
+  for (const ResolveInfo *Sym : ToErase)
+    CMJALTCandidates.erase(Sym);
+
+  ToErase.clear();
+  for (const auto &KV : QCCMJALTTCandidates)
+    if (KV.second.Index < 0)
+      ToErase.push_back(KV.first);
+  for (const ResolveInfo *Sym : ToErase)
+    QCCMJALTTCandidates.erase(Sym);
+}
+
+void RISCVTableJumpFragment::finalizeContents() {
+  selectEntries(Backend, CMJTCandidates, MaxCMJTEntrySize);
+  selectCallEntries(Backend, CMJALTCandidates, QCCMJALTTCandidates,
+                    MaxCMJALTEntrySize);
+
+  const int WordSize = Backend.config().targets().is32Bits() ? 4 : 8;
+  const unsigned CallEntryCount =
+      getCallTableCandidateCount(CMJALTCandidates, QCCMJALTTCandidates);
+
+  int SavedBoth =
+      -static_cast<int>((StartCMJALTEntryIdx + CallEntryCount) * WordSize);
   int SavedCMJTOnly = -static_cast<int>(CMJTCandidates.size() * WordSize);
 
   for (auto &KV : CMJTCandidates) {
@@ -191,18 +284,26 @@ void RISCVTableJumpFragment::finalizeContents() {
   }
   for (auto &KV : CMJALTCandidates)
     SavedBoth += KV.second.Saved;
+  for (auto &KV : QCCMJALTTCandidates)
+    SavedBoth += KV.second.Saved;
 
-  // Using cm.jalt requires padding the cm.jt region to 32 entries.
-  if (!CMJALTCandidates.empty() && SavedBoth < SavedCMJTOnly)
+  // Using the call table requires padding the jump table to 32 entries.
+  // If that padding loses more bytes than the calls save, keep only cm.jt.
+  if (CallEntryCount != 0 && SavedBoth < SavedCMJTOnly) {
     CMJALTCandidates.clear();
+    QCCMJALTTCandidates.clear();
+  }
 
   if (SavedCMJTOnly < 0) {
     CMJTCandidates.clear();
     CMJALTCandidates.clear();
+    QCCMJALTTCandidates.clear();
   }
 
-  if (!CMJALTCandidates.empty())
-    ThisSize = (StartCMJALTEntryIdx + CMJALTCandidates.size()) * WordSize;
+  const unsigned FinalCallEntryCount =
+      getCallTableCandidateCount(CMJALTCandidates, QCCMJALTTCandidates);
+  if (FinalCallEntryCount != 0)
+    ThisSize = (StartCMJALTEntryIdx + FinalCallEntryCount) * WordSize;
   else
     ThisSize = CMJTCandidates.size() * WordSize;
 }
@@ -212,9 +313,11 @@ int RISCVTableJumpFragment::getCMJTEntryIndex(const ResolveInfo *Sym) const {
   return It != CMJTCandidates.end() ? It->second.Index : -1;
 }
 
-int RISCVTableJumpFragment::getCMJALTEntryIndex(const ResolveInfo *Sym) const {
-  auto It = CMJALTCandidates.find(Sym);
-  return It != CMJALTCandidates.end()
+int RISCVTableJumpFragment::getCMJALTEntryIndex(const ResolveInfo *Sym,
+                                                unsigned Rd) const {
+  const auto &Candidates = Rd == 5 ? QCCMJALTTCandidates : CMJALTCandidates;
+  auto It = Candidates.find(Sym);
+  return It != Candidates.end()
              ? static_cast<int>(StartCMJALTEntryIdx) + It->second.Index
              : -1;
 }
@@ -228,6 +331,8 @@ void RISCVTableJumpFragment::dump(llvm::raw_ostream &OS) {
   };
 
   llvm::SmallVector<DumpEntry, 0> Entries;
+  const char *JumpInsn = HasXqccmt ? "qc.cm.jt" : "cm.jt";
+  const char *CallInsn = HasXqccmt ? "qc.cm.jalt" : "cm.jalt";
   auto AddEntries = [&](const llvm::DenseMap<const ResolveInfo *,
                                              RISCVTableJumpEntry> &Candidates,
                         int Bias, const char *Insn) {
@@ -238,9 +343,10 @@ void RISCVTableJumpFragment::dump(llvm::raw_ostream &OS) {
                          getTableJumpTargetVA(Backend, KV.first), Insn});
     }
   };
-  AddEntries(CMJTCandidates, /*Bias=*/0, "cm.jt");
-  AddEntries(CMJALTCandidates, static_cast<int>(StartCMJALTEntryIdx),
-             "cm.jalt");
+  AddEntries(CMJTCandidates, /*Bias=*/0, JumpInsn);
+  AddEntries(CMJALTCandidates, static_cast<int>(StartCMJALTEntryIdx), CallInsn);
+  AddEntries(QCCMJALTTCandidates, static_cast<int>(StartCMJALTEntryIdx),
+             CallInsn);
   if (Entries.empty())
     return;
 
@@ -256,10 +362,10 @@ void RISCVTableJumpFragment::dump(llvm::raw_ostream &OS) {
   }
 }
 
-static void
-writeEntries(RISCVLDBackend &Backend, uint8_t *Buf,
-             const llvm::DenseMap<const ResolveInfo *, RISCVTableJumpEntry>
-                 &Candidates) {
+static void writeEntries(
+    RISCVLDBackend &Backend, uint8_t *Buf,
+    const llvm::DenseMap<const ResolveInfo *, RISCVTableJumpEntry> &Candidates,
+    bool SetEntryBit0 = false) {
   llvm::SmallVector<std::pair<const ResolveInfo *, RISCVTableJumpEntry>, 0>
       Entries(Candidates.begin(), Candidates.end());
   llvm::sort(Entries, [](const auto &A, const auto &B) {
@@ -268,6 +374,10 @@ writeEntries(RISCVLDBackend &Backend, uint8_t *Buf,
 
   for (auto &KV : Entries) {
     uint64_t VA = getTableJumpTargetVA(Backend, KV.first);
+    // Xqccmt qc.cm.jalt uses bit 0 as link-register metadata. The hardware
+    // clears that bit before jumping, so this does not change the target.
+    if (SetEntryBit0)
+      VA |= 1;
     if (Backend.config().targets().is32Bits())
       llvm::support::endian::write32le(Buf, static_cast<uint32_t>(VA));
     else
@@ -276,12 +386,39 @@ writeEntries(RISCVLDBackend &Backend, uint8_t *Buf,
   }
 }
 
+static void
+writeCallEntries(RISCVLDBackend &Backend, uint8_t *Buf,
+                 unsigned StartCallEntryIdx,
+                 const llvm::DenseMap<const ResolveInfo *, RISCVTableJumpEntry>
+                     &CMJALTCandidates,
+                 const llvm::DenseMap<const ResolveInfo *, RISCVTableJumpEntry>
+                     &QCCMJALTTCandidates) {
+  const int WordSize = Backend.config().targets().is32Bits() ? 4 : 8;
+
+  auto WriteOne = [&](const ResolveInfo *Sym, const RISCVTableJumpEntry &Entry,
+                      bool SetEntryBit0) {
+    uint64_t VA = getTableJumpTargetVA(Backend, Sym);
+    if (SetEntryBit0)
+      VA |= 1;
+    uint8_t *EntryBuf = Buf + (StartCallEntryIdx + Entry.Index) * WordSize;
+    if (Backend.config().targets().is32Bits())
+      llvm::support::endian::write32le(EntryBuf, static_cast<uint32_t>(VA));
+    else
+      llvm::support::endian::write64le(EntryBuf, VA);
+  };
+
+  // Call entries from both maps share one index space. Write every entry to
+  // its exact index so ra and t0 entries never overwrite each other.
+  for (auto &KV : CMJALTCandidates)
+    WriteOne(KV.first, KV.second, /*SetEntryBit0=*/false);
+  for (auto &KV : QCCMJALTTCandidates)
+    WriteOne(KV.first, KV.second, /*SetEntryBit0=*/true);
+}
+
 void RISCVTableJumpFragment::writeTo(uint8_t *Buf) {
   if (!CMJTCandidates.empty())
     writeEntries(Backend, Buf, CMJTCandidates);
-  if (!CMJALTCandidates.empty()) {
-    const int WordSize = Backend.config().targets().is32Bits() ? 4 : 8;
-    writeEntries(Backend, Buf + StartCMJALTEntryIdx * WordSize,
-                 CMJALTCandidates);
-  }
+  if (!CMJALTCandidates.empty() || !QCCMJALTTCandidates.empty())
+    writeCallEntries(Backend, Buf, StartCMJALTEntryIdx, CMJALTCandidates,
+                     QCCMJALTTCandidates);
 }

--- a/lib/Target/RISCV/RISCVTableJump.cpp
+++ b/lib/Target/RISCV/RISCVTableJump.cpp
@@ -117,6 +117,8 @@ void RISCVTableJumpFragment::scanTableJumpEntries(ELFSection &Sec) {
       // QC.E.J has func2=0b00 and QC.E.JAL has func2=0b01. Use this as the
       // rd-equivalent selector because QC.E.J does not write a link register.
       Rd = getQCEJumpRd(R->target());
+      if (!isValidQCEJumpRd(Rd))
+        continue;
     } else {
       // CALL/CALL_PLT: read the following JALR to get rd.
       uint32_t Insn = 0;
@@ -169,7 +171,12 @@ static void selectEntries(
     llvm::DenseMap<const ResolveInfo *, RISCVTableJumpEntry> &Candidates,
     uint32_t MaxSize) {
   llvm::SmallVector<std::pair<const ResolveInfo *, RISCVTableJumpEntry>, 0>
-      Entries(Candidates.begin(), Candidates.end());
+      Entries;
+  const int WordSize = Backend.config().targets().is32Bits() ? 4 : 8;
+  for (const auto &KV : Candidates)
+    if (KV.second.Saved >= WordSize)
+      Entries.push_back(KV);
+
   llvm::sort(Entries, [&Backend](const auto &A, const auto &B) {
     if (A.second.Saved != B.second.Saved)
       return A.second.Saved > B.second.Saved;
@@ -183,20 +190,12 @@ static void selectEntries(
   if (Entries.size() > MaxSize)
     Entries.resize(MaxSize);
 
-  const int WordSize = Backend.config().targets().is32Bits() ? 4 : 8;
-  while (!Entries.empty() && Entries.back().second.Saved < WordSize)
-    Entries.pop_back();
-
-  for (size_t I = 0; I < Entries.size(); ++I)
-    Candidates[Entries[I].first].Index = static_cast<int>(I);
-
-  llvm::SmallVector<const ResolveInfo *, 0> ToErase;
-  for (const auto &KV : Candidates)
-    if (KV.second.Index < 0)
-      ToErase.push_back(KV.first);
-
-  for (const ResolveInfo *Sym : ToErase)
-    Candidates.erase(Sym);
+  Candidates.clear();
+  int Index = 0;
+  for (auto Entry : Entries) {
+    Entry.second.Index = Index++;
+    Candidates.insert(Entry);
+  }
 }
 
 static void selectCallEntries(
@@ -211,16 +210,21 @@ static void selectCallEntries(
     bool UseT0 = false;
   };
 
+  const int WordSize = Backend.config().targets().is32Bits() ? 4 : 8;
   llvm::SmallVector<CallEntry, 0> Entries;
+  auto AddCandidate = [&](const auto &KV, bool UseT0) {
+    if (KV.second.Saved >= WordSize)
+      Entries.push_back({KV.first, KV.second, UseT0});
+  };
 
   // Add the normal ra entries. They are valid for both Zcmt and Xqccmt.
   for (const auto &KV : CMJALTCandidates)
-    Entries.push_back({KV.first, KV.second, /*UseT0=*/false});
+    AddCandidate(KV, /*UseT0=*/false);
 
   // Add the Xqccmt t0 entries. They need their own JVT slot even when the
   // symbol is the same as an ra entry, because bit 0 in the slot is different.
   for (const auto &KV : QCCMJALTTCandidates)
-    Entries.push_back({KV.first, KV.second, /*UseT0=*/true});
+    AddCandidate(KV, /*UseT0=*/true);
 
   llvm::sort(Entries, [&Backend](const CallEntry &A, const CallEntry &B) {
     const uint64_t AVA = getTableJumpTargetVA(Backend, A.Sym);
@@ -236,30 +240,17 @@ static void selectCallEntries(
   if (Entries.size() > MaxSize)
     Entries.resize(MaxSize);
 
-  const int WordSize = Backend.config().targets().is32Bits() ? 4 : 8;
-  while (!Entries.empty() && Entries.back().Entry.Saved < WordSize)
-    Entries.pop_back();
+  CMJALTCandidates.clear();
+  QCCMJALTTCandidates.clear();
 
-  for (size_t I = 0; I < Entries.size(); ++I) {
-    if (Entries[I].UseT0)
-      QCCMJALTTCandidates[Entries[I].Sym].Index = static_cast<int>(I);
+  int Index = 0;
+  for (CallEntry Entry : Entries) {
+    Entry.Entry.Index = Index++;
+    if (Entry.UseT0)
+      QCCMJALTTCandidates.insert({Entry.Sym, Entry.Entry});
     else
-      CMJALTCandidates[Entries[I].Sym].Index = static_cast<int>(I);
+      CMJALTCandidates.insert({Entry.Sym, Entry.Entry});
   }
-
-  llvm::SmallVector<const ResolveInfo *, 0> ToErase;
-  for (const auto &KV : CMJALTCandidates)
-    if (KV.second.Index < 0)
-      ToErase.push_back(KV.first);
-  for (const ResolveInfo *Sym : ToErase)
-    CMJALTCandidates.erase(Sym);
-
-  ToErase.clear();
-  for (const auto &KV : QCCMJALTTCandidates)
-    if (KV.second.Index < 0)
-      ToErase.push_back(KV.first);
-  for (const ResolveInfo *Sym : ToErase)
-    QCCMJALTTCandidates.erase(Sym);
 }
 
 void RISCVTableJumpFragment::finalizeContents() {
@@ -271,9 +262,11 @@ void RISCVTableJumpFragment::finalizeContents() {
   const unsigned CallEntryCount =
       getCallTableCandidateCount(CMJALTCandidates, QCCMJALTTCandidates);
 
+  // These are signed net byte deltas: table bytes start as a negative cost,
+  // then each selected relaxation adds back the bytes it saves.
   int SavedBoth =
-      -static_cast<int>((StartCMJALTEntryIdx + CallEntryCount) * WordSize);
-  int SavedCMJTOnly = -static_cast<int>(CMJTCandidates.size() * WordSize);
+      -static_cast<int>(StartCMJALTEntryIdx + CallEntryCount) * WordSize;
+  int SavedCMJTOnly = -static_cast<int>(CMJTCandidates.size()) * WordSize;
 
   for (auto &KV : CMJTCandidates) {
     SavedCMJTOnly += KV.second.Saved;

--- a/lib/Target/RISCV/RISCVTableJump.cpp
+++ b/lib/Target/RISCV/RISCVTableJump.cpp
@@ -31,6 +31,7 @@
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/MathExtras.h"
 #include <cassert>
+#include <tuple>
 
 using namespace eld;
 RISCVTableJumpFragment::RISCVTableJumpFragment(RISCVLDBackend &B, ELFSection *O)
@@ -113,9 +114,8 @@ void RISCVTableJumpFragment::scanTableJumpEntries(ELFSection &Sec) {
     if (R->type() == llvm::ELF::R_RISCV_JAL) {
       Rd = (R->target() >> 7) & 0x1f;
     } else if (R->type() == eld::ELF::riscv::internal::R_RISCV_QC_E_CALL_PLT) {
-      // QC.E.J has func2=0b00, QC.E.JAL has func2=0b01, and QC.E.JALT
-      // has func2=0b10. Use this as the rd-equivalent selector because
-      // QC.E.J does not write a link register and QC.E.JALT writes t0.
+      // QC.E.J has func2=0b00 and QC.E.JAL has func2=0b01. Use this as the
+      // rd-equivalent selector because QC.E.J does not write a link register.
       Rd = getQCEJumpRd(R->target());
     } else {
       // CALL/CALL_PLT: read the following JALR to get rd.
@@ -223,17 +223,14 @@ static void selectCallEntries(
     Entries.push_back({KV.first, KV.second, /*UseT0=*/true});
 
   llvm::sort(Entries, [&Backend](const CallEntry &A, const CallEntry &B) {
-    if (A.Entry.Saved != B.Entry.Saved)
-      return A.Entry.Saved > B.Entry.Saved;
     const uint64_t AVA = getTableJumpTargetVA(Backend, A.Sym);
     const uint64_t BVA = getTableJumpTargetVA(Backend, B.Sym);
-    if (AVA != BVA)
-      return AVA < BVA;
-    if (A.Sym->name() != B.Sym->name())
-      return A.Sym->name() < B.Sym->name();
-    // Keep ra before t0 when every other key is the same. The order is only a
-    // tie-breaker, but stable output makes tests and maps easier to read.
-    return !A.UseT0 && B.UseT0;
+    const int ASaved = -A.Entry.Saved;
+    const int BSaved = -B.Entry.Saved;
+    const llvm::StringRef AName = A.Sym->name();
+    const llvm::StringRef BName = B.Sym->name();
+    return std::tie(ASaved, AVA, AName, A.UseT0) <
+           std::tie(BSaved, BVA, BName, B.UseT0);
   });
 
   if (Entries.size() > MaxSize)
@@ -315,6 +312,9 @@ int RISCVTableJumpFragment::getCMJTEntryIndex(const ResolveInfo *Sym) const {
 
 int RISCVTableJumpFragment::getCMJALTEntryIndex(const ResolveInfo *Sym,
                                                 unsigned Rd) const {
+  // ra and t0 call entries share one JVT index space, but are tracked in
+  // separate maps because Xqccmt encodes the link-register choice in bit 0 of
+  // the table entry rather than in the instruction.
   const auto &Candidates = Rd == 5 ? QCCMJALTTCandidates : CMJALTCandidates;
   auto It = Candidates.find(Sym);
   return It != Candidates.end()
@@ -362,10 +362,10 @@ void RISCVTableJumpFragment::dump(llvm::raw_ostream &OS) {
   }
 }
 
-static void writeEntries(
-    RISCVLDBackend &Backend, uint8_t *Buf,
-    const llvm::DenseMap<const ResolveInfo *, RISCVTableJumpEntry> &Candidates,
-    bool SetEntryBit0 = false) {
+static void
+writeEntries(RISCVLDBackend &Backend, uint8_t *Buf,
+             const llvm::DenseMap<const ResolveInfo *, RISCVTableJumpEntry>
+                 &Candidates) {
   llvm::SmallVector<std::pair<const ResolveInfo *, RISCVTableJumpEntry>, 0>
       Entries(Candidates.begin(), Candidates.end());
   llvm::sort(Entries, [](const auto &A, const auto &B) {
@@ -374,10 +374,6 @@ static void writeEntries(
 
   for (auto &KV : Entries) {
     uint64_t VA = getTableJumpTargetVA(Backend, KV.first);
-    // Xqccmt qc.cm.jalt uses bit 0 as link-register metadata. The hardware
-    // clears that bit before jumping, so this does not change the target.
-    if (SetEntryBit0)
-      VA |= 1;
     if (Backend.config().targets().is32Bits())
       llvm::support::endian::write32le(Buf, static_cast<uint32_t>(VA));
     else
@@ -407,8 +403,8 @@ writeCallEntries(RISCVLDBackend &Backend, uint8_t *Buf,
       llvm::support::endian::write64le(EntryBuf, VA);
   };
 
-  // Call entries from both maps share one index space. Write every entry to
-  // its exact index so ra and t0 entries never overwrite each other.
+  // Call entries from both maps share one index space. The maps are not laid
+  // out in separate ra-then-t0 ranges, so write every entry to its exact index.
   for (auto &KV : CMJALTCandidates)
     WriteOne(KV.first, KV.second, /*SetEntryBit0=*/false);
   for (auto &KV : QCCMJALTTCandidates)

--- a/lib/Target/RISCV/RISCVTableJump.cpp
+++ b/lib/Target/RISCV/RISCVTableJump.cpp
@@ -262,8 +262,9 @@ void RISCVTableJumpFragment::finalizeContents() {
   const unsigned CallEntryCount =
       getCallTableCandidateCount(CMJALTCandidates, QCCMJALTTCandidates);
 
-  // These are signed net byte deltas: table bytes start as a negative cost,
-  // then each selected relaxation adds back the bytes it saves.
+  // Profitability starts negative with the table emission cost. Candidate
+  // savings are added to this and if the result stays negative we discard the
+  // candidates since the jump table would increase code size.
   int SavedBoth =
       -static_cast<int>(StartCMJALTEntryIdx + CallEntryCount) * WordSize;
   int SavedCMJTOnly = -static_cast<int>(CMJTCandidates.size()) * WordSize;

--- a/lib/Target/RISCV/RISCVTableJump.h
+++ b/lib/Target/RISCV/RISCVTableJump.h
@@ -21,8 +21,9 @@ struct RISCVTableJumpEntry {
   int Index = -1;
 };
 
-// Implements the Zcmt table jump section (.riscv.jvt) used by table jump
-// relaxation (cm.jt/cm.jalt).
+// Implements the RISC-V table jump section (.riscv.jvt) used by table jump
+// relaxation. Zcmt uses cm.jt/cm.jalt. Xqccmt uses the same instruction
+// encoding, but the assembler/disassembler names are qc.cm.jt/qc.cm.jalt.
 class RISCVTableJumpFragment final : public TargetFragment {
 public:
   RISCVTableJumpFragment(RISCVLDBackend &B, ELFSection *O);
@@ -35,7 +36,7 @@ public:
   void finalizeContents();
 
   int getCMJTEntryIndex(const ResolveInfo *Sym) const;
-  int getCMJALTEntryIndex(const ResolveInfo *Sym) const;
+  int getCMJALTEntryIndex(const ResolveInfo *Sym, unsigned Rd) const;
 
 private:
   void writeTo(uint8_t *Buf);
@@ -47,6 +48,11 @@ private:
   RISCVLDBackend &Backend;
   llvm::DenseMap<const ResolveInfo *, RISCVTableJumpEntry> CMJTCandidates;
   llvm::DenseMap<const ResolveInfo *, RISCVTableJumpEntry> CMJALTCandidates;
+  // Xqccmt lets qc.cm.jalt write the return address to t0 (x5). The table
+  // entry uses bit 0 to request that behavior, so an ra entry and a t0 entry
+  // for the same symbol cannot share one slot.
+  llvm::DenseMap<const ResolveInfo *, RISCVTableJumpEntry> QCCMJALTTCandidates;
+  bool HasXqccmt = false;
   size_t ThisSize = 0;
 };
 

--- a/lib/Target/RISCV/RISCVTableJump.h
+++ b/lib/Target/RISCV/RISCVTableJump.h
@@ -22,8 +22,9 @@ struct RISCVTableJumpEntry {
 };
 
 // Implements the RISC-V table jump section (.riscv.jvt) used by table jump
-// relaxation. Zcmt uses cm.jt/cm.jalt. Xqccmt uses the same instruction
-// encoding, but the assembler/disassembler names are qc.cm.jt/qc.cm.jalt.
+// relaxation. The table contains jump target addresses. In Xqccmt mode, call
+// entries may set bit 0 to request linking through t0; hardware clears that bit
+// before jumping, so the target address remains aligned.
 class RISCVTableJumpFragment final : public TargetFragment {
 public:
   RISCVTableJumpFragment(RISCVLDBackend &B, ELFSection *O);

--- a/test/RISCV/FromLLD/riscv-tbljal-pic-shared.s
+++ b/test/RISCV/FromLLD/riscv-tbljal-pic-shared.s
@@ -1,4 +1,4 @@
-## Verify --relax-tbljal (Zcmt table-jump relaxation) is rejected for
+## Verify --relax-tbljal (Zcmt/Xqccmt table-jump relaxation) is rejected for
 ## shared libraries and position independent executables.
 #
 # RUN: %llvm-mc -filetype=obj -mattr=+relax,+zcmt %s -o %t.o
@@ -8,8 +8,20 @@
 # RUN:   | %filecheck %s
 # RUN: %not %link %linkopts --relax-tbljal --pic-executable %t.o \
 # RUN:   -o %t.pic 2>&1 | %filecheck %s
+# RUN: %not %link %linkopts --relax-tbljal=zcmt -shared %t.o -o %t.zcmt.so \
+# RUN:   2>&1 | %filecheck %s
+# RUN: %not %link %linkopts --relax-tbljal=zcmt -pie %t.o -o %t.zcmt.pie \
+# RUN:   2>&1 | %filecheck %s
+# RUN: %not %link %linkopts --relax-tbljal=zcmt --pic-executable %t.o \
+# RUN:   -o %t.zcmt.pic 2>&1 | %filecheck %s
+# RUN: %not %link %linkopts --relax-tbljal=xqccmt -shared %t.o \
+# RUN:   -o %t.xqccmt.so 2>&1 | %filecheck %s
+# RUN: %not %link %linkopts --relax-tbljal=xqccmt -pie %t.o \
+# RUN:   -o %t.xqccmt.pie 2>&1 | %filecheck %s
+# RUN: %not %link %linkopts --relax-tbljal=xqccmt --pic-executable %t.o \
+# RUN:   -o %t.xqccmt.pic 2>&1 | %filecheck %s
 #
-# CHECK: Zcmt table jump relaxation is not supported for shared libraries
+# CHECK: Zcmt/Xqccmt table jump relaxation is not supported for shared libraries
 # CHECK-SAME: or position independent code
 
 .text

--- a/test/RISCV/FromLLD/riscv-xqccmt-tbljal-call.s
+++ b/test/RISCV/FromLLD/riscv-xqccmt-tbljal-call.s
@@ -1,0 +1,30 @@
+## Test that --relax-tbljal=xqccmt can create Xqccmt table-jump instructions.
+## Xqccmt uses the same encoding as Zcmt, but the disassembler prints the
+## vendor mnemonics qc.cm.jt and qc.cm.jalt.
+#
+# RUN: %llvm-mc -filetype=obj -mattr=+relax,+experimental-xqccmt %s -o %t.o
+# RUN: %link %linkopts %t.o --relax-tbljal=xqccmt --defsym foo=0x800000 --defsym bar=0x900000 -o %t
+# RUN: %objdump -d -M no-aliases --mattr=+experimental-xqccmt --no-show-raw-insn %t \
+# RUN:   | %filecheck --check-prefix=JT %s
+# RUN: %objdump -d -M no-aliases --mattr=+experimental-xqccmt --no-show-raw-insn %t \
+# RUN:   | %filecheck --check-prefix=JALT %s
+# RUN: %readelf -x .riscv.jvt %t | %filecheck --check-prefix=JVT%xlen %s
+#
+# JT-COUNT-48: qc.cm.jt
+# JALT-COUNT-48: qc.cm.jalt
+#
+## qc.cm.jt entries start at index 0. qc.cm.jalt entries start at index 32.
+## The first non-zero word is the jump-table target. The later non-zero word is
+## the call-table target.
+# JVT4: 00008000
+# JVT4: 00009000
+# JVT8: 00008000 00000000
+# JVT8: 00009000 00000000
+
+.global _start
+.p2align 3
+_start:
+  .rept 48
+  tail foo
+  call bar
+  .endr

--- a/test/RISCV/FromLLD/riscv-xqccmt-tbljal-call.s
+++ b/test/RISCV/FromLLD/riscv-xqccmt-tbljal-call.s
@@ -4,6 +4,7 @@
 #
 # RUN: %llvm-mc -filetype=obj -mattr=+relax,+experimental-xqccmt %s -o %t.o
 # RUN: %link %linkopts %t.o --relax-tbljal=xqccmt --defsym foo=0x800000 --defsym bar=0x900000 -o %t
+# RUN: %link %linkopts %t.o --relax-tbljal=XQCCMT --defsym foo=0x800000 --defsym bar=0x900000 -o %t.upper
 # RUN: %objdump -d -M no-aliases --mattr=+experimental-xqccmt --no-show-raw-insn %t \
 # RUN:   | %filecheck --check-prefix=JT %s
 # RUN: %objdump -d -M no-aliases --mattr=+experimental-xqccmt --no-show-raw-insn %t \

--- a/test/RISCV/FromLLD/riscv-xqccmt-tbljal-call.s
+++ b/test/RISCV/FromLLD/riscv-xqccmt-tbljal-call.s
@@ -4,12 +4,18 @@
 #
 # RUN: %llvm-mc -filetype=obj -mattr=+relax,+experimental-xqccmt %s -o %t.o
 # RUN: %link %linkopts %t.o --relax-tbljal=xqccmt --defsym foo=0x800000 --defsym bar=0x900000 -o %t
-# RUN: %link %linkopts %t.o --relax-tbljal=XQCCMT --defsym foo=0x800000 --defsym bar=0x900000 -o %t.upper
 # RUN: %objdump -d -M no-aliases --mattr=+experimental-xqccmt --no-show-raw-insn %t \
 # RUN:   | %filecheck --check-prefix=JT %s
 # RUN: %objdump -d -M no-aliases --mattr=+experimental-xqccmt --no-show-raw-insn %t \
 # RUN:   | %filecheck --check-prefix=JALT %s
 # RUN: %readelf -x .riscv.jvt %t | %filecheck --check-prefix=JVT%xlen %s
+
+# RUN: %link %linkopts %t.o --relax-tbljal=XQCCMT --defsym foo=0x800000 --defsym bar=0x900000 -o %t.upper
+# RUN: %objdump -d -M no-aliases --mattr=+experimental-xqccmt --no-show-raw-insn %t.upper \
+# RUN:   | %filecheck --check-prefix=JT %s
+# RUN: %objdump -d -M no-aliases --mattr=+experimental-xqccmt --no-show-raw-insn %t.upper \
+# RUN:   | %filecheck --check-prefix=JALT %s
+# RUN: %readelf -x .riscv.jvt %t.upper | %filecheck --check-prefix=JVT%xlen %s
 #
 # JT-COUNT-48: qc.cm.jt
 # JALT-COUNT-48: qc.cm.jalt

--- a/test/RISCV/FromLLD/riscv-xqccmt-tbljal-map.s
+++ b/test/RISCV/FromLLD/riscv-xqccmt-tbljal-map.s
@@ -1,0 +1,20 @@
+## Verify map output uses the Xqccmt instruction names based on the
+## --relax-tbljal=xqccmt mode, not input mapping symbols or attributes.
+#
+# RUN: %llvm-mc -filetype=obj -mattr=+relax,+zcmt %s -o %t.o
+# RUN: %link %linkopts %t.o --relax-tbljal=xqccmt --defsym foo=0x800000 \
+# RUN:   -MapStyle txt -Map %t.map -o %t
+# RUN: %filecheck %s < %t.map
+#
+# CHECK: .riscv.jvt
+# CHECK: #{{[ \t]+}}.riscv.jvt entries:
+# CHECK: qc.cm.jt{{[ \t]+}}foo{{[ \t]+}}0x800000
+# CHECK: qc.cm.jalt{{[ \t]+}}foo{{[ \t]+}}0x800000
+
+.global _start
+.p2align 3
+_start:
+  .rept 48
+  tail foo
+  call foo
+  .endr

--- a/test/RISCV/FromLLD/riscv-xqccmt-tbljal-t0.s
+++ b/test/RISCV/FromLLD/riscv-xqccmt-tbljal-t0.s
@@ -1,0 +1,25 @@
+## Xqccmt qc.cm.jalt can link through t0 (x5). The JVT entry uses bit 0 as
+## metadata: 0 means ra (x1), and 1 means t0 (x5). The target address is still
+## the table entry with bit 0 cleared by hardware.
+#
+# RUN: %llvm-mc -filetype=obj -mattr=+relax,+experimental-xqccmt %s -o %t.o
+# RUN: %link %linkopts %t.o --relax-tbljal=xqccmt --defsym foo=0x800000 -o %t
+# RUN: %objdump -d -M no-aliases --mattr=+experimental-xqccmt --no-show-raw-insn %t \
+# RUN:   | %filecheck --check-prefix=DISASM %s
+# RUN: %readelf -x .riscv.jvt %t | %filecheck --check-prefix=JVT%xlen %s
+#
+# DISASM-COUNT-48: qc.cm.jalt
+# DISASM-NOT: qc.cm.jt
+#
+## The same target appears twice in the call-table area. The plain value is for
+## ra. The value with bit 0 set is for t0.
+# JVT4: 00008000 01008000
+# JVT8: 00008000 00000000 01008000 00000000
+
+.global _start
+.p2align 3
+_start:
+  .rept 24
+  call foo
+  call t0, foo
+  .endr

--- a/test/RISCV/standalone/Relaxation/QC_E_CALL_TO_TBLJAL/QC_E_CALL_TO_XQCCMT.s
+++ b/test/RISCV/standalone/Relaxation/QC_E_CALL_TO_TBLJAL/QC_E_CALL_TO_XQCCMT.s
@@ -1,0 +1,111 @@
+#----------QC_E_CALL_TO_XQCCMT.s----------------- Executable------------------#
+# BEGIN_COMMENT
+# Relax near QC.E.JAL/QC.E.J (Xqcilb 48-bit) to C.JAL/C.J when possible.
+# Relax far profitable calls to QC.CM.JALT/QC.CM.JT (Xqccmt 16-bit) only
+# when compressed relaxation is enabled.
+# END_COMMENT
+#--------------------------------------------------------------------
+# REQUIRES: riscv32
+
+# RUN: %llvm-mc -filetype=obj -mattr=+relax,+c,+xqcilb,+experimental-xqccmt \
+# RUN:   --defsym NEAR_TARGET=1 %s -o %t.near.o
+# RUN: %link %linkopts --relax-xqci --relax-tbljal=xqccmt %t.near.o \
+# RUN:   -o %t.near.out
+# RUN: %objdump -d -M no-aliases --mattr=+experimental-xqccmt \
+# RUN:   %t.near.out 2>&1 \
+# RUN:   | %filecheck %s --check-prefix=NEAR-DISASM
+# NEAR-DISASM: c.jal
+# NEAR-DISASM: c.j
+# NEAR-DISASM-NOT: qc.cm.jalt
+# NEAR-DISASM-NOT: qc.cm.jt
+# NEAR-DISASM-NOT: qc.e.jal
+# NEAR-DISASM-NOT: qc.e.j
+# RUN: %readelf -S %t.near.out \
+# RUN:   | %filecheck %s --check-prefix=NO-JVT
+
+# RUN: %llvm-mc -filetype=obj -mattr=+relax,+c,+xqcilb,+experimental-xqccmt \
+# RUN:   --defsym CALL_COUNT=34 --defsym TAIL_COUNT=34 %s -o %t.far.o
+# RUN: %link %linkopts --relax-xqci --relax-tbljal=xqccmt \
+# RUN:   --defsym target=0x800000 %t.far.o -o %t.far.out \
+# RUN:   --verbose 2>&1 \
+# RUN:   | %filecheck %s --check-prefix=VERBOSE-XQCCMT
+# VERBOSE-XQCCMT-COUNT-68: RISCV_TBJAL : Deleting 4 bytes
+# RUN: %objdump -d -M no-aliases --mattr=+experimental-xqccmt \
+# RUN:   %t.far.out 2>&1 \
+# RUN:   | %filecheck %s --check-prefix=XQCCMT-DISASM
+# XQCCMT-DISASM-COUNT-34: qc.cm.jalt
+# XQCCMT-DISASM-COUNT-34: qc.cm.jt
+# XQCCMT-DISASM-NOT: qc.e.jal
+# XQCCMT-DISASM-NOT: qc.e.j
+# RUN: %readelf -S %t.far.out \
+# RUN:   | %filecheck %s --check-prefix=JVT
+# JVT: .riscv.jvt PROGBITS
+
+# RUN: %link %linkopts --relax-xqci --relax-tbljal=xqccmt --no-relax-c \
+# RUN:   --defsym target=0x90000 %t.far.o -o %t.no-relax-c.out
+# RUN: %objdump -d -M no-aliases --mattr=+experimental-xqccmt \
+# RUN:   %t.no-relax-c.out 2>&1 \
+# RUN:   | %filecheck %s --check-prefix=NO-RELAX-C-DISASM \
+# RUN:   --implicit-check-not=c.jal --implicit-check-not=c.j \
+# RUN:   --implicit-check-not=qc.cm.jalt --implicit-check-not=qc.cm.jt \
+# RUN:   --implicit-check-not=qc.e.jal --implicit-check-not=qc.e.j
+# NO-RELAX-C-DISASM-COUNT-68: jal
+# RUN: %readelf -S %t.no-relax-c.out \
+# RUN:   | %filecheck %s --check-prefix=NO-JVT
+
+# RUN: %link %linkopts --relax-xqci --relax-tbljal=xqccmt \
+# RUN:   --defsym target=0x100001000 %t.far.o -o %t.out-of-u32.out
+# RUN: %objdump -d -M no-aliases --mattr=+experimental-xqccmt \
+# RUN:   %t.out-of-u32.out 2>&1 \
+# RUN:   | %filecheck %s --check-prefix=OUT-OF-U32-DISASM \
+# RUN:   --implicit-check-not=qc.cm.jalt --implicit-check-not=qc.cm.jt
+# OUT-OF-U32-DISASM-COUNT-34: qc.e.jal
+# OUT-OF-U32-DISASM-COUNT-34: qc.e.j
+# RUN: %readelf -S %t.out-of-u32.out \
+# RUN:   | %filecheck %s --check-prefix=NO-JVT
+
+# RUN: %echo "SECTIONS {" > %t.discard.t
+# RUN: %echo "  /DISCARD/ : { *(.riscv.jvt) }" >> %t.discard.t
+# RUN: %echo "}" >> %t.discard.t
+# RUN: %link %linkopts --relax-xqci --relax-tbljal=xqccmt \
+# RUN:   --defsym target=0x90000 %t.far.o -T %t.discard.t \
+# RUN:   -o %t.discard.out
+# RUN: %objdump -d -M no-aliases --mattr=+experimental-xqccmt \
+# RUN:   %t.discard.out 2>&1 \
+# RUN:   | %filecheck %s --check-prefix=NO-JVT-DISASM
+# RUN: %readelf -S %t.discard.out \
+# RUN:   | %filecheck %s --check-prefix=NO-JVT
+
+# NO-JVT-DISASM-NOT: qc.cm.jalt
+# NO-JVT-DISASM-NOT: qc.cm.jt
+# NO-JVT-DISASM-COUNT-68: jal
+
+
+# NO-JVT-NOT: .riscv.jvt
+
+  .option exact
+  .option relax
+
+  .text
+  .align 1
+  .globl _start
+  .type _start, @function
+_start:
+.ifdef NEAR_TARGET
+  qc.e.jal target
+  qc.e.j target
+
+  .align 1
+  .type target, @function
+target:
+  ret
+  .size target, .-target
+.else
+  .rept CALL_COUNT
+  qc.e.jal target
+  .endr
+  .rept TAIL_COUNT
+  qc.e.j target
+  .endr
+.endif
+  .size _start, .-_start


### PR DESCRIPTION
This patch adds support for relaxing RISC-V calls and jumps to Xqccmt table-jump instructions. Xqccmt uses the same table-jump encoding as Zcmt, but uses the vendor mnemonics qc.cm.jt and qc.cm.jalt, and also supports a  qc.cm.jalt form that links through t0.

We extend the --relax-tbljal flag from a boolean option into a mode selector. The default --relax-tbljal  continues to enable the Zcmt relaxation and can also be explicitly enable through --relax-tbljal=zcmt , while --relax-tbljal=xqccmt selects Xqccmt relaxation. 

  Update the table-jump implementation to:
    - track whether the current table-jump mode is Zcmt or Xqccmt
    - select qc.cm.jt for tail calls and qc.cm.jalt for link-register calls
    - support the Xqccmt t0-link form by storing bit 0 in the JVT entry
    - keep ra and t0 call-table entries distinct even when they target the
    same symbol
    - preserve existing Zcmt behavior for the default --relax-tbljal mode

The Xqccmt spec can be found at https://github.com/quic/riscv-unified-db/releases/download/Xqccmt-0.1.0/Xqccmt-0.1.0.pdf

Assisted by gpt-5.5