### PR TITLE
[Plugin] Apply plugin fragment replacements before syncing relocations

### DIFF
--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -545,6 +545,13 @@ public:
   /// postProcessing - Backend can do any needed modification in the final stage
   virtual eld::Expected<void> postProcessing(llvm::FileOutputBuffer &pOutput);
 
+  /// copy plugin provided replacement content (registered via
+  /// LinkerWrapper::replaceSymbolContent) into the output
+  /// buffer. This must run before relocations are synced so that relocations
+  /// targeting the replaced symbol are applied on top of the new content rather
+  /// than being clobbered by it.
+  void applyPluginFragmentReplacements(llvm::FileOutputBuffer &Output);
+
   /// dynamic - the dynamic section of the target machine.
   virtual ELFDynamic *dynamic() = 0;
 

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -2525,6 +2525,8 @@ bool ObjectLinker::emitOutput(llvm::FileOutputBuffer &POutput) {
 /// postProcessing - do modification after all processes
 eld::Expected<void>
 ObjectLinker::postProcessing(llvm::FileOutputBuffer &POutput) {
+  getTargetBackend().applyPluginFragmentReplacements(POutput);
+
   {
     eld::RegisterTimer T("Sync Relocations", "Emit Output File",
                          ThisConfig.options().printTimingStats());

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -3634,21 +3634,23 @@ GNULDBackend::postProcessing(llvm::FileOutputBuffer &pOutput) {
     eld::Expected<void> expEmit = m_pSFrameFragment->emit(region, getModule());
     ELDEXP_RETURN_DIAGENTRY_IF_ERROR(expEmit);
   }
-  {
-    eld::RegisterTimer T(
-        "Replace Fragments from Plugin", "Post Processing",
-        m_Module.getConfig().options().printTimingStats("Plugin"));
-    for (auto &V : m_Module.getReplaceFrags()) {
-      FragmentRef *F = V.first;
-      MemoryArea *M = V.second;
-      FragmentRef::Offset Off = F->getOutputOffset(m_Module);
-      size_t out_offset = F->getOutputELFSection()->offset() + Off;
-      uint8_t *target_addr = pOutput.getBufferStart() + out_offset;
-      llvm::StringRef Contents = M->getContents();
-      std::memcpy(target_addr, Contents.data(), Contents.size());
-    }
-  }
   return {};
+}
+
+void GNULDBackend::applyPluginFragmentReplacements(
+    llvm::FileOutputBuffer &Output) {
+  eld::RegisterTimer T(
+      "Replace Fragments from Plugin", "Post Processing",
+      m_Module.getConfig().options().printTimingStats("Plugin"));
+  for (auto &V : m_Module.getReplaceFrags()) {
+    FragmentRef *F = V.first;
+    MemoryArea *M = V.second;
+    FragmentRef::Offset Off = F->getOutputOffset(m_Module);
+    size_t OutOffset = F->getOutputELFSection()->offset() + Off;
+    uint8_t *TargetAddr = Output.getBufferStart() + OutOffset;
+    llvm::StringRef Contents = M->getContents();
+    std::memcpy(TargetAddr, Contents.data(), Contents.size());
+  }
 }
 
 /// elfSegmentTable - return the reference of the elf segment table

--- a/test/Common/Plugin/ReplaceSymbolContent/Inputs/1.c
+++ b/test/Common/Plugin/ReplaceSymbolContent/Inputs/1.c
@@ -1,4 +1,5 @@
 int foo_data[4] = {1, 2, 3, 4};
 int dead_data[4] = {5, 6, 7, 8};
+int *reloc_data[2] = {&foo_data[0], &foo_data[2]};
 
-int main() { return foo_data[0]; }
+int main() { return *reloc_data[0]; }

--- a/test/Common/Plugin/ReplaceSymbolContent/ReplaceSymbolContent.test
+++ b/test/Common/Plugin/ReplaceSymbolContent/ReplaceSymbolContent.test
@@ -4,6 +4,9 @@
 # content of a defined data symbol in the output binary.
 # The plugin replaces all bytes of foo_data with 0xAB; the readelf hex dump of
 # .data is checked to confirm abababab appears in the output.
+# The plugin also replays reloc_data's bytes back unchanged. reloc_data holds
+# two relocations into foo_data; the no-op replay must not clobber the resolved
+# addresses.
 # A second run with --gc-sections verifies that dead_data (unreferenced from
 # main) is skipped rather than replaced.
 #END_COMMENT
@@ -20,8 +23,10 @@ RUN:   2>&1 | %filecheck %s --check-prefix GC
 #END_TEST
 
 CHECK: ReplaceSymbolContentPlugin: replaced foo_data ({{[0-9]+}} bytes)
+CHECK: ReplaceSymbolContentPlugin: replayed reloc_data unchanged ({{[0-9]+}} bytes)
 
 HEXDUMP: abababab
+HEXDUMP-NOT: 00000000 00000000
 
 GC: ReplaceSymbolContentPlugin: replaced foo_data ({{[0-9]+}} bytes)
 GC: ReplaceSymbolContentPlugin: skipped dead_data (garbage collected)

--- a/test/Common/Plugin/ReplaceSymbolContent/ReplaceSymbolContentPlugin.cpp
+++ b/test/Common/Plugin/ReplaceSymbolContent/ReplaceSymbolContentPlugin.cpp
@@ -17,6 +17,7 @@ public:
   void ActBeforeWritingOutput() override {
     replaceIfLive("foo_data");
     replaceIfLive("dead_data");
+    replayUnchanged("reloc_data");
   }
 
 private:
@@ -46,6 +47,29 @@ private:
     }
     std::cout << "ReplaceSymbolContentPlugin: replaced " << SymName << " ("
               << size << " bytes)\n";
+  }
+
+  /// Read the symbol's current bytes via Chunk::getRawData (the pre-relocation
+  /// input fragment) and hand them straight back. Writing a symbol's own
+  /// content back unchanged must be a no-op, including for symbols whose
+  /// content contains relocations.
+  void replayUnchanged(const std::string &SymName) {
+    eld::plugin::Symbol Sym = getLinker()->getSymbol(SymName).value();
+    const char *Data = Sym.getChunk().getRawData();
+    uint32_t Size = Sym.getSize();
+    size_t Off = Sym.getOffsetInChunk();
+
+    uint8_t *Buf =
+        reinterpret_cast<uint8_t *>(getLinker()->getUninitBuffer(Size));
+    std::memcpy(Buf, Data + Off, Size);
+    eld::Expected<void> ExpReplace =
+        getLinker()->replaceSymbolContent(Sym, Buf, Size);
+    if (!ExpReplace) {
+      getLinker()->reportDiagEntry(std::move(ExpReplace.error()));
+      return;
+    }
+    std::cout << "ReplaceSymbolContentPlugin: replayed " << SymName
+              << " unchanged (" << Size << " bytes)\n";
   }
 
   void Destroy() override {}


### PR DESCRIPTION
`replaceSymbolContent`'s deferred write used to land after `syncRelocations`, silently zeroing any relocation whose target fell inside the replaced symbol. Do it before the sync so relocations land on top of the new content.