### PR TITLE
[AArch64] Add overflow check for ADR_PREL_LO21/LD_PREL_LO19

### DIFF
--- a/docs/DeveloperDocs/AArch64-Relocations.md
+++ b/docs/DeveloperDocs/AArch64-Relocations.md
@@ -52,12 +52,16 @@ movk x1, #:abs_g0_nc:u64
 
 # PC-Relative Address Relocations
 
-| Operator | Relocation | Expression | Instruction | Encoded Bits | Range Check |
-|-----------|------------|------------|-------------|--------------|-------------|
-| implicit | `LD_PREL_LO19` | `S+A-P` | literal `ldr` | `[20:2]` | `-2^20 <= X < 2^20` |
-| implicit | `LD_PREL_LO21` | `S+A-P` | `adr` | `[20:0]` | `-2^20 <= X < 2^20` |
-| `:pg_hi21:` | `ADR_PREL_PG_HI21` | `Page(S+A)-Page(P)` | `adrp` | `[31:12]` | `-2^32 <= X < 2^32` |
-| `:pg_hi21_nc:` | `ADR_PREL_PG_HI21_NC` | `Page(S+A)-Page(P)` | `adrp` | `[31:12]` | none |
+| Operator | Relocation | Expression | Instruction | Encoded Bits | Range Check | Alignment |
+|-----------|------------|------------|-------------|--------------|-------------|-----------|
+| implicit | `LD_PREL_LO19` | `S+A-P` | literal `ldr` | `[20:2]` | `-2^20 <= X < 2^20` | `X` must be a multiple of 4 |
+| implicit | `LD_PREL_LO21` | `S+A-P` | `adr` | `[20:0]` | `-2^20 <= X < 2^20` | none |
+| `:pg_hi21:` | `ADR_PREL_PG_HI21` | `Page(S+A)-Page(P)` | `adrp` | `[31:12]` | `-2^32 <= X < 2^32` | none |
+| `:pg_hi21_nc:` | `ADR_PREL_PG_HI21_NC` | `Page(S+A)-Page(P)` | `adrp` | `[31:12]` | none | none |
+
+> **`LD_PREL_LO19` alignment:** The literal `ldr` instruction addresses 4-byte-aligned
+> literals; `X` (`S+A-P`) must therefore be divisible by 4. The linker encodes `X >> 2`
+> into the 19-bit field and emits a warning if `X & 3 != 0`.
 
 ## Typical ADRP + ADD Sequence
 

--- a/docs/DeveloperDocs/AArch64-Relocations.md
+++ b/docs/DeveloperDocs/AArch64-Relocations.md
@@ -87,12 +87,19 @@ add  x0, x0, #:lo12:foo
 
 # Control Flow Relocations
 
-| Relocation | Instruction | Encoded Bits | Reach |
-|------------|-------------|--------------|--------|
-| `TSTBR14` | `tbz`, `tbnz` | `[15:2]` | `-2^15 <= X < 2^15` |
-| `CONDBR19` | `b.<cond>` | `[20:2]` | `-2^20 <= X < 2^20` |
-| `JUMP26` | `b` | `[27:2]` | `-2^27 <= X < 2^27` |
-| `CALL26` | `bl` | `[27:2]` | `-2^27 <= X < 2^27` |
+| Relocation | Instruction | Expression | Encoded Bits | Reach | Alignment | Out-of-range |
+|------------|-------------|------------|--------------|-------|-----------|--------------|
+| `TSTBR14` | `tbz`, `tbnz` | `S+A-P` | `[15:2]` | `-2^15 <= X < 2^15` | `X` must be a multiple of 4 | error |
+| `CONDBR19` | `b.<cond>` | `S+A-P` | `[20:2]` | `-2^20 <= X < 2^20` | `X` must be a multiple of 4 | error |
+| `JUMP26` | `b` | `S+A-P` | `[27:2]` | `-2^27 <= X < 2^27` | `X` must be a multiple of 4 | trampoline |
+| `CALL26` | `bl` | `S+A-P` | `[27:2]` | `-2^27 <= X < 2^27` | `X` must be a multiple of 4 | trampoline |
+
+> **Alignment:** All four control-flow relocations encode `X >> 2` into their immediate field,
+> so `X` (`S+A-P`) must be divisible by 4. The linker emits an error if `X & 3 != 0`.
+>
+> **Out-of-range (`JUMP26`/`CALL26`):** When the branch target is beyond ±128 MB the linker
+> inserts a trampoline stub for range extension rather than reporting an overflow error.
+> `TSTBR14` and `CONDBR19` have no trampoline support; exceeding their range is a hard error.
 
 ---
 

