### PR TITLE
[x86] Support R_X86_64_GOTPCRELX relaxation

### DIFF
--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -924,6 +924,10 @@ public:
 
   bool getRISCVRelax() const { return BRiscvRelax; }
 
+  void setRelax(bool Value) { ShouldRelax = Value; }
+
+  bool getRelax() const { return ShouldRelax; }
+
   void setRISCVZeroRelax(bool Relax) { RiscvZeroRelax = Relax; }
 
   bool getRISCVZeroRelax() const { return RiscvZeroRelax; }
@@ -1323,6 +1327,7 @@ private:
   bool DisableGuardForWeakUndefs = false; // hexagon specific option to
                                           // disable guard functionality.
   bool BRiscvRelax = true;                // enable riscv relaxation
+  bool ShouldRelax = false; // x86-64 GOTPCRELX relaxation (opt-in via --relax)
   bool RiscvZeroRelax = true;             // Zero-page relaxation
   bool RiscvGPRelax = true;               // GP relaxation
   bool BRiscvRelaxToC = true; // enable riscv relax to compressed code

--- a/include/eld/Diagnostics/DiagBackends.inc
+++ b/include/eld/Diagnostics/DiagBackends.inc
@@ -90,6 +90,9 @@ DIAG(expected_group_section, DiagnosticEngine::InternalError,
      "Expected %0 to be a 'group' section.")
 DIAG(warn_ignore_reloc_addend, DiagnosticEngine::Warning,
      "%2: ignoring addend for relocation `%1' referring symbol %0")
