### PR TITLE
[RELRO] Add TLS/TBSS PT_LOAD layout tests

### DIFF
--- a/test/Common/standalone/GNURelro/GNURelroExeNoRelro.test
+++ b/test/Common/standalone/GNURelro/GNURelroExeNoRelro.test
@@ -1,0 +1,11 @@
+#---GNURelroExeNoRelro.test--- Executable ---#
+#BEGIN_COMMENT
+# Verify that no PT_GNU_RELRO segment is emitted for a dynamic executable built
+# with -z norelro.
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/relro.c -o %t.exe.o
+RUN: %link %linkopts -z norelro %t.exe.o -o %t.norelro.out
+RUN: %readelf -l -W %t.norelro.out | %filecheck %s
+
+CHECK-NOT: GNU_RELRO

--- a/test/Common/standalone/GNURelro/GNURelroExeNowNoGotPlt.test
+++ b/test/Common/standalone/GNURelro/GNURelroExeNowNoGotPlt.test
@@ -1,0 +1,11 @@
+#---GNURelroExeNowNoGotPlt.test--- Executable ---#
+#BEGIN_COMMENT
+# Verify that with -z now (full RELRO), .got.plt is merged into .got and does
+# not appear in any segment's section mapping for the dynamic executable output.
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/relro.c -o %t.exe.o
+RUN: %link %linkopts -z relro -z now %t.exe.o -o %t.now.out
+RUN: %readelf -l -W %t.now.out | %filecheck %s
+
+CHECK-NOT: .got.plt

--- a/test/Common/standalone/GNURelro/GNURelroExeRelro.test
+++ b/test/Common/standalone/GNURelro/GNURelroExeRelro.test
@@ -1,0 +1,11 @@
+#---GNURelroExeRelro.test--- Executable ---#
+#BEGIN_COMMENT
+# Verify that a PT_GNU_RELRO segment is emitted for a dynamic executable built
+# with -z relro (partial RELRO).
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/relro.c -o %t.exe.o
+RUN: %link %linkopts -z relro %t.exe.o -o %t.relro.out
+RUN: %readelf -l -W %t.relro.out | %filecheck %s
+
+CHECK: GNU_RELRO

--- a/test/Common/standalone/GNURelro/GNURelroExeSections.test
+++ b/test/Common/standalone/GNURelro/GNURelroExeSections.test
@@ -1,0 +1,11 @@
+#---GNURelroExeSections.test--- Executable ---#
+#BEGIN_COMMENT
+# Verify that .init_array and .fini_array are placed in the PT_GNU_RELRO
+# segment for a dynamic executable with partial RELRO (-z relro).
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/relro.c -o %t.exe.o
+RUN: %link %linkopts -z relro %t.exe.o -o %t.relro.out
+RUN: %readelf -l -W %t.relro.out | %filecheck %s
+
+CHECK: .init_array .fini_array

--- a/test/Common/standalone/GNURelro/GNURelroMultiTBSSTLSFileSZ.test
+++ b/test/Common/standalone/GNURelro/GNURelroMultiTBSSTLSFileSZ.test
@@ -1,0 +1,13 @@
+#---GNURelroMultiTBSSTLSFileSZ.test--- TLS, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# With -fdata-sections each TLS variable gets its own .tbss.<var> section.
+# All TLS variables are uninitialized (BSS), so PT_TLS FileSiz must be zero
+# even when multiple .tbss.* sections are present.
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC -fdata-sections %p/Inputs/tbss_multi.c -o %t.so.o
+RUN: %link %linkopts -shared -z relro %t.so.o -o %t.relro.so
+
+RUN: %readelf -l -W %t.relro.so | %filecheck %s
+# CHECK: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{0x0+}} {{0x[0-9a-f]+}} R

--- a/test/Common/standalone/GNURelro/GNURelroMultiTBSSTLSMemSZ.test
+++ b/test/Common/standalone/GNURelro/GNURelroMultiTBSSTLSMemSZ.test
@@ -1,0 +1,13 @@
+#---GNURelroMultiTBSSTLSMemSZ.test--- TLS, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# With -fdata-sections each TLS variable gets its own .tbss.<var> section.
+# The runtime must allocate per-thread space for all three variables, so
+# PT_TLS MemSiz must be non-zero.
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC -fdata-sections %p/Inputs/tbss_multi.c -o %t.so.o
+RUN: %link %linkopts -shared -z relro %t.so.o -o %t.relro.so
+
+RUN: %readelf -l -W %t.relro.so | %filecheck %s
+# CHECK-NOT: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{0x0+}} {{0x0+}} R

--- a/test/Common/standalone/GNURelro/GNURelroSOGotPltNotRelro.test
+++ b/test/Common/standalone/GNURelro/GNURelroSOGotPltNotRelro.test
@@ -1,0 +1,15 @@
+#---GNURelroSOGotPltNotRelro.test--- SharedLibrary ---#
+#BEGIN_COMMENT
+# Verify that .got.plt is NOT in the PT_GNU_RELRO segment for a shared library
+# with partial RELRO (-z relro).  .got.plt must remain in the RW data segment
+# so the dynamic linker can patch it during lazy binding.
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/relro.c -o %t.so.o
+RUN: %link %linkopts -shared -z relro %t.so.o -o %t.relro.so
+RUN: %readelf -l -W %t.relro.so | %filecheck %s
+
+# .got.plt appears in the output (in the data LOAD segment)
+CHECK:     .got.plt
+# But it is NOT listed inside the GNU_RELRO segment alongside init/got
+CHECK-NOT: .init_array .fini_array .dynamic .got .got.plt

--- a/test/Common/standalone/GNURelro/GNURelroSONoRelro.test
+++ b/test/Common/standalone/GNURelro/GNURelroSONoRelro.test
@@ -1,0 +1,11 @@
+#---GNURelroSONoRelro.test--- SharedLibrary ---#
+#BEGIN_COMMENT
+# Verify that no PT_GNU_RELRO segment is emitted for a shared library built
+# with -z norelro.
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/relro.c -o %t.so.o
+RUN: %link %linkopts -shared -z norelro %t.so.o -o %t.norelro.so
+RUN: %readelf -l -W %t.norelro.so | %filecheck %s
+
+CHECK-NOT: GNU_RELRO

--- a/test/Common/standalone/GNURelro/GNURelroSONow.test
+++ b/test/Common/standalone/GNURelro/GNURelroSONow.test
@@ -1,0 +1,12 @@
+#---GNURelroSONow.test--- SharedLibrary ---#
+#BEGIN_COMMENT
+# Verify that with -z now (full RELRO), a PT_GNU_RELRO segment is emitted and
+# .got (covering all GOT entries) is in RELRO for a shared library.
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/relro.c -o %t.so.o
+RUN: %link %linkopts -shared -z relro -z now %t.so.o -o %t.now.so
+RUN: %readelf -l -W %t.now.so | %filecheck %s
+
+CHECK: GNU_RELRO
+CHECK: .init_array .fini_array .dynamic .got

--- a/test/Common/standalone/GNURelro/GNURelroSONowNoGotPlt.test
+++ b/test/Common/standalone/GNURelro/GNURelroSONowNoGotPlt.test
@@ -1,0 +1,11 @@
+#---GNURelroSONowNoGotPlt.test--- SharedLibrary ---#
+#BEGIN_COMMENT
+# Verify that with -z now (full RELRO), .got.plt is merged into .got and does
+# not appear in any segment's section mapping for the shared library output.
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/relro.c -o %t.so.o
+RUN: %link %linkopts -shared -z relro -z now %t.so.o -o %t.now.so
+RUN: %readelf -l -W %t.now.so | %filecheck %s
+
+CHECK-NOT: .got.plt

--- a/test/Common/standalone/GNURelro/GNURelroSORelro.test
+++ b/test/Common/standalone/GNURelro/GNURelroSORelro.test
@@ -1,0 +1,11 @@
+#---GNURelroSORelro.test--- SharedLibrary ---#
+#BEGIN_COMMENT
+# Verify that a PT_GNU_RELRO segment is emitted for a shared library built
+# with -z relro (partial RELRO).
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/relro.c -o %t.so.o
+RUN: %link %linkopts -shared -z relro %t.so.o -o %t.relro.so
+RUN: %readelf -l -W %t.relro.so | %filecheck %s
+
+CHECK: GNU_RELRO

