### PR TITLE
[github-workflow] Dont upload artifacts per PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,13 +183,13 @@ jobs:
 
           XZ_OPT=-T0 tar -Jcf install-pr-toolset.tar.xz inst
 
-      - name: Upload PR ELD toolset
-        if: steps.file-check.outputs.skip_build == 'false'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
-        with:
-          name: pr-eld-toolset
-          retention-days: 1
-          path: pr-${{ env.PR_NUMBER }}/install-pr-toolset.tar.xz
+      #- name: Upload PR ELD toolset
+      #  if: steps.file-check.outputs.skip_build == 'false'
+      #  uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
+      #  with:
+      #    name: pr-eld-toolset
+      #    retention-days: 1
+      #    path: pr-${{ env.PR_NUMBER }}/install-pr-toolset.tar.xz
 
       - name: Clean up
         if: always()


### PR DESCRIPTION
This looks to be added for Zephyr PR workflow verification.

This was an oversight that I missed during the code review process.

We should only trigger this for Zephyr PR workflow, which can hint the CI workflow to upload an artifact, which can then be used by the Zephyr PR workflow check.

These artifacts even for a retention of 1 day will accumulate by the number of builds that are triggered.

This needs to be designed better.