### PR TITLE
Fix --remap-inputs on Windows: normalize paths before glob matching

### DIFF
--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -595,6 +595,10 @@ public:
   const RemapInputsType &getRemapInputs() const { return RemapInputs; }
   RemapInputsType &getRemapInputs() { return RemapInputs; }
 
+  /// Apply --remap-inputs rules to \p FileName (first match wins).
+  /// Returns the replacement path if a rule matched, or std::nullopt.
+  std::optional<std::string> findRemapInput(llvm::StringRef FileName) const;
+
   // ---- add extern symbols from list file ---- //
   const ExtList &getExternList() const { return ExternList; }
   ExtList &getExternList() { return ExternList; }

--- a/lib/Config/GeneralOptions.cpp
+++ b/lib/Config/GeneralOptions.cpp
@@ -677,3 +677,16 @@ bool GeneralOptions::traceSymbol(const ResolveInfo &RI) const {
   }
   return false;
 }
+
+std::optional<std::string>
+GeneralOptions::findRemapInput(llvm::StringRef FileName) const {
+  std::string NormalizedFileName = llvm::sys::path::convert_to_slash(FileName);
+  for (const auto &Entry : RemapInputs) {
+    std::string NormalizedPattern =
+        llvm::sys::path::convert_to_slash(Entry.Pattern);
+    WildcardPattern Pat(NormalizedPattern);
+    if (Pat.matched(NormalizedFileName))
+      return Entry.Replacement;
+  }
+  return std::nullopt;
+}

--- a/lib/Input/Input.cpp
+++ b/lib/Input/Input.cpp
@@ -14,7 +14,6 @@
 #include "eld/Config/LinkerConfig.h"
 #include "eld/Input/InputFile.h"
 #include "eld/Input/InputTree.h"
-#include "eld/Script/WildcardPattern.h"
 #include "eld/Support/MsgHandling.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/Support/FileSystem.h"