--- a/test/Common/standalone/GNURelro/GNURelroSOSections.test
+++ b/test/Common/standalone/GNURelro/GNURelroSOSections.test
@@ -1,0 +1,11 @@
+#---GNURelroSOSections.test--- SharedLibrary ---#
+#BEGIN_COMMENT
+# Verify that .init_array, .fini_array, .dynamic, and .got are placed in the
+# PT_GNU_RELRO segment for a shared library with partial RELRO (-z relro).
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/relro.c -o %t.so.o
+RUN: %link %linkopts -shared -z relro %t.so.o -o %t.relro.so
+RUN: %readelf -l -W %t.relro.so | %filecheck %s
+
+CHECK: .init_array .fini_array .dynamic .got

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyMemoryLoadSizes.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyMemoryLoadSizes.test
@@ -1,0 +1,20 @@
+#---GNURelroTBSSOnlyMemoryLoadSizes.test--- TLS, Executable, LinkerScript, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with a MEMORY linker script.
+#
+# A MEMORY script places text in FLASH and data/TLS in RAM, giving the TLS
+# section a VirtAddr inside the RAM region.  The same PT_TLS invariants
+# must hold regardless of where MEMORY places the section:
+#   - PT_TLS FileSiz == 0  (.tbss is BSS; nothing stored in the file)
+#   - PT_TLS MemSiz  >  0  (runtime allocates per-thread space in RAM)
+#   - .tbss is under PT_TLS, not under any PT_LOAD
+#   - The RW PT_LOAD covering RAM has FileSiz == MemSiz
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_memory.t %t.o -o %t.out
+
+#--- RW PT_LOAD (RAM) has FileSiz == MemSiz (TBSS excluded) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: LOAD {{[0-9a-fx]+}} {{[0-9a-fx]+}} {{[0-9a-fx]+}} [[SZ:[0-9a-fx]+]] [[SZ]] RW

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyMemoryTBSSInTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyMemoryTBSSInTLS.test
@@ -1,0 +1,20 @@
+#---GNURelroTBSSOnlyMemoryTBSSInTLS.test--- TLS, Executable, LinkerScript, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with a MEMORY linker script.
+#
+# A MEMORY script places text in FLASH and data/TLS in RAM, giving the TLS
+# section a VirtAddr inside the RAM region.  The same PT_TLS invariants
+# must hold regardless of where MEMORY places the section:
+#   - PT_TLS FileSiz == 0  (.tbss is BSS; nothing stored in the file)
+#   - PT_TLS MemSiz  >  0  (runtime allocates per-thread space in RAM)
+#   - .tbss is under PT_TLS, not under any PT_LOAD
+#   - The RW PT_LOAD covering RAM has FileSiz == MemSiz
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_memory.t %t.o -o %t.out
+
+#--- .tbss is listed under PT_TLS ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: .tbss

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyMemoryTBSSNotInLoad.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyMemoryTBSSNotInLoad.test
@@ -1,0 +1,20 @@
+#---GNURelroTBSSOnlyMemoryTBSSNotInLoad.test--- TLS, Executable, LinkerScript, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with a MEMORY linker script.
+#
+# A MEMORY script places text in FLASH and data/TLS in RAM, giving the TLS
+# section a VirtAddr inside the RAM region.  The same PT_TLS invariants
+# must hold regardless of where MEMORY places the section:
+#   - PT_TLS FileSiz == 0  (.tbss is BSS; nothing stored in the file)
+#   - PT_TLS MemSiz  >  0  (runtime allocates per-thread space in RAM)
+#   - .tbss is under PT_TLS, not under any PT_LOAD
+#   - The RW PT_LOAD covering RAM has FileSiz == MemSiz
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_memory.t %t.o -o %t.out
+
+#--- .tbss is NOT listed under any PT_LOAD ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK-NOT: LOAD {{.*}} .tbss

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyMemoryTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyMemoryTLS.test
@@ -1,0 +1,20 @@
+#---GNURelroTBSSOnlyMemoryTLS.test--- TLS, Executable, LinkerScript, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with a MEMORY linker script.
+#
+# A MEMORY script places text in FLASH and data/TLS in RAM, giving the TLS
+# section a VirtAddr inside the RAM region.  The same PT_TLS invariants
+# must hold regardless of where MEMORY places the section:
+#   - PT_TLS FileSiz == 0  (.tbss is BSS; nothing stored in the file)
+#   - PT_TLS MemSiz  >  0  (runtime allocates per-thread space in RAM)
+#   - .tbss is under PT_TLS, not under any PT_LOAD
+#   - The RW PT_LOAD covering RAM has FileSiz == MemSiz
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_memory.t %t.o -o %t.out
+
+#--- PT_TLS segment is present ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: TLS

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyMemoryTLSFileSZ.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyMemoryTLSFileSZ.test
@@ -1,0 +1,20 @@
+#---GNURelroTBSSOnlyMemoryTLSFileSZ.test--- TLS, Executable, LinkerScript, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with a MEMORY linker script.
+#
+# A MEMORY script places text in FLASH and data/TLS in RAM, giving the TLS
+# section a VirtAddr inside the RAM region.  The same PT_TLS invariants
+# must hold regardless of where MEMORY places the section:
+#   - PT_TLS FileSiz == 0  (.tbss is BSS; nothing stored in the file)
+#   - PT_TLS MemSiz  >  0  (runtime allocates per-thread space in RAM)
+#   - .tbss is under PT_TLS, not under any PT_LOAD
+#   - The RW PT_LOAD covering RAM has FileSiz == MemSiz
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_memory.t %t.o -o %t.out
+
+#--- PT_TLS FileSiz == 0 (no TDATA in file) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{0x0+}} {{0x[0-9a-f]+}} R

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyMemoryTLSInRAM.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyMemoryTLSInRAM.test
@@ -1,0 +1,21 @@
+#---GNURelroTBSSOnlyMemoryTLSInRAM.test--- TLS, Executable, LinkerScript, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with a MEMORY linker script.
+#
+# A MEMORY script places text in FLASH and data/TLS in RAM, giving the TLS
+# section a VirtAddr inside the RAM region.  The same PT_TLS invariants
+# must hold regardless of where MEMORY places the section:
+#   - PT_TLS FileSiz == 0  (.tbss is BSS; nothing stored in the file)
+#   - PT_TLS MemSiz  >  0  (runtime allocates per-thread space in RAM)
+#   - .tbss is under PT_TLS, not under any PT_LOAD
+#   - The RW PT_LOAD covering RAM has FileSiz == MemSiz
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_memory.t %t.o -o %t.out
+
+#--- .tbss VirtAddr falls inside the RAM region (MEMORY directive respected) ---
+# The MEMORY script places RAM at 0x500000; PT_TLS must start at or above that.
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: TLS {{[0x0-9a-f]+}} {{0x0*5[0-9a-f]+}}

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyMemoryTLSMemSZ.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyMemoryTLSMemSZ.test
@@ -1,0 +1,20 @@
+#---GNURelroTBSSOnlyMemoryTLSMemSZ.test--- TLS, Executable, LinkerScript, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with a MEMORY linker script.
+#
+# A MEMORY script places text in FLASH and data/TLS in RAM, giving the TLS
+# section a VirtAddr inside the RAM region.  The same PT_TLS invariants
+# must hold regardless of where MEMORY places the section:
+#   - PT_TLS FileSiz == 0  (.tbss is BSS; nothing stored in the file)
+#   - PT_TLS MemSiz  >  0  (runtime allocates per-thread space in RAM)
+#   - .tbss is under PT_TLS, not under any PT_LOAD
+#   - The RW PT_LOAD covering RAM has FileSiz == MemSiz
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_memory.t %t.o -o %t.out
+
+#--- PT_TLS MemSiz > 0 (runtime reserves space for TBSS per thread) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK-NOT: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{0x0+}} {{0x0+}} R

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyNoScriptExeLoadFileSZEqMemSZ.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyNoScriptExeLoadFileSZEqMemSZ.test
@@ -1,0 +1,47 @@
+#---GNURelroTBSSOnlyNoScriptExeLoadFileSZEqMemSZ.test--- TLS, Executable, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Tests for GNU_RELRO behavior when only TBSS (uninitialized TLS) sections are
+# present — no TDATA (initialized TLS).
+#
+# GNU behavior:
+#
+# PT_TLS segment:
+#   - FileSiz == 0  (no initialized TLS data to copy from the file)
+#   - MemSiz  >  0  (runtime reserves space for the uninitialized TLS block)
+#
+# PT_LOAD segments:
+#   - .tbss must NOT be counted in any PT_LOAD's file size or memory size.
+#     It lives only in the PT_TLS segment.
+#   - The RW PT_LOAD covering non-TLS data has FileSiz == MemSiz (TBSS
+#     does not inflate the LOAD's memory size beyond its file size).
+#     This was broken before the QTOOL-21682 fix.
+#
+# Section placement:
+#   - .tbss is listed under PT_TLS in the section-to-segment mapping.
+#   - .tbss is NOT listed under any PT_LOAD.
+#
+# PT_GNU_RELRO (with -z relro):
+#   - GNU_RELRO is present and covers .dynamic and .got.
+#   - .tbss must NOT appear in the GNU_RELRO section-to-segment mapping.
+#     Before the fix, .tbss was treated as a RELRO section, which caused
+#     the RELRO segment VirtAddr to point at the TLS area and excluded
+#     .dynamic/.got from the protected range.
+#END_COMMENT
+
+# --- Build executable ---
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.exe.o
+RUN: %link %linkopts %t.exe.o -o %t.exe.out
+
+# --- Build shared library (no relro) ---
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_only.c -o %t.so.o
+RUN: %link %linkopts -shared %t.so.o -o %t.so
+
+# --- Build shared library (with relro) ---
+RUN: %link %linkopts -shared -z relro %t.so.o -o %t.relro.so
+
+#--- Executable: RW PT_LOAD has FileSiz == MemSiz (TBSS excluded from LOAD) ---
+# TBSS must not cause the LOAD's MemSiz to exceed its FileSiz. If it did,
+# the loader would incorrectly zero-fill extra memory for every non-TLS load.
+RUN: %readelf -l -W %t.exe.out | %filecheck %s
+# CHECK: LOAD {{[0-9a-fx]+}} {{[0-9a-fx]+}} {{[0-9a-fx]+}} [[SZ:[0-9a-fx]+]] [[SZ]] RW

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyNoScriptExeTBSSInTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyNoScriptExeTBSSInTLS.test
@@ -1,0 +1,46 @@
+#---GNURelroTBSSOnlyNoScriptExeTBSSInTLS.test--- TLS, Executable, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Tests for GNU_RELRO behavior when only TBSS (uninitialized TLS) sections are
+# present — no TDATA (initialized TLS).
+#
+# GNU behavior:
+#
+# PT_TLS segment:
+#   - FileSiz == 0  (no initialized TLS data to copy from the file)
+#   - MemSiz  >  0  (runtime reserves space for the uninitialized TLS block)
+#
+# PT_LOAD segments:
+#   - .tbss must NOT be counted in any PT_LOAD's file size or memory size.
+#     It lives only in the PT_TLS segment.
+#   - The RW PT_LOAD covering non-TLS data has FileSiz == MemSiz (TBSS
+#     does not inflate the LOAD's memory size beyond its file size).
+#     This was broken before the QTOOL-21682 fix.
+#
+# Section placement:
+#   - .tbss is listed under PT_TLS in the section-to-segment mapping.
+#   - .tbss is NOT listed under any PT_LOAD.
+#
+# PT_GNU_RELRO (with -z relro):
+#   - GNU_RELRO is present and covers .dynamic and .got.
+#   - .tbss must NOT appear in the GNU_RELRO section-to-segment mapping.
+#     Before the fix, .tbss was treated as a RELRO section, which caused
+#     the RELRO segment VirtAddr to point at the TLS area and excluded
+#     .dynamic/.got from the protected range.
+#END_COMMENT
+
+# --- Build executable ---
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.exe.o
+RUN: %link %linkopts %t.exe.o -o %t.exe.out
+
+# --- Build shared library (no relro) ---
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_only.c -o %t.so.o
+RUN: %link %linkopts -shared %t.so.o -o %t.so
+
+# --- Build shared library (with relro) ---
+RUN: %link %linkopts -shared -z relro %t.so.o -o %t.relro.so
+
+#--- Executable: .tbss is in the TLS segment, not in any PT_LOAD ---
+# The section-to-segment mapping must show .tbss under TLS, never under LOAD.
+RUN: %readelf -l -W %t.exe.out | %filecheck %s
+# CHECK: .tbss

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyNoScriptExeTBSSNotInLoad.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyNoScriptExeTBSSNotInLoad.test
@@ -1,0 +1,44 @@
+#---GNURelroTBSSOnlyNoScriptExeTBSSNotInLoad.test--- TLS, Executable, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Tests for GNU_RELRO behavior when only TBSS (uninitialized TLS) sections are
+# present — no TDATA (initialized TLS).
+#
+# GNU behavior:
+#
+# PT_TLS segment:
+#   - FileSiz == 0  (no initialized TLS data to copy from the file)
+#   - MemSiz  >  0  (runtime reserves space for the uninitialized TLS block)
+#
+# PT_LOAD segments:
+#   - .tbss must NOT be counted in any PT_LOAD's file size or memory size.
+#     It lives only in the PT_TLS segment.
+#   - The RW PT_LOAD covering non-TLS data has FileSiz == MemSiz (TBSS
+#     does not inflate the LOAD's memory size beyond its file size).
+#     This was broken before the QTOOL-21682 fix.
+#
+# Section placement:
+#   - .tbss is listed under PT_TLS in the section-to-segment mapping.
+#   - .tbss is NOT listed under any PT_LOAD.
+#
+# PT_GNU_RELRO (with -z relro):
+#   - GNU_RELRO is present and covers .dynamic and .got.
+#   - .tbss must NOT appear in the GNU_RELRO section-to-segment mapping.
+#     Before the fix, .tbss was treated as a RELRO section, which caused
+#     the RELRO segment VirtAddr to point at the TLS area and excluded
+#     .dynamic/.got from the protected range.
+#END_COMMENT
+
+# --- Build executable ---
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.exe.o
+RUN: %link %linkopts %t.exe.o -o %t.exe.out
+
+# --- Build shared library (no relro) ---
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_only.c -o %t.so.o
+RUN: %link %linkopts -shared %t.so.o -o %t.so
+
+# --- Build shared library (with relro) ---
+RUN: %link %linkopts -shared -z relro %t.so.o -o %t.relro.so
+
+RUN: %readelf -l -W %t.exe.out | %filecheck %s
+# CHECK-NOT: LOAD {{.*}} .tbss

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyNoScriptExeTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyNoScriptExeTLS.test
@@ -1,0 +1,45 @@
+#---GNURelroTBSSOnlyNoScriptExeTLS.test--- TLS, Executable, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Tests for GNU_RELRO behavior when only TBSS (uninitialized TLS) sections are
+# present — no TDATA (initialized TLS).
+#
+# GNU behavior:
+#
+# PT_TLS segment:
+#   - FileSiz == 0  (no initialized TLS data to copy from the file)
+#   - MemSiz  >  0  (runtime reserves space for the uninitialized TLS block)
+#
+# PT_LOAD segments:
+#   - .tbss must NOT be counted in any PT_LOAD's file size or memory size.
+#     It lives only in the PT_TLS segment.
+#   - The RW PT_LOAD covering non-TLS data has FileSiz == MemSiz (TBSS
+#     does not inflate the LOAD's memory size beyond its file size).
+#     This was broken before the QTOOL-21682 fix.
+#
+# Section placement:
+#   - .tbss is listed under PT_TLS in the section-to-segment mapping.
+#   - .tbss is NOT listed under any PT_LOAD.
+#
+# PT_GNU_RELRO (with -z relro):
+#   - GNU_RELRO is present and covers .dynamic and .got.
+#   - .tbss must NOT appear in the GNU_RELRO section-to-segment mapping.
+#     Before the fix, .tbss was treated as a RELRO section, which caused
+#     the RELRO segment VirtAddr to point at the TLS area and excluded
+#     .dynamic/.got from the protected range.
+#END_COMMENT
+
+# --- Build executable ---
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.exe.o
+RUN: %link %linkopts %t.exe.o -o %t.exe.out
+
+# --- Build shared library (no relro) ---
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_only.c -o %t.so.o
+RUN: %link %linkopts -shared %t.so.o -o %t.so
+
+# --- Build shared library (with relro) ---
+RUN: %link %linkopts -shared -z relro %t.so.o -o %t.relro.so
+
+#--- Executable: PT_TLS segment is present ---
+RUN: %readelf -l -W %t.exe.out | %filecheck %s
+# CHECK: TLS

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyNoScriptExeTLSFileSZ.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyNoScriptExeTLSFileSZ.test
@@ -1,0 +1,47 @@
+#---GNURelroTBSSOnlyNoScriptExeTLSFileSZ.test--- TLS, Executable, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Tests for GNU_RELRO behavior when only TBSS (uninitialized TLS) sections are
+# present — no TDATA (initialized TLS).
+#
+# GNU behavior:
+#
+# PT_TLS segment:
+#   - FileSiz == 0  (no initialized TLS data to copy from the file)
+#   - MemSiz  >  0  (runtime reserves space for the uninitialized TLS block)
+#
+# PT_LOAD segments:
+#   - .tbss must NOT be counted in any PT_LOAD's file size or memory size.
+#     It lives only in the PT_TLS segment.
+#   - The RW PT_LOAD covering non-TLS data has FileSiz == MemSiz (TBSS
+#     does not inflate the LOAD's memory size beyond its file size).
+#     This was broken before the QTOOL-21682 fix.
+#
+# Section placement:
+#   - .tbss is listed under PT_TLS in the section-to-segment mapping.
+#   - .tbss is NOT listed under any PT_LOAD.
+#
+# PT_GNU_RELRO (with -z relro):
+#   - GNU_RELRO is present and covers .dynamic and .got.
+#   - .tbss must NOT appear in the GNU_RELRO section-to-segment mapping.
+#     Before the fix, .tbss was treated as a RELRO section, which caused
+#     the RELRO segment VirtAddr to point at the TLS area and excluded
+#     .dynamic/.got from the protected range.
+#END_COMMENT
+
+# --- Build executable ---
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.exe.o
+RUN: %link %linkopts %t.exe.o -o %t.exe.out
+
+# --- Build shared library (no relro) ---
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_only.c -o %t.so.o
+RUN: %link %linkopts -shared %t.so.o -o %t.so
+
+# --- Build shared library (with relro) ---
+RUN: %link %linkopts -shared -z relro %t.so.o -o %t.relro.so
+
+#--- Executable: PT_TLS has FileSiz == 0 (no TDATA in file) ---
+# The TLS segment file size must be zero because all TLS variables are BSS
+# (uninitialized); there is no initialized data to store in the file.
+RUN: %readelf -l -W %t.exe.out | %filecheck %s
+# CHECK: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{0x0+}} {{0x[0-9a-f]+}} R

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyNoScriptExeTLSMemSZ.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyNoScriptExeTLSMemSZ.test
@@ -1,0 +1,47 @@
+#---GNURelroTBSSOnlyNoScriptExeTLSMemSZ.test--- TLS, Executable, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Tests for GNU_RELRO behavior when only TBSS (uninitialized TLS) sections are
+# present — no TDATA (initialized TLS).
+#
+# GNU behavior:
+#
+# PT_TLS segment:
+#   - FileSiz == 0  (no initialized TLS data to copy from the file)
+#   - MemSiz  >  0  (runtime reserves space for the uninitialized TLS block)
+#
+# PT_LOAD segments:
+#   - .tbss must NOT be counted in any PT_LOAD's file size or memory size.
+#     It lives only in the PT_TLS segment.
+#   - The RW PT_LOAD covering non-TLS data has FileSiz == MemSiz (TBSS
+#     does not inflate the LOAD's memory size beyond its file size).
+#     This was broken before the QTOOL-21682 fix.
+#
+# Section placement:
+#   - .tbss is listed under PT_TLS in the section-to-segment mapping.
+#   - .tbss is NOT listed under any PT_LOAD.
+#
+# PT_GNU_RELRO (with -z relro):
+#   - GNU_RELRO is present and covers .dynamic and .got.
+#   - .tbss must NOT appear in the GNU_RELRO section-to-segment mapping.
+#     Before the fix, .tbss was treated as a RELRO section, which caused
+#     the RELRO segment VirtAddr to point at the TLS area and excluded
+#     .dynamic/.got from the protected range.
+#END_COMMENT
+
+# --- Build executable ---
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.exe.o
+RUN: %link %linkopts %t.exe.o -o %t.exe.out
+
+# --- Build shared library (no relro) ---
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_only.c -o %t.so.o
+RUN: %link %linkopts -shared %t.so.o -o %t.so
+
+# --- Build shared library (with relro) ---
+RUN: %link %linkopts -shared -z relro %t.so.o -o %t.relro.so
+
+#--- Executable: PT_TLS MemSiz > 0 (runtime reservation for TBSS) ---
+# Although FileSiz is zero the TLS template size (MemSiz) must be non-zero
+# because the runtime still needs to allocate space for each thread's copy.
+RUN: %readelf -l -W %t.exe.out | %filecheck %s
+# CHECK-NOT: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{0x0+}} {{0x0+}} R

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyNoScriptSoTBSSInTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyNoScriptSoTBSSInTLS.test
@@ -1,0 +1,45 @@
+#---GNURelroTBSSOnlyNoScriptSoTBSSInTLS.test--- TLS, Executable, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Tests for GNU_RELRO behavior when only TBSS (uninitialized TLS) sections are
+# present — no TDATA (initialized TLS).
+#
+# GNU behavior:
+#
+# PT_TLS segment:
+#   - FileSiz == 0  (no initialized TLS data to copy from the file)
+#   - MemSiz  >  0  (runtime reserves space for the uninitialized TLS block)
+#
+# PT_LOAD segments:
+#   - .tbss must NOT be counted in any PT_LOAD's file size or memory size.
+#     It lives only in the PT_TLS segment.
+#   - The RW PT_LOAD covering non-TLS data has FileSiz == MemSiz (TBSS
+#     does not inflate the LOAD's memory size beyond its file size).
+#     This was broken before the QTOOL-21682 fix.
+#
+# Section placement:
+#   - .tbss is listed under PT_TLS in the section-to-segment mapping.
+#   - .tbss is NOT listed under any PT_LOAD.
+#
+# PT_GNU_RELRO (with -z relro):
+#   - GNU_RELRO is present and covers .dynamic and .got.
+#   - .tbss must NOT appear in the GNU_RELRO section-to-segment mapping.
+#     Before the fix, .tbss was treated as a RELRO section, which caused
+#     the RELRO segment VirtAddr to point at the TLS area and excluded
+#     .dynamic/.got from the protected range.
+#END_COMMENT
+
+# --- Build executable ---
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.exe.o
+RUN: %link %linkopts %t.exe.o -o %t.exe.out
+
+# --- Build shared library (no relro) ---
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_only.c -o %t.so.o
+RUN: %link %linkopts -shared %t.so.o -o %t.so
+
+# --- Build shared library (with relro) ---
+RUN: %link %linkopts -shared -z relro %t.so.o -o %t.relro.so
+
+#--- Shared library: .tbss is in the TLS segment ---
+RUN: %readelf -l -W %t.so | %filecheck %s
+# CHECK: .tbss

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyNoScriptSoTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyNoScriptSoTLS.test
@@ -1,0 +1,45 @@
+#---GNURelroTBSSOnlyNoScriptSoTLS.test--- TLS, Executable, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Tests for GNU_RELRO behavior when only TBSS (uninitialized TLS) sections are
+# present — no TDATA (initialized TLS).
+#
+# GNU behavior:
+#
+# PT_TLS segment:
+#   - FileSiz == 0  (no initialized TLS data to copy from the file)
+#   - MemSiz  >  0  (runtime reserves space for the uninitialized TLS block)
+#
+# PT_LOAD segments:
+#   - .tbss must NOT be counted in any PT_LOAD's file size or memory size.
+#     It lives only in the PT_TLS segment.
+#   - The RW PT_LOAD covering non-TLS data has FileSiz == MemSiz (TBSS
+#     does not inflate the LOAD's memory size beyond its file size).
+#     This was broken before the QTOOL-21682 fix.
+#
+# Section placement:
+#   - .tbss is listed under PT_TLS in the section-to-segment mapping.
+#   - .tbss is NOT listed under any PT_LOAD.
+#
+# PT_GNU_RELRO (with -z relro):
+#   - GNU_RELRO is present and covers .dynamic and .got.
+#   - .tbss must NOT appear in the GNU_RELRO section-to-segment mapping.
+#     Before the fix, .tbss was treated as a RELRO section, which caused
+#     the RELRO segment VirtAddr to point at the TLS area and excluded
+#     .dynamic/.got from the protected range.
+#END_COMMENT
+
+# --- Build executable ---
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.exe.o
+RUN: %link %linkopts %t.exe.o -o %t.exe.out
+
+# --- Build shared library (no relro) ---
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_only.c -o %t.so.o
+RUN: %link %linkopts -shared %t.so.o -o %t.so
+
+# --- Build shared library (with relro) ---
+RUN: %link %linkopts -shared -z relro %t.so.o -o %t.relro.so
+
+#--- Shared library: PT_TLS segment is present ---
+RUN: %readelf -l -W %t.so | %filecheck %s
+# CHECK: TLS

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyNoScriptSoTLSFileSZ.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyNoScriptSoTLSFileSZ.test
@@ -1,0 +1,45 @@
+#---GNURelroTBSSOnlyNoScriptSoTLSFileSZ.test--- TLS, Executable, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Tests for GNU_RELRO behavior when only TBSS (uninitialized TLS) sections are
+# present — no TDATA (initialized TLS).
+#
+# GNU behavior:
+#
+# PT_TLS segment:
+#   - FileSiz == 0  (no initialized TLS data to copy from the file)
+#   - MemSiz  >  0  (runtime reserves space for the uninitialized TLS block)
+#
+# PT_LOAD segments:
+#   - .tbss must NOT be counted in any PT_LOAD's file size or memory size.
+#     It lives only in the PT_TLS segment.
+#   - The RW PT_LOAD covering non-TLS data has FileSiz == MemSiz (TBSS
+#     does not inflate the LOAD's memory size beyond its file size).
+#     This was broken before the QTOOL-21682 fix.
+#
+# Section placement:
+#   - .tbss is listed under PT_TLS in the section-to-segment mapping.
+#   - .tbss is NOT listed under any PT_LOAD.
+#
+# PT_GNU_RELRO (with -z relro):
+#   - GNU_RELRO is present and covers .dynamic and .got.
+#   - .tbss must NOT appear in the GNU_RELRO section-to-segment mapping.
+#     Before the fix, .tbss was treated as a RELRO section, which caused
+#     the RELRO segment VirtAddr to point at the TLS area and excluded
+#     .dynamic/.got from the protected range.
+#END_COMMENT
+
+# --- Build executable ---
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.exe.o
+RUN: %link %linkopts %t.exe.o -o %t.exe.out
+
+# --- Build shared library (no relro) ---
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_only.c -o %t.so.o
+RUN: %link %linkopts -shared %t.so.o -o %t.so
+
+# --- Build shared library (with relro) ---
+RUN: %link %linkopts -shared -z relro %t.so.o -o %t.relro.so
+
+#--- Shared library: PT_TLS has FileSiz == 0 (no TDATA) ---
+RUN: %readelf -l -W %t.so | %filecheck %s
+# CHECK: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{0x0+}} {{0x[0-9a-f]+}} R

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSLoadSizes.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSLoadSizes.test
@@ -1,0 +1,23 @@
+#---GNURelroTBSSOnlyPHDRSLoadSizes.test--- TLS, Executable, LinkerScript, PHDRS ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with an explicit PHDRS linker
+# script.
+#
+# With PHDRS the programmer assigns sections to named segments.  The script
+# assigns .tbss to both ph_tls (PT_TLS) and ph_data (PT_LOAD), mirroring
+# the GNU convention where the TLS segment overlaps the data LOAD.
+#
+#   - PT_TLS FileSiz == 0   (.tbss is BSS; no initialized content in file)
+#   - PT_TLS MemSiz  >  0   (runtime reserves per-thread space)
+#   - .tbss appears under PT_TLS in the section-to-segment mapping
+#   - .tbss appears under the ph_data PT_LOAD (PHDRS overlap is intentional)
+#   - The ph_data PT_LOAD has FileSiz == MemSiz (.tbss not double-counted)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_phdrs.t %t.o -o %t.out
+
+#--- ph_data PT_LOAD has FileSiz == MemSiz (TBSS not added to LOAD sizes) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: LOAD {{[0-9a-fx]+}} {{[0-9a-fx]+}} {{[0-9a-fx]+}} [[SZ:[0-9a-fx]+]] [[SZ]] RW

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSMemoryLoadSizes.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSMemoryLoadSizes.test
@@ -1,0 +1,23 @@
+#---GNURelroTBSSOnlyPHDRSMemoryLoadSizes.test--- TLS, Executable, LinkerScript, PHDRS, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with both PHDRS and MEMORY
+# directives in the linker script.
+#
+# PHDRS defines named segments; MEMORY places text in FLASH and data/TLS in
+# RAM.  .tbss is assigned to ph_tls (PT_TLS) and ph_data (PT_LOAD), both of
+# which address RAM.
+#
+#   - PT_TLS FileSiz == 0  (TBSS is BSS; no file content)
+#   - PT_TLS MemSiz  >  0  (runtime allocates per-thread space in RAM)
+#   - PT_TLS VirtAddr falls inside the RAM region (MEMORY respected)
+#   - .tbss appears under PT_TLS in the section-to-segment mapping
+#   - ph_data PT_LOAD has FileSiz == MemSiz (TBSS excluded from LOAD sizes)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_phdrs_memory.t %t.o -o %t.out
+
+#--- ph_data PT_LOAD has FileSiz == MemSiz (TBSS excluded from LOAD) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: LOAD {{[0-9a-fx]+}} {{[0-9a-fx]+}} {{[0-9a-fx]+}} [[SZ:[0-9a-fx]+]] [[SZ]] RW

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSMemoryTBSSInTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSMemoryTBSSInTLS.test
@@ -1,0 +1,23 @@
+#---GNURelroTBSSOnlyPHDRSMemoryTBSSInTLS.test--- TLS, Executable, LinkerScript, PHDRS, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with both PHDRS and MEMORY
+# directives in the linker script.
+#
+# PHDRS defines named segments; MEMORY places text in FLASH and data/TLS in
+# RAM.  .tbss is assigned to ph_tls (PT_TLS) and ph_data (PT_LOAD), both of
+# which address RAM.
+#
+#   - PT_TLS FileSiz == 0  (TBSS is BSS; no file content)
+#   - PT_TLS MemSiz  >  0  (runtime allocates per-thread space in RAM)
+#   - PT_TLS VirtAddr falls inside the RAM region (MEMORY respected)
+#   - .tbss appears under PT_TLS in the section-to-segment mapping
+#   - ph_data PT_LOAD has FileSiz == MemSiz (TBSS excluded from LOAD sizes)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_phdrs_memory.t %t.o -o %t.out
+
+#--- .tbss is listed under PT_TLS ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: .tbss

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSMemoryTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSMemoryTLS.test
@@ -1,0 +1,23 @@
+#---GNURelroTBSSOnlyPHDRSMemoryTLS.test--- TLS, Executable, LinkerScript, PHDRS, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with both PHDRS and MEMORY
+# directives in the linker script.
+#
+# PHDRS defines named segments; MEMORY places text in FLASH and data/TLS in
+# RAM.  .tbss is assigned to ph_tls (PT_TLS) and ph_data (PT_LOAD), both of
+# which address RAM.
+#
+#   - PT_TLS FileSiz == 0  (TBSS is BSS; no file content)
+#   - PT_TLS MemSiz  >  0  (runtime allocates per-thread space in RAM)
+#   - PT_TLS VirtAddr falls inside the RAM region (MEMORY respected)
+#   - .tbss appears under PT_TLS in the section-to-segment mapping
+#   - ph_data PT_LOAD has FileSiz == MemSiz (TBSS excluded from LOAD sizes)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_phdrs_memory.t %t.o -o %t.out
+
+#--- PT_TLS segment is present ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: TLS

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSMemoryTLSFileSZ.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSMemoryTLSFileSZ.test
@@ -1,0 +1,23 @@
+#---GNURelroTBSSOnlyPHDRSMemoryTLSFileSZ.test--- TLS, Executable, LinkerScript, PHDRS, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with both PHDRS and MEMORY
+# directives in the linker script.
+#
+# PHDRS defines named segments; MEMORY places text in FLASH and data/TLS in
+# RAM.  .tbss is assigned to ph_tls (PT_TLS) and ph_data (PT_LOAD), both of
+# which address RAM.
+#
+#   - PT_TLS FileSiz == 0  (TBSS is BSS; no file content)
+#   - PT_TLS MemSiz  >  0  (runtime allocates per-thread space in RAM)
+#   - PT_TLS VirtAddr falls inside the RAM region (MEMORY respected)
+#   - .tbss appears under PT_TLS in the section-to-segment mapping
+#   - ph_data PT_LOAD has FileSiz == MemSiz (TBSS excluded from LOAD sizes)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_phdrs_memory.t %t.o -o %t.out
+
+#--- PT_TLS FileSiz == 0 (no TDATA in file) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{0x0+}} {{0x[0-9a-f]+}} RW

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSMemoryTLSInRAM.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSMemoryTLSInRAM.test
@@ -1,0 +1,23 @@
+#---GNURelroTBSSOnlyPHDRSMemoryTLSInRAM.test--- TLS, Executable, LinkerScript, PHDRS, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with both PHDRS and MEMORY
+# directives in the linker script.
+#
+# PHDRS defines named segments; MEMORY places text in FLASH and data/TLS in
+# RAM.  .tbss is assigned to ph_tls (PT_TLS) and ph_data (PT_LOAD), both of
+# which address RAM.
+#
+#   - PT_TLS FileSiz == 0  (TBSS is BSS; no file content)
+#   - PT_TLS MemSiz  >  0  (runtime allocates per-thread space in RAM)
+#   - PT_TLS VirtAddr falls inside the RAM region (MEMORY respected)
+#   - .tbss appears under PT_TLS in the section-to-segment mapping
+#   - ph_data PT_LOAD has FileSiz == MemSiz (TBSS excluded from LOAD sizes)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_phdrs_memory.t %t.o -o %t.out
+
+#--- PT_TLS VirtAddr is in the RAM region (MEMORY at 0x500000 respected) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: TLS {{[0x0-9a-f]+}} {{0x0*5[0-9a-f]+}}

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSMemoryTLSMemSZ.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSMemoryTLSMemSZ.test
@@ -1,0 +1,23 @@
+#---GNURelroTBSSOnlyPHDRSMemoryTLSMemSZ.test--- TLS, Executable, LinkerScript, PHDRS, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with both PHDRS and MEMORY
+# directives in the linker script.
+#
+# PHDRS defines named segments; MEMORY places text in FLASH and data/TLS in
+# RAM.  .tbss is assigned to ph_tls (PT_TLS) and ph_data (PT_LOAD), both of
+# which address RAM.
+#
+#   - PT_TLS FileSiz == 0  (TBSS is BSS; no file content)
+#   - PT_TLS MemSiz  >  0  (runtime allocates per-thread space in RAM)
+#   - PT_TLS VirtAddr falls inside the RAM region (MEMORY respected)
+#   - .tbss appears under PT_TLS in the section-to-segment mapping
+#   - ph_data PT_LOAD has FileSiz == MemSiz (TBSS excluded from LOAD sizes)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_phdrs_memory.t %t.o -o %t.out
+
+#--- PT_TLS MemSiz > 0 (runtime reserves per-thread space) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK-NOT: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{0x0+}} {{0x0+}} RW

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSTBSSInTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSTBSSInTLS.test
@@ -1,0 +1,23 @@
+#---GNURelroTBSSOnlyPHDRSTBSSInTLS.test--- TLS, Executable, LinkerScript, PHDRS ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with an explicit PHDRS linker
+# script.
+#
+# With PHDRS the programmer assigns sections to named segments.  The script
+# assigns .tbss to both ph_tls (PT_TLS) and ph_data (PT_LOAD), mirroring
+# the GNU convention where the TLS segment overlaps the data LOAD.
+#
+#   - PT_TLS FileSiz == 0   (.tbss is BSS; no initialized content in file)
+#   - PT_TLS MemSiz  >  0   (runtime reserves per-thread space)
+#   - .tbss appears under PT_TLS in the section-to-segment mapping
+#   - .tbss appears under the ph_data PT_LOAD (PHDRS overlap is intentional)
+#   - The ph_data PT_LOAD has FileSiz == MemSiz (.tbss not double-counted)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_phdrs.t %t.o -o %t.out
+
+#--- .tbss is listed under PT_TLS ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: .tbss

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSTLS.test
@@ -1,0 +1,23 @@
+#---GNURelroTBSSOnlyPHDRSTLS.test--- TLS, Executable, LinkerScript, PHDRS ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with an explicit PHDRS linker
+# script.
+#
+# With PHDRS the programmer assigns sections to named segments.  The script
+# assigns .tbss to both ph_tls (PT_TLS) and ph_data (PT_LOAD), mirroring
+# the GNU convention where the TLS segment overlaps the data LOAD.
+#
+#   - PT_TLS FileSiz == 0   (.tbss is BSS; no initialized content in file)
+#   - PT_TLS MemSiz  >  0   (runtime reserves per-thread space)
+#   - .tbss appears under PT_TLS in the section-to-segment mapping
+#   - .tbss appears under the ph_data PT_LOAD (PHDRS overlap is intentional)
+#   - The ph_data PT_LOAD has FileSiz == MemSiz (.tbss not double-counted)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_phdrs.t %t.o -o %t.out
+
+#--- PT_TLS segment is present ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: TLS

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSTLSFileSZ.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSTLSFileSZ.test
@@ -1,0 +1,23 @@
+#---GNURelroTBSSOnlyPHDRSTLSFileSZ.test--- TLS, Executable, LinkerScript, PHDRS ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with an explicit PHDRS linker
+# script.
+#
+# With PHDRS the programmer assigns sections to named segments.  The script
+# assigns .tbss to both ph_tls (PT_TLS) and ph_data (PT_LOAD), mirroring
+# the GNU convention where the TLS segment overlaps the data LOAD.
+#
+#   - PT_TLS FileSiz == 0   (.tbss is BSS; no initialized content in file)
+#   - PT_TLS MemSiz  >  0   (runtime reserves per-thread space)
+#   - .tbss appears under PT_TLS in the section-to-segment mapping
+#   - .tbss appears under the ph_data PT_LOAD (PHDRS overlap is intentional)
+#   - The ph_data PT_LOAD has FileSiz == MemSiz (.tbss not double-counted)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_phdrs.t %t.o -o %t.out
+
+#--- PT_TLS FileSiz == 0 (TBSS only; nothing stored in the file) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{0x0+}} {{0x[0-9a-f]+}} RW

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSTLSMemSZ.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSTLSMemSZ.test
@@ -1,0 +1,23 @@
+#---GNURelroTBSSOnlyPHDRSTLSMemSZ.test--- TLS, Executable, LinkerScript, PHDRS ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with an explicit PHDRS linker
+# script.
+#
+# With PHDRS the programmer assigns sections to named segments.  The script
+# assigns .tbss to both ph_tls (PT_TLS) and ph_data (PT_LOAD), mirroring
+# the GNU convention where the TLS segment overlaps the data LOAD.
+#
+#   - PT_TLS FileSiz == 0   (.tbss is BSS; no initialized content in file)
+#   - PT_TLS MemSiz  >  0   (runtime reserves per-thread space)
+#   - .tbss appears under PT_TLS in the section-to-segment mapping
+#   - .tbss appears under the ph_data PT_LOAD (PHDRS overlap is intentional)
+#   - The ph_data PT_LOAD has FileSiz == MemSiz (.tbss not double-counted)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_phdrs.t %t.o -o %t.out
+
+#--- PT_TLS MemSiz > 0 (runtime allocates per-thread TLS block) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK-NOT: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{0x0+}} {{0x0+}} RW

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPlainLSLoadSizes.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPlainLSLoadSizes.test
@@ -1,0 +1,20 @@
+#---GNURelroTBSSOnlyPlainLSLoadSizes.test--- TLS, Executable, LinkerScript ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with a plain SECTIONS linker
+# script (no PHDRS, no MEMORY).
+#
+# With a SECTIONS-only script the linker auto-generates segments.  The TLS
+# segment must still satisfy the invariants that hold without a script:
+#   - PT_TLS FileSiz == 0   (no initialized TLS to store in the file)
+#   - PT_TLS MemSiz  >  0   (runtime reserves per-thread space for TBSS)
+#   - .tbss is listed under PT_TLS, not under any PT_LOAD
+#   - The RW PT_LOAD covering non-TLS data has FileSiz == MemSiz
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_plain.t %t.o -o %t.out
+
+#--- RW PT_LOAD has FileSiz == MemSiz (TBSS excluded from LOAD) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: LOAD {{[0-9a-fx]+}} {{[0-9a-fx]+}} {{[0-9a-fx]+}} [[SZ:[0-9a-fx]+]] [[SZ]] RW

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPlainLSTBSSInTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPlainLSTBSSInTLS.test
@@ -1,0 +1,20 @@
+#---GNURelroTBSSOnlyPlainLSTBSSInTLS.test--- TLS, Executable, LinkerScript ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with a plain SECTIONS linker
+# script (no PHDRS, no MEMORY).
+#
+# With a SECTIONS-only script the linker auto-generates segments.  The TLS
+# segment must still satisfy the invariants that hold without a script:
+#   - PT_TLS FileSiz == 0   (no initialized TLS to store in the file)
+#   - PT_TLS MemSiz  >  0   (runtime reserves per-thread space for TBSS)
+#   - .tbss is listed under PT_TLS, not under any PT_LOAD
+#   - The RW PT_LOAD covering non-TLS data has FileSiz == MemSiz
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_plain.t %t.o -o %t.out
+
+#--- .tbss is listed under PT_TLS in the section-to-segment mapping ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: .tbss

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPlainLSTBSSNotInLoad.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPlainLSTBSSNotInLoad.test
@@ -1,0 +1,20 @@
+#---GNURelroTBSSOnlyPlainLSTBSSNotInLoad.test--- TLS, Executable, LinkerScript ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with a plain SECTIONS linker
+# script (no PHDRS, no MEMORY).
+#
+# With a SECTIONS-only script the linker auto-generates segments.  The TLS
+# segment must still satisfy the invariants that hold without a script:
+#   - PT_TLS FileSiz == 0   (no initialized TLS to store in the file)
+#   - PT_TLS MemSiz  >  0   (runtime reserves per-thread space for TBSS)
+#   - .tbss is listed under PT_TLS, not under any PT_LOAD
+#   - The RW PT_LOAD covering non-TLS data has FileSiz == MemSiz
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_plain.t %t.o -o %t.out
+
+#--- .tbss is NOT listed under any PT_LOAD ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK-NOT: LOAD {{.*}} .tbss

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPlainLSTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPlainLSTLS.test
@@ -1,0 +1,20 @@
+#---GNURelroTBSSOnlyPlainLSTLS.test--- TLS, Executable, LinkerScript ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with a plain SECTIONS linker
+# script (no PHDRS, no MEMORY).
+#
+# With a SECTIONS-only script the linker auto-generates segments.  The TLS
+# segment must still satisfy the invariants that hold without a script:
+#   - PT_TLS FileSiz == 0   (no initialized TLS to store in the file)
+#   - PT_TLS MemSiz  >  0   (runtime reserves per-thread space for TBSS)
+#   - .tbss is listed under PT_TLS, not under any PT_LOAD
+#   - The RW PT_LOAD covering non-TLS data has FileSiz == MemSiz
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_plain.t %t.o -o %t.out
+
+#--- PT_TLS segment is present ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: TLS

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPlainLSTLSFileSZ.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPlainLSTLSFileSZ.test
@@ -1,0 +1,20 @@
+#---GNURelroTBSSOnlyPlainLSTLSFileSZ.test--- TLS, Executable, LinkerScript ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with a plain SECTIONS linker
+# script (no PHDRS, no MEMORY).
+#
+# With a SECTIONS-only script the linker auto-generates segments.  The TLS
+# segment must still satisfy the invariants that hold without a script:
+#   - PT_TLS FileSiz == 0   (no initialized TLS to store in the file)
+#   - PT_TLS MemSiz  >  0   (runtime reserves per-thread space for TBSS)
+#   - .tbss is listed under PT_TLS, not under any PT_LOAD
+#   - The RW PT_LOAD covering non-TLS data has FileSiz == MemSiz
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_plain.t %t.o -o %t.out
+
+#--- PT_TLS FileSiz == 0 (no TDATA; only BSS TLS variables) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{0x0+}} {{0x[0-9a-f]+}} R

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPlainLSTLSMemSZ.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPlainLSTLSMemSZ.test
@@ -1,0 +1,20 @@
+#---GNURelroTBSSOnlyPlainLSTLSMemSZ.test--- TLS, Executable, LinkerScript ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TBSS-only (no TDATA) with a plain SECTIONS linker
+# script (no PHDRS, no MEMORY).
+#
+# With a SECTIONS-only script the linker auto-generates segments.  The TLS
+# segment must still satisfy the invariants that hold without a script:
+#   - PT_TLS FileSiz == 0   (no initialized TLS to store in the file)
+#   - PT_TLS MemSiz  >  0   (runtime reserves per-thread space for TBSS)
+#   - .tbss is listed under PT_TLS, not under any PT_LOAD
+#   - The RW PT_LOAD covering non-TLS data has FileSiz == MemSiz
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_plain.t %t.o -o %t.out
+
+#--- PT_TLS MemSiz > 0 (runtime must still reserve per-thread space) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK-NOT: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{0x0+}} {{0x0+}} R

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataMemoryBothInTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataMemoryBothInTLS.test
@@ -1,0 +1,21 @@
+#---GNURelroTBSSTDataMemoryBothInTLS.test--- TLS, Executable, LinkerScript, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS with a MEMORY linker script.
+#
+# The MEMORY script places text in FLASH and all TLS/data in RAM.  The TLS
+# segment must reflect the RAM placement and maintain correct sizes:
+#   - PT_TLS VirtAddr falls in the RAM region
+#   - PT_TLS FileSiz > 0   (.tdata stored in file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss extends per-thread space)
+#   - .tdata and .tbss are both under PT_TLS
+#   - .tdata is in the RW PT_LOAD; .tbss is not
+#   - The RW PT_LOAD (RAM) has FileSiz == MemSiz
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_memory.t %t.o -o %t.out
+
+#--- .tdata and .tbss are both listed under PT_TLS ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: .tdata .tbss

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataMemoryLoadSizes.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataMemoryLoadSizes.test
@@ -1,0 +1,21 @@
+#---GNURelroTBSSTDataMemoryLoadSizes.test--- TLS, Executable, LinkerScript, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS with a MEMORY linker script.
+#
+# The MEMORY script places text in FLASH and all TLS/data in RAM.  The TLS
+# segment must reflect the RAM placement and maintain correct sizes:
+#   - PT_TLS VirtAddr falls in the RAM region
+#   - PT_TLS FileSiz > 0   (.tdata stored in file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss extends per-thread space)
+#   - .tdata and .tbss are both under PT_TLS
+#   - .tdata is in the RW PT_LOAD; .tbss is not
+#   - The RW PT_LOAD (RAM) has FileSiz == MemSiz
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_memory.t %t.o -o %t.out
+
+#--- RW PT_LOAD (RAM) FileSiz == MemSiz (.tbss excluded from LOAD) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: LOAD {{[0-9a-fx]+}} {{[0-9a-fx]+}} {{[0-9a-fx]+}} [[SZ:[0-9a-fx]+]] [[SZ]] RW

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataMemoryTBSSNotInLoad.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataMemoryTBSSNotInLoad.test
@@ -1,0 +1,21 @@
+#---GNURelroTBSSTDataMemoryTBSSNotInLoad.test--- TLS, Executable, LinkerScript, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS with a MEMORY linker script.
+#
+# The MEMORY script places text in FLASH and all TLS/data in RAM.  The TLS
+# segment must reflect the RAM placement and maintain correct sizes:
+#   - PT_TLS VirtAddr falls in the RAM region
+#   - PT_TLS FileSiz > 0   (.tdata stored in file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss extends per-thread space)
+#   - .tdata and .tbss are both under PT_TLS
+#   - .tdata is in the RW PT_LOAD; .tbss is not
+#   - The RW PT_LOAD (RAM) has FileSiz == MemSiz
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_memory.t %t.o -o %t.out
+
+#--- .tbss is NOT listed under any PT_LOAD ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK-NOT: LOAD {{.*}} .tbss

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataMemoryTDataInLoad.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataMemoryTDataInLoad.test
@@ -1,0 +1,21 @@
+#---GNURelroTBSSTDataMemoryTDataInLoad.test--- TLS, Executable, LinkerScript, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS with a MEMORY linker script.
+#
+# The MEMORY script places text in FLASH and all TLS/data in RAM.  The TLS
+# segment must reflect the RAM placement and maintain correct sizes:
+#   - PT_TLS VirtAddr falls in the RAM region
+#   - PT_TLS FileSiz > 0   (.tdata stored in file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss extends per-thread space)
+#   - .tdata and .tbss are both under PT_TLS
+#   - .tdata is in the RW PT_LOAD; .tbss is not
+#   - The RW PT_LOAD (RAM) has FileSiz == MemSiz
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_memory.t %t.o -o %t.out
+
+#--- .tdata is in the RW PT_LOAD ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: .tdata

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataMemoryTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataMemoryTLS.test
@@ -1,0 +1,21 @@
+#---GNURelroTBSSTDataMemoryTLS.test--- TLS, Executable, LinkerScript, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS with a MEMORY linker script.
+#
+# The MEMORY script places text in FLASH and all TLS/data in RAM.  The TLS
+# segment must reflect the RAM placement and maintain correct sizes:
+#   - PT_TLS VirtAddr falls in the RAM region
+#   - PT_TLS FileSiz > 0   (.tdata stored in file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss extends per-thread space)
+#   - .tdata and .tbss are both under PT_TLS
+#   - .tdata is in the RW PT_LOAD; .tbss is not
+#   - The RW PT_LOAD (RAM) has FileSiz == MemSiz
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_memory.t %t.o -o %t.out
+
+#--- PT_TLS segment is present ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: TLS

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataMemoryTLSFileSZ.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataMemoryTLSFileSZ.test
@@ -1,0 +1,21 @@
+#---GNURelroTBSSTDataMemoryTLSFileSZ.test--- TLS, Executable, LinkerScript, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS with a MEMORY linker script.
+#
+# The MEMORY script places text in FLASH and all TLS/data in RAM.  The TLS
+# segment must reflect the RAM placement and maintain correct sizes:
+#   - PT_TLS VirtAddr falls in the RAM region
+#   - PT_TLS FileSiz > 0   (.tdata stored in file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss extends per-thread space)
+#   - .tdata and .tbss are both under PT_TLS
+#   - .tdata is in the RW PT_LOAD; .tbss is not
+#   - The RW PT_LOAD (RAM) has FileSiz == MemSiz
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_memory.t %t.o -o %t.out
+
+#--- PT_TLS FileSiz > 0 (.tdata stored in the file) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK-NOT: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{0x0+}} {{0x[0-9a-f]+}} R

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataMemoryTLSInRAM.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataMemoryTLSInRAM.test
@@ -1,0 +1,21 @@
+#---GNURelroTBSSTDataMemoryTLSInRAM.test--- TLS, Executable, LinkerScript, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS with a MEMORY linker script.
+#
+# The MEMORY script places text in FLASH and all TLS/data in RAM.  The TLS
+# segment must reflect the RAM placement and maintain correct sizes:
+#   - PT_TLS VirtAddr falls in the RAM region
+#   - PT_TLS FileSiz > 0   (.tdata stored in file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss extends per-thread space)
+#   - .tdata and .tbss are both under PT_TLS
+#   - .tdata is in the RW PT_LOAD; .tbss is not
+#   - The RW PT_LOAD (RAM) has FileSiz == MemSiz
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_memory.t %t.o -o %t.out
+
+#--- PT_TLS VirtAddr is in the RAM region (MEMORY at 0x500000 respected) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: TLS {{[0x0-9a-f]+}} {{0x0*5[0-9a-f]+}}

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataMemoryTLSSizes.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataMemoryTLSSizes.test
@@ -1,0 +1,22 @@
+#---GNURelroTBSSTDataMemoryTLSSizes.test--- TLS, Executable, LinkerScript, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS with a MEMORY linker script.
+#
+# The MEMORY script places text in FLASH and all TLS/data in RAM.  The TLS
+# segment must reflect the RAM placement and maintain correct sizes:
+#   - PT_TLS VirtAddr falls in the RAM region
+#   - PT_TLS FileSiz > 0   (.tdata stored in file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss extends per-thread space)
+#   - .tdata and .tbss are both under PT_TLS
+#   - .tdata is in the RW PT_LOAD; .tbss is not
+#   - The RW PT_LOAD (RAM) has FileSiz == MemSiz
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_memory.t %t.o -o %t.out
+
+#--- PT_TLS MemSiz > FileSiz (.tbss adds zero-init space beyond .tdata) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} [[FSIZ:0x[0-9a-f]+]] {{0x[0-9a-f]+}} R
+# CHECK-NOT: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} [[FSIZ]] [[FSIZ]] R

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptExeLoadFileSZEqMemSZ.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptExeLoadFileSZEqMemSZ.test
@@ -1,0 +1,35 @@
+#---GNURelroTBSSTDataNoScriptExeLoadFileSZEqMemSZ.test--- TLS, Executable, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Tests for GNU_RELRO behavior when both TDATA (initialized TLS) and TBSS
+# (uninitialized TLS) sections are present.
+#
+# GNU behavior:
+#
+# PT_TLS segment:
+#   - FileSiz == size of .tdata  (initialized TLS is stored in the file)
+#   - MemSiz  == size of .tdata + size of .tbss  (runtime allocates both)
+#   - Both .tdata and .tbss are listed under PT_TLS in the mapping.
+#
+# PT_LOAD segments:
+#   - .tdata is part of the RW PT_LOAD (it has file-backed contents).
+#   - .tbss is NOT counted in the RW PT_LOAD's file size or memory size;
+#     its space is only described by the PT_TLS MemSiz.
+#   - The RW PT_LOAD has FileSiz == MemSiz when no non-TLS BSS is present
+#     (TBSS does not inflate the LOAD memory size beyond its file size).
+#     This was broken before the QTOOL-21682 fix.
+#END_COMMENT
+
+# --- Build executable ---
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.exe.o
+RUN: %link %linkopts %t.exe.o -o %t.exe.out
+
+# --- Build shared library ---
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_tdata.c -o %t.so.o
+RUN: %link %linkopts -shared %t.so.o -o %t.so
+
+#--- Executable: RW PT_LOAD FileSiz == MemSiz (TBSS excluded from LOAD) ---
+# Even with .tbss present the RW LOAD must have equal file and memory sizes
+# because .tbss does not reside in the LOAD segment.
+RUN: %readelf -l -W %t.exe.out | %filecheck %s
+# CHECK: LOAD {{[0-9a-fx]+}} {{[0-9a-fx]+}} {{[0-9a-fx]+}} [[SZ:[0-9a-fx]+]] [[SZ]] RW

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptExeTBSSNotInLoad.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptExeTBSSNotInLoad.test
@@ -1,0 +1,34 @@
+#---GNURelroTBSSTDataNoScriptExeTBSSNotInLoad.test--- TLS, Executable, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Tests for GNU_RELRO behavior when both TDATA (initialized TLS) and TBSS
+# (uninitialized TLS) sections are present.
+#
+# GNU behavior:
+#
+# PT_TLS segment:
+#   - FileSiz == size of .tdata  (initialized TLS is stored in the file)
+#   - MemSiz  == size of .tdata + size of .tbss  (runtime allocates both)
+#   - Both .tdata and .tbss are listed under PT_TLS in the mapping.
+#
+# PT_LOAD segments:
+#   - .tdata is part of the RW PT_LOAD (it has file-backed contents).
+#   - .tbss is NOT counted in the RW PT_LOAD's file size or memory size;
+#     its space is only described by the PT_TLS MemSiz.
+#   - The RW PT_LOAD has FileSiz == MemSiz when no non-TLS BSS is present
+#     (TBSS does not inflate the LOAD memory size beyond its file size).
+#     This was broken before the QTOOL-21682 fix.
+#END_COMMENT
+
+# --- Build executable ---
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.exe.o
+RUN: %link %linkopts %t.exe.o -o %t.exe.out
+
+# --- Build shared library ---
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_tdata.c -o %t.so.o
+RUN: %link %linkopts -shared %t.so.o -o %t.so
+
+#--- Executable: .tbss is NOT listed under a PT_LOAD ---
+# .tbss is NOBITS with SHF_TLS; it belongs only to PT_TLS, not PT_LOAD.
+RUN: %readelf -l -W %t.exe.out | %filecheck %s
+# CHECK-NOT: LOAD {{.*}} .tbss

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptExeTDataInLoad.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptExeTDataInLoad.test
@@ -1,0 +1,33 @@
+#---GNURelroTBSSTDataNoScriptExeTDataInLoad.test--- TLS, Executable, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Tests for GNU_RELRO behavior when both TDATA (initialized TLS) and TBSS
+# (uninitialized TLS) sections are present.
+#
+# GNU behavior:
+#
+# PT_TLS segment:
+#   - FileSiz == size of .tdata  (initialized TLS is stored in the file)
+#   - MemSiz  == size of .tdata + size of .tbss  (runtime allocates both)
+#   - Both .tdata and .tbss are listed under PT_TLS in the mapping.
+#
+# PT_LOAD segments:
+#   - .tdata is part of the RW PT_LOAD (it has file-backed contents).
+#   - .tbss is NOT counted in the RW PT_LOAD's file size or memory size;
+#     its space is only described by the PT_TLS MemSiz.
+#   - The RW PT_LOAD has FileSiz == MemSiz when no non-TLS BSS is present
+#     (TBSS does not inflate the LOAD memory size beyond its file size).
+#     This was broken before the QTOOL-21682 fix.
+#END_COMMENT
+
+# --- Build executable ---
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.exe.o
+RUN: %link %linkopts %t.exe.o -o %t.exe.out
+
+# --- Build shared library ---
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_tdata.c -o %t.so.o
+RUN: %link %linkopts -shared %t.so.o -o %t.so
+
+#--- Executable: .tdata is in the RW PT_LOAD (initialized content in file) ---
+RUN: %readelf -l -W %t.exe.out | %filecheck %s
+# CHECK: .tdata

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptExeTDataTBSSInTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptExeTDataTBSSInTLS.test
@@ -1,0 +1,33 @@
+#---GNURelroTBSSTDataNoScriptExeTDataTBSSInTLS.test--- TLS, Executable, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Tests for GNU_RELRO behavior when both TDATA (initialized TLS) and TBSS
+# (uninitialized TLS) sections are present.
+#
+# GNU behavior:
+#
+# PT_TLS segment:
+#   - FileSiz == size of .tdata  (initialized TLS is stored in the file)
+#   - MemSiz  == size of .tdata + size of .tbss  (runtime allocates both)
+#   - Both .tdata and .tbss are listed under PT_TLS in the mapping.
+#
+# PT_LOAD segments:
+#   - .tdata is part of the RW PT_LOAD (it has file-backed contents).
+#   - .tbss is NOT counted in the RW PT_LOAD's file size or memory size;
+#     its space is only described by the PT_TLS MemSiz.
+#   - The RW PT_LOAD has FileSiz == MemSiz when no non-TLS BSS is present
+#     (TBSS does not inflate the LOAD memory size beyond its file size).
+#     This was broken before the QTOOL-21682 fix.
+#END_COMMENT
+
+# --- Build executable ---
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.exe.o
+RUN: %link %linkopts %t.exe.o -o %t.exe.out
+
+# --- Build shared library ---
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_tdata.c -o %t.so.o
+RUN: %link %linkopts -shared %t.so.o -o %t.so
+
+#--- Executable: .tdata and .tbss are both in the TLS segment ---
+RUN: %readelf -l -W %t.exe.out | %filecheck %s
+# CHECK: .tdata .tbss

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptExeTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptExeTLS.test
@@ -1,0 +1,33 @@
+#---GNURelroTBSSTDataNoScriptExeTLS.test--- TLS, Executable, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Tests for GNU_RELRO behavior when both TDATA (initialized TLS) and TBSS
+# (uninitialized TLS) sections are present.
+#
+# GNU behavior:
+#
+# PT_TLS segment:
+#   - FileSiz == size of .tdata  (initialized TLS is stored in the file)
+#   - MemSiz  == size of .tdata + size of .tbss  (runtime allocates both)
+#   - Both .tdata and .tbss are listed under PT_TLS in the mapping.
+#
+# PT_LOAD segments:
+#   - .tdata is part of the RW PT_LOAD (it has file-backed contents).
+#   - .tbss is NOT counted in the RW PT_LOAD's file size or memory size;
+#     its space is only described by the PT_TLS MemSiz.
+#   - The RW PT_LOAD has FileSiz == MemSiz when no non-TLS BSS is present
+#     (TBSS does not inflate the LOAD memory size beyond its file size).
+#     This was broken before the QTOOL-21682 fix.
+#END_COMMENT
+
+# --- Build executable ---
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.exe.o
+RUN: %link %linkopts %t.exe.o -o %t.exe.out
+
+# --- Build shared library ---
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_tdata.c -o %t.so.o
+RUN: %link %linkopts -shared %t.so.o -o %t.so
+
+#--- Executable: PT_TLS segment is present ---
+RUN: %readelf -l -W %t.exe.out | %filecheck %s
+# CHECK: TLS

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptExeTLSFileSZ.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptExeTLSFileSZ.test
@@ -1,0 +1,35 @@
+#---GNURelroTBSSTDataNoScriptExeTLSFileSZ.test--- TLS, Executable, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Tests for GNU_RELRO behavior when both TDATA (initialized TLS) and TBSS
+# (uninitialized TLS) sections are present.
+#
+# GNU behavior:
+#
+# PT_TLS segment:
+#   - FileSiz == size of .tdata  (initialized TLS is stored in the file)
+#   - MemSiz  == size of .tdata + size of .tbss  (runtime allocates both)
+#   - Both .tdata and .tbss are listed under PT_TLS in the mapping.
+#
+# PT_LOAD segments:
+#   - .tdata is part of the RW PT_LOAD (it has file-backed contents).
+#   - .tbss is NOT counted in the RW PT_LOAD's file size or memory size;
+#     its space is only described by the PT_TLS MemSiz.
+#   - The RW PT_LOAD has FileSiz == MemSiz when no non-TLS BSS is present
+#     (TBSS does not inflate the LOAD memory size beyond its file size).
+#     This was broken before the QTOOL-21682 fix.
+#END_COMMENT
+
+# --- Build executable ---
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.exe.o
+RUN: %link %linkopts %t.exe.o -o %t.exe.out
+
+# --- Build shared library ---
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_tdata.c -o %t.so.o
+RUN: %link %linkopts -shared %t.so.o -o %t.so
+
+#--- Executable: PT_TLS FileSiz > 0 (TDATA has file-backed content) ---
+# Initialized TLS variables are stored in the file so the loader can copy
+# them into each thread's TLS block. FileSiz must be non-zero.
+RUN: %readelf -l -W %t.exe.out | %filecheck %s
+# CHECK-NOT: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{0x0+}} {{0x[0-9a-f]+}} R

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptExeTLSSizes.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptExeTLSSizes.test
@@ -1,0 +1,36 @@
+#---GNURelroTBSSTDataNoScriptExeTLSSizes.test--- TLS, Executable, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Tests for GNU_RELRO behavior when both TDATA (initialized TLS) and TBSS
+# (uninitialized TLS) sections are present.
+#
+# GNU behavior:
+#
+# PT_TLS segment:
+#   - FileSiz == size of .tdata  (initialized TLS is stored in the file)
+#   - MemSiz  == size of .tdata + size of .tbss  (runtime allocates both)
+#   - Both .tdata and .tbss are listed under PT_TLS in the mapping.
+#
+# PT_LOAD segments:
+#   - .tdata is part of the RW PT_LOAD (it has file-backed contents).
+#   - .tbss is NOT counted in the RW PT_LOAD's file size or memory size;
+#     its space is only described by the PT_TLS MemSiz.
+#   - The RW PT_LOAD has FileSiz == MemSiz when no non-TLS BSS is present
+#     (TBSS does not inflate the LOAD memory size beyond its file size).
+#     This was broken before the QTOOL-21682 fix.
+#END_COMMENT
+
+# --- Build executable ---
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.exe.o
+RUN: %link %linkopts %t.exe.o -o %t.exe.out
+
+# --- Build shared library ---
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_tdata.c -o %t.so.o
+RUN: %link %linkopts -shared %t.so.o -o %t.so
+
+#--- Executable: PT_TLS MemSiz > FileSiz (TBSS extends MemSiz beyond TDATA) ---
+# The runtime must allocate space for both .tdata and .tbss per thread,
+# so MemSiz must be strictly larger than FileSiz.
+RUN: %readelf -l -W %t.exe.out | %filecheck %s
+# CHECK: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} [[FSIZ:0x[0-9a-f]+]] {{0x[0-9a-f]+}} R
+# CHECK-NOT: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} [[FSIZ]] [[FSIZ]] R

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptSoTBSSNotInLoad.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptSoTBSSNotInLoad.test
@@ -1,0 +1,33 @@
+#---GNURelroTBSSTDataNoScriptSoTBSSNotInLoad.test--- TLS, Executable, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Tests for GNU_RELRO behavior when both TDATA (initialized TLS) and TBSS
+# (uninitialized TLS) sections are present.
+#
+# GNU behavior:
+#
+# PT_TLS segment:
+#   - FileSiz == size of .tdata  (initialized TLS is stored in the file)
+#   - MemSiz  == size of .tdata + size of .tbss  (runtime allocates both)
+#   - Both .tdata and .tbss are listed under PT_TLS in the mapping.
+#
+# PT_LOAD segments:
+#   - .tdata is part of the RW PT_LOAD (it has file-backed contents).
+#   - .tbss is NOT counted in the RW PT_LOAD's file size or memory size;
+#     its space is only described by the PT_TLS MemSiz.
+#   - The RW PT_LOAD has FileSiz == MemSiz when no non-TLS BSS is present
+#     (TBSS does not inflate the LOAD memory size beyond its file size).
+#     This was broken before the QTOOL-21682 fix.
+#END_COMMENT
+
+# --- Build executable ---
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.exe.o
+RUN: %link %linkopts %t.exe.o -o %t.exe.out
+
+# --- Build shared library ---
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_tdata.c -o %t.so.o
+RUN: %link %linkopts -shared %t.so.o -o %t.so
+
+#--- Shared library: .tbss is NOT listed under a PT_LOAD ---
+RUN: %readelf -l -W %t.so | %filecheck %s
+# CHECK-NOT: LOAD {{.*}} .tbss

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptSoTDataTBSSInTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptSoTDataTBSSInTLS.test
@@ -1,0 +1,33 @@
+#---GNURelroTBSSTDataNoScriptSoTDataTBSSInTLS.test--- TLS, Executable, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Tests for GNU_RELRO behavior when both TDATA (initialized TLS) and TBSS
+# (uninitialized TLS) sections are present.
+#
+# GNU behavior:
+#
+# PT_TLS segment:
+#   - FileSiz == size of .tdata  (initialized TLS is stored in the file)
+#   - MemSiz  == size of .tdata + size of .tbss  (runtime allocates both)
+#   - Both .tdata and .tbss are listed under PT_TLS in the mapping.
+#
+# PT_LOAD segments:
+#   - .tdata is part of the RW PT_LOAD (it has file-backed contents).
+#   - .tbss is NOT counted in the RW PT_LOAD's file size or memory size;
+#     its space is only described by the PT_TLS MemSiz.
+#   - The RW PT_LOAD has FileSiz == MemSiz when no non-TLS BSS is present
+#     (TBSS does not inflate the LOAD memory size beyond its file size).
+#     This was broken before the QTOOL-21682 fix.
+#END_COMMENT
+
+# --- Build executable ---
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.exe.o
+RUN: %link %linkopts %t.exe.o -o %t.exe.out
+
+# --- Build shared library ---
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_tdata.c -o %t.so.o
+RUN: %link %linkopts -shared %t.so.o -o %t.so
+
+#--- Shared library: .tdata and .tbss are both in the TLS segment ---
+RUN: %readelf -l -W %t.so | %filecheck %s
+# CHECK: .tdata .tbss

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptSoTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptSoTLS.test
@@ -1,0 +1,33 @@
+#---GNURelroTBSSTDataNoScriptSoTLS.test--- TLS, Executable, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Tests for GNU_RELRO behavior when both TDATA (initialized TLS) and TBSS
+# (uninitialized TLS) sections are present.
+#
+# GNU behavior:
+#
+# PT_TLS segment:
+#   - FileSiz == size of .tdata  (initialized TLS is stored in the file)
+#   - MemSiz  == size of .tdata + size of .tbss  (runtime allocates both)
+#   - Both .tdata and .tbss are listed under PT_TLS in the mapping.
+#
+# PT_LOAD segments:
+#   - .tdata is part of the RW PT_LOAD (it has file-backed contents).
+#   - .tbss is NOT counted in the RW PT_LOAD's file size or memory size;
+#     its space is only described by the PT_TLS MemSiz.
+#   - The RW PT_LOAD has FileSiz == MemSiz when no non-TLS BSS is present
+#     (TBSS does not inflate the LOAD memory size beyond its file size).
+#     This was broken before the QTOOL-21682 fix.
+#END_COMMENT
+
+# --- Build executable ---
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.exe.o
+RUN: %link %linkopts %t.exe.o -o %t.exe.out
+
+# --- Build shared library ---
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_tdata.c -o %t.so.o
+RUN: %link %linkopts -shared %t.so.o -o %t.so
+
+#--- Shared library: PT_TLS segment is present ---
+RUN: %readelf -l -W %t.so | %filecheck %s
+# CHECK: TLS

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptSoTLSFileSZ.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataNoScriptSoTLSFileSZ.test
@@ -1,0 +1,33 @@
+#---GNURelroTBSSTDataNoScriptSoTLSFileSZ.test--- TLS, Executable, SharedLibrary ---#
+
+#BEGIN_COMMENT
+# Tests for GNU_RELRO behavior when both TDATA (initialized TLS) and TBSS
+# (uninitialized TLS) sections are present.
+#
+# GNU behavior:
+#
+# PT_TLS segment:
+#   - FileSiz == size of .tdata  (initialized TLS is stored in the file)
+#   - MemSiz  == size of .tdata + size of .tbss  (runtime allocates both)
+#   - Both .tdata and .tbss are listed under PT_TLS in the mapping.
+#
+# PT_LOAD segments:
+#   - .tdata is part of the RW PT_LOAD (it has file-backed contents).
+#   - .tbss is NOT counted in the RW PT_LOAD's file size or memory size;
+#     its space is only described by the PT_TLS MemSiz.
+#   - The RW PT_LOAD has FileSiz == MemSiz when no non-TLS BSS is present
+#     (TBSS does not inflate the LOAD memory size beyond its file size).
+#     This was broken before the QTOOL-21682 fix.
+#END_COMMENT
+
+# --- Build executable ---
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.exe.o
+RUN: %link %linkopts %t.exe.o -o %t.exe.out
+
+# --- Build shared library ---
+RUN: %clang %clangg0opts -fuse-init-array -c -fPIC %p/Inputs/tbss_tdata.c -o %t.so.o
+RUN: %link %linkopts -shared %t.so.o -o %t.so
+
+#--- Shared library: PT_TLS FileSiz > 0 (TDATA present) ---
+RUN: %readelf -l -W %t.so | %filecheck %s
+# CHECK-NOT: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{0x0+}} {{0x[0-9a-f]+}} R

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSBothInTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSBothInTLS.test
@@ -1,0 +1,21 @@
+#---GNURelroTBSSTDataPHDRSBothInTLS.test--- TLS, Executable, LinkerScript, PHDRS ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS with an explicit PHDRS linker script.
+#
+# The script assigns .tdata and .tbss to both ph_tls (PT_TLS) and ph_data
+# (PT_LOAD), so the TLS segment and the data LOAD overlap — which is the
+# standard ELF convention for TLS.
+#
+#   - PT_TLS FileSiz > 0   (.tdata PROGBITS content is in the file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss adds zero-init space)
+#   - .tdata and .tbss both appear under PT_TLS
+#   - ph_data PT_LOAD has FileSiz == MemSiz (.tbss excluded from LOAD)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_phdrs.t %t.o -o %t.out
+
+#--- .tdata and .tbss are both listed under PT_TLS ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: .tdata .tbss

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSLoadSizes.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSLoadSizes.test
@@ -1,0 +1,21 @@
+#---GNURelroTBSSTDataPHDRSLoadSizes.test--- TLS, Executable, LinkerScript, PHDRS ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS with an explicit PHDRS linker script.
+#
+# The script assigns .tdata and .tbss to both ph_tls (PT_TLS) and ph_data
+# (PT_LOAD), so the TLS segment and the data LOAD overlap — which is the
+# standard ELF convention for TLS.
+#
+#   - PT_TLS FileSiz > 0   (.tdata PROGBITS content is in the file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss adds zero-init space)
+#   - .tdata and .tbss both appear under PT_TLS
+#   - ph_data PT_LOAD has FileSiz == MemSiz (.tbss excluded from LOAD)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_phdrs.t %t.o -o %t.out
+
+#--- ph_data PT_LOAD has FileSiz == MemSiz (.tbss not counted in LOAD) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: LOAD {{[0-9a-fx]+}} {{[0-9a-fx]+}} {{[0-9a-fx]+}} [[SZ:[0-9a-fx]+]] [[SZ]] RW

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSMemoryBothInTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSMemoryBothInTLS.test
@@ -1,0 +1,22 @@
+#---GNURelroTBSSTDataPHDRSMemoryBothInTLS.test--- TLS, Executable, LinkerScript, PHDRS, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS with both PHDRS and MEMORY directives.
+#
+# PHDRS names segments explicitly; MEMORY places text in FLASH and TLS/data
+# in RAM.  .tdata and .tbss are assigned to ph_tls (PT_TLS) and ph_data
+# (PT_LOAD), both pointing into RAM.
+#
+#   - PT_TLS VirtAddr is in the RAM region
+#   - PT_TLS FileSiz > 0   (.tdata stored in file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss extends per-thread block)
+#   - .tdata and .tbss both appear under PT_TLS
+#   - ph_data PT_LOAD has FileSiz == MemSiz (.tbss excluded)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_phdrs_memory.t %t.o -o %t.out
+
+#--- .tdata and .tbss are both listed under PT_TLS ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: .tdata .tbss

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSMemoryLoadSizes.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSMemoryLoadSizes.test
@@ -1,0 +1,22 @@
+#---GNURelroTBSSTDataPHDRSMemoryLoadSizes.test--- TLS, Executable, LinkerScript, PHDRS, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS with both PHDRS and MEMORY directives.
+#
+# PHDRS names segments explicitly; MEMORY places text in FLASH and TLS/data
+# in RAM.  .tdata and .tbss are assigned to ph_tls (PT_TLS) and ph_data
+# (PT_LOAD), both pointing into RAM.
+#
+#   - PT_TLS VirtAddr is in the RAM region
+#   - PT_TLS FileSiz > 0   (.tdata stored in file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss extends per-thread block)
+#   - .tdata and .tbss both appear under PT_TLS
+#   - ph_data PT_LOAD has FileSiz == MemSiz (.tbss excluded)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_phdrs_memory.t %t.o -o %t.out
+
+#--- ph_data PT_LOAD has FileSiz == MemSiz (.tbss excluded from LOAD) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: LOAD {{[0-9a-fx]+}} {{[0-9a-fx]+}} {{[0-9a-fx]+}} [[SZ:[0-9a-fx]+]] [[SZ]] RW

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSMemoryTBSSNotInLoad.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSMemoryTBSSNotInLoad.test
@@ -1,0 +1,22 @@
+#---GNURelroTBSSTDataPHDRSMemoryTBSSNotInLoad.test--- TLS, Executable, LinkerScript, PHDRS, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS with both PHDRS and MEMORY directives.
+#
+# PHDRS names segments explicitly; MEMORY places text in FLASH and TLS/data
+# in RAM.  .tdata and .tbss are assigned to ph_tls (PT_TLS) and ph_data
+# (PT_LOAD), both pointing into RAM.
+#
+#   - PT_TLS VirtAddr is in the RAM region
+#   - PT_TLS FileSiz > 0   (.tdata stored in file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss extends per-thread block)
+#   - .tdata and .tbss both appear under PT_TLS
+#   - ph_data PT_LOAD has FileSiz == MemSiz (.tbss excluded)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_phdrs_memory.t %t.o -o %t.out
+
+#--- .tbss is NOT listed under any PT_LOAD ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK-NOT: LOAD {{.*}} .tbss

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSMemoryTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSMemoryTLS.test
@@ -1,0 +1,22 @@
+#---GNURelroTBSSTDataPHDRSMemoryTLS.test--- TLS, Executable, LinkerScript, PHDRS, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS with both PHDRS and MEMORY directives.
+#
+# PHDRS names segments explicitly; MEMORY places text in FLASH and TLS/data
+# in RAM.  .tdata and .tbss are assigned to ph_tls (PT_TLS) and ph_data
+# (PT_LOAD), both pointing into RAM.
+#
+#   - PT_TLS VirtAddr is in the RAM region
+#   - PT_TLS FileSiz > 0   (.tdata stored in file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss extends per-thread block)
+#   - .tdata and .tbss both appear under PT_TLS
+#   - ph_data PT_LOAD has FileSiz == MemSiz (.tbss excluded)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_phdrs_memory.t %t.o -o %t.out
+
+#--- PT_TLS segment is present ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: TLS

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSMemoryTLSFileSZ.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSMemoryTLSFileSZ.test
@@ -1,0 +1,22 @@
+#---GNURelroTBSSTDataPHDRSMemoryTLSFileSZ.test--- TLS, Executable, LinkerScript, PHDRS, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS with both PHDRS and MEMORY directives.
+#
+# PHDRS names segments explicitly; MEMORY places text in FLASH and TLS/data
+# in RAM.  .tdata and .tbss are assigned to ph_tls (PT_TLS) and ph_data
+# (PT_LOAD), both pointing into RAM.
+#
+#   - PT_TLS VirtAddr is in the RAM region
+#   - PT_TLS FileSiz > 0   (.tdata stored in file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss extends per-thread block)
+#   - .tdata and .tbss both appear under PT_TLS
+#   - ph_data PT_LOAD has FileSiz == MemSiz (.tbss excluded)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_phdrs_memory.t %t.o -o %t.out
+
+#--- PT_TLS FileSiz > 0 (.tdata content in the file) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK-NOT: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{0x0+}} {{0x[0-9a-f]+}} RW

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSMemoryTLSInRAM.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSMemoryTLSInRAM.test
@@ -1,0 +1,22 @@
+#---GNURelroTBSSTDataPHDRSMemoryTLSInRAM.test--- TLS, Executable, LinkerScript, PHDRS, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS with both PHDRS and MEMORY directives.
+#
+# PHDRS names segments explicitly; MEMORY places text in FLASH and TLS/data
+# in RAM.  .tdata and .tbss are assigned to ph_tls (PT_TLS) and ph_data
+# (PT_LOAD), both pointing into RAM.
+#
+#   - PT_TLS VirtAddr is in the RAM region
+#   - PT_TLS FileSiz > 0   (.tdata stored in file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss extends per-thread block)
+#   - .tdata and .tbss both appear under PT_TLS
+#   - ph_data PT_LOAD has FileSiz == MemSiz (.tbss excluded)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_phdrs_memory.t %t.o -o %t.out
+
+#--- PT_TLS VirtAddr is in the RAM region (MEMORY at 0x500000 respected) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: TLS {{[0x0-9a-f]+}} {{0x0*5[0-9a-f]+}}

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSMemoryTLSSizes.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSMemoryTLSSizes.test
@@ -1,0 +1,23 @@
+#---GNURelroTBSSTDataPHDRSMemoryTLSSizes.test--- TLS, Executable, LinkerScript, PHDRS, MEMORY ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS with both PHDRS and MEMORY directives.
+#
+# PHDRS names segments explicitly; MEMORY places text in FLASH and TLS/data
+# in RAM.  .tdata and .tbss are assigned to ph_tls (PT_TLS) and ph_data
+# (PT_LOAD), both pointing into RAM.
+#
+#   - PT_TLS VirtAddr is in the RAM region
+#   - PT_TLS FileSiz > 0   (.tdata stored in file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss extends per-thread block)
+#   - .tdata and .tbss both appear under PT_TLS
+#   - ph_data PT_LOAD has FileSiz == MemSiz (.tbss excluded)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_phdrs_memory.t %t.o -o %t.out
+
+#--- PT_TLS MemSiz > FileSiz (.tbss extends the TLS template) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} [[FSIZ:0x[0-9a-f]+]] {{0x[0-9a-f]+}} RW
+# CHECK-NOT: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} [[FSIZ]] [[FSIZ]] RW

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSTBSSNotInLoad.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSTBSSNotInLoad.test
@@ -1,0 +1,21 @@
+#---GNURelroTBSSTDataPHDRSTBSSNotInLoad.test--- TLS, Executable, LinkerScript, PHDRS ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS with an explicit PHDRS linker script.
+#
+# The script assigns .tdata and .tbss to both ph_tls (PT_TLS) and ph_data
+# (PT_LOAD), so the TLS segment and the data LOAD overlap — which is the
+# standard ELF convention for TLS.
+#
+#   - PT_TLS FileSiz > 0   (.tdata PROGBITS content is in the file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss adds zero-init space)
+#   - .tdata and .tbss both appear under PT_TLS
+#   - ph_data PT_LOAD has FileSiz == MemSiz (.tbss excluded from LOAD)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_phdrs.t %t.o -o %t.out
+
+#--- .tbss is NOT listed under any PT_LOAD ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK-NOT: LOAD {{.*}} .tbss

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSTLS.test
@@ -1,0 +1,21 @@
+#---GNURelroTBSSTDataPHDRSTLS.test--- TLS, Executable, LinkerScript, PHDRS ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS with an explicit PHDRS linker script.
+#
+# The script assigns .tdata and .tbss to both ph_tls (PT_TLS) and ph_data
+# (PT_LOAD), so the TLS segment and the data LOAD overlap — which is the
+# standard ELF convention for TLS.
+#
+#   - PT_TLS FileSiz > 0   (.tdata PROGBITS content is in the file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss adds zero-init space)
+#   - .tdata and .tbss both appear under PT_TLS
+#   - ph_data PT_LOAD has FileSiz == MemSiz (.tbss excluded from LOAD)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_phdrs.t %t.o -o %t.out
+
+#--- PT_TLS segment is present ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: TLS

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSTLSFileSZ.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSTLSFileSZ.test
@@ -1,0 +1,21 @@
+#---GNURelroTBSSTDataPHDRSTLSFileSZ.test--- TLS, Executable, LinkerScript, PHDRS ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS with an explicit PHDRS linker script.
+#
+# The script assigns .tdata and .tbss to both ph_tls (PT_TLS) and ph_data
+# (PT_LOAD), so the TLS segment and the data LOAD overlap — which is the
+# standard ELF convention for TLS.
+#
+#   - PT_TLS FileSiz > 0   (.tdata PROGBITS content is in the file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss adds zero-init space)
+#   - .tdata and .tbss both appear under PT_TLS
+#   - ph_data PT_LOAD has FileSiz == MemSiz (.tbss excluded from LOAD)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_phdrs.t %t.o -o %t.out
+
+#--- PT_TLS FileSiz > 0 (.tdata has file-backed initialized content) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK-NOT: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{0x0+}} {{0x[0-9a-f]+}} RW

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSTLSSizes.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataPHDRSTLSSizes.test
@@ -1,0 +1,22 @@
+#---GNURelroTBSSTDataPHDRSTLSSizes.test--- TLS, Executable, LinkerScript, PHDRS ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS with an explicit PHDRS linker script.
+#
+# The script assigns .tdata and .tbss to both ph_tls (PT_TLS) and ph_data
+# (PT_LOAD), so the TLS segment and the data LOAD overlap — which is the
+# standard ELF convention for TLS.
+#
+#   - PT_TLS FileSiz > 0   (.tdata PROGBITS content is in the file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss adds zero-init space)
+#   - .tdata and .tbss both appear under PT_TLS
+#   - ph_data PT_LOAD has FileSiz == MemSiz (.tbss excluded from LOAD)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_phdrs.t %t.o -o %t.out
+
+#--- PT_TLS MemSiz > FileSiz (.tbss extends the per-thread block) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} [[FSIZ:0x[0-9a-f]+]] {{0x[0-9a-f]+}} RW
+# CHECK-NOT: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} [[FSIZ]] [[FSIZ]] RW

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataPlainLSBothInTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataPlainLSBothInTLS.test
@@ -1,0 +1,21 @@
+#---GNURelroTBSSTDataPlainLSBothInTLS.test--- TLS, Executable, LinkerScript ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS (initialized and uninitialized TLS)
+# with a plain SECTIONS linker script (no PHDRS, no MEMORY).
+#
+# With a SECTIONS-only script the linker auto-generates segments.  The TLS
+# segment invariants for mixed TDATA+TBSS:
+#   - PT_TLS FileSiz > 0   (.tdata is PROGBITS; its content is in the file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss extends the per-thread block beyond .tdata)
+#   - .tdata and .tbss both appear under PT_TLS
+#   - .tdata is in the RW PT_LOAD (.tbss is not)
+#   - The RW PT_LOAD has FileSiz == MemSiz (.tbss not counted in LOAD)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_plain.t %t.o -o %t.out
+
+#--- .tdata and .tbss are both listed under PT_TLS ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: .tdata .tbss

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataPlainLSLoadSizes.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataPlainLSLoadSizes.test
@@ -1,0 +1,21 @@
+#---GNURelroTBSSTDataPlainLSLoadSizes.test--- TLS, Executable, LinkerScript ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS (initialized and uninitialized TLS)
+# with a plain SECTIONS linker script (no PHDRS, no MEMORY).
+#
+# With a SECTIONS-only script the linker auto-generates segments.  The TLS
+# segment invariants for mixed TDATA+TBSS:
+#   - PT_TLS FileSiz > 0   (.tdata is PROGBITS; its content is in the file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss extends the per-thread block beyond .tdata)
+#   - .tdata and .tbss both appear under PT_TLS
+#   - .tdata is in the RW PT_LOAD (.tbss is not)
+#   - The RW PT_LOAD has FileSiz == MemSiz (.tbss not counted in LOAD)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_plain.t %t.o -o %t.out
+
+#--- RW PT_LOAD FileSiz == MemSiz (.tbss excluded from LOAD) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: LOAD {{[0-9a-fx]+}} {{[0-9a-fx]+}} {{[0-9a-fx]+}} [[SZ:[0-9a-fx]+]] [[SZ]] RW

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataPlainLSTBSSNotInLoad.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataPlainLSTBSSNotInLoad.test
@@ -1,0 +1,21 @@
+#---GNURelroTBSSTDataPlainLSTBSSNotInLoad.test--- TLS, Executable, LinkerScript ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS (initialized and uninitialized TLS)
+# with a plain SECTIONS linker script (no PHDRS, no MEMORY).
+#
+# With a SECTIONS-only script the linker auto-generates segments.  The TLS
+# segment invariants for mixed TDATA+TBSS:
+#   - PT_TLS FileSiz > 0   (.tdata is PROGBITS; its content is in the file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss extends the per-thread block beyond .tdata)
+#   - .tdata and .tbss both appear under PT_TLS
+#   - .tdata is in the RW PT_LOAD (.tbss is not)
+#   - The RW PT_LOAD has FileSiz == MemSiz (.tbss not counted in LOAD)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_plain.t %t.o -o %t.out
+
+#--- .tbss is NOT listed under any PT_LOAD ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK-NOT: LOAD {{.*}} .tbss

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataPlainLSTDataInLoad.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataPlainLSTDataInLoad.test
@@ -1,0 +1,21 @@
+#---GNURelroTBSSTDataPlainLSTDataInLoad.test--- TLS, Executable, LinkerScript ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS (initialized and uninitialized TLS)
+# with a plain SECTIONS linker script (no PHDRS, no MEMORY).
+#
+# With a SECTIONS-only script the linker auto-generates segments.  The TLS
+# segment invariants for mixed TDATA+TBSS:
+#   - PT_TLS FileSiz > 0   (.tdata is PROGBITS; its content is in the file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss extends the per-thread block beyond .tdata)
+#   - .tdata and .tbss both appear under PT_TLS
+#   - .tdata is in the RW PT_LOAD (.tbss is not)
+#   - The RW PT_LOAD has FileSiz == MemSiz (.tbss not counted in LOAD)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_plain.t %t.o -o %t.out
+
+#--- .tdata is in the RW PT_LOAD ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: .tdata

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataPlainLSTLS.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataPlainLSTLS.test
@@ -1,0 +1,21 @@
+#---GNURelroTBSSTDataPlainLSTLS.test--- TLS, Executable, LinkerScript ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS (initialized and uninitialized TLS)
+# with a plain SECTIONS linker script (no PHDRS, no MEMORY).
+#
+# With a SECTIONS-only script the linker auto-generates segments.  The TLS
+# segment invariants for mixed TDATA+TBSS:
+#   - PT_TLS FileSiz > 0   (.tdata is PROGBITS; its content is in the file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss extends the per-thread block beyond .tdata)
+#   - .tdata and .tbss both appear under PT_TLS
+#   - .tdata is in the RW PT_LOAD (.tbss is not)
+#   - The RW PT_LOAD has FileSiz == MemSiz (.tbss not counted in LOAD)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_plain.t %t.o -o %t.out
+
+#--- PT_TLS segment is present ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: TLS

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataPlainLSTLSFileSZ.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataPlainLSTLSFileSZ.test
@@ -1,0 +1,21 @@
+#---GNURelroTBSSTDataPlainLSTLSFileSZ.test--- TLS, Executable, LinkerScript ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS (initialized and uninitialized TLS)
+# with a plain SECTIONS linker script (no PHDRS, no MEMORY).
+#
+# With a SECTIONS-only script the linker auto-generates segments.  The TLS
+# segment invariants for mixed TDATA+TBSS:
+#   - PT_TLS FileSiz > 0   (.tdata is PROGBITS; its content is in the file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss extends the per-thread block beyond .tdata)
+#   - .tdata and .tbss both appear under PT_TLS
+#   - .tdata is in the RW PT_LOAD (.tbss is not)
+#   - The RW PT_LOAD has FileSiz == MemSiz (.tbss not counted in LOAD)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_plain.t %t.o -o %t.out
+
+#--- PT_TLS FileSiz > 0 (.tdata stored in the file) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK-NOT: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{0x0+}} {{0x[0-9a-f]+}} R