+DIAG(error_x86_gotpcrelx_relax_overflow, DiagnosticEngine::Error,
+     "%0: relaxing relocation %1 out of range: %2 is not in [%3, %4]; "
+     "references '%5'; relink with --no-relax")
 DIAG(error_build_id_not_hex, DiagnosticEngine::Error,
     "build id specified is not hexadecimal : %0")
 DIAG(error_unknown_build_id, DiagnosticEngine::Error,

--- a/include/eld/Diagnostics/DiagVerbose.inc
+++ b/include/eld/Diagnostics/DiagVerbose.inc
@@ -34,6 +34,8 @@ DIAG(not_relaxed, DiagnosticEngine::Verbose,
 DIAG(relax_to_compress, DiagnosticEngine::Verbose,
      "%0 : relaxing instruction 0x%1 to compressed instruction 0x%2 for symbol "
      "%3 in section %4+0x%5 file %6")
+DIAG(trace_relax_gotpcrelx, DiagnosticEngine::Trace,
+     "%0: relaxed GOTPCRELX (%1) for symbol '%2' to PC-relative access")
 DIAG(verbose_ehframe_remove_fde, DiagnosticEngine::Verbose, "EhFrame %0")
 DIAG(verbose_ehframe_read_fde, DiagnosticEngine::Verbose, "EhFrame %0")
 DIAG(verbose_ehframe_read_cie, DiagnosticEngine::Verbose, "EhFrame %0")

--- a/include/eld/Diagnostics/DiagnosticPrinter.h
+++ b/include/eld/Diagnostics/DiagnosticPrinter.h
@@ -47,6 +47,7 @@ public:
     TraceMergeStrings = 0x8000,
     TraceLinkerScript = 0x10000,
     TraceUntar = 0x20000,
+    TraceRelax = 0x40000,
     TraceSymDef = 0x100000,
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
     TraceSymbolVersioning = 0x200000
@@ -101,6 +102,8 @@ public:
   bool traceLinkerScript() { return (Trace & TraceLinkerScript); }
 
   bool traceUntar() { return (Trace & TraceUntar); }
+
+  bool traceRelax() { return (Trace & TraceRelax); }
 
   bool traceSymDef() { return (Trace & TraceSymDef); }
 

--- a/include/eld/Driver/x86_64LinkerOptions.td
+++ b/include/eld/Driver/x86_64LinkerOptions.td
@@ -5,3 +5,13 @@
 //===----------------------------------------------------------------------===//
 
 include "GnuLinkerOptions.td"
+
+def grp_x86_64_linker : OptionGroup<"opts">, HelpText<"X86-64 Linker Options">;
+
+def relax : Flag<["--"], "relax">,
+            HelpText<"Enable GOTPCRELX relaxation (GOT-indirect to PC-relative)">,
+            Group<grp_x86_64_linker>;
+
+def no_relax : Flag<["--"], "no-relax">,
+               HelpText<"Disable GOTPCRELX relaxation">,
+               Group<grp_x86_64_linker>;

--- a/lib/Config/GeneralOptions.cpp
+++ b/lib/Config/GeneralOptions.cpp
@@ -235,6 +235,7 @@ eld::Expected<void> GeneralOptions::setTrace(const char *PTraceType) {
             .Case("lto", DiagEngine->getPrinter()->TraceLTO)
             .Case("merge-strings", DiagEngine->getPrinter()->TraceMergeStrings)
             .Case("plugin", DiagEngine->getPrinter()->TracePlugin)
+            .Case("relax", DiagEngine->getPrinter()->TraceRelax)
             .Case("threads", DiagEngine->getPrinter()->TraceThreads)
             .Case("trampolines", DiagEngine->getPrinter()->TraceTrampolines)
             .Case("wrap-symbols", DiagEngine->getPrinter()->TraceWrap)

--- a/lib/LinkerWrapper/x86_64LinkDriver.cpp
+++ b/lib/LinkerWrapper/x86_64LinkDriver.cpp
@@ -97,6 +97,12 @@ x86_64LinkDriver::parseOptions(ArrayRef<const char *> Args,
   Config.options().setUnknownOptions(
       ArgList.getAllArgValues(OPT_x86_64LinkOptTable::UNKNOWN));
 
+  // --relax/--no-relax: enable/disable GOTPCRELX relaxation (disabled by
+  // default)
+  Config.options().setRelax(ArgList.hasFlag(OPT_x86_64LinkOptTable::relax,
+                                            OPT_x86_64LinkOptTable::no_relax,
+                                            /*default=*/false));
+
   return {};
 }
 

--- a/lib/Target/X86/x86_64LDBackend.cpp
+++ b/lib/Target/X86/x86_64LDBackend.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 #include "x86_64LDBackend.h"
 #include "eld/Config/LinkerConfig.h"
+#include "eld/Fragment/RegionFragment.h"
 #include "eld/Fragment/Stub.h"
 #include "eld/Input/ELFObjectFile.h"
 #include "eld/Object/ObjectBuilder.h"
@@ -22,7 +23,10 @@
 #include "x86_64StandaloneInfo.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/Endian.h"
+#include "llvm/Support/MathExtras.h"
 #include "llvm/TargetParser/Host.h"
+#include <limits>
 
 using namespace eld;
 using namespace llvm;
@@ -96,6 +100,190 @@ void x86_64LDBackend::initTargetSymbols() {
 bool x86_64LDBackend::initBRIslandFactory() { return true; }
 
 bool x86_64LDBackend::initStubFactory() { return true; }
+
+x86_64LDBackend::GOTPCRELXOpcode
+x86_64LDBackend::getGOTPCRELXOpcode(uint8_t op, uint8_t modrm) const {
+  if (op == 0x8b)
+    return GOTPCRELXOpcode::MOV;
+  if (op == 0xff && modrm == 0x15)
+    return GOTPCRELXOpcode::CALL;
+  if (op == 0xff && modrm == 0x25)
+    return GOTPCRELXOpcode::JMP;
+  return GOTPCRELXOpcode::Unknown;
+}
+
+bool x86_64LDBackend::isGOTPCRELXRelaxable(const Relocation *reloc) const {
+  // Partial links have no final layout, so relaxation is not possible; keep
+  // the GOT slot and let the final link decide.
+  if (config().isLinkPartial())
+    return false;
+  if (reloc->type() != llvm::ELF::R_X86_64_GOTPCRELX)
+    return false;
+  // GNU as may emit GOTPCRELX with addend != -4. Such an instruction does not
+  // load the full GOT entry (e.g. movl x@GOTPCREL+4(%rip) loads the high 32
+  // bits), so it cannot be relaxed. Matches lld's adjustGotPcExpr.
+  if (static_cast<int64_t>(reloc->addend()) != -4)
+    return false;
+  const ResolveInfo *rsym = reloc->symInfo();
+  // IFUNC symbols must retain their GOT slot: the IRELATIVE resolver runs at
+  // load time and deposits the selected implementation's address there.
+  // Relaxing to a PC-relative access would bypass that resolution. Note a
+  // hidden/local IFUNC is non-preemptible, so the isIFunc() check is not
+  // redundant with isSymbolPreemptible().
+  if (isSymbolPreemptible(*rsym) || rsym->isIFunc())
+    return false;
+  auto *RF = llvm::dyn_cast<RegionFragment>(reloc->targetRef()->frag());
+  if (!RF)
+    return false;
+  uint32_t offset = reloc->targetRef()->offset();
+  // The opcode and ModR/M byte sit at offset-2 and offset-1 relative to the
+  // displacement field. A corrupt or hand-crafted object could place the
+  // relocation at offset 0 or 1, making those reads out-of-bounds.
+  if (offset < 2)
+    return false;
+  // The two bytes preceding the 4-byte displacement hold the opcode and,
+  // for CALL/JMP, the ModR/M byte. Only MOV/CALL/JMP are relaxable.
+  const uint8_t *loc =
+      reinterpret_cast<const uint8_t *>(RF->getRegion().data()) + offset;
+  uint8_t op = loc[-2];
+  uint8_t modrm = loc[-1];
+  return getGOTPCRELXOpcode(op, modrm) != GOTPCRELXOpcode::Unknown;
+}
+
+bool x86_64LDBackend::shouldIgnoreRelocSync(Relocation *reloc) const {
+  return isGOTPCRELXRelaxCandidate(reloc);
+}
+
+eld::Expected<void>
+x86_64LDBackend::postProcessing(llvm::FileOutputBuffer &pOutput) {
+  ELDEXP_RETURN_DIAGENTRY_IF_ERROR(GNULDBackend::postProcessing(pOutput));
+
+  // Relaxation rewrites bytes in the laid-out output image; it is not
+  // applicable to partial links, which have no final layout.
+  if (config().options().getRelax() && !config().isLinkPartial())
+    ELDEXP_RETURN_DIAGENTRY_IF_ERROR(doRelax(pOutput));
+
+  return {};
+}
+
+eld::Expected<void> x86_64LDBackend::doRelax(llvm::FileOutputBuffer &pOutput) {
+  uint8_t *buf = pOutput.getBufferStart();
+  // The scan phase already identified every relaxation candidate (skipping
+  // debug relocations and internal files, which never carry a relaxable
+  // relocation). Iterate that cached set instead of re-walking all
+  // relocations, and dispatch on the relocation type. Future relaxable types
+  // (e.g. R_X86_64_REX_GOTPCRELX, TLS relaxations) add a case here.
+  for (Relocation *reloc : m_GOTPCRELXRelaxCandidates) {
+    switch (reloc->type()) {
+    case llvm::ELF::R_X86_64_GOTPCRELX:
+      ELDEXP_RETURN_DIAGENTRY_IF_ERROR(relaxGOTPCRELXReloc(reloc, buf));
+      break;
+    default:
+      // Only relaxable types are recorded as candidates; skip anything else.
+      break;
+    }
+  }
+  return {};
+}
+
+eld::Expected<void> x86_64LDBackend::relaxGOTPCRELXReloc(Relocation *reloc,
+                                                         uint8_t *buf) {
+  // Only RegionFragment relocations are recorded as relaxation candidates
+  // (isGOTPCRELXRelaxable requires a RegionFragment), so this cast must
+  // succeed.
+  auto *RF = llvm::dyn_cast<RegionFragment>(reloc->targetRef()->frag());
+  assert(RF && "GOTPCRELX relax candidate must reference a RegionFragment");
+
+  uint32_t offset = reloc->targetRef()->offset();
+  // isGOTPCRELXRelaxable checks offset >= 2 before recording a candidate,
+  // so this must hold for every relocation that reaches here.
+  assert(offset >= 2 && "GOTPCRELX relax candidate must have offset >= 2");
+  // Opcode/ModR/M bytes live just before the 4-byte displacement field.
+  const uint8_t *loc =
+      reinterpret_cast<const uint8_t *>(RF->getRegion().data()) + offset;
+
+  ResolveInfo *rsym = reloc->symInfo();
+  Relocator::Address S = reloc->symValue(m_Module);
+  Relocator::DWord A = reloc->addend();
+  Relocator::DWord P = reloc->place(m_Module);
+  // Relaxed form is a direct PC-relative access: displacement = S + A - P.
+  int64_t val = static_cast<int64_t>(S) + static_cast<int64_t>(A) -
+                static_cast<int64_t>(P);
+
+  if (!llvm::isInt<32>(val)) {
+    // Unlike lld (which relayouts and can fall back to the GOT slot), eld
+    // decides relaxability at scan time and has already dropped the GOT slot,
+    // so an out-of-range displacement here is a hard error. Report it with the
+    // source location and abort the link (matching GNU ld's --no-relax hint).
+    std::string location;
+    ELFSection *overflowSect = RF->getOwningSection();
+    assert(overflowSect &&
+           "RegionFragment in relax candidate must have an owning section");
+    location = overflowSect->getLocation(offset, config().options());
+    return std::make_unique<plugin::DiagnosticEntry>(plugin::DiagnosticEntry(
+        Diag::error_x86_gotpcrelx_relax_overflow,
+        {std::move(location), "R_X86_64_GOTPCRELX", llvm::itostr(val),
+         llvm::itostr(std::numeric_limits<int32_t>::min()),
+         llvm::itostr(std::numeric_limits<int32_t>::max()),
+         std::string(rsym->name())}));
+  }
+
+  FragmentRef::Offset off = reloc->targetRef()->getOutputOffset(m_Module);
+  if (off == (FragmentRef::Offset)-1)
+    return {};
+  size_t out_off = reloc->targetRef()->getOutputELFSection()->offset() + off;
+
+  uint8_t op = loc[-2];
+  uint8_t modrm = loc[-1];
+  const char *kind = nullptr;
+  switch (getGOTPCRELXOpcode(op, modrm)) {
+  case GOTPCRELXOpcode::MOV:
+    // mov foo@GOTPCREL(%rip), reg  ->  lea foo(%rip), reg
+    // The GOT-load opcode 0x8b becomes the address-load opcode 0x8d; the
+    // ModR/M and displacement encoding are otherwise identical.
+    buf[out_off - 2] = 0x8d;
+    llvm::support::endian::write32le(buf + out_off, static_cast<uint32_t>(val));
+    kind = "mov->lea";
+    break;
+  case GOTPCRELXOpcode::CALL:
+    // call *foo@GOTPCREL(%rip)  ->  addr32 call foo
+    // The 2-byte "ff 15" indirect call is 6 bytes; the direct "e8 rel32" is
+    // 5 bytes, so a 0x67 (addr32) prefix pads it back to 6 bytes.
+    buf[out_off - 2] = 0x67;
+    buf[out_off - 1] = 0xe8;
+    llvm::support::endian::write32le(buf + out_off, static_cast<uint32_t>(val));
+    kind = "call->direct";
+    break;
+  case GOTPCRELXOpcode::JMP:
+    // jmp *foo@GOTPCREL(%rip)  ->  jmp foo; nop
+    // "ff 25" indirect jmp (6 bytes) becomes "e9 rel32" direct jmp (5 bytes)
+    // followed by a 0x90 nop for padding. The displacement shifts one byte
+    // earlier (no ModR/M), so it is written at out_off-1 with val+1 to account
+    // for the one-byte-shorter instruction prefix.
+    buf[out_off - 2] = 0xe9;
+    llvm::support::endian::write32le(buf + out_off - 1,
+                                     static_cast<uint32_t>(val + 1));
+    buf[out_off + 3] = 0x90;
+    kind = "jmp->direct";
+    break;
+  case GOTPCRELXOpcode::Unknown:
+    // isGOTPCRELXRelaxable only records MOV/CALL/JMP candidates, so this is
+    // not expected; leave the instruction untouched if it is ever reached.
+    break;
+  }
+
+  if (m_Module.getPrinter()->traceRelax()) {
+    std::string location;
+    ELFSection *traceSect = RF->getOwningSection();
+    assert(traceSect &&
+           "RegionFragment in relax candidate must have an owning section");
+    location = traceSect->getLocation(offset, config().options());
+    config().raise(Diag::trace_relax_gotpcrelx)
+        << location << kind << rsym->name();
+  }
+
+  return {};
+}
 
 /// finalizeSymbol - finalize the symbol value
 bool x86_64LDBackend::finalizeTargetSymbols() {

--- a/lib/Target/X86/x86_64LDBackend.h
+++ b/lib/Target/X86/x86_64LDBackend.h
@@ -14,6 +14,7 @@
 #include "eld/Target/GNULDBackend.h"
 #include "x86_64PLT.h"
 #include "llvm/BinaryFormat/ELF.h"
+#include <unordered_set>
 
 namespace eld {
 
@@ -47,6 +48,10 @@ public:
   bool initBRIslandFactory() override;
 
   bool initStubFactory() override;
+
+  bool shouldIgnoreRelocSync(Relocation *Reloc) const override;
+
+  eld::Expected<void> postProcessing(llvm::FileOutputBuffer &pOutput) override;
 
   /// getTargetSectionOrder - compute the layout order of target section
   unsigned int getTargetSectionOrder(const ELFSection &pSectHdr) const override;
@@ -98,6 +103,27 @@ public:
 
   void sortRelocation(ELFSection &pSection) override;
 
+  /// Returns true if the relocation is eligible for GOTPCRELX relaxation.
+  /// Checks: type R_X86_64_GOTPCRELX, addend == -4, non-preemptible,
+  /// not IFUNC, and opcode is MOV/CALL/JMP (read directly from the input
+  /// fragment). Relaxation is disabled for partial links.
+  bool isGOTPCRELXRelaxable(const Relocation *reloc) const;
+
+  /// Records a relocation that the scan phase has decided to relax, so that
+  /// postProcessing can iterate only these candidates instead of re-walking
+  /// every relocation. Thread-safe: called from the parallel scan under the
+  /// relocator mutex.
+  void recordGOTPCRELXRelaxCandidate(Relocation *reloc) {
+    m_GOTPCRELXRelaxCandidates.insert(reloc);
+  }
+
+  /// Returns true if this relocation was recorded as a relaxation candidate
+  /// during the scan phase. O(1) lookup used by shouldIgnoreRelocSync and
+  /// the apply-path guard to avoid re-deriving relaxability.
+  bool isGOTPCRELXRelaxCandidate(Relocation *reloc) const {
+    return m_GOTPCRELXRelaxCandidates.count(reloc) != 0;
+  }
+
   DynRelocType getDynRelocType(const Relocation *X) const override {
     if (X->type() == llvm::ELF::R_X86_64_GLOB_DAT)
       return DynRelocType::GLOB_DAT;
@@ -144,6 +170,18 @@ private:
 
   uint64_t maxBranchOffset() override { return 0; }
 
+  enum class GOTPCRELXOpcode { MOV, CALL, JMP, Unknown };
+  GOTPCRELXOpcode getGOTPCRELXOpcode(uint8_t op, uint8_t modrm) const;
+
+  /// Rewrites the GOT-indirect instruction referenced by a single relaxation
+  /// candidate into its PC-relative form, patching the output buffer.
+  /// Returns an error (and does not patch) if the displacement overflows a
+  /// signed 32-bit field.
+  eld::Expected<void> relaxGOTPCRELXReloc(Relocation *reloc, uint8_t *buf);
+
+  /// Iterates the cached relaxation candidates and rewrites each one.
+  eld::Expected<void> doRelax(llvm::FileOutputBuffer &pOutput);
+
 private:
   Relocator *m_pRelocator;
 
@@ -155,6 +193,11 @@ private:
   llvm::DenseMap<ResolveInfo *, x86_64GOT *> m_GOTMap;
   llvm::DenseMap<ResolveInfo *, x86_64GOT *> m_GOTPLTMap;
   llvm::DenseMap<ResolveInfo *, x86_64PLT *> m_PLTMap;
+  /// Relocations selected for GOTPCRELX relaxation during the scan phase.
+  /// Populated under the relocator mutex; consumed single-threaded in
+  /// postProcessing. unordered_set for O(1) membership checks in
+  /// shouldIgnoreRelocSync and the apply-path guard.
+  std::unordered_set<Relocation *> m_GOTPCRELXRelaxCandidates;
 };
 } // namespace eld
 

--- a/lib/Target/X86/x86_64Relocator.cpp
+++ b/lib/Target/X86/x86_64Relocator.cpp
@@ -292,6 +292,25 @@ void x86_64Relocator::scanLocalReloc(InputFile &pInputFile, Relocation &pReloc,
     rsym->setReserved(rsym->reserved() | ReserveGOT);
     return;
   }
+  case llvm::ELF::R_X86_64_GOTPCRELX: {
+    std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
+    // Relaxability is decided per relocation (it inspects this reference's own
+    // opcode bytes), so it must be checked before the per-symbol ReserveGOT
+    // short-circuit: a non-relaxable reference to the same symbol may have
+    // reserved a GOT slot first. With --relax, local symbols are always
+    // non-preemptible; skip the GOT slot for the relaxable reference and record
+    // it so postProcessing can patch it without re-walking.
+    if (config().options().getRelax() &&
+        m_Target.isGOTPCRELXRelaxable(&pReloc)) {
+      m_Target.recordGOTPCRELXRelaxCandidate(&pReloc);
+      return;
+    }
+    if (rsym->reserved() & ReserveGOT)
+      return;
+    CreateGOT(Obj, pReloc, !config().isCodeStatic(), m_Target);
+    rsym->setReserved(rsym->reserved() | ReserveGOT);
+    return;
+  }
   case llvm::ELF::R_X86_64_TLSLD: {
     std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
     getTLSModuleID(pReloc.symInfo(), config().isCodeStatic());
@@ -402,9 +421,34 @@ void x86_64Relocator::scanGlobalReloc(InputFile &pInputFile, Relocation &pReloc,
     rsym->setReserved(rsym->reserved() | ReservePLT);
     return;
   }
-
-  case llvm::ELF::R_X86_64_GOTPCREL:
-  case llvm::ELF::R_X86_64_GOTPCRELX:
+  case llvm::ELF::R_X86_64_GOTPCRELX: {
+    std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
+    // Relaxability is decided per relocation (it inspects this reference's own
+    // opcode bytes), so it must be checked before the per-symbol ReserveGOT
+    // short-circuit: a non-relaxable reference to the same symbol may have
+    // reserved a GOT slot first. With --relax, non-preemptible non-IFUNC
+    // symbols with a relaxable opcode are handled by postProcessing: no GOT
+    // slot is needed and an out-of-range displacement is a link error. An
+    // addend != -4 or an unknown opcode keeps the GOT slot.
+    if (config().options().getRelax() &&
+        m_Target.isGOTPCRELXRelaxable(&pReloc)) {
+      m_Target.recordGOTPCRELXRelaxCandidate(&pReloc);
+      return;
+    }
+    if (rsym->reserved() & ReserveGOT)
+      return;
+    CreateGOT(Obj, pReloc, !config().isCodeStatic(), m_Target);
+    rsym->setReserved(rsym->reserved() | ReserveGOT);
+    return;
+  }
+  case llvm::ELF::R_X86_64_GOTPCREL: {
+    std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
+    if (rsym->reserved() & ReserveGOT)
+      return;
+    CreateGOT(Obj, pReloc, !config().isCodeStatic(), m_Target);
+    rsym->setReserved(rsym->reserved() | ReserveGOT);
+    return;
+  }
   case llvm::ELF::R_X86_64_REX_GOTPCRELX: {
     std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
     if (rsym->reserved() & ReserveGOT)
@@ -688,6 +732,11 @@ Relocator::Result eld::relocGOTRelative(Relocation &pReloc,
   DiagnosticEngine *DiagEngine = pParent.config().getDiagEngine();
   ResolveInfo *symInfo = pReloc.symInfo();
   const GeneralOptions &options = pParent.config().options();
+
+  // For relaxable GOTPCRELX relocations, postProcessing handles the opcode
+  // patch and displacement. Skip apply here to avoid a null GOT entry lookup.
+  if (pParent.getTarget().isGOTPCRELXRelaxCandidate(&pReloc))
+    return Relocator::OK;
 
   Relocator::DWord A = pReloc.addend();
   Relocator::DWord P = pReloc.place(pParent.module());

--- a/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_AddendNonM4.test
+++ b/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_AddendNonM4.test
@@ -1,0 +1,14 @@
+#--GOTPCRELXRelax_AddendNonM4.test----------Shared Library--------#
+# R_X86_64_GOTPCRELX with addend != -4 must not be relaxed.
+# GNU as may emit GOTPCRELX with addend != -4 (e.g. addend=0 loads the high
+# 32 bits of the GOT entry). Relaxing such a relocation would produce wrong
+# output, so the GOT slot must be preserved and the instruction left as-is.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/addend_nonm4.s -o %t.o
+RUN: %link %linkopts --relax -shared -o %t.so %t.o
+RUN: %objdump -d %t.so | %filecheck %s
+#END_TEST
+
+# Instruction must remain a movl (8b), not an lea (8d).
+CHECK: <h>:
+CHECK-NEXT: {{[0-9a-f]+}}: 8b 05 {{.*}} movl

--- a/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_BadInput.test
+++ b/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_BadInput.test
@@ -1,0 +1,30 @@
+#--GOTPCRELXRelax_BadInput.test----------Executable--------#
+# A GOTPCRELX relocation placed at offset 0 (via .reloc) means the opcode
+# bytes at loc[-2]/loc[-1] would be before the fragment buffer. The linker
+# must not crash; it must skip relaxation and keep the GOT slot instead.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/badinput.s -o %t.o
+RUN: %link %linkopts --relax -shared -o %t.so %t.o
+
+# Before: input object has a nop with a GOTPCRELX relocation at offset 0.
+RUN: %objdump -dr %t.o | %filecheck %s --check-prefix=BEFORE
+
+# After: output must not contain a leal (8d) — the relocation was not relaxed.
+RUN: %objdump -d %t.so | %filecheck %s --check-prefix=AFTER
+
+# A GOT slot must still exist (kept because the relocation was not relaxable).
+RUN: %readelf -r %t.so | %filecheck %s --check-prefix=RELOC
+#END_TEST
+
+# Input: nop at offset 0 with the GOTPCRELX reloc attached to it.
+BEFORE: <h>:
+BEFORE-NEXT: {{[ \t]+}}0: 90{{.*}}nop
+BEFORE: R_X86_64_GOTPCRELX
+
+# Output: not relaxed to leal (no opcode 8d).
+AFTER: <h>:
+AFTER-NOT: 8d {{.*}} leal
+
+# GOT slot kept with a RELATIVE dynamic relocation (foo is hidden/non-preemptible).
+RELOC: .rela.dyn
+RELOC: R_X86_64_RELATIVE

--- a/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_Basic.test
+++ b/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_Basic.test
@@ -1,0 +1,16 @@
+#--GOTPCRELXRelax_Basic.test----------Shared Library--------#
+# Basic R_X86_64_GOTPCRELX relaxation.
+# movl sym@GOTPCREL(%rip), %eax -> leal sym(%rip), %eax.
+# Also verifies that no GOT slot is allocated for the relaxed symbol.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/mov.s -o %t.o
+RUN: %link %linkopts --relax -shared -o %t.so %t.o
+RUN: %objdump -d %t.so | %filecheck %s
+RUN: %readelf -r %t.so | %filecheck %s --check-prefix=NORELOC
+#END_TEST
+
+CHECK: <h_hidden>:
+CHECK-NEXT: {{[0-9a-f]+}}: 8d 05 {{.*}} leal
+
+# No dynamic relocation should exist for the relaxed hidden symbol.
+NORELOC-NOT: sym_hidden

--- a/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_Call.test
+++ b/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_Call.test
@@ -1,0 +1,11 @@
+#--GOTPCRELXRelax_Call.test----------Shared Library--------#
+# CALL rewrite: call *sym@GOTPCREL(%rip) (ff 15) -> addr32 callq sym (67 e8).
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/call.s -o %t.o
+RUN: %link %linkopts --relax -shared -o %t.so %t.o
+RUN: %objdump -d %t.so | %filecheck %s
+#END_TEST
+
+# Instruction must be rewritten to addr32 call (67 e8), not indirect call (ff 15).
+CHECK: <h>:
+CHECK-NEXT: {{[0-9a-f]+}}: 67 e8 {{.*}} addr32 call

--- a/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_IFunc.test
+++ b/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_IFunc.test
@@ -1,0 +1,20 @@
+#--GOTPCRELXRelax_IFunc.test----------Shared Library--------#
+# A hidden (non-preemptible) STT_GNU_IFUNC symbol must NOT be relaxed.
+# isSymbolPreemptible() returns false for a hidden ifunc (it is stopped at
+# the non-default-visibility check before reaching the ifunc case), so the
+# explicit isIFunc() guard is what prevents relaxation. Relaxing would bypass
+# the IRELATIVE/PLT resolution the ifunc requires at load time.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/ifunc.s -o %t.o
+RUN: %link %linkopts --relax -shared -o %t.so %t.o
+RUN: %objdump -d %t.so | %filecheck %s
+RUN: %readelf -r %t.so | %filecheck %s --check-prefix=RELOC
+#END_TEST
+
+# The instruction must remain a GOT-indirect movl (opcode 8b), NOT relaxed to
+# leal (opcode 8d).
+CHECK: <h>:
+CHECK-NEXT: {{[0-9a-f]+}}: 8b 05 {{.*}} movl
+
+# A GOT slot with a dynamic relocation must still exist for the ifunc.
+RELOC: .rela.dyn

--- a/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_Jmp.test
+++ b/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_Jmp.test
@@ -1,0 +1,12 @@
+#--GOTPCRELXRelax_Jmp.test----------Shared Library--------#
+# JMP rewrite: jmp *sym@GOTPCREL(%rip) (ff 25) -> jmpq sym; nop (e9 ... 90).
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/jmp.s -o %t.o
+RUN: %link %linkopts --relax -shared -o %t.so %t.o
+RUN: %objdump -d %t.so | %filecheck %s
+#END_TEST
+
+# Instruction must be rewritten to direct jmp (e9) followed by nop (90).
+CHECK: <h>:
+CHECK-NEXT: {{[0-9a-f]+}}: e9 {{.*}} jmp
+CHECK-NEXT: {{.*}}90{{.*}}nop

--- a/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_Overflow.test
+++ b/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_Overflow.test
@@ -1,0 +1,9 @@
+#--GOTPCRELXRelax_Overflow.test----------Shared Library--------#
+# Out-of-range: displacement overflows 32 bits, linker must error.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/overflow.s -o %t.o
+RUN: %not %link %linkopts --relax -T %p/Inputs/script_overflow.t -o %t.out %t.o 2>&1 \
+RUN:   | %filecheck %s
+#END_TEST
+
+CHECK: {{.*}}: relaxing relocation R_X86_64_GOTPCRELX out of range: {{[0-9]+}} is not in [-2147483648, 2147483647]; references 'sym'; relink with --no-relax

--- a/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_PIE.test
+++ b/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_PIE.test
@@ -1,0 +1,34 @@
+#--GOTPCRELXRelax_PIE.test----------PIE--------#
+# R_X86_64_GOTPCRELX relaxation in PIE (-pie) mode.
+# In a PIE executable, default-visibility symbols are also non-preemptible
+# (the executable is the final definition), so both hidden and
+# default-visibility references relax to leal.
+# Also verifies that a non-relaxable GOTPCRELX (addend != -4) in PIE mode
+# correctly creates a GOT slot with a dynamic relocation.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/mov.s -o %t.o
+RUN: %link %linkopts --relax -pie -o %t.pie %t.o
+RUN: %objdump -d %t.pie | %filecheck %s
+
+# Non-relaxable: addend != -4 falls through to CreateGOT; verify GOT slot
+# is created with a dynamic relocation.
+RUN: %clang %clangopts -c %p/Inputs/addend_nonm4.s -o %t.nonm4.o
+RUN: %link %linkopts --relax -pie -o %t.nonm4.pie %t.nonm4.o
+RUN: %objdump -d %t.nonm4.pie | %filecheck %s --check-prefix=NONRELAX
+RUN: %readelf -r %t.nonm4.pie | %filecheck %s --check-prefix=DYNREL
+#END_TEST
+
+# Hidden symbol relaxes to leal.
+CHECK: <h_hidden>:
+CHECK-NEXT: {{[0-9a-f]+}}: 8d 05 {{.*}} leal
+
+# Default-visibility symbol also relaxes in PIE (non-preemptible in an exe).
+CHECK: <h_default>:
+CHECK-NEXT: {{[0-9a-f]+}}: 8d 05 {{.*}} leal
+
+# Non-relaxable GOTPCRELX stays as movl (8b) — not relaxed to leal (8d).
+NONRELAX: <h>:
+NONRELAX-NEXT: {{[0-9a-f]+}}: 8b 05 {{.*}} movl
+
+# GOT slot must exist with a dynamic relocation.
+DYNREL: .rela.dyn

--- a/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_PartialRelink.test
+++ b/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_PartialRelink.test
@@ -1,0 +1,35 @@
+#--GOTPCRELXRelax_PartialRelink.test----------Shared Library--------#
+# Two-stage link: a partial link (-r) must NOT relax (it has no final
+# layout), and must preserve the R_X86_64_GOTPCRELX relocations so the final
+# link can relax them. Relinking the partial output into a final shared object
+# must then relax the non-preemptible (hidden) reference.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/mov.s -o %t.o
+
+# Stage 1: partial link with --relax. Relaxation must be skipped; the
+# GOTPCRELX relocation and the GOT-indirect movl (opcode 8b) must survive.
+RUN: %link %linkopts -r --relax -o %t.partial.o %t.o
+RUN: %readelf -r %t.partial.o | %filecheck %s --check-prefix=PARTIAL
+RUN: %objdump -dr %t.partial.o | %filecheck %s --check-prefix=PARTIALDIS
+
+# Stage 2: relink the partial output into a final shared object with --relax.
+# The hidden reference must now relax to leal (opcode 8d); the preemptible
+# reference must remain movl (opcode 8b).
+RUN: %link %linkopts --relax -shared -o %t.so %t.partial.o
+RUN: %objdump -d %t.so | %filecheck %s --check-prefix=FINAL
+#END_TEST
+
+# Partial output keeps the GOTPCRELX relocations.
+PARTIAL: R_X86_64_GOTPCRELX {{.*}} sym_hidden
+PARTIAL: R_X86_64_GOTPCRELX {{.*}} sym_default
+
+# Partial output is not relaxed: still a GOT-indirect movl.
+PARTIALDIS: <h_hidden>:
+PARTIALDIS-NEXT: {{[0-9a-f]+}}: 8b 05 {{.*}} movl
+
+# Final output: hidden reference relaxed to leal.
+FINAL: <h_hidden>:
+FINAL-NEXT: {{[0-9a-f]+}}: 8d 05 {{.*}} leal
+# Final output: preemptible reference not relaxed.
+FINAL: <h_default>:
+FINAL-NEXT: {{[0-9a-f]+}}: 8b 05 {{.*}} movl

--- a/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_Preemptible.test
+++ b/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_Preemptible.test
@@ -1,0 +1,11 @@
+#--GOTPCRELXRelax_Preemptible.test----------Shared Library--------#
+# Default-visible symbol in DSO must not relax.
+# Preemptible symbols require GOT indirection for runtime interposition.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/mov.s -o %t.o
+RUN: %link %linkopts --relax -shared -o %t.so %t.o
+RUN: %objdump -d %t.so | %filecheck %s
+#END_TEST
+
+CHECK: <h_default>:
+CHECK-NEXT: {{[0-9a-f]+}}: 8b 05 {{.*}} movl

--- a/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_Trace.test
+++ b/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_Trace.test
@@ -1,0 +1,11 @@
+#--GOTPCRELXRelax_Trace.test----------Shared Library--------#
+# --trace=relax emits a message for each relaxed GOTPCRELX reference.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/mov.s -o %t.o
+RUN: %link %linkopts --relax --trace=relax -shared -o %t.so %t.o 2>&1 \
+RUN:   | %filecheck %s
+#END_TEST
+
+# The hidden (non-preemptible) reference is relaxed and traced; the
+# preemptible one is not.
+CHECK: Trace: {{.*}}: relaxed GOTPCRELX (mov->lea) for symbol 'sym_hidden' to PC-relative access

--- a/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_Type9.test
+++ b/test/x86_64/linux/GOTPCRELXRelaxation/GOTPCRELXRelax_Type9.test
@@ -1,0 +1,11 @@
+#--GOTPCRELXRelax_Type9.test----------Shared Library--------#
+# Plain R_X86_64_GOTPCREL (type 9) must never be relaxed.
+# Only types 41/42 opt in to relaxation.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/gotpcrel.s -o %t.o
+RUN: %link %linkopts --relax -shared -o %t.so %t.o
+RUN: %objdump -d %t.so | %filecheck %s
+#END_TEST
+
+CHECK: <h>:
+CHECK-NEXT: {{[0-9a-f]+}}: 8b 05 {{.*}} movl

--- a/test/x86_64/linux/GOTPCRELXRelaxation/Inputs/addend_nonm4.s
+++ b/test/x86_64/linux/GOTPCRELXRelaxation/Inputs/addend_nonm4.s
@@ -1,0 +1,12 @@
+        .globl sym
+        .hidden sym
+        .data
+sym:    .long 42
+
+        .text
+        .globl h
+        .type  h,@function
+h:
+        movl 0(%rip), %eax
+        .reloc .-4, R_X86_64_GOTPCRELX, sym+0
+        retq

--- a/test/x86_64/linux/GOTPCRELXRelaxation/Inputs/badinput.s
+++ b/test/x86_64/linux/GOTPCRELXRelaxation/Inputs/badinput.s
@@ -1,0 +1,16 @@
+        # A GOTPCRELX relocation placed at offset 0 via .reloc, so the
+        # opcode bytes at loc[-2]/loc[-1] would be before the start of the
+        # fragment buffer. The linker must not crash; it should skip
+        # relaxation and keep the GOT slot.
+        .globl foo
+        .hidden foo
+        .data
+foo:    .long 42
+
+        .text
+        .globl h
+        .type h,@function
+h:
+        .reloc ., R_X86_64_GOTPCRELX, foo
+        nop
+        ret

--- a/test/x86_64/linux/GOTPCRELXRelaxation/Inputs/call.s
+++ b/test/x86_64/linux/GOTPCRELXRelaxation/Inputs/call.s
@@ -1,0 +1,12 @@
+        .globl callee
+        .hidden callee
+        .type  callee,@function
+        .text
+callee:
+        ret
+
+        .globl h
+        .type  h,@function
+h:
+        call *callee@GOTPCREL(%rip)
+        ret

--- a/test/x86_64/linux/GOTPCRELXRelaxation/Inputs/gotpcrel.s
+++ b/test/x86_64/linux/GOTPCRELXRelaxation/Inputs/gotpcrel.s
@@ -1,0 +1,12 @@
+        .globl sym
+        .hidden sym
+        .data
+sym:    .long 42
+
+        .text
+        .globl h
+        .type  h,@function
+h:
+        movl 0(%rip), %eax
+        .reloc .-4, R_X86_64_GOTPCREL, sym-4
+        ret

--- a/test/x86_64/linux/GOTPCRELXRelaxation/Inputs/ifunc.s
+++ b/test/x86_64/linux/GOTPCRELXRelaxation/Inputs/ifunc.s
@@ -1,0 +1,21 @@
+        # A hidden (non-preemptible) STT_GNU_IFUNC symbol. Even though it is
+        # non-preemptible, it must NOT be relaxed: the IRELATIVE resolver runs
+        # at load time and deposits the selected implementation's address in
+        # the GOT slot. Relaxing to a PC-relative access would bypass that.
+        .text
+        .globl resolver
+        .hidden resolver
+        .type  resolver,@function
+resolver:
+        ret
+
+        .globl my_ifunc
+        .hidden my_ifunc
+        .type  my_ifunc,@gnu_indirect_function
+        .set   my_ifunc, resolver
+
+        .globl h
+        .type  h,@function
+h:
+        movl    my_ifunc@GOTPCREL(%rip), %eax
+        ret

--- a/test/x86_64/linux/GOTPCRELXRelaxation/Inputs/jmp.s
+++ b/test/x86_64/linux/GOTPCRELXRelaxation/Inputs/jmp.s
@@ -1,0 +1,11 @@
+        .globl target
+        .hidden target
+        .type  target,@function
+        .text
+target:
+        ret
+
+        .globl h
+        .type  h,@function
+h:
+        jmp *target@GOTPCREL(%rip)

--- a/test/x86_64/linux/GOTPCRELXRelaxation/Inputs/mov.s
+++ b/test/x86_64/linux/GOTPCRELXRelaxation/Inputs/mov.s
@@ -1,0 +1,21 @@
+        .globl sym_hidden
+        .hidden sym_hidden
+        .data
+sym_hidden: .long 42
+
+        .globl sym_default
+        .data
+sym_default: .long 99
+
+        .text
+        .globl h_hidden
+        .type  h_hidden,@function
+h_hidden:
+        movl    sym_hidden@GOTPCREL(%rip), %eax
+        ret
+
+        .globl h_default
+        .type  h_default,@function
+h_default:
+        movl    sym_default@GOTPCREL(%rip), %eax
+        ret

--- a/test/x86_64/linux/GOTPCRELXRelaxation/Inputs/overflow.s
+++ b/test/x86_64/linux/GOTPCRELXRelaxation/Inputs/overflow.s
@@ -1,0 +1,11 @@
+        .globl sym
+        .hidden sym
+        .data
+sym:    .long 42
+
+        .text
+        .globl h
+        .type  h,@function
+h:
+        movl    sym@GOTPCREL(%rip), %eax
+        ret

--- a/test/x86_64/linux/GOTPCRELXRelaxation/Inputs/script_overflow.t
+++ b/test/x86_64/linux/GOTPCRELXRelaxation/Inputs/script_overflow.t
@@ -1,0 +1,6 @@
+SECTIONS {
+    . = 0x2000;
+    .text : { *(.text*) }
+    . = 0x100020000;
+    .data : { *(.data*) *(.bss*) }
+}


### PR DESCRIPTION
Implement relaxation for R_X86_64_GOTPCRELX (type 41) relocations.

For non-preemptible symbols, GOT-indirect references may be rewritten to direct RIP-relative accesses when:

- The symbol is non-preemptible (hidden, protected, bound by -Bsymbolic, or resolved in an executable)
- The symbol is not STT_GNU_IFUNC
- --relax is enabled
- The resulting S + A - P displacement fits in a signed 32-bit range

If the relaxed displacement cannot be represented in 32 bits, the link fails with an error.

Introduces the x86-64 relaxation framework modeled on the RISCV pattern.

This change only handles R_X86_64_GOTPCRELX (41). Support for R_X86_64_REX_GOTPCRELX (42) will be added separately.

Tests:
- GOTPCRELXRelax_Basic.test
- GOTPCRELXRelax_Preemptible.test
- GOTPCRELXRelax_Type9.test
- GOTPCRELXRelax_Overflow.test
- GOTPCRELXRelax_AddendNonM4.test
Fixes https://github.com/qualcomm/eld/issues/1361