### PR TITLE
[CI] Add nightly ELD code coverage workflow with regression detection

### DIFF
--- a/.github/workflows/nightly-eld-code-coverage.yml
+++ b/.github/workflows/nightly-eld-code-coverage.yml
@@ -1,0 +1,220 @@
+name: Nightly ELD code coverage
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch: {}
+  pull_request: {} # Uncomment only to test this WF file update.
+
+jobs:
+  coverage:
+    if: github.repository == 'qualcomm/eld'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}
+      cancel-in-progress: true
+    permissions:
+      contents: write
+
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_COMPILERCHECK: content
+      CCACHE_NOHASHDIR: true
+
+    steps:
+      - name: Checkout llvm-project
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: llvm/llvm-project
+          path: llvm-project
+
+      - name: Checkout eld
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          path: llvm-project/llvm/tools/eld
+
+      - name: Install cross-compilation toolchains
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            gcc-arm-linux-gnueabi g++-arm-linux-gnueabi \
+            gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
+            gcc-riscv64-linux-gnu g++-riscv64-linux-gnu \
+            qemu-user ccache ninja-build
+
+      - uses: ./llvm-project/llvm/tools/eld/.github/workflows/FetchNightlyToolset
+
+      - name: Set LLVM_BIN from nightly toolchain
+        run: |
+          echo "LLVM_BIN=$(pwd)/inst/bin" >> "$GITHUB_ENV"
+          COV_IGNORE_REGEX=$(cat "${{ github.workspace }}/llvm-project/llvm/tools/eld/utils/coverage/coverage-filter-regex.txt")
+          echo "COV_IGNORE_REGEX=$COV_IGNORE_REGEX" >> "$GITHUB_ENV"
+
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-coverage-${{ github.sha }}
+          restore-keys: ccache-coverage-
+
+      - name: Run CMake
+        run: |
+          mkdir -p "$CCACHE_DIR"
+          ccache --zero-stats
+          ccache --set-config "max_size=0"
+
+          rm -rf obj
+          mkdir -p obj
+          cd obj
+          cmake -G Ninja \
+            ../llvm-project/llvm \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON \
+            -DLLVM_ENABLE_PROJECTS="llvm" \
+            -DLLVM_ENABLE_ASSERTIONS:BOOL=ON \
+            -DCMAKE_INSTALL_RPATH:STRING="$ORIGIN/../lib" \
+            -DCMAKE_C_COMPILER="$LLVM_BIN/clang" \
+            -DCMAKE_CXX_COMPILER="$LLVM_BIN/clang++" \
+            -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
+            -DLLVM_TARGETS_TO_BUILD="ARM;AArch64;RISCV;X86" \
+            -DELD_TARGETS_TO_BUILD='ARM;AArch64;RISCV;X86' \
+            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+            -DLLVM_CCACHE_BUILD:BOOL=ON \
+            -DLLVM_CCACHE_DIR:STRING="$CCACHE_DIR" \
+            -DELD_ENABLE_SYMBOL_VERSIONING=ON \
+            -DLLVM_ENABLE_WERROR:BOOL=ON \
+            -DELD_ENABLE_RUN_TESTS:BOOL=On \
+            -DELD_COVERAGE=ON
+
+      - name: Build
+        working-directory: obj
+        run: ninja ld.eld
+
+      - name: Run tests with coverage profiling
+        working-directory: obj
+        run: |
+          export ELD_ARM_C_COMPILER=arm-linux-gnueabi-gcc
+          export ELD_ARM_CXX_COMPILER=arm-linux-gnueabi-g++
+          export ELD_AARCH64_C_COMPILER=aarch64-linux-gnu-gcc
+          export ELD_AARCH64_CXX_COMPILER=aarch64-linux-gnu-g++
+          export ELD_RISCV64_C_COMPILER=riscv64-linux-gnu-gcc
+          export ELD_RISCV64_CXX_COMPILER=riscv64-linux-gnu-g++
+
+          LLVM_PROFILE_FILE="$PWD/eld-%p.profraw" LIT_OPTS="--timeout=600" ninja check-eld
+
+      - name: Summarize test results
+        working-directory: obj
+        run: ninja check-eld-summary
+
+      - name: Save ccache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-coverage-${{ github.sha }}
+
+      - name: Merge profile data
+        working-directory: obj
+        run: $LLVM_BIN/llvm-profdata merge -sparse eld-*.profraw -o eld.profdata
+
+      - name: Generate HTML coverage report
+        working-directory: obj
+        run: |
+          $LLVM_BIN/llvm-cov show \
+            --format=html \
+            --instr-profile=eld.profdata \
+            --object lib/libLW.so \
+            --show-branches=count \
+            --show-expansions \
+            --show-instantiations \
+            --ignore-filename-regex="$COV_IGNORE_REGEX" \
+            -o coverage-report
+
+      - name: Extract coverage and check for regression
+        working-directory: obj
+        run: |
+          COV_SUMMARY=$($LLVM_BIN/llvm-cov report \
+            --instr-profile=eld.profdata \
+            --object lib/libLW.so \
+            --ignore-filename-regex="$COV_IGNORE_REGEX")
+
+          TOTAL_LINE=$(echo "$COV_SUMMARY" | grep '^TOTAL')
+
+          REGION_COV=$(echo "$TOTAL_LINE" | awk '{print $4}')
+          FUNC_COV=$(echo   "$TOTAL_LINE" | awk '{print $7}')
+          LINE_COV=$(echo   "$TOTAL_LINE" | awk '{print $10}')
+          BRANCH_COV=$(echo "$TOTAL_LINE" | awk '{print $13}')
+
+          echo "LINE_COV=$LINE_COV"       >> "$GITHUB_ENV"
+          echo "FUNC_COV=$FUNC_COV"       >> "$GITHUB_ENV"
+          echo "REGION_COV=$REGION_COV"   >> "$GITHUB_ENV"
+          echo "BRANCH_COV=$BRANCH_COV"   >> "$GITHUB_ENV"
+
+          # Fetch baseline from the code-coverage-reports branch (if it exists)
+          git -C "${{ github.workspace }}/llvm-project/llvm/tools/eld" \
+            fetch origin code-coverage-reports:refs/remotes/origin/code-coverage-reports 2>/dev/null || true
+          BASELINE=$(git -C "${{ github.workspace }}/llvm-project/llvm/tools/eld" \
+            show origin/code-coverage-reports:coverage-baseline.txt 2>/dev/null || true)
+
+          if [ -z "$BASELINE" ]; then
+            echo "No baseline found — first run, will record baseline."
+            exit 0
+          fi
+
+          echo "Baseline:"
+          echo "$BASELINE"
+
+          PREV_LINE=$(echo     "$BASELINE" | grep '^LINE='     | cut -d= -f2)
+          PREV_FUNC=$(echo     "$BASELINE" | grep '^FUNCTION=' | cut -d= -f2)
+          PREV_REGION=$(echo   "$BASELINE" | grep '^REGION='   | cut -d= -f2)
+          PREV_BRANCH=$(echo   "$BASELINE" | grep '^BRANCH='   | cut -d= -f2)
+
+          # awk_lt a b — exits 0 (true) when a < b (strips trailing %)
+          awk_lt() {
+            awk -v a="${1%%%}" -v b="${2%%%}" 'BEGIN { exit !(a+0 < b+0) }'
+          }
+
+          REGRESSIONS=""
+          awk_lt "$LINE_COV"   "$PREV_LINE"   && REGRESSIONS="${REGRESSIONS}  LINE:     $LINE_COV < $PREV_LINE (baseline)\n"
+          awk_lt "$FUNC_COV"   "$PREV_FUNC"   && REGRESSIONS="${REGRESSIONS}  FUNCTION: $FUNC_COV < $PREV_FUNC (baseline)\n"
+          awk_lt "$REGION_COV" "$PREV_REGION" && REGRESSIONS="${REGRESSIONS}  REGION:   $REGION_COV < $PREV_REGION (baseline)\n"
+          awk_lt "$BRANCH_COV" "$PREV_BRANCH" && REGRESSIONS="${REGRESSIONS}  BRANCH:   $BRANCH_COV < $PREV_BRANCH (baseline)\n"
+
+          if [ -n "$REGRESSIONS" ]; then
+            echo "Coverage regression detected:"
+            printf "%b" "$REGRESSIONS"
+            echo "COVERAGE_REGRESSED=1" >> "$GITHUB_ENV"
+          else
+            echo "No regression detected."
+          fi
+
+      - name: Deploy coverage report to code-coverage-reports branch
+        run: |
+          REPORT_SRC="${{ github.workspace }}/obj/coverage-report"
+
+          cd llvm-project/llvm/tools/eld
+          git config user.name  'github-actions'
+          git config user.email 'github-actions@github.com'
+
+          git checkout --orphan code-coverage-reports
+          git rm -rf .
+
+          cp -r "${REPORT_SRC}/." .
+
+          printf 'LINE=%s\nFUNCTION=%s\nREGION=%s\nBRANCH=%s\n' \
+            "${LINE_COV}" "${FUNC_COV}" "${REGION_COV}" "${BRANCH_COV}" \
+            > coverage-baseline.txt
+
+          touch .nojekyll
+          git add .
+          git commit -m "Update ELD coverage report ($(date -u '+%Y-%m-%d'))"
+          git push -f origin HEAD:refs/heads/code-coverage-reports
+
+      - name: Fail if coverage regressed
+        if: env.COVERAGE_REGRESSED == '1'
+        run: |
+          echo "Coverage regression was detected — see 'Extract coverage and check for regression' step above."
+          exit 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,9 +217,9 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${CMAKE_CURRENT_SOURCE_DIR}/include/eld/PluginAPI/)
 
