### PR TITLE
[RISC-V] Don't retarget pcrel_lo/tlsdesc_lo symbol in partial links

### DIFF
--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -1953,6 +1953,11 @@ bool RISCVLDBackend::handlePendingRelocations(ELFSection *section) {
                      return A->getOffset() < B->getOffset();
                    });
 
+  // Skip HI20/LO12 pairing, R_RISCV_RELAX marking, and vendor relocation
+  // grouping under -r.
+  if (config().isLinkPartial())
+    return true;
+
   struct Less {
     bool operator()(const Relocation *X, uint64_t Y) const {
       return !X->targetRef()->isNull() && X->targetRef()->offset() < Y;

--- a/test/RISCV/standalone/PCRELPartialLink/pcrel-partial-link.s
+++ b/test/RISCV/standalone/PCRELPartialLink/pcrel-partial-link.s
@@ -1,0 +1,32 @@
+## A partial link should keep a pcrel_lo relocation pointing at the label on its
+## paired pcrel_hi instruction, not at the final symbol. The partial output is
+## then linked to a final image to confirm the preserved pair still resolves.
+
+# RUN: %llvm-mc -filetype=obj -triple=riscv32 -mattr=-relax %s -o %t.o
+# RUN: %link %linkopts -o %t.part.o %t.o -r
+# RUN: %readelf -r %t.part.o | %filecheck %s
+# RUN: %link -m elf32lriscv --defsym=gvar=0x8000 -Ttext=0x1000 -e nonpaired %t.part.o -o %t.elf
+# RUN: %objdump -d %t.elf | %filecheck --check-prefix=DISASM %s
+
+# CHECK:      R_RISCV_PCREL_LO12_I {{[0-9a-f]+}} .Lutype
+# CHECK-NEXT: R_RISCV_PCREL_HI20 {{[0-9a-f]+}} gvar
+# CHECK-NEXT: R_RISCV_PCREL_LO12_S {{[0-9a-f]+}} .Lutype
+
+# DISASM:      lw a0, -0x10(a1)
+# DISASM:      auipc a1, 0x7
+# DISASM:      sw t1, -0x10(a1)
+
+	.text
+	.globl	nonpaired
+nonpaired:
+	j	.Lutype                      ## break HI20/LO12 adjacency
+.Lload:
+	lw	a0, %pcrel_lo(.Lutype)(a1)   ## PCREL_LO12_I, sym = .Lutype (HI20 site)
+	addi	t1, a0, 42
+	j	.Lstore
+.Lutype:
+	auipc	a1, %pcrel_hi(gvar)          ## PCREL_HI20,   sym = gvar (final target)
+	j	.Lload
+.Lstore:
+	sw	t1, %pcrel_lo(.Lutype)(a1)   ## PCREL_LO12_S, sym = .Lutype (HI20 site)
+	ret


### PR DESCRIPTION
2c6503d2 rewrote the pcrel_lo/tlsdesc_lo symbol to its paired pcrel_hi/tlsdesc_hi symbol unconditionally. Under -r that rewrite is emitted to the output, where the pcrel_lo must instead reference the local label on its hi20 instruction so the pair can be re-resolved. Skip the retarget for partial links.