### PR TITLE
[TBSS] PHDRS : Fix spurious PT_LOAD created for TBSS-only sections

### DIFF
--- a/lib/Target/CreateScriptProgramHeaders.hpp
+++ b/lib/Target/CreateScriptProgramHeaders.hpp
@@ -303,9 +303,14 @@ bool GNULDBackend::createScriptProgramHdrs() {
     } else if (isStartOfSegment)
       is_previous_start_of_segment = true;
 
-    if (cur->isAlloc())
+    // Do not advance layout state for TBSS. TBSS occupies no file space and
+    // does not advance the dot counter, so letting it update prev or
+    // last_seen_alloc_section would cause the next real section to be placed
+    // relative to a phantom boundary.
+    if (cur->isAlloc() && !cur->isTBSS())
       last_seen_alloc_section = cur;
-    prev = cur;
+    if (!cur->isTBSS())
+      prev = cur;
 
     if (isNoLoad)
       noLoadSections.push_back(cur);
@@ -317,6 +322,10 @@ bool GNULDBackend::createScriptProgramHdrs() {
       if (cur->isWanted() || cur->wantedInOutput() ||
           (scriptvma && scriptvma.value())) {
         seg->append(*out);
+        // Always update segment flags, including for TBSS, so that a segment
+        // containing only TBSS sections gets the correct p_flags (PF_R|PF_W).
+        // Skipping this for TBSS would leave a PHDRS-defined TLS segment with
+        // p_flags=0 when no other section in that segment updates the flags.
         seg->updateFlagPhdr(getSegmentFlag(cur->getFlags()));
       }
       if (seg->isLoadSegment() && !config().options().isOMagic())

--- a/test/Common/standalone/TLS/TBSSNoteSegmentReuse/Inputs/1.s
+++ b/test/Common/standalone/TLS/TBSSNoteSegmentReuse/Inputs/1.s
@@ -1,0 +1,8 @@
+.section .note.one, "a", %note
+.quad 1
+
+.section .tbss.tbss, "awT", %nobits
+.long 0
+
+.section .note.two, "a", %note
+.quad 2

--- a/test/Common/standalone/TLS/TBSSNoteSegmentReuse/Inputs/s.t
+++ b/test/Common/standalone/TLS/TBSSNoteSegmentReuse/Inputs/s.t
@@ -1,0 +1,5 @@
+SECTIONS {
+  .note1 : { *(.note.one) }
+  .tbss  : { *(.tbss.tbss) }
+  .note2 : { *(.note.two) }
+}

--- a/test/Common/standalone/TLS/TBSSNoteSegmentReuse/TBSSNoteSegmentReuse.test
+++ b/test/Common/standalone/TLS/TBSSNoteSegmentReuse/TBSSNoteSegmentReuse.test
@@ -1,0 +1,17 @@
+#---TBSSNoteSegmentReuse.test----------------------- TLS, Executable -----------------#
+#BEGIN_COMMENT
+# This tests that two NOTE sections separated by a TBSS section are placed in
+# the same PT_NOTE segment. Before the fix, prevOut was updated for TBSS, so
+# the NOTE reuse lookup (_noteSegmentsForSection[prevOut]) returned null after
+# TBSS and a spurious second PT_NOTE segment was created.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.s -o %t1.o
+RUN: %link %linkopts %t1.o -T %p/Inputs/s.t -o %t.out
+RUN: %readelf -l -W %t.out | %filecheck %s
+
+# Exactly one PT_NOTE segment containing both note sections.
+#CHECK:      NOTE
+#CHECK:      {{[0-9]+}}     .note1 .note2
+#CHECK-NOT:  NOTE
+#END_TEST

--- a/test/Common/standalone/TLS/TBSSRelro/Inputs/1.c
+++ b/test/Common/standalone/TLS/TBSSRelro/Inputs/1.c
@@ -1,0 +1,3 @@
+int foo() { return 0; }
+__thread int tbss = 0;
+int data = 10;

--- a/test/Common/standalone/TLS/TBSSRelro/Inputs/s.t
+++ b/test/Common/standalone/TLS/TBSSRelro/Inputs/s.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  .foo  : { *(.text.foo) }
+  .tbss : { *(.tbss.tbss) }
+  .data : { *(.data.data) }
+  /DISCARD/ : { *(.ARM.exidx*) }
+}