--- a/test/Common/standalone/GNURelro/GNURelroTBSSTDataPlainLSTLSSizes.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSTDataPlainLSTLSSizes.test
@@ -1,0 +1,22 @@
+#---GNURelroTBSSTDataPlainLSTLSSizes.test--- TLS, Executable, LinkerScript ---#
+
+#BEGIN_COMMENT
+# Tests PT_TLS behavior for TDATA+TBSS (initialized and uninitialized TLS)
+# with a plain SECTIONS linker script (no PHDRS, no MEMORY).
+#
+# With a SECTIONS-only script the linker auto-generates segments.  The TLS
+# segment invariants for mixed TDATA+TBSS:
+#   - PT_TLS FileSiz > 0   (.tdata is PROGBITS; its content is in the file)
+#   - PT_TLS MemSiz  > FileSiz  (.tbss extends the per-thread block beyond .tdata)
+#   - .tdata and .tbss both appear under PT_TLS
+#   - .tdata is in the RW PT_LOAD (.tbss is not)
+#   - The RW PT_LOAD has FileSiz == MemSiz (.tbss not counted in LOAD)
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_tdata.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_tdata_plain.t %t.o -o %t.out
+
+#--- PT_TLS MemSiz > FileSiz (.tbss adds zero-init space beyond .tdata) ---
+RUN: %readelf -l -W %t.out | %filecheck %s
+# CHECK: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} [[FSIZ:0x[0-9a-f]+]] {{0x[0-9a-f]+}} R
+# CHECK-NOT: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} [[FSIZ]] [[FSIZ]] R

