### PR TITLE
[Security] Fix GitHub actions mutable action tags

### DIFF
--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -42,14 +42,14 @@ jobs:
           'P:\' | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Checkout llvm-project
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: llvm/llvm-project
           ref: ${{ env.BASE_BRANCH_NAME }}
           path: nightly/llvm-project
 
       - name: Checkout ELD
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ env.ELD_REPO }}
           ref: ${{ env.ELD_REF }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,14 +45,14 @@ jobs:
 
     steps:
       - name: Checkout llvm-project
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: llvm/llvm-project
           ref: ${{ env.BASE_BRANCH_NAME }}
           path: pr-${{ env.PR_NUMBER }}/llvm-project
 
       - name: Checkout qualcomm/eld PR branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/clang-format-pr.yml
+++ b/.github/workflows/clang-format-pr.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/cpp-linter-pr.yml
+++ b/.github/workflows/cpp-linter-pr.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -189,7 +189,7 @@ jobs:
 
       - name: Upload cpp-linter report artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
           # Stable artifact name referenced by PR comment and docs.
           name: cpp-linter-report

--- a/.github/workflows/docs-multiversion.yaml
+++ b/.github/workflows/docs-multiversion.yaml
@@ -24,14 +24,14 @@ jobs:
 
     steps:
       - name: Checkout llvm-project
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: llvm/llvm-project
           path: llvm-project
           ref: main
 
       - name: Checkout eld
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: llvm-project/llvm/tools/eld
           fetch-depth: 0
@@ -40,7 +40,7 @@ jobs:
         uses: ./llvm-project/llvm/tools/eld/.github/workflows/ConfigureBuildWorkflowENV
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 #v6.3.0
         with:
           python-version: '3.11'
 
@@ -79,7 +79,7 @@ jobs:
         run: cmake --build build --target eld-docs-multiversion
 
       - name: Checkout documentation branch
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: documentation
           path: docs-branch

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -21,14 +21,14 @@ jobs:
 
     steps:
       - name: Checkout llvm-project
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: llvm/llvm-project
           path: llvm-project
           ref: main
 
       - name: Checkout eld
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: llvm-project/llvm/tools/eld
           ref: main
@@ -37,7 +37,7 @@ jobs:
         uses: ./llvm-project/llvm/tools/eld/.github/workflows/ConfigureBuildWorkflowENV
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 #v6.3.0
         with:
           python-version: '3.11.4'
 

--- a/.github/workflows/nightly-musl-builder.yml
+++ b/.github/workflows/nightly-musl-builder.yml
@@ -20,7 +20,7 @@ jobs:
       ELD_SOURCE_DIR: llvm-project/llvm/tools/eld
     steps:
       - name: Checkout eld
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: llvm-project/llvm/tools/eld
 
@@ -131,7 +131,7 @@ jobs:
       ELD_SOURCE_DIR: ${{ github.workspace }}/llvm-project/llvm/tools/eld
     steps:
       - name: Checkout eld
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: llvm-project/llvm/tools/eld
 
@@ -206,7 +206,7 @@ jobs:
           CC=${{ matrix.arch }}-unknown-linux-musl${arm_toolchain_name_suffix}-clang make RUN_WRAP="$(pwd)/qemu-${{ matrix.arch }}-wrapper.sh"
 
       - name: Upload libc-test
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
           name: libc-test-${{ matrix.arch }}.zip
           retention-days: 2

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -54,7 +54,7 @@ jobs:
           free -h # or cat /proc/meminfo
 
       - name: Checkout llvm-project
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: llvm/llvm-project
           path: llvm-project
@@ -71,7 +71,7 @@ jobs:
           echo "::notice::Using base branch '${PR_BASE_REF}' for llvm-project checkout"
 
       - name: Checkout eld
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: llvm-project/llvm/tools/eld
           repository: ${{ env.ELD_REPO }}
@@ -83,7 +83,7 @@ jobs:
 
       - name: Restore ccache
         id: cache-ccache
-        uses: actions/cache/restore@v6
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           path: ${{ github.workspace }}/obj/ccache
           key: nightly-ccache-${{ runner.os }}-${{ github.run_id }}
@@ -229,7 +229,7 @@ jobs:
 
       - name: Save ccache
         if: always()
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           path: ${{ github.workspace }}/obj/ccache
           key: nightly-ccache-${{ runner.os }}-${{ github.run_id }}
@@ -257,7 +257,7 @@ jobs:
               -Jcvf eld-unstable.tar.xz eld-unstable
 
       - name: Upload toolchain tarball
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
           name: install-nightly-toolchain.tar.xz
           path: install-nightly-toolchain.tar.xz

--- a/.github/workflows/picolibc-builder.yml
+++ b/.github/workflows/picolibc-builder.yml
@@ -75,7 +75,7 @@ jobs:
           git clone --branch main --single-branch --depth 1 https://github.com/llvm/llvm-project ${{ github.workspace }}/llvm-project
 
       - name: Checkout ELD
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: llvm-project/llvm/tools/eld
 
@@ -167,7 +167,7 @@ jobs:
 
       - name: Upload toolchain tarball
         if: false
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
           name: install-${{ matrix.arch.name }}-toolchain.tar.xz
           path: install-${{ matrix.arch.name }}-toolchain.tar.xz
@@ -260,7 +260,7 @@ jobs:
 
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
           name: test-results-${{ matrix.arch.name }}
           path: |

--- a/.github/workflows/qualcomm-organization-repolinter.yml
+++ b/.github/workflows/qualcomm-organization-repolinter.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Verify repolinter config file is present
         id: check_files
         uses: andstor/file-existence-action@v3

--- a/.github/workflows/reviter.yml
+++ b/.github/workflows/reviter.yml
@@ -46,14 +46,14 @@ jobs:
           free -h # or cat /proc/meminfo
 
       - name: Checkout llvm-project
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: llvm/llvm-project
           path: llvm-project
           ref: main
 
       - name: Checkout eld
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: llvm-project/llvm/tools/eld
           ref: main

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -42,14 +42,14 @@ jobs:
           ./test_clang
 
       - name: Checkout llvm-project
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: llvm/llvm-project
           path: ./llvm-project/
           ref: main
 
       - name: Checkout eld
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: ./llvm-project/llvm/tools/eld
           ref: main
@@ -59,7 +59,7 @@ jobs:
 
       - name: Restore ccache
         id: cache-ccache
-        uses: actions/cache/restore@v6
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           path: ${{ github.workspace }}/obj/ccache
           key: sanitizer-ccache-${{ runner.os }}-${{ github.run_id }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Save ccache
         if: always()
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           path: ${{ github.workspace }}/obj/ccache
           key: sanitizer-ccache-${{ runner.os }}-${{ github.run_id }}

--- a/.github/workflows/update-build-dashboard-data.yml
+++ b/.github/workflows/update-build-dashboard-data.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout ELD
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: llvm-project/llvm/tools/eld
 

--- a/.github/workflows/zephyr-nightly.yml
+++ b/.github/workflows/zephyr-nightly.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout eld
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: llvm-project/llvm/tools/eld
 
@@ -59,7 +59,7 @@ jobs:
           ccache --version | head -1
 
       - name: Restore ccache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ matrix.target.arch }}-cpullvm${{ env.CPULLVM_VERSION }}-${{ github.run_id }}
@@ -110,7 +110,7 @@ jobs:
           ${CPULLVM_DIR}/bin/clang --version | head -1
 
       - name: Clone Zephyr
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: zephyrproject-rtos/zephyr
           path: zephyr
@@ -185,7 +185,7 @@ jobs:
 
       - name: Upload twister results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
           name: zephyr-twister-results-${{ matrix.target.board }}
           retention-days: 2
@@ -195,7 +195,7 @@ jobs:
 
       - name: Upload build artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
           name: zephyr-build-artifacts-${{ matrix.target.board }}
           retention-days: 2


### PR DESCRIPTION
Pin GitHub Actions to full 40-character commit SHAs to prevent supply-chain risks and resolve Semgrep finding.

Fix: qualcomm#1374