### PR TITLE
[TLS] Fix PT_TLS file size and memory size

### DIFF
--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -2405,6 +2405,20 @@ bool GNULDBackend::setupSegment(ELFSegment *E) {
                                 E->type() == llvm::ELF::PT_GNU_RELRO))
       continue;
 
+    // For PT_TLS, .tbss is SHT_NOBITS and its sh_offset is inherited from
+    // a preceding non-NOBITS section (it occupies no file space).  Exclude
+    // .tbss from all file-offset tracking so it doesn't corrupt lower_offset
+    // or upper_offset.  Memory-size tracking (lower/upper) is still needed.
+    bool isTBSS = isTLS && isCurBSS;
+    if (isTBSS && E->type() == llvm::ELF::PT_TLS) {
+      // Only update memory bounds; skip file-offset tracking below.
+      if (cur->addr() < lower)
+        lower = cur->addr();
+      if ((cur->addr() + cur->size()) > upper)
+        upper = cur->addr() + cur->size();
+      continue;
+    }
+
     // Dont count empty sections.
     if (!cur->size())
       continue;

--- a/test/Common/RunTests/RelRO/Inputs/relro_phdrs.t
+++ b/test/Common/RunTests/RelRO/Inputs/relro_phdrs.t
@@ -1,0 +1,55 @@
+/* Minimal PHDRS script for the RelROPHDRS runtime test.
+ *
+ * Rather than prescribing the full section layout, this script only names
+ * the program headers explicitly and lets ELD place sections normally.
+ * This exercises the PHDRS code path in createProgramHdrs while keeping
+ * the binary loadable by the dynamic linker.
+ *
+ * The key invariant tested: .tbss must NOT appear in PT_GNU_RELRO, and
+ * PT_GNU_RELRO's VirtAddr must be set from the first real RELRO section
+ * (.init_array/.got), not from .tbss.
+ */
+PHDRS {
+  ph_phdr   PT_PHDR      PHDRS;
+  ph_interp PT_INTERP;
+  ph_text   PT_LOAD      FILEHDR PHDRS FLAGS(5);
+  ph_data   PT_LOAD      FLAGS(6);
+  ph_tls    PT_TLS;
+  ph_relro  PT_GNU_RELRO;
+  ph_dyn    PT_DYNAMIC;
+}
+SECTIONS {
+  .interp     : { *(.interp) }                             :ph_interp :ph_text
+  .note.ABI-tag : { *(.note.ABI-tag) }                     :ph_text
+  .note.gnu.build-id : { *(.note.gnu.build-id) }           :ph_text
+  .dynsym     : { *(.dynsym) }                             :ph_text
+  .dynstr     : { *(.dynstr) }                             :ph_text
+  .gnu.version   : { *(.gnu.version) }                    :ph_text
+  .gnu.version_d : { *(.gnu.version_d) }                  :ph_text
+  .gnu.version_r : { *(.gnu.version_r) }                  :ph_text
+  .gnu.hash   : { *(.gnu.hash) }                           :ph_text
+  .rel.dyn    : { *(.rel.dyn) }                            :ph_text
+  .rela.dyn   : { *(.rela.dyn) }                           :ph_text
+  .rel.plt    : { *(.rel.plt) }                            :ph_text
+  .rela.plt   : { *(.rela.plt) }                           :ph_text
+  .init       : { *(.init) }                               :ph_text
+  .plt        : { *(.plt*) }                               :ph_text
+  . = ALIGN(4K);
+  .text       : { *(.text*) }                :ph_text
+  .fini       : { *(.fini) }                               :ph_text
+  .rodata     : { *(.rodata*) }                            :ph_text
+  .eh_frame   : { *(.eh_frame*) }                          :ph_text
+  .ARM.exidx  : { *(.ARM.exidx*) }                         :ph_text
+  . = ALIGN(4K);
+  .tdata      : { *(.tdata*) }                             :ph_tls :ph_data
+  .tbss       : { *(.tbss*) }                              :ph_tls :ph_data
+  .init_array : { KEEP(*(.init_array*)) }    :ph_relro :ph_data
+  .fini_array : { KEEP(*(.fini_array*)) }                  :ph_relro :ph_data
+  .dynamic    : { *(.dynamic) }                            :ph_relro :ph_data :ph_dyn
+  .got        : { *(.got) }                                :ph_relro :ph_data
+  . = ALIGN(4K);
+  .got.plt    : { *(.got.plt) }              :ph_data
+  __global_pointer$ = .;
+  .data       : { *(.data*) }                              :ph_data
+  .bss        : { *(.bss*) *(COMMON) }                     :ph_data
+}

