### PR TITLE
Reorganize .sbss section and move __bss_start for H2 + Picolibc templateconfig

### DIFF
--- a/templates/staticExecutable/static-executable-h2-picolibc.lcs.template
+++ b/templates/staticExecutable/static-executable-h2-picolibc.lcs.template
@@ -163,27 +163,28 @@ SECTIONS
   {
     PROVIDE (_SDA_BASE_ = .);
     *(.sdata.1 .sdata.1.* .gnu.linkonce.s.1.*)
-    *(.sbss.1 .sbss.1.* .gnu.linkonce.sb.1.*)
-    *(.scommon.1 .scommon.1.*)
     *(.sdata.2 .sdata.2.* .gnu.linkonce.s.2.*)
-    *(.sbss.2 .sbss.2.* .gnu.linkonce.sb.2.*)
-    *(.scommon.2 .scommon.2.*)
     *(.sdata.4 .sdata.4.* .gnu.linkonce.s.4.*)
-    *(.sbss.4 .sbss.4.* .gnu.linkonce.sb.4.*)
-    *(.scommon.4 .scommon.4.*)
     *(.lit[a4] .lit[a4].* .gnu.linkonce.l[a4].*)
     *(.sdata.8 .sdata.8.* .gnu.linkonce.s.8.*)
-    *(.sbss.8 .sbss.8.* .gnu.linkonce.sb.8.*)
-    *(.scommon.8 .scommon.8.*)
     *(.lit8 .lit8.* .gnu.linkonce.l8.*)
     *(.sdata.hot .sdata.hot.* .gnu.linkonce.s.hot.*)
     *(.sdata .sdata.* .gnu.linkonce.s.*)
   }
   .sbss           :
   {
+    __bss_start = .;
     PROVIDE (__sbss_start = .);
     PROVIDE (___sbss_start = .);
     *(.dynsbss)
+    *(.sbss.1 .sbss.1.* .gnu.linkonce.sb.1.*)
+    *(.scommon.1 .scommon.1.*)
+    *(.sbss.2 .sbss.2.* .gnu.linkonce.sb.2.*)
+    *(.scommon.2 .scommon.2.*)
+    *(.sbss.4 .sbss.4.* .gnu.linkonce.sb.4.*)
+    *(.scommon.4 .scommon.4.*)
+    *(.sbss.8 .sbss.8.* .gnu.linkonce.sb.8.*)
+    *(.scommon.8 .scommon.8.*)
     *(.sbss.hot .sbss.hot.* .gnu.linkonce.sb.hot.*)
     *(.sbss .sbss.* .gnu.linkonce.sb.*)
     *(.scommon .scommon.*)
@@ -194,7 +195,6 @@ SECTIONS
   . = ALIGN (64);
   .bss            :
   {
-    __bss_start = .;
     *(.dynbss)
     *(.bss.hot .bss.hot.* .gnu.linkonce.b.hot.*)
     *(.bss .bss.* .gnu.linkonce.b.*)


### PR DESCRIPTION
There is an issue in the Picolibc + H2 linker file template where the .sbss section is a part of .sdata section, which prevents it from being zeroed out by picolibc startup code.

This PR moves __bss_start symbol from .bss to .sbss section and reorganizes section ordering to group related small data and small BSS sections together.