### PR TITLE
[AArch64] Fix TLSDESC relaxation for non-preemptible symbols

### DIFF
--- a/lib/Target/AArch64/AArch64Relocator.cpp
+++ b/lib/Target/AArch64/AArch64Relocator.cpp
@@ -331,7 +331,7 @@ void AArch64Relocator::scanLocalReloc(InputFile &pInput, Relocation &pReloc,
     if (rsym->reserved() & ReserveGOT)
       return;
 
-    if (config().isCodeStatic()) {
+    if (config().isCodeStatic() || config().isBuildingExecutable()) {
       AArch64GOT *G = m_Target.createGOT(GOT::TLS_IE, Obj, rsym);
       rsym->setReserved(rsym->reserved() | ReserveGOT);
       G->setValueType(GOT::TLSStaticSymbolValue);
@@ -565,7 +565,8 @@ void AArch64Relocator::scanGlobalReloc(InputFile &pInput, Relocation &pReloc,
     if (rsym->reserved() & ReserveGOT)
       return;
 
-    if (config().isCodeStatic()) {
+    if (config().isCodeStatic() || (config().isBuildingExecutable() &&
+                                    !m_Target.isSymbolPreemptible(*rsym))) {
       AArch64GOT *G = m_Target.createGOT(GOT::TLS_IE, Obj, rsym);
       rsym->setReserved(rsym->reserved() | ReserveGOT);
       G->setValueType(GOT::TLSStaticSymbolValue);
@@ -1220,12 +1221,24 @@ Relocator::Result tls_tprel(Relocation &pReloc, AArch64Relocator &pParent) {
   return Relocator::OK;
 }
 
+// Returns true when a TLSDESC relocation was resolved statically at link
+// time (i.e. the GOT entry holds a TP-relative offset, not a descriptor
+// pair).  This happens for static executables and for non-preemptible
+// symbols in dynamic executables; in both cases the TLSDESC instruction
+// sequence must be converted to the IE movz/movk/nop pattern.
+bool AArch64Relocator::isTLSDescStatic(Relocation &pReloc) const {
+  if (!(pReloc.symInfo()->reserved() & Relocator::ReserveGOT))
+    return true;
+  AArch64GOT *G = getTarget().findEntryInGOT(pReloc.symInfo());
+  return G && G->getValueType() == GOT::TLSStaticSymbolValue;
+}
+
 // R_AARCH64_TLSDESC_ADR_PAGE21 : PAGE(G(GTLSDESC(S+A))) - PAGE(P)
 Relocator::Result tls_tlsdesc_page(Relocation &pReloc,
                                    AArch64Relocator &pParent) {
   Relocator::DWord A = pReloc.addend();
 
-  if (!(pReloc.symInfo()->reserved() & Relocator::ReserveGOT)) {
+  if (pParent.isTLSDescStatic(pReloc)) {
     Relocator::DWord X =
         pParent.getSymValue(&pReloc) + AArch64LDBackend::getStaticTCBSize();
     // Convert to movz
@@ -1251,10 +1264,10 @@ Relocator::Result tls_tlsdesc_lo(Relocation &pReloc,
                                  AArch64Relocator &pParent) {
   Relocator::DWord A = pReloc.addend();
 
-  if (!(pReloc.symInfo()->reserved() & Relocator::ReserveGOT)) {
+  if (pParent.isTLSDescStatic(pReloc)) {
     Relocator::DWord X =
         pParent.getSymValue(&pReloc) + AArch64LDBackend::getStaticTCBSize();
-    // Convert to movk, save to x0
+    // Convert to movk with x0 as destination
     uint32_t movk = 0xF2800000;
     pReloc.target() = helper_reencode_movzk_imm(movk, X);
     return Relocator::OK;
@@ -1266,10 +1279,6 @@ Relocator::Result tls_tlsdesc_lo(Relocation &pReloc,
   Relocator::DWord GX = helper_get_page_offset(GOT_S + A);
   pReloc.target() = helper_reencode_ldst_pos_imm(pReloc.target(), GX >> 3);
 
-  // Convert Rt to X0 if static
-  if (pParent.config().isCodeStatic())
-    pReloc.target() = pReloc.target() & ~0x1F;
-
   return Relocator::OK;
 }
 
@@ -1277,7 +1286,7 @@ Relocator::Result tls_tlsdesc_lo(Relocation &pReloc,
 Relocator::Result tls_tlsdesc_add(Relocation &pReloc,
                                   AArch64Relocator &pParent) {
   Relocator::DWord A = pReloc.addend();
-  if (pParent.config().isCodeStatic()) {
+  if (pParent.isTLSDescStatic(pReloc)) {
     // Convert to nop
     pReloc.target() = 0xD503201F;
     return Relocator::OK;
@@ -1294,7 +1303,7 @@ Relocator::Result tls_tlsdesc_add(Relocation &pReloc,
 
 // R_AARCH64_TLSDESC_CALL
 Relocator::Result tls_call(Relocation &pReloc, AArch64Relocator &pParent) {
-  if (pParent.config().isCodeStatic()) {
+  if (pParent.isTLSDescStatic(pReloc)) {
     // Convert to nop
     pReloc.target() = 0xD503201F;
     return Relocator::OK;

--- a/lib/Target/AArch64/AArch64Relocator.h
+++ b/lib/Target/AArch64/AArch64Relocator.h
@@ -60,6 +60,8 @@ public:
 
   Size getSize(Relocation::Type pType) const override;
 
+  bool isTLSDescStatic(Relocation &pReloc) const;
+
   /// scanRelocation - determine the empty entries are needed or not and create
   /// the empty entries if needed.
   /// For AArch64, following entries are check to create:

--- a/test/AArch64/standalone/TLS_DESC/DESC.test
+++ b/test/AArch64/standalone/TLS_DESC/DESC.test
@@ -1,10 +1,16 @@
 RUN: %clangas %clangasopts -filetype obj -target-cpu generic -target-feature +neon -mrelax-all %p/Inputs/t.s -o %t.o
 RUN: %link %linkopts  -march aarch64 -static %t.o -z max-page-size=0x1000 -o %t.out
-RUN: llvm-objdump -d %t.out | %filecheck %s
+RUN: %objdump -d %t.out | %filecheck %s
 
+# Static linking converts TLSDESC to IE inline (movz/movk/nop/nop) — no GOT
+# access needed, TP-relative offset is encoded directly in the instructions.
 #CHECK: {{.*}} <_test_tls_desc>:
-#CHECK: {{.*}} adrp    x0, 0x1000
-#CHECK: {{.*}} ldr     x0, [x0]
+#CHECK: {{.*}} movz    x0, #0x0, lsl #16
+#CHECK: {{.*}} movk    x0, #0x10
+#CHECK: {{.*}} nop
+#CHECK: {{.*}} nop
 #CHECK: {{.*}} <_test_tls_desc_local>:
-#CHECK: {{.*}} adrp    x0, 0x1000
-#CHECK: {{.*}} ldr     x0, [x0, #0x8]
+#CHECK: {{.*}} movz    x0, #0x0, lsl #16
+#CHECK: {{.*}} movk    x0, #0x14
+#CHECK: {{.*}} nop
+#CHECK: {{.*}} nop

--- a/test/AArch64/standalone/TLS_DESC/DESC_hidden.test
+++ b/test/AArch64/standalone/TLS_DESC/DESC_hidden.test
@@ -1,0 +1,24 @@
+#---DESC_hidden.test-------------------------------------------------------#
+#BEGIN_COMMENT
+# Verify that a hidden-visibility TLS symbol accessed via TLSDESC is relaxed
+# to the IE inline sequence (movz/movk/nop/nop) when linking as a dynamic
+# executable (-dy) or as PIE.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -target aarch64 -fpic -c %p/Inputs/tdesc_relax.c     -o %t.relax.o
+RUN: %clang %clangopts -target aarch64 -fpic -c %p/Inputs/tdesc_relax_def.c -o %t.def.o
+
+# Dynamic executable (-dy)
+RUN: %link %linkopts -march aarch64 -dy %t.relax.o %t.def.o -z max-page-size=0x1000 -o %t_dy.out
+RUN: %objdump -d %t_dy.out | %filecheck %s --check-prefix=IE
+
+# PIE
+RUN: %link %linkopts -march aarch64 -pie %t.relax.o %t.def.o -z max-page-size=0x1000 -o %t_pie.out
+RUN: %objdump -d %t_pie.out | %filecheck %s --check-prefix=IE
+
+IE: <get_tls>:
+IE:      movz    x0,
+IE-NEXT: movk    x0,
+IE-NEXT: nop
+IE-NEXT: nop
+#END_TEST

--- a/test/AArch64/standalone/TLS_DESC/DESC_pie.test
+++ b/test/AArch64/standalone/TLS_DESC/DESC_pie.test
@@ -1,0 +1,17 @@
+#---DESC_pie.test----------------------------------------------------------#
+#BEGIN_COMMENT
+# Verify that a hidden-visibility TLS symbol accessed via TLSDESC is relaxed
+# to the IE inline sequence (movz/movk/nop/nop) when linking as PIE.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -target aarch64 -fpic -c %p/Inputs/tdesc_relax.c     -o %t.relax.o
+RUN: %clang %clangopts -target aarch64 -fpic -c %p/Inputs/tdesc_relax_def.c -o %t.def.o
+RUN: %link %linkopts -march aarch64 -pie %t.relax.o %t.def.o -z max-page-size=0x1000 -o %t.out
+RUN: %objdump -d %t.out | %filecheck %s
+
+CHECK: <get_tls>:
+CHECK:      movz    x0,
+CHECK-NEXT: movk    x0,
+CHECK-NEXT: nop
+CHECK-NEXT: nop
+#END_TEST

--- a/test/AArch64/standalone/TLS_DESC/DESC_so.test
+++ b/test/AArch64/standalone/TLS_DESC/DESC_so.test
@@ -1,0 +1,20 @@
+#---DESC_so.test-----------------------------------------------------------#
+#BEGIN_COMMENT
+# Verify TLSDESC relocation emission when building a shared object.
+#
+# In a shared object both default-visibility (preemptible) and
+# hidden-visibility (non-preemptible) TLS symbols are accessed via the GD
+# model and receive R_AARCH64_TLSDESC dynamic relocations.  The dynamic
+# linker resolves both at load time; relaxation to IE only happens when
+# linking an executable or PIE.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -target aarch64 -fpic -c %p/Inputs/tdesc_so.c -o %t.o
+RUN: %link %linkopts -march aarch64 -shared %t.o -o %t.so
+RUN: %readelf -r %t.so | %filecheck %s
+
+# Both the preemptible and the non-preemptible symbol must have a
+# R_AARCH64_TLSDESC dynamic relocation in the shared object.
+CHECK: R_AARCH64_TLSDESC{{.*}}tls_preemptible
+CHECK: R_AARCH64_TLSDESC{{.*}}tls_nonpreemptible
+#END_TEST

--- a/test/AArch64/standalone/TLS_DESC/Inputs/tdesc_relax.c
+++ b/test/AArch64/standalone/TLS_DESC/Inputs/tdesc_relax.c
@@ -1,0 +1,3 @@
+extern __thread int tls_var;
+
+int get_tls(void) { return tls_var; }

--- a/test/AArch64/standalone/TLS_DESC/Inputs/tdesc_relax_def.c
+++ b/test/AArch64/standalone/TLS_DESC/Inputs/tdesc_relax_def.c
@@ -1,0 +1,1 @@
+__attribute__((visibility("hidden"))) __thread int tls_var;

--- a/test/AArch64/standalone/TLS_DESC/Inputs/tdesc_so.c
+++ b/test/AArch64/standalone/TLS_DESC/Inputs/tdesc_so.c
@@ -1,0 +1,8 @@
+/* Preemptible: default visibility, accessible from outside the DSO. */
+__thread int tls_preemptible = 10;
+
+/* Non-preemptible: hidden visibility, resolved at DSO link time. */
+__attribute__((visibility("hidden"))) __thread int tls_nonpreemptible = 20;
+
+int get_preemptible(void) { return tls_preemptible; }
+int get_nonpreemptible(void) { return tls_nonpreemptible; }

--- a/test/Common/RunTests/RelRO/RelROGDTBSSBss.test
+++ b/test/Common/RunTests/RelRO/RelROGDTBSSBss.test
@@ -1,5 +1,4 @@
 REQUIRES: run_test, linux
-UNSUPPORTED: aarch64
 #---RelROGDTBSSBss.test--------------------- Executable------------------#
 #BEGIN_COMMENT
 # Runtime test: TBSS + non-TLS BSS with partial RELRO (-z relro), GD TLS model.

--- a/test/Common/RunTests/RelRO/RelROGDTBSSOnly.test
+++ b/test/Common/RunTests/RelRO/RelROGDTBSSOnly.test
@@ -1,5 +1,4 @@
 REQUIRES: run_test, linux
-UNSUPPORTED: aarch64
 #---RelROGDTBSSOnly.test--------------------- Executable------------------#
 #BEGIN_COMMENT
 # Runtime test: TBSS-only with partial RELRO (-z relro), GD TLS model.

--- a/test/Common/RunTests/RelRO/RelROGDTBSSOnlyNow.test
+++ b/test/Common/RunTests/RelRO/RelROGDTBSSOnlyNow.test
@@ -1,5 +1,4 @@
 REQUIRES: run_test, linux
-UNSUPPORTED: aarch64
 #---RelROGDTBSSOnlyNow.test--------------------- Executable------------------#
 #BEGIN_COMMENT
 # Runtime test: TBSS-only with full RELRO (-z relro -z now), GD TLS model.

--- a/test/Common/RunTests/RelRO/RelROGDTBSSTData.test
+++ b/test/Common/RunTests/RelRO/RelROGDTBSSTData.test
@@ -1,5 +1,4 @@
 REQUIRES: run_test, linux
-UNSUPPORTED: aarch64
 #---RelROGDTBSSTData.test--------------------- Executable------------------#
 #BEGIN_COMMENT
 # Runtime test: TBSS + TDATA with partial RELRO (-z relro), GD TLS model.


### PR DESCRIPTION
When building a dynamic executable (-dy), TLSDESC relocations for non-preemptible TLS symbols must be relaxed.  Previously the relaxation only triggered for fully static binaries (isCodeStatic()), leaving dynamic executables with descriptor calls that would fault at runtime because no resolver is registered for the local symbol.