--- a/test/Common/standalone/TLS/TBSSRelro/TBSSRelro.test
+++ b/test/Common/standalone/TLS/TBSSRelro/TBSSRelro.test
@@ -1,0 +1,17 @@
+#---TBSSRelro.test----------------------- TLS, Executable -----------------#
+#BEGIN_COMMENT
+# This tests that when -z relro is used with a TBSS section, the LOAD segments
+# have correct flags (text is R E, data is RW) and the GNU_RELRO segment is
+# empty (TBSS is not a real loadable section and must not pollute RELRO).
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangg0opts -c %p/Inputs/1.c -o %t1.o -ffunction-sections -fdata-sections
+RUN: %link %linkopts %t1.o -T %p/Inputs/s.t -z relro -o %t.out
+RUN: %readelf -l -W %t.out | %filecheck %s
+
+#CHECK:      LOAD {{.*}} R E
+#CHECK:      LOAD {{.*}} RW
+#CHECK-NOT:  LOAD
+#CHECK:      00     .foo
+#CHECK:      01     .data
+#END_TEST

--- a/test/Common/standalone/TLS/TBSSSegmentFlagsMemory/Inputs/1.c
+++ b/test/Common/standalone/TLS/TBSSSegmentFlagsMemory/Inputs/1.c
@@ -1,0 +1,3 @@
+int foo() { return 0; }
+__thread int tbss = 0;
+int data = 10;

--- a/test/Common/standalone/TLS/TBSSSegmentFlagsMemory/Inputs/s.t
+++ b/test/Common/standalone/TLS/TBSSSegmentFlagsMemory/Inputs/s.t
@@ -1,0 +1,9 @@
+MEMORY {
+  rom (rx) : ORIGIN = 0x1000, LENGTH = 1M
+  ram (rw) : ORIGIN = 0x100000, LENGTH = 1M
+}
+SECTIONS {
+  .foo  : { *(.text.foo) }  > rom
+  .tbss : { *(.tbss.tbss) } > ram
+  .data : { *(.data.data) } > ram
+}

--- a/test/Common/standalone/TLS/TBSSSegmentFlagsMemory/TBSSSegmentFlagsMemory.test
+++ b/test/Common/standalone/TLS/TBSSSegmentFlagsMemory/TBSSSegmentFlagsMemory.test
@@ -1,0 +1,18 @@
+#---TBSSSegmentFlagsMemory.test----------------------- TLS, Executable -----------------#
+#BEGIN_COMMENT
+# This tests that when a MEMORY command is used, a TBSS section in a RAM region
+# following a text section in a ROM region does not prevent the data section
+# from being placed in a separate LOAD segment, and that the text segment flags
+# are not polluted by the TBSS Write flag.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangg0opts -c %p/Inputs/1.c -o %t1.o -ffunction-sections -fdata-sections
+RUN: %link %linkopts %t1.o -T %p/Inputs/s.t -o %t.out
+RUN: %readelf -l -W %t.out | %filecheck %s
+
+#CHECK:      LOAD {{.*}} R E
+#CHECK:      LOAD {{.*}} RW
+#CHECK-NOT:  LOAD
+#CHECK:      00     .foo
+#CHECK:      01     .data
+#END_TEST

--- a/test/Common/standalone/TLS/TBSSSegmentFlagsMemorySameRegion/Inputs/1.c
+++ b/test/Common/standalone/TLS/TBSSSegmentFlagsMemorySameRegion/Inputs/1.c
@@ -1,0 +1,3 @@
+int foo() { return 0; }
+__thread int tbss = 0;
+int data = 10;

