### PR TITLE
Fix stats-file-option.ll output check

### DIFF
--- a/test/lld/ELF/stats-file-option.ll
+++ b/test/lld/ELF/stats-file-option.ll
@@ -9,7 +9,7 @@
 ; CHECK: {
 ; CHECK: "asm-printer.EmittedInsts":
 ; CHECK: "inline.NumInlined":
-; CHECK: "prologepilog.NumFuncSeen":
+; CHECK: "prolog-epilog.NumFuncSeen":
 ; CHECK: }
 
 declare i32 @patatino()


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/207870 renamed prologpeilog to prolog-epilog leading to the test failure. Modify the check line in the test to match this.