### PR TITLE
[TLS] Add regression tests for TBSS segment layout

### DIFF
--- a/test/Common/standalone/TLS/TBSSMultipleVarsOmagic/Inputs/1.c
+++ b/test/Common/standalone/TLS/TBSSMultipleVarsOmagic/Inputs/1.c
@@ -1,0 +1,5 @@
+int foo() { return 0; }
+__thread int tls_a = 0;
+__thread int tls_b = 0;
+__thread int tls_c = 0;
+int data = 10;

--- a/test/Common/standalone/TLS/TBSSMultipleVarsOmagic/Inputs/s.t
+++ b/test/Common/standalone/TLS/TBSSMultipleVarsOmagic/Inputs/s.t
@@ -1,0 +1,7 @@
+SECTIONS {
+  .foo    : { *(.text.foo) }
+  .tbss.a : { *(.tbss.tls_a) }
+  .tbss.b : { *(.tbss.tls_b) }
+  .tbss.c : { *(.tbss.tls_c) }
+  .data   : { *(.data.data) }
+}

--- a/test/Common/standalone/TLS/TBSSMultipleVarsOmagic/TBSSMultipleVarsOmagic.test
+++ b/test/Common/standalone/TLS/TBSSMultipleVarsOmagic/TBSSMultipleVarsOmagic.test
@@ -1,0 +1,17 @@
+#---TBSSMultipleVarsOmagic.test------------- TLS, Executable -----------------#
+#BEGIN_COMMENT
+# This tests that --omagic with multiple per-variable TBSS sections (produced
+# by -fdata-sections) between text and data produces a single merged RWE LOAD
+# segment containing both .foo and .data. No TBSS section must appear in any
+# LOAD segment.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o -ffunction-sections -fdata-sections
+RUN: %link %linkopts %t1.o -T %p/Inputs/s.t --omagic -o %t.out
+RUN: %readelf -l -W %t.out | %filecheck %s
+
+#CHECK:      LOAD {{.*}} RWE
+#CHECK-NOT:  LOAD
+#CHECK:      00     .foo {{.*}}.data
+#CHECK:      {{[0-9]+}}     .tbss.a .tbss.b .tbss.c
+#END_TEST

--- a/test/Common/standalone/TLS/TBSSMultipleVarsRelro/Inputs/1.c
+++ b/test/Common/standalone/TLS/TBSSMultipleVarsRelro/Inputs/1.c
@@ -1,0 +1,5 @@
+int foo() { return 0; }
+__thread int tls_a = 0;
+__thread int tls_b = 0;
+__thread int tls_c = 0;
+int data = 10;

--- a/test/Common/standalone/TLS/TBSSMultipleVarsRelro/Inputs/s.t
+++ b/test/Common/standalone/TLS/TBSSMultipleVarsRelro/Inputs/s.t
@@ -1,0 +1,7 @@
+SECTIONS {
+  .foo    : { *(.text.foo) }
+  .tbss.a : { *(.tbss.tls_a) }
+  .tbss.b : { *(.tbss.tls_b) }
+  .tbss.c : { *(.tbss.tls_c) }
+  .data   : { *(.data.data) }
+}

--- a/test/Common/standalone/TLS/TBSSMultipleVarsRelro/TBSSMultipleVarsRelro.test
+++ b/test/Common/standalone/TLS/TBSSMultipleVarsRelro/TBSSMultipleVarsRelro.test
@@ -1,0 +1,19 @@
+#---TBSSMultipleVarsRelro.test-------------- TLS, Executable -----------------#
+#BEGIN_COMMENT
+# This tests that -z relro with multiple per-variable TBSS sections between
+# text and data produces correct separate LOAD segments (R E for text, RW for
+# data). No TBSS section must appear in any LOAD segment, and TBSS must not
+# contaminate segment flags.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o -ffunction-sections -fdata-sections
+RUN: %link %linkopts %t1.o -T %p/Inputs/s.t -z relro -o %t.out
+RUN: %readelf -l -W %t.out | %filecheck %s
+
+#CHECK:      LOAD {{.*}} R E
+#CHECK:      LOAD {{.*}} RW
+#CHECK-NOT:  LOAD
+#CHECK:      00     .foo
+#CHECK:      01     {{.*}}.data
+#CHECK:      {{[0-9]+}}     .tbss.a .tbss.b .tbss.c
+#END_TEST

--- a/test/Common/standalone/TLS/TBSSMultipleVarsSeparateLoad/Inputs/1.c
+++ b/test/Common/standalone/TLS/TBSSMultipleVarsSeparateLoad/Inputs/1.c
@@ -1,0 +1,5 @@
+int foo() { return 0; }
+__thread int tls_a = 0;
+__thread int tls_b = 0;
+__thread int tls_c = 0;
+int data = 10;

--- a/test/Common/standalone/TLS/TBSSMultipleVarsSeparateLoad/Inputs/s.t
+++ b/test/Common/standalone/TLS/TBSSMultipleVarsSeparateLoad/Inputs/s.t
@@ -1,0 +1,7 @@
+SECTIONS {
+  .foo    : { *(.text.foo) }
+  .tbss.a : { *(.tbss.tls_a) }
+  .tbss.b : { *(.tbss.tls_b) }
+  .tbss.c : { *(.tbss.tls_c) }
+  .data   : { *(.data.data) }
+}