--- a/test/Common/standalone/TLS/TBSSSegmentFlagsMemorySameRegion/Inputs/s.t
+++ b/test/Common/standalone/TLS/TBSSSegmentFlagsMemorySameRegion/Inputs/s.t
@@ -1,0 +1,8 @@
+MEMORY {
+  ram (rwx) : ORIGIN = 0x1000, LENGTH = 1M
+}
+SECTIONS {
+  .foo  : { *(.text.foo) }  > ram
+  .tbss : { *(.tbss.tbss) } > ram
+  .data : { *(.data.data) } > ram
+}

--- a/test/Common/standalone/TLS/TBSSSegmentFlagsMemorySameRegion/TBSSSegmentFlagsMemorySameRegion.test
+++ b/test/Common/standalone/TLS/TBSSSegmentFlagsMemorySameRegion/TBSSSegmentFlagsMemorySameRegion.test
@@ -1,0 +1,20 @@
+#---TBSSSegmentFlagsMemorySameRegion.test------------ TLS, Executable -----------------#
+#BEGIN_COMMENT
+# This tests that when text, TBSS, and data sections all share the same MEMORY
+# region, the TBSS section does not prevent the data section from being placed
+# in a separate LOAD segment from the text section, and that the text segment
+# flags are not polluted by the TBSS Write flag. Before the fix, prev_mem_region
+# was updated for TBSS, making the data section appear to be in the same region
+# as the previous section and suppressing new segment creation.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangg0opts -c %p/Inputs/1.c -o %t1.o -ffunction-sections -fdata-sections
+RUN: %link %linkopts %t1.o -T %p/Inputs/s.t -o %t.out
+RUN: %readelf -l -W %t.out | %filecheck %s
+
+#CHECK:      LOAD {{.*}} R E
+#CHECK:      LOAD {{.*}} RW
+#CHECK-NOT:  LOAD
+#CHECK:      00     .foo
+#CHECK:      01     .data
+#END_TEST

--- a/test/Common/standalone/TLS/TBSSSegmentFlagsPHDRS/Inputs/1.c
+++ b/test/Common/standalone/TLS/TBSSSegmentFlagsPHDRS/Inputs/1.c
@@ -1,0 +1,3 @@
+int foo() { return 0; }
+__thread int tbss = 0;
+int data = 10;

--- a/test/Common/standalone/TLS/TBSSSegmentFlagsPHDRS/Inputs/s.t
+++ b/test/Common/standalone/TLS/TBSSSegmentFlagsPHDRS/Inputs/s.t
@@ -1,0 +1,10 @@
+PHDRS {
+  text PT_LOAD;
+  data PT_LOAD;
+  tls  PT_TLS;
+}
+SECTIONS {
+  .foo  : { *(.text.foo) }  :text
+  .tbss : { *(.tbss.tbss) } :data :tls
+  .data : { *(.data.data) } :data
+}

--- a/test/Common/standalone/TLS/TBSSSegmentFlagsPHDRS/TBSSSegmentFlagsPHDRS.test
+++ b/test/Common/standalone/TLS/TBSSSegmentFlagsPHDRS/TBSSSegmentFlagsPHDRS.test
@@ -1,0 +1,18 @@
+#---TBSSSegmentFlagsPHDRS.test----------------------- TLS, Executable -----------------#
+#BEGIN_COMMENT
+# This tests that when PHDRS are specified, a TBSS section between a text
+# segment and a data segment does not pollute the text segment flags with the
+# TBSS Write flag.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangg0opts -c %p/Inputs/1.c -o %t1.o -ffunction-sections -fdata-sections
+RUN: %link %linkopts %t1.o -T %p/Inputs/s.t -o %t.out
+RUN: %readelf -l -W %t.out | %filecheck %s
+
+#CHECK:      LOAD {{.*}} R E
+#CHECK:      LOAD {{.*}} RW
+#CHECK-NOT:  LOAD
+#CHECK:      00     .foo
+#CHECK:      01     .data
+#CHECK:      02     .tbss
+#END_TEST


### PR DESCRIPTION
CreateScriptProgramHdrs() had the same stale-state problem as the auto-layout path: it updated prev and last_seen_alloc_section for TBSS sections, which caused the next real section to be placed relative to a phantom boundary.

Unlike the auto-layout path, the script path must still call updateFlagPhdr() for TBSS matching GNU behavior.

Tests written using Claude.