--- a/test/Common/RunTests/RelRO/RelROPHDRS.test
+++ b/test/Common/RunTests/RelRO/RelROPHDRS.test
@@ -1,0 +1,46 @@
+REQUIRES: run_test, linux
+#---RelROPHDRS.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+# Runtime tests for the PT_GNU_RELRO fix using an explicit PHDRS linker
+# script.  The script names all program headers and assigns each section to
+# its segment, exercising the createScriptProgramHeaders code path.
+#END_COMMENT
+#START_TEST
+
+# Use -ftls-model=initial-exec to avoid TLSDESC relocations.
+
+# --- Case 1: TBSS-only, partial RELRO ---
+RUN: %run_cc %clangopts -fuse-init-array -c -fPIC -ftls-model=initial-exec %p/Inputs/relro_tbss.c -o %t.tbss.o
+RUN: %run_cc %clangopts -o %t.tbss.out %t.tbss.o -Wl,-z,relro -Wl,-dy -T %p/Inputs/relro_phdrs.t -Wl,-z,max-page-size=0x1000
+RUN: %run %t.tbss.out | %filecheck %s --check-prefix=TBSS
+RUN: %readelf -l -W %t.tbss.out | %filecheck %s --check-prefix=TBSS-FILESZ
+
+# --- Case 2: TBSS-only, full RELRO (-z relro -z now) ---
+RUN: %run_cc %clangopts -o %t.now.out %t.tbss.o -Wl,-z,relro -Wl,-z,now -Wl,-dy -T %p/Inputs/relro_phdrs.t -Wl,-z,max-page-size=0x1000
+RUN: %run %t.now.out | %filecheck %s --check-prefix=TBSS
+
+# --- Case 3: TBSS + TDATA, partial RELRO ---
+RUN: %run_cc %clangopts -fuse-init-array -c -fPIC -ftls-model=initial-exec %p/Inputs/relro_tdata_tbss.c -o %t.tdata.o
+RUN: %run_cc %clangopts -o %t.tdata.out %t.tdata.o -Wl,-z,relro -Wl,-dy -T %p/Inputs/relro_phdrs.t -Wl,-z,max-page-size=0x1000
+RUN: %run %t.tdata.out | %filecheck %s --check-prefix=TDATA
+
+# --- Case 4: TBSS + non-TLS BSS, partial RELRO ---
+RUN: %run_cc %clangopts -fuse-init-array -c -fPIC -ftls-model=initial-exec %p/Inputs/relro_bss_tbss.c -o %t.bss.o
+RUN: %run_cc %clangopts -o %t.bss.out %t.bss.o -Wl,-z,relro -Wl,-dy -T %p/Inputs/relro_phdrs.t -Wl,-z,max-page-size=0x1000
+RUN: %run %t.bss.out | %filecheck %s --check-prefix=BSS
+
+#END_TEST
+
+# Case 1 (ELF structure): PT_TLS FileSiz == 0 for TBSS-only; MemSiz > 0
+# The offset field is verified by the runtime test passing (p_offset % p_align
+# == p_vaddr % p_align must hold or the dynamic loader rejects the binary).
+TBSS-FILESZ: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{0x0+}} {{0x[0-9a-f]+}}
+
+# Case 1 & 2: TBSS written by constructor is readable
+TBSS: 42
+
+# Case 3: initialized TLS value followed by zero-initialized TLS value
+TDATA: tdata=7 tbss=0
+
+# Case 4: non-TLS BSS is zero, TBSS written by constructor is still 42
+BSS: bss=0 tbss=42