--- a/test/Common/standalone/TLS/TBSSMultipleVarsSeparateLoad/TBSSMultipleVarsSeparateLoad.test
+++ b/test/Common/standalone/TLS/TBSSMultipleVarsSeparateLoad/TBSSMultipleVarsSeparateLoad.test
@@ -1,0 +1,19 @@
+#---TBSSMultipleVarsSeparateLoad.test------- TLS, Executable -----------------#
+#BEGIN_COMMENT
+# This tests that -z separate-loadable-segments with multiple per-variable
+# TBSS sections between text and data still produces correct separate LOAD
+# segments (R E for text, RW for data). No TBSS section must appear in any
+# LOAD segment, and TBSS must not contaminate the text segment flags with PF_W.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o -ffunction-sections -fdata-sections
+RUN: %link %linkopts %t1.o -T %p/Inputs/s.t -z separate-loadable-segments -o %t.out
+RUN: %readelf -l -W %t.out | %filecheck %s
+
+#CHECK:      LOAD {{.*}} R E
+#CHECK:      LOAD {{.*}} RW
+#CHECK-NOT:  LOAD
+#CHECK:      00     .foo
+#CHECK:      01     {{.*}}.data
+#CHECK:      {{[0-9]+}}     .tbss.a .tbss.b .tbss.c
+#END_TEST

--- a/test/Common/standalone/TLS/TBSSSegmentFlagsOmagic/Inputs/1.c
+++ b/test/Common/standalone/TLS/TBSSSegmentFlagsOmagic/Inputs/1.c
@@ -1,0 +1,3 @@
+int foo() { return 0; }
+__thread int tbss = 0;
+int data = 10;

--- a/test/Common/standalone/TLS/TBSSSegmentFlagsOmagic/Inputs/s.t
+++ b/test/Common/standalone/TLS/TBSSSegmentFlagsOmagic/Inputs/s.t
@@ -1,0 +1,5 @@
+SECTIONS {
+  .foo : { *(.text.foo) }
+  .tbss : { *(.tbss.tbss) }
+  .data : { *(.data.data) }
+}

--- a/test/Common/standalone/TLS/TBSSSegmentFlagsOmagic/TBSSSegmentFlagsOmagic.test
+++ b/test/Common/standalone/TLS/TBSSSegmentFlagsOmagic/TBSSSegmentFlagsOmagic.test
@@ -1,0 +1,15 @@
+#---TBSSSegmentFlagsOmagic.test------------- TLS, Executable -----------------#
+#BEGIN_COMMENT
+# This tests that --omagic with a TBSS section between text and data produces
+# a single merged RWE LOAD segment containing both .foo and .data. TBSS must
+# not create a spurious extra segment or appear in any LOAD segment.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o -ffunction-sections -fdata-sections
+RUN: %link %linkopts %t1.o -T %p/Inputs/s.t --omagic -o %t.out
+RUN: %readelf -l -W %t.out | %filecheck %s
+
+#CHECK:      LOAD {{.*}} RWE
+#CHECK-NOT:  LOAD
+#CHECK:      00     .foo {{.*}}.data
+#END_TEST

--- a/test/Common/standalone/TLS/TBSSSegmentFlagsSeparateLoad/Inputs/1.c
+++ b/test/Common/standalone/TLS/TBSSSegmentFlagsSeparateLoad/Inputs/1.c
@@ -1,0 +1,3 @@
+int foo() { return 0; }
+__thread int tbss = 0;
+int data = 10;

--- a/test/Common/standalone/TLS/TBSSSegmentFlagsSeparateLoad/Inputs/s.t
+++ b/test/Common/standalone/TLS/TBSSSegmentFlagsSeparateLoad/Inputs/s.t
@@ -1,0 +1,5 @@
+SECTIONS {
+  .foo : { *(.text.foo) }
+  .tbss : { *(.tbss.tbss) }
+  .data : { *(.data.data) }
+}

--- a/test/Common/standalone/TLS/TBSSSegmentFlagsSeparateLoad/TBSSSegmentFlagsSeparateLoad.test
+++ b/test/Common/standalone/TLS/TBSSSegmentFlagsSeparateLoad/TBSSSegmentFlagsSeparateLoad.test
@@ -1,0 +1,18 @@
+#---TBSSSegmentFlagsSeparateLoad.test------- TLS, Executable -----------------#
+#BEGIN_COMMENT
+# This tests that -z separate-loadable-segments with a TBSS section between
+# text and data still produces correct separate LOAD segments (R E for text,
+# RW for data). TBSS must not contaminate the text segment flags with PF_W
+# nor prevent the data section from getting its own RW segment.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o -ffunction-sections -fdata-sections
+RUN: %link %linkopts %t1.o -T %p/Inputs/s.t -z separate-loadable-segments -o %t.out
+RUN: %readelf -l -W %t.out | %filecheck %s
+
+#CHECK:      LOAD {{.*}} R E
+#CHECK:      LOAD {{.*}} RW
+#CHECK-NOT:  LOAD
+#CHECK:      00     .foo
+#CHECK:      01     {{.*}}.data
+#END_TEST


### PR DESCRIPTION
Add five standalone tests verifying that TBSS sections are correctly excluded from LOAD segments and do not contaminate segment flags under various linking modes: --omagic, -z relro, and -z separate-loadable- segments. Tests also cover the multiple per-variable TBSS sections (produced by -fdata-sections) case.