--- a/include/eld/Diagnostics/DiagRelocations.inc
+++ b/include/eld/Diagnostics/DiagRelocations.inc
@@ -52,6 +52,9 @@ DIAG(unsupported_relocation_moreinfo, DiagnosticEngine::Fatal,
 DIAG(not_aligned, DiagnosticEngine::Warning,
      "Relocation `%0' for symbol `%1' referred from `%2' and defined in `%3' "
      "has alignment %4 but is not aligned")
+DIAG(error_reloc_not_aligned, DiagnosticEngine::Error,
+     "Relocation `%0' for symbol `%1' in %2 requires %3-byte alignment (%4 is "
+     "not aligned)")
 DIAG(reloc_truncated, DiagnosticEngine::Warning,
      "Relocation `%0' for symbol `%1' referred from `%2' and defined in `%3' "
      "is truncated to fit relocation field")

--- a/lib/Target/AArch64/AArch64Relocator.cpp
+++ b/lib/Target/AArch64/AArch64Relocator.cpp
@@ -932,6 +932,14 @@ Relocator::Result call(Relocation &pReloc, AArch64Relocator &pParent) {
 
   Relocator::DWord X = S + A - P;
 
+  if (X & 0x3) {
+    DiagEngine->raise(Diag::error_reloc_not_aligned)
+        << pParent.getName(pReloc.type()) << pReloc.symInfo()->name()
+        << pReloc.getSourcePath(pParent.config().options()) << "4"
+        << ("PC-relative offset 0x" + llvm::utohexstr(X));
+    return Relocator::BadReloc;
+  }
+
   pReloc.target() = helper_reencode_branch_offset_26(pReloc.target(), X >> 2);
 
   return Relocator::OK;

--- a/lib/Target/AArch64/AArch64Relocator.cpp
+++ b/lib/Target/AArch64/AArch64Relocator.cpp
@@ -864,7 +864,10 @@ Relocator::Result adr_prel_lo21(Relocation &pReloc, AArch64Relocator &pParent) {
   Relocator::DWord P = pReloc.place(pParent.module());
 
   Relocator::DWord X = S + A - P;
-  // TODO:: check overflow
+
+  Relocator::Result R = checkSignedRange(pReloc, pParent, X, 21);
+  if (R != Relocator::OK)
+    return R;
 
   pReloc.target() = helper_reencode_adr_imm(pReloc.target(), X);
 
@@ -884,7 +887,18 @@ Relocator::Result ld_prel_lo19(Relocation &pReloc, AArch64Relocator &pParent) {
   Relocator::DWord P = pReloc.place(pParent.module());
 
   Relocator::DWord X = S + A - P;
-  // TODO:: check overflow
+
+  if (X & 0x3) {
+    DiagEngine->raise(Diag::error_reloc_not_aligned)
+        << pParent.getName(pReloc.type()) << pReloc.symInfo()->name()
+        << pReloc.getSourcePath(pParent.config().options()) << "4"
+        << ("PC-relative offset 0x" + llvm::utohexstr(X));
+    return Relocator::BadReloc;
+  }
+
+  Relocator::Result R = checkSignedRange(pReloc, pParent, X, 21);
+  if (R != Relocator::OK)
+    return R;
 
   pReloc.target() = helper_reencode_ld_literal_19(pReloc.target(), X >> 2);
 
@@ -917,7 +931,6 @@ Relocator::Result call(Relocation &pReloc, AArch64Relocator &pParent) {
             ->getAddr(DiagEngine);
 
   Relocator::DWord X = S + A - P;
-  // TODO: check overflow..
 
   pReloc.target() = helper_reencode_branch_offset_26(pReloc.target(), X >> 2);
 

--- a/test/AArch64/standalone/AdrOverflow/Inputs/t.s
+++ b/test/AArch64/standalone/AdrOverflow/Inputs/t.s
@@ -1,0 +1,9 @@
+	.text
+	.globl	foo
+	.p2align	2
+	.type	foo,@function
+foo:
+	adr	x0, bar
+	ret
+.Lfunc_end0:
+	.size	foo, .Lfunc_end0-foo

--- a/test/AArch64/standalone/AdrOverflow/R_AARCH64_ADR_PREL_LO21.overflow.test
+++ b/test/AArch64/standalone/AdrOverflow/R_AARCH64_ADR_PREL_LO21.overflow.test
@@ -1,0 +1,22 @@
+#---R_AARCH64_ADR_PREL_LO21.overflow.test--------------------- Executable --------------------#
+#START_COMMENT
+# Check that R_AARCH64_ADR_PREL_LO21 overflow is correctly detected.
+# The ADR instruction encodes (S + A) - P in a 21-bit signed field,
+# so the PC-relative offset must be in [-1048576, 1048575].
+# foo links at 0x0 (bare metal), so --defsym bar=<value> sets X = value directly:
+#   bar = 0xFFFFF -> X = 1048575 (max positive, in range)
+#   bar = 0x100000 -> X = 1048576 (one past max, overflow)
+#END_COMMENT
+#START_TEST
+RUN: %clangas %clangasopts -filetype obj -mrelocation-model static -o %t.o %p/Inputs/t.s
+
+# bar = 0xFFFFF: offset 1048575 — top of 21-bit signed range.
+RUN: %link %linkopts -march aarch64 %t.o --defsym bar=0xFFFFF -o %t.out
+RUN: %nm %t.out | %filecheck %s
+CHECK: foo
+
+# bar = 0x100000: offset 1048576 — one past the 21-bit max.
+RUN: %not %link %linkopts -march aarch64 %t.o --defsym bar=0x100000 -o %t.out 2>&1 | %filecheck %s -check-prefix=OVER
+OVER: relocation R_AARCH64_ADR_PREL_LO21 out of range: 1048576 is not in [-1048576, 1048575]
+
+#END_TEST

--- a/test/AArch64/standalone/BranchOverflow/Inputs/t.s
+++ b/test/AArch64/standalone/BranchOverflow/Inputs/t.s
@@ -1,0 +1,17 @@
+	.text
+	.globl	foo
+	.p2align	2
+	.type	foo,@function
+foo:
+	bl	bar
+	ret
+.Lfunc_end0:
+	.size	foo, .Lfunc_end0-foo
+
+	.globl	baz
+	.p2align	2
+	.type	baz,@function
+baz:
+	b	bar
+.Lfunc_end1:
+	.size	baz, .Lfunc_end1-baz

--- a/test/AArch64/standalone/BranchOverflow/R_AARCH64_CALL26_JUMP26.overflow.test
+++ b/test/AArch64/standalone/BranchOverflow/R_AARCH64_CALL26_JUMP26.overflow.test
@@ -1,0 +1,31 @@
+#---R_AARCH64_CALL26_JUMP26.overflow.test--------------------- Executable --------------------#
+#START_COMMENT
+# Verify that R_AARCH64_CALL26 and R_AARCH64_JUMP26 relocations are handled
+# correctly for in-range, out-of-range, and misaligned targets.
+# BL/B encodes (S + A) - P in a 26-bit signed field scaled by 4 (+/-128MB range).
+# When the target is out of range, the linker inserts a trampoline stub for
+# range extension rather than reporting an overflow error.
+# The target must also be 4-byte aligned; a misaligned target is always an error.
+# foo/baz link at 0x0 (bare metal), so:
+#   bar = 0x7FFFFFC -> X = 134217724 (within +/-128MB range, no trampoline needed)
+#   bar = 0x8000000 -> X = 134217728 (beyond +128MB, trampoline inserted)
+#   bar = 0x5       -> X = 5 (in range but not 4-byte aligned, alignment error)
+#END_COMMENT
+#START_TEST
+RUN: %clangas %clangasopts -filetype obj -mrelocation-model static -o %t.o %p/Inputs/t.s
+
+# bar at 0x7FFFFFC: within the 26-bit signed scaled range — links directly.
+RUN: %link %linkopts -march aarch64 %t.o --defsym bar=0x7FFFFFC -o %t.out
+RUN: %nm %t.out | %filecheck %s
+CHECK: foo
+
+# bar at 0x8000000: beyond +128MB — linker inserts a trampoline for range extension.
+RUN: %link %linkopts -march aarch64 %t.o --defsym bar=0x8000000 -o %t.out
+RUN: %nm %t.out | %filecheck %s -check-prefix=TRAMP
+TRAMP: trampoline_for_bar
+
+# bar at 0x5: in range but not 4-byte aligned — alignment error.
+RUN: %not %link %linkopts -march aarch64 %t.o --defsym bar=0x5 -o %t.out 2>&1 | %filecheck %s -check-prefix=ALIGN
+ALIGN: Relocation `R_AARCH64_CALL26' for symbol `bar'{{.*}}requires 4-byte alignment (PC-relative offset 0x5 is not aligned)
+
+#END_TEST

--- a/test/AArch64/standalone/LdOverflow/Inputs/t.s
+++ b/test/AArch64/standalone/LdOverflow/Inputs/t.s
@@ -1,0 +1,9 @@
+	.text
+	.globl	foo
+	.p2align	2
+	.type	foo,@function
+foo:
+	ldr	x0, bar
+	ret
+.Lfunc_end0:
+	.size	foo, .Lfunc_end0-foo

--- a/test/AArch64/standalone/LdOverflow/R_AARCH64_LD_PREL_LO19.overflow.test
+++ b/test/AArch64/standalone/LdOverflow/R_AARCH64_LD_PREL_LO19.overflow.test
@@ -1,0 +1,28 @@
+#---R_AARCH64_LD_PREL_LO19.overflow.test--------------------- Executable --------------------#
+#START_COMMENT
+# Check that R_AARCH64_LD_PREL_LO19 overflow and alignment errors are correctly detected.
+# The LDR (literal) instruction encodes (S + A) - P in a 19-bit signed field
+# scaled by 4. The range check uses 21 signed bits on the raw byte offset,
+# so the checked range is [-2^20, 2^20 - 1]. X must also be divisible by 4.
+# foo links at 0x0 (bare metal), so --defsym bar=<value> sets X = value directly:
+#   bar = 0xFFFFC -> X = 1048572 (largest 4-byte aligned value in range)
+#   bar = 0x100000 -> X = 1048576 (one past the 21-bit max, overflow)
+#   bar = 0x5     -> X = 5 (in range but not 4-byte aligned, error)
+#END_COMMENT
+#START_TEST
+RUN: %clangas %clangasopts -filetype obj -mrelocation-model static -o %t.o %p/Inputs/t.s
+
+# bar = 0xFFFFC: offset 1048572 — within 21-bit signed range and 4-byte aligned.
+RUN: %link %linkopts -march aarch64 %t.o --defsym bar=0xFFFFC -o %t.out
+RUN: %nm %t.out | %filecheck %s
+CHECK: foo
+
+# bar = 0x100000: offset 1048576 — one past the 21-bit max.
+RUN: %not %link %linkopts -march aarch64 %t.o --defsym bar=0x100000 -o %t.out 2>&1 | %filecheck %s -check-prefix=OVER
+OVER: relocation R_AARCH64_LD_PREL_LO19 out of range: 1048576 is not in [-1048576, 1048575]
+
+# bar = 0x5: offset 5 — in range but not 4-byte aligned, expect alignment error.
+RUN: %not %link %linkopts -march aarch64 %t.o --defsym bar=0x5 -o %t.out 2>&1 | %filecheck %s -check-prefix=ALIGN
+ALIGN: Relocation `R_AARCH64_LD_PREL_LO19' for symbol `bar'{{.*}}requires 4-byte alignment (PC-relative offset 0x5 is not aligned)
+
+#END_TEST


### PR DESCRIPTION
The ADR instruction encodes (S + A) - P in a 21-bit signed immediate field. Add a signed 21-bit range check for R_AARCH64_ADR_PREL_LO21.

The LDR (literal) instruction encodes (S + A) - P in a 19-bit signed field scaled by 4. Add a signed 21-bit range check on the raw byte offset for R_AARCH64_LD_PREL_LO19.

Add a lit test that verifies a link within range succeeds and a link that overflows the 21-bit field is caught with an overflow diagnostic.