### PR TITLE
[Relocator] Resolve IE TLS GOT entries statically in PIE

### DIFF
--- a/lib/Target/AArch64/AArch64Relocator.cpp
+++ b/lib/Target/AArch64/AArch64Relocator.cpp
@@ -255,8 +255,15 @@ void AArch64Relocator::scanLocalReloc(InputFile &pInput, Relocation &pReloc,
     if (config().isCodeStatic())
       return;
     AArch64GOT *G = m_Target.createGOT(GOT::TLS_IE, Obj, rsym);
+    if (config().isBuildingExecutable()) {
+      G->setValueType(GOT::TLSStaticSymbolValue);
+      if (rsym->reserved() == Relocator::None)
+        rsym->setReserved(rsym->reserved() | ReserveGOT);
+      return;
+    }
     helper_DynRel_init(Obj, &pReloc, rsym, G, 0x0,
                        llvm::ELF::R_AARCH64_TLS_TPREL64, m_Target);
+    m_Target.setHasStaticTLS();
     if (rsym->reserved() == Relocator::None)
       rsym->setReserved(rsym->reserved() | ReserveGOT);
     return;
@@ -471,13 +478,15 @@ void AArch64Relocator::scanGlobalReloc(InputFile &pInput, Relocation &pReloc,
 
     // set up the got and the corresponding rel entry
     AArch64GOT *G = m_Target.createGOT(GOT::TLS_IE, Obj, rsym);
-    if (config().isCodeStatic()) {
+    if (config().isCodeStatic() || (config().isBuildingExecutable() &&
+                                    !m_Target.isSymbolPreemptible(*rsym))) {
       rsym->setReserved(rsym->reserved() | ReserveGOT);
       G->setValueType(GOT::TLSStaticSymbolValue);
       return;
     }
     helper_DynRel_init(Obj, &pReloc, rsym, G, 0x0,
                        llvm::ELF::R_AARCH64_TLS_TPREL64, m_Target);
+    m_Target.setHasStaticTLS();
     rsym->setReserved(rsym->reserved() | ReserveGOT);
     return;
   }

--- a/lib/Target/ARM/ARMRelocator.cpp
+++ b/lib/Target/ARM/ARMRelocator.cpp
@@ -481,13 +481,14 @@ void ARMRelocator::scanLocalReloc(InputFile &pInput, Relocation::Type Type,
 
     // set up the got and the corresponding rel entry
     ARMGOT *G = m_Target.createGOT(GOT::TLS_IE, Obj, rsym);
-    if (config().isCodeStatic()) {
+    if (config().isCodeStatic() || config().isBuildingExecutable()) {
       rsym->setReserved(rsym->reserved() | ReserveGOT);
       G->setValueType(GOT::TLSStaticSymbolValue);
       return;
     }
     helper_DynRel_init(Obj, &pReloc, rsym, G, 0x0, llvm::ELF::R_ARM_TLS_TPOFF32,
                        m_Target);
+    m_Target.setHasStaticTLS();
     if (rsym->reserved() == Relocator::None)
       rsym->setReserved(rsym->reserved() | ReserveGOT);
     return;
@@ -785,13 +786,15 @@ void ARMRelocator::scanGlobalReloc(InputFile &pInput, Relocation::Type Type,
 
     // set up the got and the corresponding rel entry
     ARMGOT *G = m_Target.createGOT(GOT::TLS_IE, Obj, rsym);
-    if (config().isCodeStatic()) {
+    if (config().isCodeStatic() || (config().isBuildingExecutable() &&
+                                    !m_Target.isSymbolPreemptible(*rsym))) {
       rsym->setReserved(rsym->reserved() | ReserveGOT);
       G->setValueType(GOT::TLSStaticSymbolValue);
       return;
     }
     helper_DynRel_init(Obj, &pReloc, rsym, G, 0x0, llvm::ELF::R_ARM_TLS_TPOFF32,
                        m_Target);
+    m_Target.setHasStaticTLS();
     rsym->setReserved(rsym->reserved() | ReserveGOT);
     return;
   }

--- a/lib/Target/Hexagon/HexagonRelocator.cpp
+++ b/lib/Target/Hexagon/HexagonRelocator.cpp
@@ -137,7 +137,8 @@ void HexagonRelocator::CreateGOTIE(ELFObjectFile *Obj,
 
   // set up the got and the corresponding rel entry
   HexagonGOT *G = m_Target.createGOT(GOT::TLS_IE, Obj, rsym);
-  if (config().isCodeStatic())
+  if (config().isCodeStatic() ||
+      (config().isBuildingExecutable() && !m_Target.isSymbolPreemptible(*rsym)))
     G->setValueType(GOT::TLSStaticSymbolValue);
   else
     helper_DynRel_init(Obj, &pReloc, rsym, G, 0x0, llvm::ELF::R_HEX_TPREL_32,
@@ -644,7 +645,7 @@ void HexagonRelocator::defineSymbolforGuard(eld::IRBuilder &pBuilder,
       config().raise(Diag::target_specific_symbol) << SymbolName;
     if (layoutInfo)
       layoutInfo->recordFragment(guardSection->getInputFile(), guardSection,
-                                    frag);
+                                 frag);
   }
   config().raise(Diag::resolve_undef_weak_guard)
       << pSym->name() << pSym->resolvedOrigin()->getInput()->decoratedPath()

--- a/lib/Target/RISCV/RISCVRelocator.cpp
+++ b/lib/Target/RISCV/RISCVRelocator.cpp
@@ -541,7 +541,7 @@ void RISCVRelocator::scanLocalReloc(InputFile &pInput, Relocation &pReloc,
       return;
     RISCVGOT *G = m_Target.createGOT(GOT::TLS_IE, Obj, rsym);
     rsym->setReserved(rsym->reserved() | ReserveGOT);
-    if (config().isCodeStatic()) {
+    if (config().isCodeStatic() || config().isBuildingExecutable()) {
       G->setValueType(GOT::TLSStaticSymbolValue);
       return;
     }
@@ -549,6 +549,7 @@ void RISCVRelocator::scanLocalReloc(InputFile &pInput, Relocation &pReloc,
                        is32bit() ? llvm::ELF::R_RISCV_TLS_TPREL32
                                  : llvm::ELF::R_RISCV_TLS_TPREL64,
                        m_Target);
+    m_Target.setHasStaticTLS();
     break;
   }
 
@@ -691,7 +692,8 @@ void RISCVRelocator::scanGlobalReloc(InputFile &pInputFile, Relocation &pReloc,
       return;
     RISCVGOT *G = m_Target.createGOT(GOT::TLS_IE, Obj, rsym);
     rsym->setReserved(rsym->reserved() | ReserveGOT);
-    if (config().isCodeStatic()) {
+    if (config().isCodeStatic() || (config().isBuildingExecutable() &&
+                                    !m_Target.isSymbolPreemptible(*rsym))) {
       G->setValueType(GOT::TLSStaticSymbolValue);
       return;
     }
@@ -699,6 +701,7 @@ void RISCVRelocator::scanGlobalReloc(InputFile &pInputFile, Relocation &pReloc,
                        is32bit() ? llvm::ELF::R_RISCV_TLS_TPREL32
                                  : llvm::ELF::R_RISCV_TLS_TPREL64,
                        m_Target);
+    m_Target.setHasStaticTLS();
     break;
   }
 

--- a/test/Common/standalone/TLS/TLSIEPIE/TLSIEPIE.test
+++ b/test/Common/standalone/TLS/TLSIEPIE/TLSIEPIE.test
@@ -1,0 +1,30 @@
+/// Verifies that R_*_GOTTPOFF / R_*_TLSIE relocations against a static TLS
+/// symbol cause the linker to emit a TPREL/TPOFF dynamic relocation when the
+/// output is a shared object, and are statically resolved for PIE. Both a
+/// local and a non-preemptible global TLS symbol are tested.
+
+// RUN: %clang %clangopts -c -x c %s -fPIC -ftls-model=initial-exec -o %t.o
+// RUN: %link %linkopts -shared %t.o -o %t.so
+// RUN: %readelf -r -d %t.so | %filecheck %s --check-prefix=SHARED
+// RUN: %link %linkopts -pie %t.o -o %t.pie --defsym __libc_start_main=0
+// RUN: %readelf -r %t.pie | %filecheck %s --check-prefix=PIE
+
+/// Target relocation types:
+///   R_X86_64_TPOFF64
+///   R_AARCH64_TLS_TPREL64
+///   R_ARM_TLS_TPOFF32
+///   R_RISCV_TLS_TPREL64
+///   R_RISCV_TLS_TPREL32
+///   R_HEX_TPREL_32
+// SHARED: FLAGS
+// SHARED-SAME: STATIC_TLS
+/// Local symbol: dynamic reloc with no symbol name.
+// SHARED: R_{{.*}}TP{{(REL|OFF)_?[0-9]+}}
+/// Global symbol: dynamic reloc naming the symbol.
+// SHARED: R_{{.*}}TP{{(REL|OFF)_?[0-9]+}} {{.*}}global_tls
+// PIE: There are no relocations in this file.
+
+static __thread int local_tls = 10;
+__thread int global_tls = 20;
+int foo(void) { return local_tls + global_tls; }
+void *__aeabi_read_tp(void) { return 0; }

--- a/test/Common/standalone/TLS/TLSIEPIERun/TLSIEPIERun.test
+++ b/test/Common/standalone/TLS/TLSIEPIERun/TLSIEPIERun.test
@@ -1,0 +1,20 @@
+// REQUIRES: run_test
+
+/// Runtime counterpart to TLSIEPIE: build a PIE executable that uses
+/// initial-exec TLS for both a local-static and a non-preemptible global TLS
+/// symbol, and run it under the target emulator.
+
+// RUN: %run_cc %clangopts -x c %s -fPIE -ftls-model=initial-exec -pie -o %t.pie.out
+// RUN: %run %t.pie.out | %filecheck %s
+
+// CHECK: local_tls=10 global_tls=20
+
+#include <stdio.h>
+
+static __thread int local_tls = 10;
+__thread int global_tls = 20;
+
+int main(void) {
+  printf("local_tls=%d global_tls=%d\n", local_tls, global_tls);
+  return 0;
+}


### PR DESCRIPTION
For non-preemptible symbols accessed through R_*_GOTTPOFF / R_*_TLS_IE, the IE-mode GOT entry was being initialized with a dynamic TPREL/TPOFF relocation in any non-static link, including -pie. PIE executables are not preempted, so the static TLS offset is known at link time and a dynamic relocation is both unnecessary and rejected by the loader.

Also set `DF_STATIC_TLS` on AArch64, ARM, and RISCV (Hexagon and X86 already do).

Fixes: #1110