--- a/test/Common/standalone/GNURelro/Inputs/relro.c
+++ b/test/Common/standalone/GNURelro/Inputs/relro.c
@@ -1,0 +1,5 @@
+__attribute__((constructor)) int cfoo() { return 0; }
+__attribute__((destructor)) int dbar() { return 0; }
+int val = 10;
+int foo() { return val; }
+int bar() { return foo(); }

--- a/test/Common/standalone/GNURelro/Inputs/tbss_only_memory.t
+++ b/test/Common/standalone/GNURelro/Inputs/tbss_only_memory.t
@@ -1,0 +1,9 @@
+MEMORY {
+  FLASH (rx)  : ORIGIN = 0x400000, LENGTH = 0x10000
+  RAM   (rwx) : ORIGIN = 0x500000, LENGTH = 0x10000
+}
+SECTIONS {
+  .text  : { *(.text*) *(.eh_frame*) } > FLASH
+  .tbss  : { *(.tbss*) }               > RAM
+  .data  : { *(.data*) }               > RAM
+}

--- a/test/Common/standalone/GNURelro/Inputs/tbss_only_phdrs.t
+++ b/test/Common/standalone/GNURelro/Inputs/tbss_only_phdrs.t
@@ -1,0 +1,10 @@
+PHDRS {
+  ph_text PT_LOAD;
+  ph_tls  PT_TLS;
+  ph_data PT_LOAD;
+}
+SECTIONS {
+  .text  : { *(.text*) *(.eh_frame*) } :ph_text
+  .tbss  : { *(.tbss*) }               :ph_tls :ph_data
+  .data  : { *(.data*) }               :ph_data
+}

