### PR TITLE
[AArch64] Add overflow check for R_AARCH64_ADR_PREL_PG_HI21

### DIFF
--- a/lib/Target/AArch64/AArch64Relocator.cpp
+++ b/lib/Target/AArch64/AArch64Relocator.cpp
@@ -840,6 +840,12 @@ Relocator::Result adr_prel_pg_hi21(Relocation &pReloc,
   Relocator::DWord X =
       helper_get_page_address(S + A) - helper_get_page_address(P);
 
+  if (pReloc.type() == llvm::ELF::R_AARCH64_ADR_PREL_PG_HI21) {
+    Relocator::Result R = checkSignedRange(pReloc, pParent, X, 33);
+    if (R != Relocator::OK)
+      return R;
+  }
+
   pReloc.target() = helper_reencode_adr_imm(pReloc.target(), (X >> 12));
 
   return Relocator::OK;

--- a/test/AArch64/standalone/AdrpOverflow/Inputs/t.s
+++ b/test/AArch64/standalone/AdrpOverflow/Inputs/t.s
@@ -1,0 +1,9 @@
+	.text
+	.globl	foo
+	.p2align	2
+	.type	foo,@function
+foo:
+	adrp	x0, bar
+	ret
+.Lfunc_end0:
+	.size	foo, .Lfunc_end0-foo

--- a/test/AArch64/standalone/AdrpOverflow/overflow.test
+++ b/test/AArch64/standalone/AdrpOverflow/overflow.test
@@ -1,0 +1,19 @@
+#---overflow.test--------------------- Executable --------------------#
+#START_COMMENT
+# Check that R_AARCH64_ADR_PREL_PG_HI21 overflow is correctly detected.
+# The ADRP instruction encodes (PG(S+A) - PG(P)) >> 12 in a 21-bit signed
+# field, so the page-relative offset must be in [-2^32, 2^32 - 4096].
+#END_COMMENT
+#START_TEST
+RUN: %clangas %clangasopts -filetype obj -mrelocation-model static -o %t.o %p/Inputs/t.s
+
+# bar at 0xFFFFF000: page diff from ~0 is 0xFFFFF pages — within 21-bit signed range.
+RUN: %link %linkopts -march aarch64 %t.o --defsym bar=0xFFFFF000 -o %t.out
+RUN: %nm %t.out | %filecheck %s
+CHECK: foo
+
+# bar at 0x100000000: page diff >> 12 = 0x100000, one past the 21-bit max — overflow.
+RUN: %not %link %linkopts -march aarch64 %t.o --defsym bar=0x100000000 -o %t.out 2>&1 | %filecheck %s -check-prefix=OVER
+OVER: relocation R_AARCH64_ADR_PREL_PG_HI21 out of range: 4294967296 is not in [-4294967296, 4294967295]
+
+#END_TEST


### PR DESCRIPTION
The ADRP instruction encodes (PG(S+A) - PG(P)) >> 12 in a 21-bit signed immediate field. Add a signed 21-bit range check for R_AARCH64_ADR_PREL_PG_HI21; the _NC (no-check) variant intentionally skips the check.

Add a lit test that verifies a link within range succeeds and a link that overflows the 21-bit field is caught with an overflow diagnostic.