### PR TITLE
[Linker] Skip file emission when outputs are not generated

### DIFF
--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -219,6 +219,10 @@ public:
 
   bool hasOutputFileName() const { return OutputFileName.has_value(); }
 
+  void setEmitOutputFile(bool Enable = true) { EmitOutputFile = Enable; }
+
+  bool shouldEmitOutputFile() { return EmitOutputFile; }
+
   void setVerbose(int8_t PVerbose = 1);
 
   void setColor(bool PEnabled = true) { BColor = PEnabled; }
@@ -1421,6 +1425,7 @@ private:
   std::string LinkLaunchDirectory;
   bool ShowRMSectNameInDiag = false;
   bool UseDefaultPlugins = true;
+  bool EmitOutputFile = true;
 };
 
 } // namespace eld

--- a/include/eld/Support/Utils.h
+++ b/include/eld/Support/Utils.h
@@ -12,6 +12,8 @@
 namespace eld {
 namespace utility {
 const std::string toHex(uint64_t number);
+
+bool isNullDevice(const std::string &Path);
 } // namespace utility
 } // namespace eld
 

--- a/lib/Core/Linker.cpp
+++ b/lib/Core/Linker.cpp
@@ -208,6 +208,10 @@ bool Linker::link() {
     }
   }
 
+  // Skip if out file does not need to be emitted.
+  if (!ThisConfig->options().shouldEmitOutputFile())
+    return true;
+
   if (ThisModule->getPrinter()->isVerbose())
     ThisConfig->raise(Diag::emit_output_file)
         << ThisConfig->options().outputFileName();
@@ -765,57 +769,53 @@ bool Linker::emit() {
   if (layoutInfo)
     layoutInfo->recordOutputFileSize(OutputFileSize);
 
-  if (Path != "/dev/null" && Path != "NUL") {
-    std::error_code Ec;
-    int OutputFlag = 0;
-    if (Perm & 0x755)
-      OutputFlag = llvm::FileOutputBuffer::F_executable;
-    auto OutputOrError =
-        llvm::FileOutputBuffer::create(Path, OutputFileSize, OutputFlag);
-    // If there is an error, return with a fatal error message.
-    if (!OutputOrError) {
-      ThisConfig->raise(Diag::fatal_unwritable_output)
-          << Path << llvm::toString(OutputOrError.takeError());
-      return false;
-    }
-    {
-      LinkerProgress->incrementAndDisplayProgress();
-      eld::RegisterTimer T("Write All Sections", "Emit Output File",
-                           ThisConfig->options().printTimingStats());
-      ObjLinker->emitOutput(*OutputOrError.get());
-    }
-
+  std::error_code Ec;
+  int OutputFlag = 0;
+  if (Perm & 0x755)
+    OutputFlag = llvm::FileOutputBuffer::F_executable;
+  auto OutputOrError =
+      llvm::FileOutputBuffer::create(Path, OutputFileSize, OutputFlag);
+  // If there is an error, return with a fatal error message.
+  if (!OutputOrError) {
+    ThisConfig->raise(Diag::fatal_unwritable_output)
+        << Path << llvm::toString(OutputOrError.takeError());
+    return false;
+  }
+  {
     LinkerProgress->incrementAndDisplayProgress();
-    eld::Expected<void> ExpPostProcess =
-        ObjLinker->postProcessing(*OutputOrError.get());
-    if (!ExpPostProcess) {
-      ThisConfig->raiseDiagEntry(std::move(ExpPostProcess.error()));
-      return false;
-    }
+    eld::RegisterTimer T("Write All Sections", "Emit Output File",
+                         ThisConfig->options().printTimingStats());
+    ObjLinker->emitOutput(*OutputOrError.get());
+  }
 
-    // Update Build ID and sync
-    eld::Expected<void> E =
-        Backend->finalizeAndEmitBuildID(*OutputOrError.get());
-    if (!E) {
-      ThisConfig->raiseDiagEntry(std::move(E.error()));
-      return false;
-    }
+  LinkerProgress->incrementAndDisplayProgress();
+  eld::Expected<void> ExpPostProcess =
+      ObjLinker->postProcessing(*OutputOrError.get());
+  if (!ExpPostProcess) {
+    ThisConfig->raiseDiagEntry(std::move(ExpPostProcess.error()));
+    return false;
+  }
 
-    {
-      LinkerProgress->incrementAndDisplayProgress();
-      eld::RegisterTimer T("Commit File", "Emit Output File",
-                           ThisConfig->options().printTimingStats());
-      if (auto E = (*OutputOrError)->commit()) {
-        ThisConfig->raise(Diag::unable_to_write_output_file)
-            << Path << llvm::toString(std::move(E));
-        return false;
-      }
+  // Update Build ID and sync
+  eld::Expected<void> E = Backend->finalizeAndEmitBuildID(*OutputOrError.get());
+  if (!E) {
+    ThisConfig->raiseDiagEntry(std::move(E.error()));
+    return false;
+  }
+
+  {
+    LinkerProgress->incrementAndDisplayProgress();
+    eld::RegisterTimer T("Commit File", "Emit Output File",
+                         ThisConfig->options().printTimingStats());
+    if (auto E = (*OutputOrError)->commit()) {
+      ThisConfig->raise(Diag::unable_to_write_output_file)
+          << Path << llvm::toString(std::move(E));
+      return false;
     }
   }
 
   LinkerProgress->incrementAndDisplayProgress();
-  if ((Path != "/dev/null" && Path != "NUL") &&
-      (ThisConfig->options().verifyLink())) {
+  if (ThisConfig->options().verifyLink()) {
     llvm::sys::fs::file_status FileStatus;
     std::error_code Ec = llvm::sys::fs::status(Path, FileStatus);
     if (Ec != std::error_code()) {

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -37,6 +37,7 @@
 #include "eld/Support/StringUtils.h"
 #include "eld/Support/TargetRegistry.h"
 #include "eld/Support/TargetSelect.h"
+#include "eld/Support/Utils.h"
 #include "eld/Target/TargetMachine.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/LTO/LTO.h"
@@ -988,6 +989,8 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
     Config.options().setOutputFileName(outputFileName);
     Config.addCommandLine(Table->getOptionName(T::output_file),
                           outputFileName.c_str());
+    Config.options().setEmitOutputFile(
+        !eld::utility::isNullDevice(outputFileName));
   }
 
   std::string conflictingOption;

--- a/lib/Support/Utils.cpp
+++ b/lib/Support/Utils.cpp
@@ -14,5 +14,9 @@ const std::string toHex(uint64_t Number) {
   std::string HexNumber = Ss.str();
   return HexNumber;
 }
+
+bool isNullDevice(const std::string &Path) {
+  return Path == "/dev/null" || Path == "NUL";
+}
 } // namespace utility
 } // namespace eld


### PR DESCRIPTION
Simplify logic by bypassing file emission steps when no output files are produced. Improves code clarity and avoids unnecessary processing.

Fix: qualcomm#1370