-option(ELD_COVERAGE "Build ELD with coverage" OFF)
+option(ELD_COVERAGE "Build ELD with LLVM source-based coverage instrumentation" OFF)
 if(ELD_COVERAGE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
 endif()
 
 option(ELD_SANITIZE "Build ELD with Sanitizer" OFF)

--- a/utils/coverage/coverage-filter-regex.txt
+++ b/utils/coverage/coverage-filter-regex.txt
@@ -1,0 +1,1 @@
+llvm-project/llvm/(include|lib|utils|unittests|examples|docs|cmake|test|benchmarks|projects|runtimes)/|llvm-project/llvm/tools/[^e]|llvm-project/llvm/tools/e[^l]|llvm-project/llvm/tools/el[^d]|third-party/|/obj/tools/[^e]|/obj/tools/e[^l]|/obj/tools/el[^d]|/obj/(include|lib|bin)/|llvm-project/llvm/tools/eld/test/|llvm-project/llvm/tools/eld/Plugins/HelloWorldPlugin/


### PR DESCRIPTION
Added a workflow which runs nightly and computes the code coverage, and when ran at first creates a baseline text file on orphan branch called code-coverage, and from the next time, it checks with the previous coverage numbers and if any metric goes down, it fails, and if no regression is detected then we push the html report and update the baseline text file. 