### PR TITLE
[ARM] Implement R_ARM_LDR_PC_G0 relocation

### DIFF
--- a/docs/DeveloperDocs/ARM-Relocations.md
+++ b/docs/DeveloperDocs/ARM-Relocations.md
@@ -71,6 +71,7 @@ movt r0, #:upper16:symbol   @ R_ARM_THM_MOVT_ABS
 | `R_ARM_THM_MOVW_BREL` | `((S + A) \| T) - B(S)` | `[15:0]` | none |
 | `R_ARM_ALU_PC_G0` | `((S + A) \| T) - P` | top 8 bits, 4-bit rotation | none |
 | `R_ARM_LDR_PC_G2` | `S + A - P` | imm12 (bits 11:0) | [0, 4095] |
+| `R_ARM_LDR_PC_G0` | `S + A - P` | imm12 (bits 11:0) | [0, 4095] |
 
 `R_ARM_SBREL32` uses the same handler as `R_ARM_REL32` but produces a segment-base-relative offset. `R_ARM_PREL31` is used in ARM exception table entries.
 
@@ -129,7 +130,6 @@ The table below lists every relocation that ELD's ARM backend maps to the `unsup
 
 | Type | Relocation | ABI category | TODO |
 |------|-----------|--------------|------|
-| 4 | `R_ARM_LDR_PC_G0` | Group reloc — literal-pool PC-relative LDR (G0) | Implement LDR PC-group G0 |
 | 5 | `R_ARM_ABS16` | 16-bit absolute | Implement 16-bit absolute |
 | 6 | `R_ARM_ABS12` | 12-bit absolute (LDR/STR immediate) | Implement ABS12 |
 | 7 | `R_ARM_THM_ABS5` | Thumb 5-bit absolute (LDR/STR) | |

--- a/lib/Target/ARM/ARMRelocationFunctions.h
+++ b/lib/Target/ARM/ARMRelocationFunctions.h
@@ -52,12 +52,13 @@
   DECL_ARM_APPLY_RELOC_FUNC(relocAddPREL1)                                     \
   DECL_ARM_APPLY_RELOC_FUNC(relocAddPREL2)                                     \
   DECL_ARM_APPLY_RELOC_FUNC(relocLDR12)                                        \
+  DECL_ARM_APPLY_RELOC_FUNC(ldr_pc_g0)                                         \
   DECL_ARM_APPLY_RELOC_FUNC(unsupport)
 
 #define DECL_ARM_APPLY_RELOC_FUNC_PTRS                                         \
   {&none, 0, "R_ARM_NONE"}, {&call, 1, "R_ARM_PC24"},                          \
       {&abs32, 2, "R_ARM_ABS32"}, {&rel32, 3, "R_ARM_REL32"},                  \
-      {&unsupport, 4, "R_ARM_LDR_PC_G0"}, {&unsupport, 5, "R_ARM_ABS16"},      \
+      {&ldr_pc_g0, 4, "R_ARM_LDR_PC_G0"}, {&unsupport, 5, "R_ARM_ABS16"},      \
       {&unsupport, 6, "R_ARM_ABS12"}, {&unsupport, 7, "R_ARM_THM_ABS5"},       \
       {&unsupport, 8, "R_ARM_ABS8"}, {&rel32, 9, "R_ARM_SBREL32"},             \
       {&thm_call, 10, "R_ARM_THM_CALL"}, {&unsupport, 11, "R_ARM_THM_PC8"},    \

--- a/lib/Target/ARM/ARMRelocationFunctions.h
+++ b/lib/Target/ARM/ARMRelocationFunctions.h
@@ -52,6 +52,7 @@
   DECL_ARM_APPLY_RELOC_FUNC(thm_jump19)                                        \
   DECL_ARM_APPLY_RELOC_FUNC(alu_pc)                                            \
   DECL_ARM_APPLY_RELOC_FUNC(ldr_pc_g2)                                         \
+  DECL_ARM_APPLY_RELOC_FUNC(ldr_pc_g0)                                         \
   DECL_ARM_APPLY_RELOC_FUNC(relocAddPREL1)                                     \
   DECL_ARM_APPLY_RELOC_FUNC(relocAddPREL2)                                     \
   DECL_ARM_APPLY_RELOC_FUNC(relocLDR12)                                        \
@@ -91,6 +92,7 @@
   Func(llvm::ELF::R_ARM_THM_JUMP19, thm_jump19, "R_ARM_THM_JUMP19")            \
   Func(llvm::ELF::R_ARM_ALU_PC_G0, alu_pc, "R_ARM_ALU_PC_G0")                  \
   Func(llvm::ELF::R_ARM_LDR_PC_G2, ldr_pc_g2, "R_ARM_LDR_PC_G2")               \