@@ -111,16 +110,11 @@ bool Input::resolvePath(const LinkerConfig &PConfig) {
   if (PConfig.options().hasMappingFile() && !isInternal())
     return resolvePathMappingFile(PConfig);
   // Apply --remap-inputs remappings (in order, first match wins).
-  for (const auto &Entry : PConfig.options().getRemapInputs()) {
-    WildcardPattern Pat(Entry.Pattern);
-    if (Pat.matched(FileName)) {
-      if (PConfig.getPrinter()->isVerbose())
-        PConfig.raise(Diag::verbose_remap_input)
-            << FileName << Entry.Replacement;
-      OriginalFileName = FileName;
-      FileName = Entry.Replacement;
-      break;
-    }
+  if (auto Replacement = PConfig.options().findRemapInput(FileName)) {
+    if (PConfig.getPrinter()->isVerbose())
+      PConfig.raise(Diag::verbose_remap_input) << FileName << *Replacement;
+    OriginalFileName = FileName;
+    FileName = std::move(*Replacement);
   }
   auto &PSearchDirs = PConfig.directories();
 

--- a/lib/ScriptParser/ScriptParser.cpp
+++ b/lib/ScriptParser/ScriptParser.cpp
@@ -41,6 +41,7 @@
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MemoryBufferRef.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/SaveAndRestore.h"
 #include <optional>
 #include <utility>
@@ -1449,15 +1450,12 @@ bool ScriptParser::readInclude(llvm::StringRef Tok) {
   llvm::StringRef FileName = unquote(next());
   // Apply --remap-inputs to the INCLUDE filename before searching.
   std::string RemappedFileName = FileName.str();
-  for (const auto &Entry : ThisConfig.options().getRemapInputs()) {
-    WildcardPattern Pat(Entry.Pattern);
-    if (Pat.matched(RemappedFileName)) {
-      if (ThisConfig.getPrinter()->isVerbose())
-        ThisConfig.raise(Diag::verbose_remap_input)
-            << RemappedFileName << Entry.Replacement;
-      RemappedFileName = Entry.Replacement;
-      break;
-    }
+  if (auto Replacement =
+          ThisConfig.options().findRemapInput(RemappedFileName)) {
+    if (ThisConfig.getPrinter()->isVerbose())
+      ThisConfig.raise(Diag::verbose_remap_input)
+          << RemappedFileName << *Replacement;
+    RemappedFileName = std::move(*Replacement);
   }
   LayoutInfo *layoutInfo = ThisScriptFile.module().getLayoutInfo();
   bool Result = true;

--- a/test/Common/standalone/RemapInputs/RemapInputs.test
+++ b/test/Common/standalone/RemapInputs/RemapInputs.test
@@ -27,21 +27,24 @@ RUN:   %t1.main.o %t1.foo.o -T %p/Inputs/script.t
 RUN: %readelf -s %t1.wildcard.out | %filecheck %s --check-prefix=LINKED
 
 #--- Test 3: --remap-inputs-file with = separator ---------------------------
-RUN: echo "%t1.foo.o=%t1.bar.o" > %t1.remap_eq.txt
+RUN: %echo "%t1.foo.o=%t1.bar.o" > %t1.remap_eq.txt
 RUN: %link %linkopts -o %t1.remapfile_eq.out \
 RUN:   --remap-inputs-file=%t1.remap_eq.txt \
 RUN:   %t1.main.o %t1.foo.o -T %p/Inputs/script.t
 RUN: %readelf -s %t1.remapfile_eq.out | %filecheck %s --check-prefix=LINKED
 
 #--- Test 4: --remap-inputs-file with whitespace separator ------------------
-RUN: echo "%t1.foo.o %t1.bar.o" > %t1.remap_ws.txt
+RUN: %echo "%t1.foo.o %t1.bar.o" > %t1.remap_ws.txt
 RUN: %link %linkopts -o %t1.remapfile_ws.out \
 RUN:   --remap-inputs-file=%t1.remap_ws.txt \
 RUN:   %t1.main.o %t1.foo.o -T %p/Inputs/script.t
 RUN: %readelf -s %t1.remapfile_ws.out | %filecheck %s --check-prefix=LINKED
 
 #--- Test 5: --remap-inputs-file with comments and blank lines --------------
-RUN: printf "# this is a comment\n\n%t1.foo.o=%t1.bar.o\n# another comment\n" > %t1.remap_comments.txt
+RUN: %echo "# this is a comment" > %t1.remap_comments.txt
+RUN: %echo "" >> %t1.remap_comments.txt
+RUN: %echo "%t1.foo.o=%t1.bar.o" >> %t1.remap_comments.txt
+RUN: %echo "# another comment" >> %t1.remap_comments.txt
 RUN: %link %linkopts -o %t1.remapfile_comments.out \
 RUN:   --remap-inputs-file=%t1.remap_comments.txt \
 RUN:   %t1.main.o %t1.foo.o -T %p/Inputs/script.t
@@ -64,7 +67,7 @@ RUN:   %t1.main.o %t1.libfoo.a -T %p/Inputs/script.t
 RUN: %readelf -s %t1.archive.out | %filecheck %s --check-prefix=LINKED
 
 #--- Test 8: remap applied to INPUT() in linker script ----------------------
-RUN: echo "INPUT(%t1.foo.o)" > %t1.input_script.t
+RUN: %echo "INPUT(%t1.foo.o)" > %t1.input_script.t
 RUN: %link %linkopts -o %t1.lscinput.out \
 RUN:   --remap-inputs=%t1.foo.o=%t1.bar.o \
 RUN:   %t1.main.o -T %t1.input_script.t -T %p/Inputs/script.t

--- a/test/Common/standalone/linkerscript/RemapInputs/RemapInputs.test
+++ b/test/Common/standalone/linkerscript/RemapInputs/RemapInputs.test
@@ -70,7 +70,7 @@ RUN: %filecheck %s --check-prefix=INCLUDE_MAP < %t1.include.map.txt
 
 #--- Test 6: INPUT() in linker script is remapped ---------------------------
 # Script uses INPUT(foo.o); remap foo.o -> bar.o.
-RUN: echo "INPUT(%t1.foo.o)" > %t1.input_cmd.t
+RUN: %echo "INPUT(%t1.foo.o)" > %t1.input_cmd.t
 RUN: %link %linkopts -o %t1.inputcmd.out \
 RUN:   --remap-inputs=%t1.foo.o=%t1.bar.o \
 RUN:   %t1.main.o -T %t1.input_cmd.t -T %p/Inputs/script.t


### PR DESCRIPTION
llvm::GlobPattern treats backslash as an escape character, so Windows absolute paths passed as --remap-inputs patterns (e.g. C:\path\foo.o) were silently mis-parsed and never matched. Fix this by normalizing both the stored pattern and the input filename to forward slashes via llvm::sys::path::convert_to_slash before constructing WildcardPattern and calling matched().

Fixes #1286