### PR TITLE
[RELRO] Fix isRelROSection to exclude .tbss

### DIFF
--- a/lib/Target/CreateProgramHeaders.hpp
+++ b/lib/Target/CreateProgramHeaders.hpp
@@ -545,7 +545,14 @@ bool GNULDBackend::createProgramHdrs() {
       // same page. This is a difference between ELD and GNU linker. This is
       // done only if the previous section and the new section fall in the same
       // segment.
-      if (enable_RELRO && isPrevRelRO && !isCurRelRO &&
+      //
+      // .tbss is excluded even though !isCurRelRO is true for it: .tbss is a
+      // virtual NOBITS TLS section with no file content that sits between
+      // .tdata (RELRO) and .dynamic/.got (also RELRO) in section order.
+      // Treating it as the end of the RELRO region would bump the VMA by a
+      // page and permanently clear enable_RELRO before .dynamic/.got are
+      // processed, causing them to be excluded from PT_GNU_RELRO.
+      if (enable_RELRO && isPrevRelRO && !isCurRelRO && !cur->isTBSS() &&
           !linkerScriptHasSectionsCommand)
         vma += abiPageSize();
       if (cur->isFixedAddr() && (vma != cur->addr())) {
@@ -595,7 +602,12 @@ bool GNULDBackend::createProgramHdrs() {
     if (load_seg && isCurAlloc) {
       if (!last_section_needs_new_segment &&
           (createPT_LOAD || cur->isWanted())) {
-        if (isPrevRelRO && !isCurRelRO)
+        // Close the RELRO region when we reach the first genuinely non-RELRO
+        // section after a RELRO section.  .tbss is excluded for the same
+        // reason as the page-gap above: it is a virtual NOBITS TLS section
+        // that appears between RELRO sections (.tdata and .dynamic/.got) in
+        // section order but is not the true end of the RELRO region.
+        if (isPrevRelRO && !isCurRelRO && !cur->isTBSS())
           enable_RELRO = false;
         // Check if the current section is a NOTE section and create appropriate
         // NOTE segments.
@@ -636,7 +648,6 @@ bool GNULDBackend::createProgramHdrs() {
             note_seg->setAlign(note_seg->getMaxSectionAlign());
           }
         }
-        // Handle GNU RELRO sections.
         if (isRelROSection(cur) && enable_RELRO) {
           bool sectionHasRelROSegment = true;
           bool needRelRoSegment = false;

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -1446,6 +1446,10 @@ unsigned int GNULDBackend::getSectionOrder(const ELFSection &pSectHdr) const {
         // We can use the same function isRELRO for both cases, but we need to
         // also determine the case of Partial RELRO versus Full RELRO. This code
         // is mainly duplicated to assume that.
+        // .tbss uses SHO_RELRO for ordering only, so it is placed adjacent to
+        // .tdata (also SHO_RELRO) as required for a contiguous PT_TLS.
+        // It is NOT a RELRO section for segment-membership purposes; see
+        // isRelROSection() which explicitly excludes .tbss.
         if (sectionName == ".ctors" || sectionName == ".data.rel.ro.local" ||
             sectionName == ".data.rel.ro" || sectionName == ".dtors" ||
             sectionName == ".fini_array" || sectionName == ".init_array" ||
@@ -1528,12 +1532,16 @@ bool GNULDBackend::isRelROSection(const ELFSection *section) const {
   if (isGOTAndGOTPLTMerged() && sectionName == ".got" &&
       !config().options().hasNow())
     return false;
+  // .tbss is SHT_NOBITS TLS BSS: it carries no file content and is not
+  // covered by PT_GNU_RELRO.  Treating it as a RELRO section suppresses the
+  // page-gap that separates the RELRO region from subsequent non-RELRO data
+  // and prevents enable_RELRO from being cleared at the right point.
   if (sectionName == ".ctors" || sectionName == ".data.rel.ro.local" ||
       sectionName == ".data.rel.ro" || sectionName == ".dtors" ||
       sectionName == ".fini_array" || sectionName == ".got" ||
       sectionName == ".init_array" || sectionName == ".tdata" ||
-      sectionName == ".tbss" || sectionName == ".preinit_array" ||
-      sectionName == ".jcr" || sectionName == ".dynamic")
+      sectionName == ".preinit_array" || sectionName == ".jcr" ||
+      sectionName == ".dynamic")
     return true;
   if (config().options().hasNow() && sectionName == ".got.plt")
     return true;
@@ -2475,11 +2483,12 @@ bool GNULDBackend::setupProgramHdrs() {
         continue;
       }
 
-      Seg->setOffset(Seg->front()->offset());
-      Seg->setVaddr(Seg->front()->addr());
-      Seg->setPaddr(Seg->front()->pAddr());
+      ELFSection *FirstSec = Seg->front();
+      Seg->setOffset(FirstSec->offset());
+      Seg->setVaddr(FirstSec->addr());
+      Seg->setPaddr(FirstSec->pAddr());
 
-      segmentOffset = Seg->front()->offset();
+      segmentOffset = FirstSec->offset();
 
       if (!setupSegment(Seg))
         return false;

--- a/test/Common/RunTests/RelRO/Inputs/relro_bss_tbss.c
+++ b/test/Common/RunTests/RelRO/Inputs/relro_bss_tbss.c
@@ -1,0 +1,17 @@
+/* Corner case 4: non-TLS BSS + TBSS.
+ * plain_bss is an ordinary BSS variable (SHT_NOBITS, no TLS flag); it must
+ * not be confused with .tbss.  tval goes to .tbss.  After the fix the RELRO
+ * segment's VirtAddr/Offset must skip both BSS regions and land on the first
+ * real RELRO section (.init_array / .got).  Both variables must be
+ * accessible after the loader maps the binary. */
+#include <stdio.h>
+
+int plain_bss;
+__thread int tval;
+
+__attribute__((constructor)) static void init_tval(void) { tval = 42; }
+
+int main(void) {
+  printf("bss=%d tbss=%d\n", plain_bss, tval);
+  return 0;
+}

--- a/test/Common/RunTests/RelRO/Inputs/relro_tbss.c
+++ b/test/Common/RunTests/RelRO/Inputs/relro_tbss.c
@@ -1,0 +1,15 @@
+/* TLS BSS variable — contributes a .tbss section (SHT_NOBITS + SHF_TLS).
+ * When linked with -z relro this must NOT appear in PT_GNU_RELRO; the
+ * segment must start at the first real RELRO section (.init_array / .got).
+ * The program just reads and writes the thread-local to prove that TLS
+ * itself is still functional after the PT_GNU_RELRO fix. */
+#include <stdio.h>
+
+__thread int tval;
+
+__attribute__((constructor)) static void init_tval(void) { tval = 42; }
+
+int main(void) {
+  printf("%d\n", tval);
+  return 0;
+}

--- a/test/Common/RunTests/RelRO/Inputs/relro_tdata_tbss.c
+++ b/test/Common/RunTests/RelRO/Inputs/relro_tdata_tbss.c
@@ -1,0 +1,14 @@
+/* Corner case 3: TBSS + TDATA.
+ * tval_init goes to .tdata (initialized TLS, FileSiz > 0 in PT_TLS).
+ * tval_bss  goes to .tbss  (uninitialized TLS, must be zero at startup).
+ * The RELRO segment must not include either TLS section; both values must
+ * survive the dynamic loader's RELRO protection pass unchanged. */
+#include <stdio.h>
+
+__thread int tval_init = 7;
+__thread int tval_bss;
+
+int main(void) {
+  printf("tdata=%d tbss=%d\n", tval_init, tval_bss);
+  return 0;
+}

--- a/test/Common/RunTests/RelRO/RelROGDTBSSBss.test
+++ b/test/Common/RunTests/RelRO/RelROGDTBSSBss.test
@@ -1,0 +1,18 @@
+REQUIRES: run_test, linux
+UNSUPPORTED: aarch64
+#---RelROGDTBSSBss.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+# Runtime test: TBSS + non-TLS BSS with partial RELRO (-z relro), GD TLS model.
+# A regular (non-TLS) BSS variable must not be confused with TBSS.  Both
+# must be readable/writable after the loader maps the binary.
+#END_COMMENT
+#START_TEST
+
+RUN: %run_cc %clangopts -fuse-init-array -c -fPIC %p/Inputs/relro_bss_tbss.c -o %t.bss.o
+RUN: %run_cc %clangopts -o %t.bss.out %t.bss.o -Wl,-z,relro -Wl,-dy
+RUN: %run %t.bss.out | %filecheck %s
+
+#END_TEST
+
+# Non-TLS BSS is zero, TBSS written by constructor is still 42
+CHECK: bss=0 tbss=42

--- a/test/Common/RunTests/RelRO/RelROGDTBSSOnly.test
+++ b/test/Common/RunTests/RelRO/RelROGDTBSSOnly.test
@@ -1,0 +1,18 @@
+REQUIRES: run_test, linux
+UNSUPPORTED: aarch64
+#---RelROGDTBSSOnly.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+# Runtime test: TBSS-only with partial RELRO (-z relro), GD TLS model.
+# GD (global-dynamic) is the most general TLS model and is the compiler
+# default for -fPIC on most targets.
+#END_COMMENT
+#START_TEST
+
+RUN: %run_cc %clangopts -fuse-init-array -c -fPIC %p/Inputs/relro_tbss.c -o %t.tbss.o
+RUN: %run_cc %clangopts -o %t.tbss.out %t.tbss.o -Wl,-z,relro -Wl,-dy
+RUN: %run %t.tbss.out | %filecheck %s
+
+#END_TEST
+
+# TBSS written by constructor is readable
+CHECK: 42

--- a/test/Common/RunTests/RelRO/RelROGDTBSSOnlyNow.test
+++ b/test/Common/RunTests/RelRO/RelROGDTBSSOnlyNow.test
@@ -1,0 +1,18 @@
+REQUIRES: run_test, linux
+UNSUPPORTED: aarch64
+#---RelROGDTBSSOnlyNow.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+# Runtime test: TBSS-only with full RELRO (-z relro -z now), GD TLS model.
+# Full RELRO merges .got.plt into .got.  The segment's first section is still
+# a real RELRO section (not .tbss).  TLS and constructors must still work.
+#END_COMMENT
+#START_TEST
+
+RUN: %run_cc %clangopts -fuse-init-array -c -fPIC %p/Inputs/relro_tbss.c -o %t.tbss.o
+RUN: %run_cc %clangopts -o %t.now.out %t.tbss.o -Wl,-z,relro -Wl,-z,now -Wl,-dy
+RUN: %run %t.now.out | %filecheck %s
+
+#END_TEST
+
+# TBSS written by constructor is readable
+CHECK: 42

--- a/test/Common/RunTests/RelRO/RelROGDTBSSTData.test
+++ b/test/Common/RunTests/RelRO/RelROGDTBSSTData.test
@@ -1,0 +1,19 @@
+REQUIRES: run_test, linux
+UNSUPPORTED: aarch64
+#---RelROGDTBSSTData.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+# Runtime test: TBSS + TDATA with partial RELRO (-z relro), GD TLS model.
+# Both initialized (.tdata) and uninitialized (.tbss) TLS are present.  The
+# initialized value must survive and the uninitialized slot must be zero at
+# startup; neither should be affected by RELRO protection.
+#END_COMMENT
+#START_TEST
+
+RUN: %run_cc %clangopts -fuse-init-array -c -fPIC %p/Inputs/relro_tdata_tbss.c -o %t.tdata.o
+RUN: %run_cc %clangopts -o %t.tdata.out %t.tdata.o -Wl,-z,relro -Wl,-dy
+RUN: %run %t.tdata.out | %filecheck %s
+
+#END_TEST
+
+# Initialized TLS value followed by zero-initialized TLS value
+CHECK: tdata=7 tbss=0

--- a/test/Common/RunTests/RelRO/RelROTBSSBss.test
+++ b/test/Common/RunTests/RelRO/RelROTBSSBss.test
@@ -1,0 +1,17 @@
+REQUIRES: run_test, linux
+#---RelROTBSSBss.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+# Runtime test: TBSS + non-TLS BSS with partial RELRO (-z relro).
+# A regular (non-TLS) BSS variable must not be confused with TBSS.  Both
+# must be readable/writable after the loader maps the binary.
+#END_COMMENT
+#START_TEST
+
+RUN: %run_cc %clangopts -fuse-init-array -c -fPIC -ftls-model=initial-exec %p/Inputs/relro_bss_tbss.c -o %t.bss.o
+RUN: %run_cc %clangopts -o %t.bss.out %t.bss.o -Wl,-z,relro -Wl,-dy
+RUN: %run %t.bss.out | %filecheck %s
+
+#END_TEST
+
+# Non-TLS BSS is zero, TBSS written by constructor is still 42
+CHECK: bss=0 tbss=42

--- a/test/Common/RunTests/RelRO/RelROTBSSOnly.test
+++ b/test/Common/RunTests/RelRO/RelROTBSSOnly.test
@@ -1,0 +1,17 @@
+REQUIRES: run_test, linux
+#---RelROTBSSOnly.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+# Runtime test: TBSS-only with partial RELRO (-z relro).
+# A constructor writes a TBSS variable; the loader must protect the correct
+# RELRO range without touching the TLS area.
+#END_COMMENT
+#START_TEST
+
+RUN: %run_cc %clangopts -fuse-init-array -c -fPIC -ftls-model=initial-exec %p/Inputs/relro_tbss.c -o %t.tbss.o
+RUN: %run_cc %clangopts -o %t.tbss.out %t.tbss.o -Wl,-z,relro -Wl,-dy
+RUN: %run %t.tbss.out | %filecheck %s
+
+#END_TEST
+
+# TBSS written by constructor is readable
+CHECK: 42

--- a/test/Common/RunTests/RelRO/RelROTBSSOnlyNow.test
+++ b/test/Common/RunTests/RelRO/RelROTBSSOnlyNow.test
@@ -1,0 +1,17 @@
+REQUIRES: run_test, linux
+#---RelROTBSSOnlyNow.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+# Runtime test: TBSS-only with full RELRO (-z relro -z now).
+# Full RELRO merges .got.plt into .got.  The segment's first section is still
+# a real RELRO section (not .tbss).  TLS and constructors must still work.
+#END_COMMENT
+#START_TEST
+
+RUN: %run_cc %clangopts -fuse-init-array -c -fPIC -ftls-model=initial-exec %p/Inputs/relro_tbss.c -o %t.tbss.o
+RUN: %run_cc %clangopts -o %t.now.out %t.tbss.o -Wl,-z,relro -Wl,-z,now -Wl,-dy
+RUN: %run %t.now.out | %filecheck %s
+
+#END_TEST
+
+# TBSS written by constructor is readable
+CHECK: 42

--- a/test/Common/RunTests/RelRO/RelROTBSSTData.test
+++ b/test/Common/RunTests/RelRO/RelROTBSSTData.test
@@ -1,0 +1,18 @@
+REQUIRES: run_test, linux
+#---RelROTBSSTData.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+# Runtime test: TBSS + TDATA with partial RELRO (-z relro).
+# Both initialized (.tdata) and uninitialized (.tbss) TLS are present.  The
+# initialized value must survive and the uninitialized slot must be zero at
+# startup; neither should be affected by RELRO protection.
+#END_COMMENT
+#START_TEST
+
+RUN: %run_cc %clangopts -fuse-init-array -c -fPIC -ftls-model=initial-exec %p/Inputs/relro_tdata_tbss.c -o %t.tdata.o
+RUN: %run_cc %clangopts -o %t.tdata.out %t.tdata.o -Wl,-z,relro -Wl,-dy
+RUN: %run %t.tdata.out | %filecheck %s
+
+#END_TEST
+
+# Initialized TLS value followed by zero-initialized TLS value
+CHECK: tdata=7 tbss=0

--- a/test/Common/standalone/GNURelro/GNURelroMultiTBSSRelroPresent.test
+++ b/test/Common/standalone/GNURelro/GNURelroMultiTBSSRelroPresent.test
@@ -1,0 +1,13 @@
+#---GNURelroMultiTBSSRelroPresent.test--- TLS, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# With -fdata-sections each TLS variable gets its own .tbss.<var> section.
+# Verify that PT_GNU_RELRO is still emitted when multiple .tbss.* sections
+# are present.
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC -fdata-sections %p/Inputs/tbss_multi.c -o %t.so.o
+RUN: %link %linkopts -shared -z relro %t.so.o -o %t.relro.so
+
+RUN: %readelf -l -W %t.relro.so | %filecheck %s
+# CHECK: GNU_RELRO

--- a/test/Common/standalone/GNURelro/GNURelroMultiTBSSTBSSNotInRelro.test
+++ b/test/Common/standalone/GNURelro/GNURelroMultiTBSSTBSSNotInRelro.test
@@ -1,0 +1,19 @@
+#---GNURelroMultiTBSSTBSSNotInRelro.test--- TLS, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# With -fdata-sections each TLS variable gets its own .tbss.<var> section.
+# Verify that none of the .tbss.* sections appear inside the PT_GNU_RELRO
+# segment mapping.
+#
+# The section-to-segment mapping row for GNU_RELRO must end with .got and must
+# not contain .tbss.  We verify this by asserting that the RELRO mapping row is
+# exactly ".dynamic .got" with nothing after it — if .tbss appeared there the
+# trailing-whitespace anchor would fail.
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC -fdata-sections %p/Inputs/tbss_multi.c -o %t.so.o
+RUN: %link %linkopts -shared -z relro %t.so.o -o %t.relro.so
+
+RUN: %readelf -l -W %t.relro.so | %filecheck %s
+# CHECK: GNU_RELRO
+# CHECK: .dynamic .got{{[[:space:]]*$}}

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyNoScriptRelroPresent.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyNoScriptRelroPresent.test
@@ -1,0 +1,45 @@
+#---GNURelroTBSSOnlyNoScriptRelroPresent.test--- TLS, Executable, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Tests for GNU_RELRO behavior when only TBSS (uninitialized TLS) sections are
+# present — no TDATA (initialized TLS).
+#
+# GNU behavior:
+#
+# PT_TLS segment:
+#   - FileSiz == 0  (no initialized TLS data to copy from the file)
+#   - MemSiz  >  0  (runtime reserves space for the uninitialized TLS block)
+#
+# PT_LOAD segments:
+#   - .tbss must NOT be counted in any PT_LOAD's file size or memory size.
+#     It lives only in the PT_TLS segment.
+#   - The RW PT_LOAD covering non-TLS data has FileSiz == MemSiz (TBSS
+#     does not inflate the LOAD's memory size beyond its file size).
+#     This was broken before the QTOOL-21682 fix.
+#
+# Section placement:
+#   - .tbss is listed under PT_TLS in the section-to-segment mapping.
+#   - .tbss is NOT listed under any PT_LOAD.
+#
+# PT_GNU_RELRO (with -z relro):
+#   - GNU_RELRO is present and covers .dynamic and .got.
+#   - .tbss must NOT appear in the GNU_RELRO section-to-segment mapping.
+#     Before the fix, .tbss was treated as a RELRO section, which caused
+#     the RELRO segment VirtAddr to point at the TLS area and excluded
+#     .dynamic/.got from the protected range.
+#END_COMMENT
+
+# --- Build executable ---
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.exe.o
+RUN: %link %linkopts %t.exe.o -o %t.exe.out
+
+# --- Build shared library (no relro) ---
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_only.c -o %t.so.o
+RUN: %link %linkopts -shared %t.so.o -o %t.so
+
+# --- Build shared library (with relro) ---
+RUN: %link %linkopts -shared -z relro %t.so.o -o %t.relro.so
+
+#--- Shared library with -z relro: GNU_RELRO segment is present ---
+RUN: %readelf -l -W %t.relro.so | %filecheck %s
+# CHECK: GNU_RELRO

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyNoScriptRelroSections.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyNoScriptRelroSections.test
@@ -1,0 +1,49 @@
+#---GNURelroTBSSOnlyNoScriptRelroSections.test--- TLS, Executable, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Tests for GNU_RELRO behavior when only TBSS (uninitialized TLS) sections are
+# present — no TDATA (initialized TLS).
+#
+# GNU behavior:
+#
+# PT_TLS segment:
+#   - FileSiz == 0  (no initialized TLS data to copy from the file)
+#   - MemSiz  >  0  (runtime reserves space for the uninitialized TLS block)
+#
+# PT_LOAD segments:
+#   - .tbss must NOT be counted in any PT_LOAD's file size or memory size.
+#     It lives only in the PT_TLS segment.
+#   - The RW PT_LOAD covering non-TLS data has FileSiz == MemSiz (TBSS
+#     does not inflate the LOAD's memory size beyond its file size).
+#     This was broken before the QTOOL-21682 fix.
+#
+# Section placement:
+#   - .tbss is listed under PT_TLS in the section-to-segment mapping.
+#   - .tbss is NOT listed under any PT_LOAD.
+#
+# PT_GNU_RELRO (with -z relro):
+#   - GNU_RELRO is present and covers .dynamic and .got.
+#   - .tbss must NOT appear in the GNU_RELRO section-to-segment mapping.
+#     Before the fix, .tbss was treated as a RELRO section, which caused
+#     the RELRO segment VirtAddr to point at the TLS area and excluded
+#     .dynamic/.got from the protected range.
+#END_COMMENT
+
+# --- Build executable ---
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.exe.o
+RUN: %link %linkopts %t.exe.o -o %t.exe.out
+
+# --- Build shared library (no relro) ---
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_only.c -o %t.so.o
+RUN: %link %linkopts -shared %t.so.o -o %t.so
+
+# --- Build shared library (with relro) ---
+RUN: %link %linkopts -shared -z relro %t.so.o -o %t.relro.so
+
+#--- Shared library with -z relro: .dynamic and .got are in GNU_RELRO ---
+# .tbss must NOT be in GNU_RELRO — it is a virtual TLS section excluded from
+# PT_LOAD.  Before the fix, .tbss was incorrectly treated as a RELRO section,
+# causing the RELRO segment to point at the TLS area and miss .dynamic/.got.
+RUN: %readelf -l -W %t.relro.so | %filecheck %s
+# CHECK: GNU_RELRO
+# CHECK: .dynamic .got{{[[:space:]]*$}}

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptRelroPresent.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptRelroPresent.test
@@ -1,0 +1,18 @@
+#---GNURelroTBSSTDataNoScriptRelroPresent.test--- TLS, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Verify PT_GNU_RELRO is emitted for a shared library with both TDATA and TBSS
+# when -z relro is used.
+#
+# The CreateProgramHeaders fix guards the enable_RELRO transition with
+# !cur->isTBSS().  Without it, when .tbss follows .tdata (which is RELRO),
+# the isPrevRelRO && !isCurRelRO transition fires on .tbss and clears
+# enable_RELRO before .dynamic/.got are processed, causing PT_GNU_RELRO to
+# be omitted or truncated.
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_tdata.c -o %t.so.o
+RUN: %link %linkopts -shared -z relro %t.so.o -o %t.relro.so
+
+RUN: %readelf -l -W %t.relro.so | %filecheck %s
+# CHECK: GNU_RELRO

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptRelroSections.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptRelroSections.test
@@ -1,0 +1,19 @@
+#---GNURelroTBSSTDataNoScriptRelroSections.test--- TLS, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Verify that .dynamic and .got are covered by PT_GNU_RELRO for a shared
+# library with both TDATA and TBSS when -z relro is used.
+#
+# The CreateProgramHeaders fix guards the enable_RELRO transition with
+# !cur->isTBSS().  Without it, when .tbss follows .tdata (which is RELRO),
+# the isPrevRelRO && !isCurRelRO transition fires on .tbss and clears
+# enable_RELRO before .dynamic/.got are processed, so .dynamic/.got are
+# excluded from PT_GNU_RELRO.
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_tdata.c -o %t.so.o
+RUN: %link %linkopts -shared -z relro %t.so.o -o %t.relro.so
+
+RUN: %readelf -l -W %t.relro.so | %filecheck %s
+# CHECK: GNU_RELRO
+# CHECK: .tdata .dynamic .got{{[[:space:]]*$}}

--- a/test/Common/standalone/GNURelro/Inputs/tbss_multi.c
+++ b/test/Common/standalone/GNURelro/Inputs/tbss_multi.c
@@ -1,0 +1,5 @@
+__thread int tls_a;
+__thread int tls_b;
+__thread int tls_c;
+int data = 42;
+int main(void) { return tls_a + tls_b + tls_c + data; }

--- a/test/Common/standalone/GNURelro/Inputs/tbss_only.c
+++ b/test/Common/standalone/GNURelro/Inputs/tbss_only.c
@@ -1,0 +1,7 @@
+__thread int a = 0;
+__thread int b = 0;
+int data = 30;
+int main() { return a + b + data; }
+/* ARM TLS helper stub — satisfies __aeabi_read_tp reference on bare-metal ARM
+ */
+void *__aeabi_read_tp(void) { return (void *)0; }

--- a/test/Common/standalone/GNURelro/Inputs/tbss_tdata.c
+++ b/test/Common/standalone/GNURelro/Inputs/tbss_tdata.c
@@ -1,0 +1,9 @@
+__thread int tdata1 = 10;
+__thread int tdata2 = 20;
+__thread int tbss1 = 0;
+__thread int tbss2 = 0;
+int data = 30;
+int main() { return tdata1 + tdata2 + tbss1 + tbss2 + data; }
+/* ARM TLS helper stub — satisfies __aeabi_read_tp reference on bare-metal ARM
+ */
+void *__aeabi_read_tp(void) { return (void *)0; }


### PR DESCRIPTION
.tbss is SHT_NOBITS TLS BSS: it has no file-backed content and must not appear in PT_GNU_RELRO.

Changes
--------
- GNULDBackend::isRelROSection() returns false for SHT_NOBITS TLS sections.
- CreateProgramHeaders skips the enable_RELRO-disabling transition when the current section is TBSS, preventing .tbss from prematurely closing the RELRO window and excluding .dynamic/.got.

Tests
------
- PT_GNU_RELRO is present when TBSS sections exist.
- .tbss does NOT appear in the PT_GNU_RELRO section-to-segment mapping.
- .dynamic and .got remain inside the RELRO-protected range.
- Runtime behavior: TBSS variables remain accessible after the loader applies RELRO protection (RunTests).

Tests coauthored by Claude.

Fixes #1317