--- a/test/Common/standalone/GNURelro/Inputs/tbss_only_phdrs_memory.t
+++ b/test/Common/standalone/GNURelro/Inputs/tbss_only_phdrs_memory.t
@@ -1,0 +1,14 @@
+PHDRS {
+  ph_text PT_LOAD;
+  ph_tls  PT_TLS;
+  ph_data PT_LOAD;
+}
+MEMORY {
+  FLASH (rx)  : ORIGIN = 0x400000, LENGTH = 0x10000
+  RAM   (rwx) : ORIGIN = 0x500000, LENGTH = 0x10000
+}
+SECTIONS {
+  .text  : { *(.text*) *(.eh_frame*) } > FLASH :ph_text
+  .tbss  : { *(.tbss*) }               > RAM   :ph_tls :ph_data
+  .data  : { *(.data*) }               > RAM   :ph_data
+}

--- a/test/Common/standalone/GNURelro/Inputs/tbss_only_plain.t
+++ b/test/Common/standalone/GNURelro/Inputs/tbss_only_plain.t
@@ -1,0 +1,5 @@
+SECTIONS {
+  .text  : { *(.text*) *(.eh_frame*) }
+  .tbss  : { *(.tbss*) }
+  .data  : { *(.data*) }
+}

--- a/test/Common/standalone/GNURelro/Inputs/tbss_tdata_memory.t
+++ b/test/Common/standalone/GNURelro/Inputs/tbss_tdata_memory.t
@@ -1,0 +1,10 @@
+MEMORY {
+  FLASH (rx)  : ORIGIN = 0x400000, LENGTH = 0x10000
+  RAM   (rwx) : ORIGIN = 0x500000, LENGTH = 0x10000
+}
+SECTIONS {
+  .text  : { *(.text*) *(.eh_frame*) } > FLASH
+  .tdata : { *(.tdata*) }              > RAM
+  .tbss  : { *(.tbss*) }               > RAM
+  .data  : { *(.data*) }               > RAM
+}

