### PR TITLE
refactor: establish HasHighSectionCount once during file parsing

### DIFF
--- a/lib/Readers/ELFReader.cpp
+++ b/lib/Readers/ELFReader.cpp
@@ -121,6 +121,7 @@ void ELFReader<ELFT>::setSectionInInputFile(ELFSection *S,
     break;
   case llvm::ELF::SHT_SYMTAB_SHNDX:
     EFileBase->setExtendedSymbolTable(S);
+    EFileBase->setHasHighSectionCount();
     break;
   case llvm::ELF::SHT_STRTAB:
     EFileBase->setStringTable(S);
@@ -239,12 +240,8 @@ ELFReader<ELFT>::createSymbol(llvm::StringRef stringTable, Elf_Sym rawSym,
   ELFFileBase *EFileBase = llvm::cast<ELFFileBase>(&m_InputFile);
 
   bool is_ordinary = true;
-  // FIXME: Instead of checking this when creating each symbol (which can be
-  // relatively expensive as there can be too many symbols), can we instead set
-  // this using 'e_shnum'? Or perhaps, by seeing if there is any entry in
-  // section of type SHT_SYMTAB_SHNDX?
+
   if (rawSym.st_shndx == llvm::ELF::SHN_XINDEX) {
-    EFileBase->setHasHighSectionCount();
     is_ordinary = false;
   }
 


### PR DESCRIPTION
### Description

This PR addresses the design issue where the file-level property
`HasHighSectionCount` was being updated from the per-symbol path in
`createSymbol()`.

### Changes
- Move the `setHasHighSectionCount()` call from `createSymbol()` to
  `setSectionInInputFile()` when `SHT_SYMTAB_SHNDX` is encountered.
- Keep `createSymbol()` responsible only for determining the local
  `is_ordinary` state.

This change moves the determination of a file-level property to the
ELF parsing stage, improving separation of responsibilities and
keeping file state management out of the per-symbol path.

Fixes #1303