+  Func(llvm::ELF::R_ARM_LDR_PC_G0, ldr_pc_g0, "R_ARM_LDR_PC_G0")               \
   Func(llvm::ELF::R_ARM_THM_MOVW_BREL_NC, thm_movw_brel,                       \
        "R_ARM_THM_MOVW_BREL_NC")                                               \
   Func(llvm::ELF::R_ARM_THM_MOVT_BREL, thm_movt_prel, "R_ARM_THM_MOVT_BREL")   \

--- a/lib/Target/ARM/ARMRelocator.cpp
+++ b/lib/Target/ARM/ARMRelocator.cpp
@@ -1015,6 +1015,11 @@ static Relocator::Result ldr_pc_group(Relocation &pReloc, ARMRelocator &pParent,
   return Relocator::OK;
 }
 
+// R_ARM_LDR_PC_G0: S + A - P
+Relocator::Result ldr_pc_g0(Relocation &pReloc, ARMRelocator &pParent) {
+  return ldr_pc_group(pReloc, pParent, 0);
+}
+
 // R_ARM_LDR_PC_G2: S + A - P
 Relocator::Result ldr_pc_g2(Relocation &pReloc, ARMRelocator &pParent) {
   return ldr_pc_group(pReloc, pParent, 2);

--- a/lib/Target/ARM/ARMRelocator.cpp
+++ b/lib/Target/ARM/ARMRelocator.cpp
@@ -984,6 +984,45 @@ Relocator::Result abs32(Relocation &pReloc, ARMRelocator &pParent) {
   return Relocator::OK;
 }
 
+// R_ARM_LDR_PC_G0: S + A - P
+// See ARM IHI0044 Table 4-15.
+// R_ARM_LDR_PC_Gn is S + A - P, we have ((S + A) | T) - P, if S is a
+// function then addr is 0 (modulo 2) and Pa is 0 (modulo 4) so we can
+// clear bottom bit to recover S + A - P.
+// LDR (literal): U bit = bit23, imm12 = bits[11:0]
+Relocator::Result ldr_pc_g0(Relocation &pReloc, ARMRelocator &pParent) {
+  Relocator::Address S = pParent.getSymValue(&pReloc);
+  Relocator::Address P = pReloc.place(pParent.module());
+
+  // Extract addend from LDR instruction (imm12 field with sign from U bit)
+  bool isAdd = pReloc.target() & 0x00800000;
+  int32_t instrAddend = isAdd ? (int32_t)(pReloc.target() & 0xfff)
+                              : -(int32_t)(pReloc.target() & 0xfff);
+  Relocator::DWord A = instrAddend + pReloc.addend();
+
+  // Clear thumb bit if symbol is a function
+  if (pReloc.symInfo()->type() == ResolveInfo::Function)
+    S &= ~0x1;
+
+  int64_t imm = (int64_t)(S + A) - (int64_t)P;
+
+  // LDR (literal): U bit = bit23 (1=add, 0=subtract)
+  uint32_t u = 0x00800000; // U=1
+  if (imm < 0) {
+    imm = -imm;
+    u = 0x0; // U=0
+  }
+
+  if (imm > 0xfff) {
+    pReloc.issueUnsignedOverflow(pParent, imm, 0, 0xfff);
+    return ARMRelocator::Overflow;
+  }
+
+  // Keep existing bits, set U bit and imm12
+  pReloc.target() = (pReloc.target() & 0xff7ff000) | u | imm;
+  return Relocator::OK;
+}
+
 // R_ARM_REL32: ((S + A) | T) - P
 // R_ARM_SBREL32: ((S + A) | T) - B(S)
 Relocator::Result rel32(Relocation &pReloc, ARMRelocator &pParent) {

--- a/test/ARM/FromLLD/arm-ldrlit-err.s
+++ b/test/ARM/FromLLD/arm-ldrlit-err.s
@@ -1,0 +1,32 @@
+// REQUIRES: arm
+// RUN: llvm-mc --triple=armv7a-none-eabi --arm-add-build-attributes -filetype=obj -o %t.o %s
+// RUN: %not %link -n %t.o -o %t 2>&1 | %filecheck %s
+
+ .section .text.0, "ax", %progbits
+ .thumb_func
+ .balign 4
+low:
+  bx lr
+  nop
+  nop
+  nop
+  nop
+  nop
+
+ .section .text.1, "ax", %progbits
+ .global _start
+ .arm
+_start:
+// CHECK: Error: {{.*}}(.text.1{{.*}}): relocation R_ARM_LDR_PC_G0 out of range: 4096 is not in [0, 4095]
+ .inst 0xe51f0ff4
+ .reloc 0, R_ARM_LDR_PC_G0, low
+// CHECK: Error: {{.*}}(.text.1+0x4): relocation R_ARM_LDR_PC_G0 out of range: 4096 is not in [0, 4095]
+ .inst 0xe59f0ffc
+ .reloc 4, R_ARM_LDR_PC_G0, high
+
+ .section .text.2
+ .thumb_func
+ .balign 4
+high:
+ bx lr
+ nop

--- a/test/ARM/FromLLD/arm-ldrlit.s
+++ b/test/ARM/FromLLD/arm-ldrlit.s
@@ -1,0 +1,125 @@
+// REQUIRES: arm
+// RUN: llvm-mc --triple=armv7a-none-eabi --arm-add-build-attributes -filetype=obj -o %t.o %s
+// RUN: echo "SECTIONS { \
+// RUN:                 .rodata.low 0x8012  : { *(.rodata.low) } \
+// RUN:                 .text.low   0x8f00  : { *(.text.low) } \
+// RUN:                 .text.neg   0x9000  : { *(.text.neg) } \
+// RUN:                 .text.pos   0x10000 : { *(.text.pos) } \
+// RUN:                 .text.high  0x10100 : { *(.text.high) } \
+// RUN:                 .data_high  0x1100f : { *(.data.high) } \
+// RUN:               } " > %t.script
+// RUN: %link -n --script %t.script %t.o -o %t
+// RUN: %readelf --symbols %t | %filecheck %s --check-prefix=SYMS
+// RUN: %readelf -x .text.neg %t | %filecheck %s --check-prefix=NEG
+// RUN: %readelf -x .text.pos %t | %filecheck %s --check-prefix=POS
+
+/// Test the various legal cases for the R_ARM_LDR_PC_G0 relocation
+/// Range is +- 4095 bytes
+/// The Thumb bit for function symbols is ignored
+ .section .rodata.low, "a", %progbits
+dat1:
+ .byte 0
+dat2:
+ .byte 1
+dat3:
+ .byte 2
+dat4:
+ .byte 3
+
+ .section .text.low, "ax", %progbits
+ .balign 4
+ .global target1
+ .type target1, %function
+target1:
+ bx lr
+ .type target2, %function
+target2:
+ bx lr
+
+ .section .text.neg, "ax", %progbits
+ .balign 4
+ .global _start
+ .type _start, %function
+_start:
+/// ldr r0, dat1  [pc, #-4086]
+ .inst 0xe51f0008
+ .reloc 0, R_ARM_LDR_PC_G0, dat1
+/// ldr r1, dat2  [pc, #-4089]
+ .inst 0xe51f1008
+ .reloc 4, R_ARM_LDR_PC_G0, dat2
+/// ldr r2, dat3  [pc, #-4092]
+ .inst 0xe51f2008
+ .reloc 8, R_ARM_LDR_PC_G0, dat3
+/// ldr r3, dat4  [pc, #-4095]
+ .inst 0xe51f3008
+ .reloc 0xc, R_ARM_LDR_PC_G0, dat4
+/// ldr r0, target1  [pc, #-280]
+ .inst 0xe51f0008
+ .reloc 0x10, R_ARM_LDR_PC_G0, target1
+/// ldr r1, target2  [pc, #-280]
+ .inst 0xe51f1008
+ .reloc 0x14, R_ARM_LDR_PC_G0, target2
+
+ .section .text.pos, "ax", %progbits
+ .balign 4
+ .global pos
+ .type pos, %function
+pos:
+/// ldr r2, target3  [pc, #248]
+ .inst 0xe51f2008
+ .reloc 0, R_ARM_LDR_PC_G0, target3
+/// ldr r3, target4  [pc, #248]
+ .inst 0xe51f3008
+ .reloc 4, R_ARM_LDR_PC_G0, target4
+/// ldr r0, dat5  [pc, #4095]
+ .inst 0xe51f0008
+ .reloc 8, R_ARM_LDR_PC_G0, dat5
+/// ldr r1, dat6  [pc, #4092]
+ .inst 0xe51f1008
+ .reloc 0xc, R_ARM_LDR_PC_G0, dat6
+/// ldr r2, dat7  [pc, #4089]
+ .inst 0xe51f2008
+ .reloc 0x10, R_ARM_LDR_PC_G0, dat7
+/// ldr r3, dat8  [pc, #4086]
+ .inst 0xe51f3008
+ .reloc 0x14, R_ARM_LDR_PC_G0, dat8
+/// ldr r4, dat5+8  [pc, #4087]
+ .inst 0xe59f4000
+ .reloc 0x18, R_ARM_LDR_PC_G0, dat5
+
+ .section .text.high, "ax", %progbits
+ .balign 4
+ .type target3, %function
+ .global target3
+target3:
+ bx lr
+ .thumb_func
+target4:
+ bx lr
+
+ .section .data.high, "aw", %progbits
+dat5:
+ .byte 0
+dat6:
+ .byte 1
+dat7:
+ .byte 2
+dat8:
+ .byte 3
+
+// SYMS: 00008012 {{.*}} dat1
+// SYMS: 00008013 {{.*}} dat2
+// SYMS: 00008014 {{.*}} dat3
+// SYMS: 00008015 {{.*}} dat4
+// SYMS: 0001100f {{.*}} dat5
+// SYMS: 00011010 {{.*}} dat6
+// SYMS: 00011011 {{.*}} dat7
+// SYMS: 00011012 {{.*}} dat8
+
+/// Negative offsets: U=0, ldr r0 [pc, #-4086], r1 [pc, #-4089] etc
+// NEG: f60f1fe5 f91f1fe5 fc2f1fe5 ff3f1fe5
+// NEG: 18011fe5 18111fe5
+
+/// Positive offsets: U=1
+// POS: f8209fe5 f8309fe5 ff0f9fe5 fc1f9fe5
+// POS: f92f9fe5 f63f9fe5 f74f9fe5

--- a/test/ARM/RunTests/R_ARM_LDR_PC_G0/Inputs/main.c
+++ b/test/ARM/RunTests/R_ARM_LDR_PC_G0/Inputs/main.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+extern int get_target(void);
+
+int main() {
+  printf("target = %d\n", get_target());
+  return 0;
+}

--- a/test/ARM/RunTests/R_ARM_LDR_PC_G0/Inputs/main.s
+++ b/test/ARM/RunTests/R_ARM_LDR_PC_G0/Inputs/main.s
@@ -1,0 +1,24 @@
+.syntax unified
+.arm
+
+.data
+.globl target
+.type target, %object
+target:
+    .word 42
+
+.globl ldr_pc_g0_slot
+.type ldr_pc_g0_slot, %object
+ldr_pc_g0_slot:
+    .reloc ldr_pc_g0_slot, R_ARM_LDR_PC_G0, target
+    .word 0
+
+.text
+.globl get_target
+.type get_target, %function
+get_target:
+    ldr r1, =ldr_pc_g0_slot
+    ldr r0, [r1]
+    sub r1, r1, r0
+    ldr r0, [r1]
+    bx lr

--- a/test/ARM/RunTests/R_ARM_LDR_PC_G0/Inputs/startup.s
+++ b/test/ARM/RunTests/R_ARM_LDR_PC_G0/Inputs/startup.s
@@ -1,0 +1,5 @@
+.global _start
+_start:
+  bl main
+  mov r7, #1
+  swi 0

--- a/test/ARM/RunTests/R_ARM_LDR_PC_G0/R_ARM_LDR_PC_G0.test
+++ b/test/ARM/RunTests/R_ARM_LDR_PC_G0/R_ARM_LDR_PC_G0.test
@@ -1,0 +1,16 @@
+REQUIRES: run_test
+#---R_ARM_LDR_PC_G0.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+# Test the ARM R_ARM_LDR_PC_G0 relocation at runtime.
+# Verifies that the relocation correctly encodes the PC-relative offset
+# to target, and the value 42 can be loaded via the relocation slot.
+#END_COMMENT
+#START_TEST
+RUN: %run_cc -nostdlib -c -o %t.main.o %p/Inputs/main.s
+RUN: %readelf -r %t.main.o | %filecheck %s --check-prefix RELOCS
+RUN: %run_cc -c -o %t.driver.o %p/Inputs/main.c
+RUN: %run_cc -static -o %t.static.out %t.main.o %t.driver.o
+RUN: %run %t.static.out | %filecheck %s
+RELOCS: R_ARM_LDR_PC_G0 {{.*}} target
+CHECK: target = 42
+#END_TEST

--- a/test/ARM/standalone/R_ARM_LDR_PC_G0/Inputs/ldr.s
+++ b/test/ARM/standalone/R_ARM_LDR_PC_G0/Inputs/ldr.s
@@ -1,0 +1,15 @@
+.syntax unified
+.arm
+
+/* target data object */
+.globl target
+.type target, %object
+target:
+    .word 42
+
+/* data slot with R_ARM_LDR_PC_G0 relocation applied */
+.globl ldr_pc_g0_slot
+.type ldr_pc_g0_slot, %object
+ldr_pc_g0_slot:
+    .reloc ldr_pc_g0_slot, R_ARM_LDR_PC_G0, target
+    .word 0

--- a/test/ARM/standalone/R_ARM_LDR_PC_G0/Inputs/main.c
+++ b/test/ARM/standalone/R_ARM_LDR_PC_G0/Inputs/main.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+extern int target;
+extern int ldr_pc_g0_slot;
+
+int main() {
+  printf("target = %d\n", target);
+  return target == 42 ? 0 : 1;
+}

--- a/test/ARM/standalone/R_ARM_LDR_PC_G0/Inputs/main.s
+++ b/test/ARM/standalone/R_ARM_LDR_PC_G0/Inputs/main.s
@@ -1,0 +1,20 @@
+.syntax unified
+.arm
+
+.globl target
+.type target, %object
+target:
+    .word 0
+
+.globl ldr_pc_g0_slot
+.type ldr_pc_g0_slot, %object
+ldr_pc_g0_slot:
+    .reloc ldr_pc_g0_slot, R_ARM_LDR_PC_G0, target
+    .word 0
+
+.text
+.globl main
+.type main, %function
+main:
+    mov r0, #0
+    bx  lr

--- a/test/ARM/standalone/R_ARM_LDR_PC_G0/Inputs/overflow.s
+++ b/test/ARM/standalone/R_ARM_LDR_PC_G0/Inputs/overflow.s
@@ -1,0 +1,14 @@
+.syntax unified
+.arm
+
+.section .text.1, "ax", %progbits
+.globl overflow_func
+.type overflow_func, %function
+overflow_func:
+    .reloc 0, R_ARM_LDR_PC_G0, overflow_target
+    .inst 0xe51f0008
+    bx lr
+
+.section .text.2, "ax", %progbits
+overflow_target:
+    .word 0

--- a/test/ARM/standalone/R_ARM_LDR_PC_G0/Inputs/overflow.t
+++ b/test/ARM/standalone/R_ARM_LDR_PC_G0/Inputs/overflow.t
@@ -1,0 +1,4 @@
+SECTIONS {
+  .text.1 0x10000 : { *(.text.1) }
+  .text.2 0x15000 : { *(.text.2) }
+}

--- a/test/ARM/standalone/R_ARM_LDR_PC_G0/R_ARM_LDR_PC_G0.test
+++ b/test/ARM/standalone/R_ARM_LDR_PC_G0/R_ARM_LDR_PC_G0.test
@@ -1,0 +1,11 @@
+#---R_ARM_LDR_PC_G0.test--------------------- Executable ------------------#
+#BEGIN_COMMENT
+# Verify R_ARM_LDR_PC_G0 relocation is supported and correctly applied.
+# Formula: S + A - P encoded in LDR (literal) instruction.
+#END_COMMENT
+#START_TEST
+RUN: %clangas -c %p/Inputs/main.s -o %t.o
+RUN: %link %linkopts -march arm -static %t.o -o %t.out
+RUN: %readelf -x .text %t.out | %filecheck %s
+CHECK: 00000000 04000000
+#END_TEST

--- a/test/ARM/standalone/R_ARM_LDR_PC_G0/R_ARM_LDR_PC_G0_Overflow.test
+++ b/test/ARM/standalone/R_ARM_LDR_PC_G0/R_ARM_LDR_PC_G0_Overflow.test
@@ -1,0 +1,11 @@
+#---R_ARM_LDR_PC_G0_Overflow.test--------------------- Executable ------------------#
+#BEGIN_COMMENT
+# Verify R_ARM_LDR_PC_G0 reports overflow when offset exceeds 4095 bytes.
+# Uses linker script to place sections more than 4095 bytes apart.
+#END_COMMENT
+#START_TEST
+RUN: %clangas -c %p/Inputs/overflow.s -o %t.o
+RUN: %not %link %linkopts -march arm -static \
+RUN:   -T %p/Inputs/overflow.t %t.o -o %t.out 2>&1 | %filecheck %s
+CHECK: R_ARM_LDR_PC_G0 out of range
+#END_TEST


### PR DESCRIPTION
Implement the `apply` function for `R_ARM_LDR_PC_G0` by reusing the  shared `ldr_pc_group` helper (group=0), which encodes the result of `S + A - P` into the LDR (literal) instruction format. The implementation sets the `U` bit (bit 23) based on the sign of the offset and encodes the absolute value into the 12-bit immediate field (`imm12`).

Fixes #1336 

cc @quic-seaswara @quic-areg @parth-07 @Steven6798 