--- a/test/Common/standalone/GNURelro/Inputs/tbss_tdata_phdrs.t
+++ b/test/Common/standalone/GNURelro/Inputs/tbss_tdata_phdrs.t
@@ -1,0 +1,11 @@
+PHDRS {
+  ph_text PT_LOAD;
+  ph_tls  PT_TLS;
+  ph_data PT_LOAD;
+}
+SECTIONS {
+  .text  : { *(.text*) *(.eh_frame*) } :ph_text
+  .tdata : { *(.tdata*) }              :ph_tls :ph_data
+  .tbss  : { *(.tbss*) }               :ph_tls :ph_data
+  .data  : { *(.data*) }               :ph_data
+}

--- a/test/Common/standalone/GNURelro/Inputs/tbss_tdata_phdrs_memory.t
+++ b/test/Common/standalone/GNURelro/Inputs/tbss_tdata_phdrs_memory.t
@@ -1,0 +1,15 @@
+PHDRS {
+  ph_text PT_LOAD;
+  ph_tls  PT_TLS;
+  ph_data PT_LOAD;
+}
+MEMORY {
+  FLASH (rx)  : ORIGIN = 0x400000, LENGTH = 0x10000
+  RAM   (rwx) : ORIGIN = 0x500000, LENGTH = 0x10000
+}
+SECTIONS {
+  .text  : { *(.text*) *(.eh_frame*) } > FLASH :ph_text
+  .tdata : { *(.tdata*) }              > RAM   :ph_tls :ph_data
+  .tbss  : { *(.tbss*) }               > RAM   :ph_tls :ph_data
+  .data  : { *(.data*) }               > RAM   :ph_data
+}

--- a/test/Common/standalone/GNURelro/Inputs/tbss_tdata_plain.t
+++ b/test/Common/standalone/GNURelro/Inputs/tbss_tdata_plain.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  .text  : { *(.text*) *(.eh_frame*) }
+  .tdata : { *(.tdata*) }
+  .tbss  : { *(.tbss*) }
+  .data  : { *(.data*) }
+}


### PR DESCRIPTION
Adds standalone tests covering TLS segment sizes, PT_LOAD layout, and section-to-segment mappings for executables and shared libraries with TBSS and TDATA sections under various linker script modes (no-script, plain, PHDRS, MEMORY).