### PR TITLE
[Zephyr] Add opt-in PR workflow 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,34 @@ jobs:
         working-directory: pr-${{ env.PR_NUMBER }}/obj
         run: ninja check-eld-summary
 
+      # Package the PR-built ld.eld (+ libs) for zephyr-pr.yml. `inst/` layout
+      # matches FetchNightlyToolset (~18MB compressed).
+      - name: Package PR ELD toolset
+        if: steps.file-check.outputs.skip_build == 'false'
+        working-directory: pr-${{ env.PR_NUMBER }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p inst/bin inst/lib
+
+          cp obj/bin/ld.eld          inst/bin/
+          cp -P obj/lib/libLW.so.4   inst/lib/
+          ln -sf libLW.so.4          inst/lib/libLW.so
+
+          # Bundle libc++/libc++abi dependencies.
+          bash llvm-project/llvm/tools/eld/.github/workflows/scripts/BundleSharedLibDeps.sh \
+            inst ld.eld
+
+          XZ_OPT=-T0 tar -Jcf install-pr-toolset.tar.xz inst
+
+      - name: Upload PR ELD toolset
+        if: steps.file-check.outputs.skip_build == 'false'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
+        with:
+          name: pr-eld-toolset
+          retention-days: 1
+          path: pr-${{ env.PR_NUMBER }}/install-pr-toolset.tar.xz
+
       - name: Clean up
         if: always()
         run: |

--- a/.github/workflows/zephyr-nightly.yml
+++ b/.github/workflows/zephyr-nightly.yml
@@ -9,214 +9,25 @@ on:
 
 permissions:
   contents: write
+  actions: read
 jobs:
-  zephyr-build-and-test:
+  zephyr:
     if: github.repository == 'qualcomm/eld' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/zephyrproject-rtos/ci-base:main
-      options: --user 0
     strategy:
       fail-fast: false
       matrix:
         target:
-          - board: qemu_riscv32
-            arch: riscv32
-            extra_args: CONFIG_PICOLIBC_USE_TOOLCHAIN=y
-          - board: qemu_riscv32_xip
-            arch: riscv32
-            extra_args: CONFIG_PICOLIBC_USE_TOOLCHAIN=y
-          - board: qemu_riscv64
-            arch: riscv64
-            extra_args: CONFIG_PICOLIBC_USE_TOOLCHAIN=y
-          - board: qemu_cortex_m3
-            arch: arm
-            # cpullvm ARM picolibc is missing a _nopic version, so its
-            # objects have GOT relocations that fail when .got is discarded.
-            extra_args: CONFIG_PICOLIBC_USE_MODULE=y
-          - board: qemu_cortex_a53
-            arch: aarch64
-            extra_args: CONFIG_PICOLIBC_USE_TOOLCHAIN=y
-    env:
-      CPULLVM_VERSION: "22.1.0"
-      CPULLVM_DIR: /opt/cpullvm
-      CCACHE_DIR: /root/.ccache
-      CCACHE_BASEDIR: ${{ github.workspace }}
-      CCACHE_NOHASHDIR: "1"
-      CCACHE_MAXSIZE: "2G"
-      CCACHE_COMPRESS: "1"
-      CCACHE_COMPILERCHECK: "content"
-
-    steps:
-      - name: Checkout eld
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          path: llvm-project/llvm/tools/eld
-
-      - name: Prepare ccache dir
-        run: |
-          mkdir -p "$CCACHE_DIR"
-          ccache --version | head -1
-
-      - name: Restore ccache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
-        with:
-          path: ${{ env.CCACHE_DIR }}
-          key: ccache-${{ matrix.target.arch }}-cpullvm${{ env.CPULLVM_VERSION }}-${{ github.run_id }}
-          restore-keys: |
-            ccache-${{ matrix.target.arch }}-cpullvm${{ env.CPULLVM_VERSION }}-
-
-      - name: ccache stats (before build)
-        run: ccache -s -v || ccache -s
-
-      - name: Record pre-build entry
-        if: github.event_name == 'schedule'
-        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
-        with:
-          enabled: true
-          project: "llvm-project/llvm/tools/eld"
-          stage: "pre-"
-          workflow-name: "zephyr"
-          record-mode: "record"
-          status: "fail"
-          run-id: ${{github.run_id}}
-          arch-name: ${{ matrix.target.arch }}
-          branch-name: "main"
-
-      - name: Fetch nightly ELD
-        uses: ./llvm-project/llvm/tools/eld/.github/workflows/FetchNightlyToolset
-
-      - name: Install cpullvm toolchain and splice nightly ELD
-        run: |
-          # Download cpullvm release
-          wget -q --tries=3 --retry-on-http-error=429,500,502,503,504 --waitretry=5 https://github.com/qualcomm/cpullvm-toolchain/releases/download/cpullvm-${CPULLVM_VERSION}/cpullvm-${CPULLVM_VERSION}-Linux-x86_64.tar.xz
-          tar -xf cpullvm-${CPULLVM_VERSION}-Linux-x86_64.tar.xz
-          mv cpullvm-${CPULLVM_VERSION}-Linux-x86_64 ${CPULLVM_DIR}
-          rm cpullvm-${CPULLVM_VERSION}-Linux-x86_64.tar.xz
-
-          # Splice nightly ELD into cpullvm
-          cp inst/bin/ld.eld ${CPULLVM_DIR}/bin/ld.eld
-          cp inst/lib/libLW.so.4 ${CPULLVM_DIR}/lib/libLW.so.4
-          ln -sf libLW.so.4 ${CPULLVM_DIR}/lib/libLW.so
-
-          # ld.eld and libLW.so.4 are linked against nightly's libc++; cpullvm/lib
-          # has none, so copy the matching libc++/libc++abi alongside them.
-          cp -P inst/lib/libc++.so.1*    ${CPULLVM_DIR}/lib/
-          cp -P inst/lib/libc++abi.so.1* ${CPULLVM_DIR}/lib/
-
-          echo "Nightly ELD version:"
-          ${CPULLVM_DIR}/bin/ld.eld --version
-          echo "cpullvm clang version:"
-          ${CPULLVM_DIR}/bin/clang --version | head -1
-
-      - name: Clone Zephyr
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: zephyrproject-rtos/zephyr
-          path: zephyr
-
-      - name: Set safe.directory
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE/zephyr"
-
-      - name: Download and apply ELD support patch
-        run: |
-          cd zephyr
-          wget -q --tries=3 --retry-on-http-error=429,500,502,503,504 --waitretry=5 https://github.com/zephyrproject-rtos/zephyr/pull/103778.patch -O eld-support.patch
-          git apply eld-support.patch
-
-      - name: West setup
-        run: |
-          cd zephyr
-          west init -l .
-          west update
-
-      - name: Install Zephyr SDK hosttools
-        run: |
-          west sdk install --no-gnu-toolchains --install-base /opt/toolchains
-
-      - name: Build hello_world for ${{ matrix.target.board }} with ELD
-        shell: bash
-        run: |
-          cd zephyr
-          source zephyr-env.sh
-          export ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/
-          export ZEPHYR_TOOLCHAIN_VARIANT=host/llvm
-          export LLVM_TOOLCHAIN_PATH=${CPULLVM_DIR}
-          west build -p always -b ${{ matrix.target.board }} samples/hello_world -- \
-            -DCONFIG_LLVM_USE_ELD=y \
-            -DCONFIG_COMPILER_RT_RTLIB=y \
-            ${{ matrix.target.extra_args && format('-D{0}', matrix.target.extra_args) }}
-
-      - name: Run hello_world on QEMU
-        shell: bash
-        run: |
-          cd zephyr
-          source zephyr-env.sh
-          # No pipe to tee: qemu_riscv32_xip uses -machine sifive_e which has
-          # no QEMU exit mechanism, so QEMU outlives `timeout` and would keep
-          # tee blocked. pkill below frees the CPU for the next step.
-          timeout -k 1s 5s west build -t run > run_output.log 2>&1 || true
-          pkill -KILL -f "qemu-system.*build/zephyr/zephyr.elf" 2>/dev/null || true
-          cat run_output.log
-          if grep -q "Hello World" run_output.log; then
-            echo "hello_world executed successfully"
-          else
-            echo "hello_world did not produce expected output"
-            exit 1
-          fi
-
-      - name: Run twister tests for ${{ matrix.target.board }} with ELD
-        shell: bash
-        run: |
-          cd zephyr
-          source zephyr-env.sh
-          export ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/
-          export LLVM_TOOLCHAIN_PATH=${CPULLVM_DIR}
-          west twister -W -p ${{ matrix.target.board }} \
-            -T tests \
-            --inline-logs \
-            --timestamps \
-            -j 3 \
-            -v \
-            -x=ZEPHYR_TOOLCHAIN_VARIANT=host/llvm \
-            -x=CONFIG_LLVM_USE_ELD=y \
-            -x=CONFIG_COMPILER_RT_RTLIB=y \
-            ${{ matrix.target.extra_args && format('-x={0}', matrix.target.extra_args) }}
-
-      - name: Upload twister results
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
-        with:
-          name: zephyr-twister-results-${{ matrix.target.board }}
-          retention-days: 2
-          path: |
-            zephyr/twister-out/twister.log
-            zephyr/twister-out/twister.json
-
-      - name: Upload build artifacts
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
-        with:
-          name: zephyr-build-artifacts-${{ matrix.target.board }}
-          retention-days: 2
-          path: |
-            zephyr/build/zephyr/zephyr.elf
-            zephyr/build/zephyr/zephyr.map
-
-      - name: ccache stats (after build)
-        if: always()
-        run: ccache -s -v || ccache -s
-
-      - name: Update build entry
-        if: success() && github.event_name == 'schedule'
-        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
-        with:
-          enabled: true
-          project: "llvm-project/llvm/tools/eld"
-          stage: "post-"
-          workflow-name: "zephyr"
-          record-mode: "update"
-          status: "pass"
-          run-id: ${{github.run_id}}
-          arch-name: ${{ matrix.target.arch }}
-          branch-name: "main"
+          - { board: qemu_riscv32,     arch: riscv32,  extra_args: CONFIG_PICOLIBC_USE_TOOLCHAIN=y }
+          - { board: qemu_riscv32_xip, arch: riscv32,  extra_args: CONFIG_PICOLIBC_USE_TOOLCHAIN=y }
+          - { board: qemu_riscv64,     arch: riscv64,  extra_args: CONFIG_PICOLIBC_USE_TOOLCHAIN=y }
+          # cpullvm ARM picolibc is missing a _nopic version, so its objects
+          # have GOT relocations that fail when .got is discarded.
+          - { board: qemu_cortex_m3,   arch: arm,      extra_args: CONFIG_PICOLIBC_USE_MODULE=y }
+          - { board: qemu_cortex_a53,  arch: aarch64,  extra_args: CONFIG_PICOLIBC_USE_TOOLCHAIN=y }
+    uses: ./.github/workflows/zephyr-run.yml
+    with:
+      board: ${{ matrix.target.board }}
+      arch: ${{ matrix.target.arch }}
+      extra_args: ${{ matrix.target.extra_args }}
+      test_scope: tests
+      eld_source: nightly

--- a/.github/workflows/zephyr-pr.yml
+++ b/.github/workflows/zephyr-pr.yml
@@ -1,0 +1,106 @@
+name: Zephyr on ELD PR
+
+# Opt-in: run Zephyr against a PR's *own* ELD build (not nightly). Assumes ci.yml
+# passed for the PR and uploaded the `pr-eld-toolset` artifact. Given a PR number,
+# finds the latest successful ci.yml run for its head commit; ci_run_id overrides.
+# Scope: aarch64 (qemu_cortex_a53), tests/kernel. Add arches later by mirroring
+# zephyr-nightly.yml's matrix.
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number (auto-discovers the latest successful CI run for its head commit)"
+        required: false
+      ci_run_id:
+        description: "CI (ci.yml) run id to pull ld.eld from (overrides auto-discovery)"
+        required: false
+  # pull_request: {} # Uncomment only to test this WF file update.
+
+permissions:
+  contents: read
+  actions: read       # needed to list/download artifacts from the ci.yml run
+  pull-requests: read # needed to resolve a PR number's head SHA
+
+jobs:
+  resolve:
+    if: github.repository == 'qualcomm/eld' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    outputs:
+      run_id: ${{ steps.find.outputs.run_id }}
+    steps:
+      - name: Resolve ci.yml run id
+        id: find
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9.0.0
+        env:
+          CI_RUN_ID: ${{ github.event.inputs.ci_run_id }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          # Fallback for the `pull_request:` test trigger (empty on dispatch).
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const ciRunId = (process.env.CI_RUN_ID || '').trim();
+            const prNumber = (process.env.PR_NUMBER || process.env.EVENT_PR_NUMBER || '').trim();
+
+            // Explicit run id wins.
+            if (ciRunId) {
+              core.info(`Using explicit ci_run_id: ${ciRunId}`);
+              core.setOutput('run_id', ciRunId);
+              return;
+            }
+
+            if (!prNumber) {
+              core.setFailed('Provide either pr_number or ci_run_id.');
+              return;
+            }
+
+            // Resolve the PR's head commit, then find the newest successful
+            // ci.yml run for that exact SHA.
+            const pr = await github.rest.pulls.get({
+              owner, repo, pull_number: Number(prNumber),
+            });
+            const headSha = pr.data.head.sha;
+            core.info(`PR #${prNumber} head SHA: ${headSha}`);
+
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
+              {
+                owner, repo,
+                workflow_id: 'ci.yml',
+                event: 'pull_request',
+                head_sha: headSha,
+                per_page: 100,
+              }
+            );
+
+            const success = runs
+              .filter(r => r.conclusion === 'success')
+              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+            if (success.length === 0) {
+              core.setFailed(
+                `No successful ci.yml run found for PR #${prNumber} (SHA ${headSha}). ` +
+                `Ensure CI passed for the PR's latest commit.`);
+              return;
+            }
+
+            const run = success[0];
+            core.info(`Latest successful ci.yml run: id=${run.id}, run_number=${run.run_number}`);
+            core.setOutput('run_id', String(run.id));
+
+  zephyr:
+    needs: resolve
+    permissions:
+      contents: write # zephyr-run.yml requires write (unused outside the nightly schedule path)
+      actions: read
+    uses: ./.github/workflows/zephyr-run.yml
+    with:
+      board: qemu_cortex_a53
+      arch: aarch64
+      extra_args: CONFIG_PICOLIBC_USE_TOOLCHAIN=y
+      test_scope: tests/kernel
+      eld_source: artifact
+      artifact_run_id: ${{ needs.resolve.outputs.run_id }}

--- a/.github/workflows/zephyr-run.yml
+++ b/.github/workflows/zephyr-run.yml
@@ -1,0 +1,256 @@
+name: Zephyr build and test (reusable)
+
+# Reusable Zephyr build + twister body. Called by zephyr-nightly.yml (5-board
+# matrix, nightly ELD) and zephyr-pr.yml (aarch64, ELD from a PR's CI artifact).
+# Only `eld_source` differs between callers; the splice step onward is identical.
+
+on:
+  workflow_call:
+    inputs:
+      board:
+        description: "QEMU board to build/run (e.g. qemu_cortex_a53)"
+        required: true
+        type: string
+      arch:
+        description: "Arch label, used for ccache keys and build-status records"
+        required: true
+        type: string
+      extra_args:
+        description: "Extra Kconfig passed to west build (-D) and twister (-x); may be empty"
+        required: false
+        type: string
+        default: ""
+      test_scope:
+        description: "Path passed to twister -T (e.g. tests or tests/kernel)"
+        required: false
+        type: string
+        default: "tests"
+      eld_source:
+        description: "Where ld.eld comes from: 'nightly' (FetchNightlyToolset) or 'artifact' (PR CI upload)"
+        required: false
+        type: string
+        default: "nightly"
+      artifact_run_id:
+        description: "ci.yml run id to download the pr-eld-toolset artifact from (eld_source=artifact)"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+  actions: read
+jobs:
+  zephyr-build-and-test:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/zephyrproject-rtos/ci-base:main
+      options: --user 0
+    env:
+      CPULLVM_VERSION: "22.1.0"
+      CPULLVM_DIR: /opt/cpullvm
+      CCACHE_DIR: /root/.ccache
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_NOHASHDIR: "1"
+      CCACHE_MAXSIZE: "2G"
+      CCACHE_COMPRESS: "1"
+      CCACHE_COMPILERCHECK: "content"
+
+    steps:
+      - name: Checkout eld
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: llvm-project/llvm/tools/eld
+
+      - name: Prepare ccache dir
+        run: |
+          mkdir -p "$CCACHE_DIR"
+          ccache --version | head -1
+
+      - name: Restore ccache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ inputs.arch }}-cpullvm${{ env.CPULLVM_VERSION }}-${{ github.run_id }}
+          restore-keys: |
+            ccache-${{ inputs.arch }}-cpullvm${{ env.CPULLVM_VERSION }}-
+
+      - name: ccache stats (before build)
+        run: ccache -s -v || ccache -s
+
+      - name: Record pre-build entry
+        if: github.event_name == 'schedule'
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "pre-"
+          workflow-name: "zephyr"
+          record-mode: "record"
+          status: "fail"
+          run-id: ${{github.run_id}}
+          arch-name: ${{ inputs.arch }}
+          branch-name: "main"
+
+      # Both branches normalize the payload to ./inst so the splice is identical.
+      - name: Fetch nightly ELD
+        if: inputs.eld_source == 'nightly'
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/FetchNightlyToolset
+
+      - name: Download PR ELD artifact
+        if: inputs.eld_source == 'artifact'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
+        with:
+          name: pr-eld-toolset
+          run-id: ${{ inputs.artifact_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Extract PR ELD artifact
+        if: inputs.eld_source == 'artifact'
+        shell: bash
+        run: |
+          mkdir -p inst
+          tar -xf install-pr-toolset.tar.xz -C inst --strip-components=1
+          ls inst
+          echo "PATH=$(pwd)/inst/bin:$PATH" >> $GITHUB_ENV
+
+      - name: Install cpullvm toolchain and splice ELD
+        run: |
+          # Download cpullvm release
+          wget -q --tries=3 --retry-on-http-error=429,500,502,503,504 --waitretry=5 https://github.com/qualcomm/cpullvm-toolchain/releases/download/cpullvm-${CPULLVM_VERSION}/cpullvm-${CPULLVM_VERSION}-Linux-x86_64.tar.xz
+          tar -xf cpullvm-${CPULLVM_VERSION}-Linux-x86_64.tar.xz
+          mv cpullvm-${CPULLVM_VERSION}-Linux-x86_64 ${CPULLVM_DIR}
+          rm cpullvm-${CPULLVM_VERSION}-Linux-x86_64.tar.xz
+
+          # Splice ELD (nightly or PR build) into cpullvm
+          cp inst/bin/ld.eld ${CPULLVM_DIR}/bin/ld.eld
+          cp inst/lib/libLW.so.4 ${CPULLVM_DIR}/lib/libLW.so.4
+          ln -sf libLW.so.4 ${CPULLVM_DIR}/lib/libLW.so
+
+          # ld.eld/libLW.so.4 link against the build's libc++; cpullvm/lib has
+          # none, so bundle the matching libc++/libc++abi.
+          cp -P inst/lib/libc++.so.1*    ${CPULLVM_DIR}/lib/
+          cp -P inst/lib/libc++abi.so.1* ${CPULLVM_DIR}/lib/
+
+          echo "ELD version:"
+          ${CPULLVM_DIR}/bin/ld.eld --version
+          echo "cpullvm clang version:"
+          ${CPULLVM_DIR}/bin/clang --version | head -1
+
+      - name: Clone Zephyr
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: zephyrproject-rtos/zephyr
+          path: zephyr
+
+      - name: Set safe.directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE/zephyr"
+
+      - name: Download and apply ELD support patch
+        run: |
+          cd zephyr
+          wget -q --tries=3 --retry-on-http-error=429,500,502,503,504 --waitretry=5 https://github.com/zephyrproject-rtos/zephyr/pull/103778.patch -O eld-support.patch
+          git apply eld-support.patch
+
+      - name: West setup
+        run: |
+          cd zephyr
+          west init -l .
+          west update
+
+      - name: Install Zephyr SDK hosttools
+        run: |
+          west sdk install --no-gnu-toolchains --install-base /opt/toolchains
+
+      - name: Build hello_world for ${{ inputs.board }} with ELD
+        shell: bash
+        env:
+          BOARD: ${{ inputs.board }}
+          EXTRA_ARGS: ${{ inputs.extra_args }}
+        run: |
+          cd zephyr
+          source zephyr-env.sh
+          export ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/
+          export ZEPHYR_TOOLCHAIN_VARIANT=host/llvm
+          export LLVM_TOOLCHAIN_PATH=${CPULLVM_DIR}
+          west build -p always -b "$BOARD" samples/hello_world -- \
+            -DCONFIG_LLVM_USE_ELD=y \
+            -DCONFIG_COMPILER_RT_RTLIB=y \
+            ${EXTRA_ARGS:+-D"$EXTRA_ARGS"}
+
+      - name: Run hello_world on QEMU
+        shell: bash
+        run: |
+          cd zephyr
+          source zephyr-env.sh
+          # No pipe to tee: qemu_riscv32_xip uses -machine sifive_e which has
+          # no QEMU exit mechanism, so QEMU outlives `timeout` and would keep
+          # tee blocked. pkill below frees the CPU for the next step.
+          timeout -k 1s 5s west build -t run > run_output.log 2>&1 || true
+          pkill -KILL -f "qemu-system.*build/zephyr/zephyr.elf" 2>/dev/null || true
+          cat run_output.log
+          if grep -q "Hello World" run_output.log; then
+            echo "hello_world executed successfully"
+          else
+            echo "hello_world did not produce expected output"
+            exit 1
+          fi
+
+      - name: Run twister tests for ${{ inputs.board }} with ELD
+        shell: bash
+        env:
+          BOARD: ${{ inputs.board }}
+          TEST_SCOPE: ${{ inputs.test_scope }}
+          EXTRA_ARGS: ${{ inputs.extra_args }}
+        run: |
+          cd zephyr
+          source zephyr-env.sh
+          export ZEPHYR_SDK_INSTALL_DIR=/opt/toolchains/
+          export LLVM_TOOLCHAIN_PATH=${CPULLVM_DIR}
+          west twister -W -p "$BOARD" \
+            -T "$TEST_SCOPE" \
+            --inline-logs \
+            --timestamps \
+            -j 3 \
+            -v \
+            -x=ZEPHYR_TOOLCHAIN_VARIANT=host/llvm \
+            -x=CONFIG_LLVM_USE_ELD=y \
+            -x=CONFIG_COMPILER_RT_RTLIB=y \
+            ${EXTRA_ARGS:+-x="$EXTRA_ARGS"}
+
+      - name: Upload twister results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
+        with:
+          name: zephyr-twister-results-${{ inputs.board }}
+          retention-days: 2
+          path: |
+            zephyr/twister-out/twister.log
+            zephyr/twister-out/twister.json
+
+      - name: Upload build artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
+        with:
+          name: zephyr-build-artifacts-${{ inputs.board }}
+          retention-days: 2
+          path: |
+            zephyr/build/zephyr/zephyr.elf
+            zephyr/build/zephyr/zephyr.map
+
+      - name: ccache stats (after build)
+        if: always()
+        run: ccache -s -v || ccache -s
+
+      - name: Update build entry
+        if: success() && github.event_name == 'schedule'
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "post-"
+          workflow-name: "zephyr"
+          record-mode: "update"
+          status: "pass"
+          run-id: ${{github.run_id}}
+          arch-name: ${{ inputs.arch }}
+          branch-name: "main"


### PR DESCRIPTION
Factor the Zephyr build+twister body into zephyr-run.yml, which zephyr-nightly.yml now calls. Adds zephyr-pr.yml, a manual workflow_dispatch that downloads the PR's own ld.eld artifact from a successful ci.yml run and runs tests/kernel on qemu_cortex_a53.

ci.yml packages the built ld.eld + libLW.so.4 + libc++ so zephyr-pr.yml can consume it.