--- a/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSTLSFileSZZero.test
+++ b/test/Common/standalone/GNURelro/GNURelroTBSSOnlyPHDRSTLSFileSZZero.test
@@ -1,0 +1,26 @@
+#---GNURelroTBSSOnlyPHDRSTLSFileSZZero.test--- TLS, Executable, LinkerScript, PHDRS ---#
+
+#BEGIN_COMMENT
+# PT_TLS FileSiz must be zero when only .tbss sections are present (no .tdata).
+#
+# .tbss is SHT_NOBITS: it occupies no space in the file.  The PT_TLS segment
+# therefore has no file-backed content, so FileSiz == 0 and MemSiz > 0
+# (the runtime still reserves per-thread storage).
+#
+# Before the fix in setupSegment(), .tbss was included in the file-offset
+# tracking for PT_TLS, corrupting FileSiz.  This test locks in the correct
+# behavior.
+#END_COMMENT
+
+RUN: %clang %clangg0opts -fuse-init-array -c %p/Inputs/tbss_only.c -o %t.o
+RUN: %link %linkopts -T %p/Inputs/tbss_only_phdrs.t %t.o -o %t.out
+RUN: %readelf --elf-output-style LLVM -l -W %t.out | %filecheck %s
+
+# PT_TLS FileSiz == 0 (.tbss is SHT_NOBITS; nothing written to file)
+# PT_TLS MemSiz > 0  (runtime must reserve per-thread space)
+# CHECK:      Type: PT_TLS
+# CHECK-NEXT: Offset:
+# CHECK-NEXT: VirtualAddress:
+# CHECK-NEXT: PhysicalAddress:
+# CHECK-NEXT: FileSize: 0
+# CHECK-NEXT: MemSize: {{[1-9][0-9]*}}

--- a/test/Common/standalone/TLS/TLSPhdrsFileSiz/Inputs/1.c
+++ b/test/Common/standalone/TLS/TLSPhdrsFileSiz/Inputs/1.c
@@ -1,0 +1,4 @@
+__thread int a = 1;
+__thread int b;
+
+int main() { return a + b; }

--- a/test/Common/standalone/TLS/TLSPhdrsFileSiz/Inputs/t.t
+++ b/test/Common/standalone/TLS/TLSPhdrsFileSiz/Inputs/t.t
@@ -1,0 +1,14 @@
+PHDRS {
+  text PT_LOAD FLAGS(5);
+  data PT_LOAD FLAGS(6);
+  tls  PT_TLS  FLAGS(4);
+}
+
+SECTIONS {
+  .text 0x100000 : { *(.text*) *(.init*) } :text
+  .rodata        : { *(.rodata*) }          :text
+  .data 0x500000 : { *(.data*) }            :data
+  .tdata         : { *(.tdata*) }           :data :tls
+  .tbss  (NOLOAD): { *(.tbss*) }            :tls
+  .bss   (NOLOAD): { *(.bss*) *(COMMON) }   :data
+}

--- a/test/Common/standalone/TLS/TLSPhdrsFileSiz/TLSPhdrsFileSiz.test
+++ b/test/Common/standalone/TLS/TLSPhdrsFileSiz/TLSPhdrsFileSiz.test
@@ -1,0 +1,16 @@
+UNSUPPORTED: ndk-build
+#---TLSPhdrsFileSiz.test-------------------- TLS, Executable, LinkerScript ---#
+
+#BEGIN_COMMENT
+# Tests that PT_TLS FileSiz reflects only the initialized TLS data (.tdata)
+# and not the uninitialized .tbss when a PHDRS linker script is used.
+#END_COMMENT
+
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.o %clangg0opts
+RUN: %link %linkopts -T %p/Inputs/t.t %t.o -o %t.out --defsym __aeabi_read_tp=0
+
+RUN: %readelf -l -W %t.out | %filecheck %s
+
+# CHECK: TLS {{[x0-9a-f]+}} {{[x0-9a-f]+}} {{[x0-9a-f]+}} 0x{{[0]+}}4 0x{{[0]+}}8 R
+#END_TEST


### PR DESCRIPTION
Exclude .tbss from file-offset (lower_offset / upper_offset) tracking for PT_TLS segments. .tbss is SHT_NOBITS and occupies no file space. its sh_offset is inherited from the preceding non-NOBITS section. range. Including it corrupts the filesz computation for PT_TLS. Memory-size bounds (lower / upper) are still updated so PT_TLS p_memsz accounts for the per-thread TBSS reservation.