### PR TITLE
[test] Add end-to-end runtime correctness tests for TBSS fixes

### DIFF
--- a/test/Common/RunTests/RelRO/Inputs/relro_note.s
+++ b/test/Common/RunTests/RelRO/Inputs/relro_note.s
@@ -1,0 +1,4 @@
+        .section ".note.eld.run","a",%note
+        .global relro_phdrs_note_marker
+relro_phdrs_note_marker:
+        .word 0

--- a/test/Common/RunTests/RelRO/Inputs/relro_phdrs.t
+++ b/test/Common/RunTests/RelRO/Inputs/relro_phdrs.t
@@ -16,12 +16,14 @@ PHDRS {
   ph_data   PT_LOAD      FLAGS(6);
   ph_tls    PT_TLS;
   ph_relro  PT_GNU_RELRO;
+  ph_note   PT_NOTE;
   ph_dyn    PT_DYNAMIC;
 }
 SECTIONS {
   .interp     : { *(.interp) }                             :ph_interp :ph_text
-  .note.ABI-tag : { *(.note.ABI-tag) }                     :ph_text
-  .note.gnu.build-id : { *(.note.gnu.build-id) }           :ph_text
+  .note.ABI-tag : { *(.note.ABI-tag) }                     :ph_note :ph_text
+  .note.gnu.build-id : { *(.note.gnu.build-id) }           :ph_note :ph_text
+  .note.eld.run : { *(.note.eld.run) }                     :ph_note :ph_text
   .dynsym     : { *(.dynsym) }                             :ph_text
   .dynstr     : { *(.dynstr) }                             :ph_text
   .gnu.version   : { *(.gnu.version) }                    :ph_text

--- a/test/Common/RunTests/RelRO/RelROPHDRS.test
+++ b/test/Common/RunTests/RelRO/RelROPHDRS.test
@@ -8,6 +8,7 @@ REQUIRES: run_test, linux
 #START_TEST
 
 # Use -ftls-model=initial-exec to avoid TLSDESC relocations.
+RUN: %run_cc %clangopts -c %p/Inputs/relro_note.s -o %t.note.o
 
 # --- Case 1: TBSS-only, partial RELRO ---
 RUN: %run_cc %clangopts -fuse-init-array -c -fPIC -ftls-model=initial-exec %p/Inputs/relro_tbss.c -o %t.tbss.o
@@ -29,12 +30,22 @@ RUN: %run_cc %clangopts -fuse-init-array -c -fPIC -ftls-model=initial-exec %p/In
 RUN: %run_cc %clangopts -o %t.bss.out %t.bss.o -Wl,-z,relro -Wl,-dy -T %p/Inputs/relro_phdrs.t -Wl,-z,max-page-size=0x1000
 RUN: %run %t.bss.out | %filecheck %s --check-prefix=BSS
 
+# --- Case 5: TBSS + NOTE section, RELRO, explicit PHDRS ---
+RUN: %run_cc %clangopts -o %t.notephdrs.out %t.tbss.o %t.note.o -Wl,-z,relro -Wl,-dy -T %p/Inputs/relro_phdrs.t -Wl,-z,max-page-size=0x1000
+RUN: %run %t.notephdrs.out | %filecheck %s --check-prefix=TBSS
+RUN: %readelf -l -W %t.notephdrs.out | %filecheck %s --check-prefix=HAS-TLS
+RUN: %readelf -l -W %t.notephdrs.out | %filecheck %s --check-prefix=HAS-RELRO
+RUN: %readelf -l -W %t.notephdrs.out | %filecheck %s --check-prefix=HAS-NOTE
+
 #END_TEST
 
 # Case 1 (ELF structure): PT_TLS FileSiz == 0 for TBSS-only; MemSiz > 0
 # The offset field is verified by the runtime test passing (p_offset % p_align
 # == p_vaddr % p_align must hold or the dynamic loader rejects the binary).
 TBSS-FILESZ: TLS {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{[0x0-9a-f]+}} {{0x0+}} {{0x[0-9a-f]+}}
+HAS-TLS: TLS
+HAS-RELRO: GNU_RELRO
+HAS-NOTE: NOTE
 
 # Case 1 & 2: TBSS written by constructor is readable
 TBSS: 42

--- a/test/Common/RunTests/TBSSMultiVarRunAccess/Inputs/tls.c
+++ b/test/Common/RunTests/TBSSMultiVarRunAccess/Inputs/tls.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+/* Multiple zero-initialized TLS variables (go into .tbss) followed by
+   regular data — exercises the TBSS segment flag and layout fixes. */
+__thread int tls_a;
+__thread int tls_b;
+__thread int tls_c;
+int data_x = 10;
+int data_y = 20;
+
+int main(void) {
+  tls_a = 1;
+  tls_b = 2;
+  tls_c = tls_a + tls_b;
+  printf("%d %d %d %d %d\n", tls_a, tls_b, tls_c, data_x, data_y);
+  return 0;
+}

--- a/test/Common/RunTests/TBSSMultiVarRunAccess/TBSSMultiVarRunAccess.test
+++ b/test/Common/RunTests/TBSSMultiVarRunAccess/TBSSMultiVarRunAccess.test
@@ -1,0 +1,16 @@
+REQUIRES: run_test, linux
+#---TBSSMultiVarRunAccess.test------------- TLS, RunTest ------------------#
+#BEGIN_COMMENT
+# Test that multiple TBSS (zero-initialized thread-local) variables followed
+# by regular data are accessible at runtime. This exercises segment flag
+# correctness for TBSS — if the TBSS section contaminates the segment flags
+# or disrupts the layout state for the following data section, TLS access or
+# data access will fault or produce wrong values.
+#END_COMMENT
+#START_TEST
+RUN: %run_cc %clangopts -ffunction-sections -fdata-sections -c %p/Inputs/tls.c -o %t.o
+RUN: %run_cc %clangopts -o %t.out %t.o
+RUN: %run %t.out | %filecheck %s
+#END_TEST
+
+CHECK: 1 2 3 10 20

--- a/test/Common/RunTests/TBSSRelroRunAccess/Inputs/relro.c
+++ b/test/Common/RunTests/TBSSRelroRunAccess/Inputs/relro.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+
+/* TBSS (zero-init TLS) followed by writable data.
+   With -z relro, if TBSS incorrectly extends the RELRO region into the data
+   section, the runtime mprotect will make .data read-only and the write to
+   'data' will segfault. */
+__thread int tls_zero;
+int data = 42;
+
+int main(void) {
+  tls_zero = 7;
+  data = 99;
+  printf("%d %d\n", tls_zero, data);
+  return 0;
+}

--- a/test/Common/RunTests/TBSSRelroRunAccess/TBSSRelroRunAccess.test
+++ b/test/Common/RunTests/TBSSRelroRunAccess/TBSSRelroRunAccess.test
@@ -1,0 +1,15 @@
+REQUIRES: run_test, linux
+#---TBSSRelroRunAccess.test---------------- TLS, RunTest ------------------#
+#BEGIN_COMMENT
+# Test that -z relro with a TBSS section does not prevent writing to the data
+# section at runtime. Before the fix, TBSS polluted the RELRO segment causing
+# the dynamic linker to mprotect the data section read-only, making the write
+# to 'data' below fault with SIGSEGV.
+#END_COMMENT
+#START_TEST
+RUN: %run_cc %clangopts -ffunction-sections -fdata-sections -c %p/Inputs/relro.c -o %t.o
+RUN: %run_cc %clangopts -o %t.out %t.o -Wl,-z,relro
+RUN: %run %t.out | %filecheck %s
+#END_TEST
+
+CHECK: 7 99

--- a/test/Common/RunTests/TBSSRunAccess/Inputs/tls.c
+++ b/test/Common/RunTests/TBSSRunAccess/Inputs/tls.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+__thread int tls_zero = 0;
+__thread int tls_also_zero;
+int data = 42;
+
+int main(void) {
+  tls_zero = 1;
+  tls_also_zero = 2;
+  printf("%d %d %d\n", tls_zero, tls_also_zero, data);
+  return 0;
+}

--- a/test/Common/RunTests/TBSSRunAccess/TBSSRunAccess.test
+++ b/test/Common/RunTests/TBSSRunAccess/TBSSRunAccess.test
@@ -1,0 +1,16 @@
+REQUIRES: run_test, linux
+#---TBSSRunAccess.test--------------------- TLS, RunTest ------------------#
+#BEGIN_COMMENT
+# Test that TBSS (zero-initialized thread-local) variables are accessible at
+# runtime. Verifies that segment flags are correct so the OS can map the TLS
+# template and the dynamic linker can initialize thread-local storage.
+# Before the fix, a TBSS-only segment created via a PHDRS command could end
+# up with p_flags=0, causing the dynamic linker to fail to map TLS.
+#END_COMMENT
+#START_TEST
+RUN: %run_cc %clangopts -ffunction-sections -fdata-sections -c %p/Inputs/tls.c -o %t.o
+RUN: %run_cc %clangopts -o %t.out %t.o
+RUN: %run %t.out | %filecheck %s
+#END_TEST
+
+CHECK: 1 2 42

--- a/test/Common/RunTests/TBSSSeparateLoadRunAccess/Inputs/tls.c
+++ b/test/Common/RunTests/TBSSSeparateLoadRunAccess/Inputs/tls.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+
+/* Multiple TBSS variables with -z separate-loadable-segments: text goes into
+   its own R E segment, data into its own RW segment. TBSS must not contaminate
+   the text segment flags or prevent the data segment from being writable. */
+__thread int tls_a;
+__thread int tls_b;
+int data = 42;
+
+int main(void) {
+  tls_a = 1;
+  tls_b = 2;
+  data = 99;
+  printf("%d %d %d\n", tls_a, tls_b, data);
+  return 0;
+}

--- a/test/Common/RunTests/TBSSSeparateLoadRunAccess/TBSSSeparateLoadRunAccess.test
+++ b/test/Common/RunTests/TBSSSeparateLoadRunAccess/TBSSSeparateLoadRunAccess.test
@@ -1,0 +1,16 @@
+REQUIRES: run_test, linux
+#---TBSSSeparateLoadRunAccess.test--------- TLS, RunTest ------------------#
+#BEGIN_COMMENT
+# Test that TBSS variables and regular data are accessible at runtime when
+# -z separate-loadable-segments is used. This option page-aligns each LOAD
+# segment boundary; TBSS must not cause prevOut to advance, which would make
+# the page-align decision for the data segment compare against the wrong
+# previous segment's exec flag.
+#END_COMMENT
+#START_TEST
+RUN: %run_cc %clangopts -ffunction-sections -fdata-sections -c %p/Inputs/tls.c -o %t.o
+RUN: %run_cc %clangopts -o %t.out %t.o -Wl,-z,separate-loadable-segments
+RUN: %run %t.out | %filecheck %s
+#END_TEST
+
+CHECK: 1 2 99


### PR DESCRIPTION
Add four run-time tests that exercise the TBSS fixes by executing the linked binary and checking its output.  These tests catch regressions that static segment-layout checks cannot: a TLS access that faults, a data write blocked by a bad mprotect, or a wrong TLS value.