### PR TITLE
Fix --wrap option when dealing with archives

### DIFF
--- a/docs/userguide/documentation/linker_faq.rst
+++ b/docs/userguide/documentation/linker_faq.rst
@@ -3076,6 +3076,34 @@ The wrapper function prints the number of bytes that is requested by user using
   # '4' bytes requested using my_malloc
   # p: 11
 
+Archive Member Extraction
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When '--wrap=<sym>' is specified, three names form the *wrap chain* for that
+symbol: 'sym' (the original name, any reference to which is renamed to
+'__wrap_sym'), '__wrap_sym' (the wrapper definition supplied by the user),
+and '__real_sym' (any reference to which is renamed to 'sym', letting the
+wrapper call through to the original definition).
+
+Archive member extraction still follows the ordinary rule: a member is only
+pulled from an archive to resolve an undefined reference that actually
+exists after wrap-renaming has been applied.
+
+Debugging Wrap Symbols
+^^^^^^^^^^^^^^^^^^^^^^
+
+To trace symbol wrapping operations, use '--trace=wrap-symbols':
+
+.. code-block:: bash
+
+  eld ... --wrap=add --trace=wrap-symbols
+
+This will report:
+
+- Which symbols are renamed by the wrap mechanism
+- Which archive members are pulled for wrapped symbols
+- The complete symbol resolution chain
+
 Build time issues
 ==================
 

--- a/include/eld/Diagnostics/DiagSymbolResolutions.inc
+++ b/include/eld/Diagnostics/DiagSymbolResolutions.inc
@@ -42,6 +42,8 @@ DIAG(insert_wrapper, DiagnosticEngine::Note,
      "Inserting wrapper `%0' for bitcode symbol")
 DIAG(real_sym_reference, DiagnosticEngine::Note,
      "Found real symbol `%0' for wrapped symbol `%1'")
+DIAG(trace_wrap_archive_pull, DiagnosticEngine::Trace,
+     "Pulling archive member from `%0' for wrapped symbol `%1'")
 DIAG(comm_override_by_definition, DiagnosticEngine::Warning,
      "common symbol %0 in file %1 is overridden by definition from %2")
 DIAG(common_symbol_doesnot_override_definition, DiagnosticEngine::Warning,

--- a/lib/Core/Module.cpp
+++ b/lib/Core/Module.cpp
@@ -667,8 +667,19 @@ LDSymbol *Module::addSymbolFromBitCode(
                                getPrinter());
     if (!ThisConfig.options().renameMap().empty() &&
         Desc == ResolveInfo::Undefined) {
-      if (ThisConfig.options().renameMap().count(Name))
+      auto RenameSym = ThisConfig.options().renameMap().find(Name);
+      if (RenameSym != ThisConfig.options().renameMap().end()) {
         saveWrapReference(Name);
+        // Also insert the rename target as undefined so archive scanning
+        // can find it and pull the archive member that defines it.
+        const std::string &RenamedName = RenameSym->getValue();
+        Resolver::Result RenameResult = {nullptr, false, false};
+        getNamePool().insertSymbol(
+            &CurInput, RenamedName, /*IsSymbolInDynamicLibrary=*/false, Type,
+            Desc, Binding, Size, /*Value=*/0, Visibility,
+            /*OldSymbolInfo=*/nullptr, RenameResult, /*IsLtoPhase=*/false,
+            /*IsBitCode=*/true, PIdx, getPrinter());
+      }
     }
   }
 

--- a/lib/Readers/ArchiveParser.cpp
+++ b/lib/Readers/ArchiveParser.cpp
@@ -501,9 +501,19 @@ ArchiveParser::shouldIncludeSymbol(const ArchiveFile &archive,
   // If there is a wrap option specified for that symbol, we only pull from
   // an archive, if the real symbol is still undefined.
   std::string realSymbol = ("__real_" + SymName).str();
-  ResolveInfo *RealSymbol = m_Module.getNamePool().findInfo(realSymbol);
-  if (RealSymbol && RealSymbol->isUndef())
-    return ArchiveFile::Symbol::Include;
+  if (m_Module.hasWrapReference(realSymbol)) {
+    ResolveInfo *RealSymbol = m_Module.getNamePool().findInfo(realSymbol);
+    if (!RealSymbol || RealSymbol->isUndef()) {
+      // Emit a trace message when pulling archive members for wrapped symbols
+      // to aid in debugging the wrap chain and archive resolution process.
+      if (m_Module.getPrinter()->traceWrapSymbols()) {
+        m_Module.getConfig().raise(Diag::trace_wrap_archive_pull)
+            << archive.getInput()->decoratedPath() // archive filename
+            << SymName;                            // wrapped symbol name
+      }
+      return ArchiveFile::Symbol::Include;
+    }
+  }
 
   return ArchiveFile::Symbol::Exclude;
 }

--- a/lib/SymbolResolver/IRBuilder.cpp
+++ b/lib/SymbolResolver/IRBuilder.cpp
@@ -84,6 +84,9 @@ LDSymbol *IRBuilder::addSymbol(InputFile &Input, const std::string &SymbolName,
       bool TraceWrap = ThisModule.getPrinter()->traceWrapSymbols();
       // If the renameMap is not empty, some symbols should be renamed.
       // --wrap and --portable defines the symbol rename map.
+      if (Desc == ResolveInfo::Undefined)
+        ThisModule.saveWrapReference(SymbolName);
+
       if (ResolveInfo::Undefined == Desc && (!EObj || !EObj->isLTOObject())) {
         Name = RenameSym->getValue();
         if (TraceWrap)

--- a/test/Common/standalone/WrapSymbolArchive/Inputs/1.c
+++ b/test/Common/standalone/WrapSymbolArchive/Inputs/1.c
@@ -1,0 +1,6 @@
+/* main.c: calls add() which will be intercepted by --wrap=add */
+extern int add(int a, int b);
+int main() {
+  int sum = add(40, 2);
+  return sum;
+}

--- a/test/Common/standalone/WrapSymbolArchive/Inputs/2.c
+++ b/test/Common/standalone/WrapSymbolArchive/Inputs/2.c
@@ -1,0 +1,6 @@
+/* wrap.c: the __wrap_add function that calls __real_add.
+   When --wrap=add is used, IRBuilder renames the undefined reference to
+   __real_add into 'add'.  This is the reference that must trigger pulling
+   add.o out of the archive. */
+extern int __real_add(int a, int b);
+int __wrap_add(int a, int b) { return __real_add(a, b) * 2; }

--- a/test/Common/standalone/WrapSymbolArchive/Inputs/3.c
+++ b/test/Common/standalone/WrapSymbolArchive/Inputs/3.c
@@ -1,0 +1,4 @@
+/* add.c: the real add function, placed in an archive.
+   The linker must pull this member from the archive when --wrap=add is
+   active and __real_add (renamed to 'add') remains undefined. */
+int add(int a, int b) { return a + b; }

--- a/test/Common/standalone/WrapSymbolArchive/Inputs/4.c
+++ b/test/Common/standalone/WrapSymbolArchive/Inputs/4.c
@@ -1,0 +1,4 @@
+/* wrap.c: the __wrap_add function that never calls __real_add.
+   when __wrap_add is defined but never calls __real_add,
+   the archive member is not required and linking succeeds cleanly.. */
+int __wrap_add(int a, int b) { return (a + b) * 2; }

--- a/test/Common/standalone/WrapSymbolArchive/Inputs/5.c
+++ b/test/Common/standalone/WrapSymbolArchive/Inputs/5.c
@@ -1,0 +1,3 @@
+int fn(int u, int v);
+
+int main() { return fn(3, 5); }

--- a/test/Common/standalone/WrapSymbolArchive/Inputs/6.c
+++ b/test/Common/standalone/WrapSymbolArchive/Inputs/6.c
@@ -1,0 +1,3 @@
+int __real_add(int u, int v);
+
+int fn(int u, int v) { return __real_add(u, v); }

--- a/test/Common/standalone/WrapSymbolArchive/WrapSymbolArchivePull.test
+++ b/test/Common/standalone/WrapSymbolArchive/WrapSymbolArchivePull.test
@@ -1,0 +1,64 @@
+
+#---WrapSymbolArchivePull.test------------------------ Executable ----------#
+#BEGIN_COMMENT
+# Test that an archive member providing the real symbol is pulled when a
+# wrapper calls __real_<sym> (verifies archive extraction for wrapped symbols).
+#END_COMMENT
+#START_TEST
+
+# Compile inputs.
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.1.main.o
+RUN: %clang %clangopts -c %p/Inputs/2.c -o %t.1.wrap.o
+RUN: %clang %clangopts -c %p/Inputs/3.c -o %t.1.add.o
+
+# Place the real add() implementation inside an archive.
+RUN: %ar cr %aropts %t.2.libfoo.a %t.1.add.o
+
+# Link: main.o + wrap.o are direct inputs; add.o is only reachable via the
+# archive.  The linker must pull add.o from libfoo.a because __real_add
+# (renamed to 'add') remains undefined after processing the object files.
+# Use -t (trace) to confirm the archive member is actually included.
+RUN: %link %linkopts %t.1.main.o %t.1.wrap.o %t.2.libfoo.a --wrap=add -o %t.2.out -t 2>&1 | %filecheck %s
+
+# Compile inputs with LTO enabled.
+RUN: %clang %clangopts -flto -c %p/Inputs/1.c -o %t.1.main.o
+RUN: %clang %clangopts -flto -c %p/Inputs/2.c -o %t.1.wrap.o
+RUN: %clang %clangopts -flto -c %p/Inputs/3.c -o %t.1.add.o
+
+# Place the real add() implementation inside an archive.
+RUN: %ar cr %aropts %t.2.libfoo.a %t.1.add.o
+
+# Link with LTO: main.o + wrap.o are direct inputs;
+# add.o is only reachable via the archive.
+RUN: %link %linkopts -flto %t.1.main.o %t.1.wrap.o %t.2.libfoo.a \
+RUN:   --wrap=add -o %t.2.out -t 2>&1 | %filecheck %s
+
+# Compile inputs with ThinLTO enabled.
+RUN: %clang %clangopts -flto=thin  -c %p/Inputs/1.c -o %t.1.main.o
+RUN: %clang %clangopts -flto=thin  -c %p/Inputs/2.c -o %t.1.wrap.o
+RUN: %clang %clangopts -flto=thin  -c %p/Inputs/3.c -o %t.1.add.o
+
+# Place the real add() implementation inside an archive.
+RUN: %ar cr %aropts %t.2.libfoo.a %t.1.add.o
+
+# Link with ThinLTO: main.o + wrap.o are direct inputs;
+# add.o is only reachable via the archive.
+RUN: %link %linkopts -flto=thin %t.1.main.o %t.1.wrap.o %t.2.libfoo.a \
+RUN:   --wrap=add -o %t.2.out -t 2>&1 | %filecheck %s
+
+# Compile inputs with function/data sections enabled for --gc-sections.
+RUN: %clang %clangopts -ffunction-sections -fdata-sections -c %p/Inputs/1.c -o %t.1.main.o
+RUN: %clang %clangopts -ffunction-sections -fdata-sections -c %p/Inputs/2.c -o %t.1.wrap.o
+RUN: %clang %clangopts -ffunction-sections -fdata-sections -c %p/Inputs/3.c -o %t.1.add.o
+
+# Place the real add() implementation inside an archive.
+RUN: %ar cr %aropts %t.2.libfoo.a %t.1.add.o
+
+# Link with --gc-sections: add.o must still be pulled from the archive
+# because __real_add (renamed to 'add') remains undefined, and the
+# resulting section must survive garbage collection.
+RUN: %link %linkopts %t.1.main.o %t.1.wrap.o %t.2.libfoo.a --wrap=add \
+RUN:   --gc-sections -o %t.2.out -t 2>&1 | %filecheck %s
+
+# Verify the archive member was pulled in.
+#CHECK: {{.*}}libfoo.a{{.*}}add.o

--- a/test/Common/standalone/WrapSymbolArchive/WrapSymbolArchivePullRealRef.test
+++ b/test/Common/standalone/WrapSymbolArchive/WrapSymbolArchivePullRealRef.test
@@ -1,0 +1,49 @@
+#---WrapSymbolArchivePullRealRefLTO.test---------- Executable -----------------#
+#BEGIN_COMMENT
+# Verify that when --wrap=<sym> is specified and an LTO bitcode file contains
+# an undefined reference to __real_<sym>, the linker correctly pulls the
+# archive member that defines <sym> from a static library.
+#END_COMMENT
+#START_TEST
+
+# Compile inputs
+RUN: %clang %clangopts -c %p/Inputs/5.c -o %t.1.main.o
+RUN: %clang %clangopts -c %p/Inputs/6.c -o %t.1.wrap.o
+RUN: %clang %clangopts -c %p/Inputs/3.c -o %t.1.add.o
+
+# Place the real add() implementation inside an archive.
+RUN: %ar cr %aropts %t.2.libfoo.a %t.1.add.o
+
+# Link with trace enabled to verify archive pull is reported
+RUN: %link %linkopts %t.1.main.o %t.1.wrap.o %t.2.libfoo.a \
+RUN:   --wrap=add -o %t.2.out --trace=wrap-symbols 2>&1 | %filecheck %s
+
+# Compile input with LTO
+RUN: %clang %clangopts -c %p/Inputs/6.c -o %t.1.wrap.o -flto
+
+# Link with trace enabled to verify archive pull is reported
+RUN: %link %linkopts %t.1.main.o %t.1.wrap.o %t.2.libfoo.a \
+RUN:   --wrap=add -o %t.2.out --trace=wrap-symbols 2>&1 | %filecheck %s
+
+# Compile input with ThinLTO
+RUN: %clang %clangopts -c %p/Inputs/6.c -o %t.1.wrap.o -flto=thin
+
+# Link with trace enabled to verify archive pull is reported
+RUN: %link %linkopts %t.1.main.o %t.1.wrap.o %t.2.libfoo.a \
+RUN:   --wrap=add -o %t.2.out --trace=wrap-symbols 2>&1 | %filecheck %s
+
+# Compile inputs with function/data sections enabled for --gc-sections.
+RUN: %clang %clangopts -ffunction-sections -fdata-sections -c %p/Inputs/5.c -o %t.1.main.o
+RUN: %clang %clangopts -ffunction-sections -fdata-sections -c %p/Inputs/6.c -o %t.1.wrap.o
+RUN: %clang %clangopts -ffunction-sections -fdata-sections -c %p/Inputs/3.c -o %t.1.add.o
+
+# Place the real add() implementation inside an archive.
+RUN: %ar cr %aropts %t.2.libfoo.a %t.1.add.o
+
+# Link with --gc-sections: archive pull must still be reported and the
+# pulled section must survive garbage collection.
+RUN: %link %linkopts %t.1.main.o %t.1.wrap.o %t.2.libfoo.a \
+RUN:   --wrap=add --gc-sections -o %t.2.out --trace=wrap-symbols 2>&1 | %filecheck %s
+
+# Verify archive pull trace message (your new trace)
+#CHECK: Pulling archive member from `{{.*}}libfoo.a' for wrapped symbol `add'

--- a/test/Common/standalone/WrapSymbolArchive/WrapSymbolArchivePullTrace.test
+++ b/test/Common/standalone/WrapSymbolArchive/WrapSymbolArchivePullTrace.test
@@ -1,0 +1,25 @@
+#---WrapSymbolArchivePullTrace.test---------- Executable ------------------#
+#BEGIN_COMMENT
+# Test that --trace=wrap-symbols reports archive extraction for wrapped
+# symbols.
+#END_COMMENT
+#START_TEST
+
+# Compile inputs.
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.1.main.o
+RUN: %clang %clangopts -c %p/Inputs/2.c -o %t.1.wrap.o
+RUN: %clang %clangopts -c %p/Inputs/3.c -o %t.1.add.o
+
+# Place the real add() implementation inside an archive.
+RUN: %ar cr %aropts %t.2.libfoo.a %t.1.add.o
+
+# Link with trace enabled to verify archive pull is reported
+RUN: %link %linkopts %t.1.main.o %t.1.wrap.o %t.2.libfoo.a \
+RUN:   --wrap=add -o %t.2.out --trace=wrap-symbols 2>&1 | %filecheck %s
+
+# Verify wrap rename messages
+#CHECK: Renaming undefined symbol `add' to `__wrap_add'
+#CHECK: Renaming undefined symbol `__real_add' to `add'
+
+# Verify archive pull trace message (your new trace)
+#CHECK: Pulling archive member from `{{.*}}libfoo.a' for wrapped symbol `add'

--- a/test/Common/standalone/WrapSymbolArchive/WrapSymbolNoRealRef.test
+++ b/test/Common/standalone/WrapSymbolArchive/WrapSymbolNoRealRef.test
@@ -1,0 +1,69 @@
+#---WrapSymbolNoRealRef.test---------- Executable ------------------#
+#BEGIN_COMMENT
+# Test that a wrapper that does not call __real_<sym> does not force the
+# archive member with the real symbol to be pulled.
+#
+# Includes native, LTO, and ThinLTO variants: LTO in particular exercises
+# Module::addSymbolFromBitCode's unconditional insertSymbol of the rename
+# target for undefined bitcode symbols, which must not cause the archive
+# member to be pulled when the wrapper never calls __real_<sym>.
+#END_COMMENT
+#START_TEST
+
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.1.main.o
+RUN: %clang %clangopts -c %p/Inputs/3.c -o %t.1.add.o
+RUN: %clang %clangopts -c %p/Inputs/4.c -o %t.1.wrap.o
+RUN: %ar cr %aropts %t.2.libfoo.a %t.1.add.o
+
+
+# Should link successfully. __real_add never referenced
+RUN: %link %linkopts %t.1.main.o %t.1.wrap.o %t.2.libfoo.a \
+RUN:   --wrap=add -o %t.2.out -t 2>&1 | %filecheck %s --allow-empty
+
+#CHECK-NOT: undefined reference
+#CHECK-NOT: error
+#CHECK-NOT: {{.*}}libfoo.a{{.*}}add.o
+
+# Compile inputs with function/data sections enabled for --gc-sections.
+RUN: %clang %clangopts -ffunction-sections -fdata-sections -c %p/Inputs/1.c -o %t.1.main.o
+RUN: %clang %clangopts -ffunction-sections -fdata-sections -c %p/Inputs/3.c -o %t.1.add.o
+RUN: %clang %clangopts -ffunction-sections -fdata-sections -c %p/Inputs/4.c -o %t.1.wrap.o
+RUN: %ar cr %aropts %t.2.libfoo.a %t.1.add.o
+
+# Should link successfully with --gc-sections. __real_add never referenced.
+RUN: %link %linkopts %t.1.main.o %t.1.wrap.o %t.2.libfoo.a \
+RUN:   --wrap=add --gc-sections -o %t.2.out -t 2>&1 | %filecheck %s --allow-empty
+
+# Compile inputs with LTO enabled. Both main.o (undefined reference to add)
+# and wrap.o (defines __wrap_add, never calls __real_add) are bitcode.
+RUN: %clang %clangopts -flto -c %p/Inputs/1.c -o %t.1.main.o
+RUN: %clang %clangopts -flto -c %p/Inputs/3.c -o %t.1.add.o
+RUN: %clang %clangopts -flto -c %p/Inputs/4.c -o %t.1.wrap.o
+RUN: %ar cr %aropts %t.2.libfoo.a %t.1.add.o
+
+# Should link successfully with LTO. __real_add never referenced, so the
+# archive member providing add() must not be pulled in.
+RUN: %link %linkopts -flto %t.1.main.o %t.1.wrap.o %t.2.libfoo.a \
+RUN:   --wrap=add -o %t.2.out -t 2>&1 | %filecheck %s --allow-empty
+
+# Compile inputs with ThinLTO enabled.
+RUN: %clang %clangopts -flto=thin -c %p/Inputs/1.c -o %t.1.main.o
+RUN: %clang %clangopts -flto=thin -c %p/Inputs/3.c -o %t.1.add.o
+RUN: %clang %clangopts -flto=thin -c %p/Inputs/4.c -o %t.1.wrap.o
+RUN: %ar cr %aropts %t.2.libfoo.a %t.1.add.o
+
+# Should link successfully with ThinLTO. __real_add never referenced.
+RUN: %link %linkopts -flto=thin %t.1.main.o %t.1.wrap.o %t.2.libfoo.a \
+RUN:   --wrap=add -o %t.2.out -t 2>&1 | %filecheck %s --allow-empty
+
+# Mixed native/bitcode: main.o is bitcode (undefined reference to add via
+# LTO), wrap.o is a native object (never calls __real_add). Exercises the
+# bitcode-side insertSymbol interacting with the native shouldIncludeSymbol
+# gate on the same link.
+RUN: %clang %clangopts -flto -c %p/Inputs/1.c -o %t.1.main.o
+RUN: %clang %clangopts -c %p/Inputs/4.c -o %t.1.wrap.o
+RUN: %clang %clangopts -flto -c %p/Inputs/3.c -o %t.1.add.o
+RUN: %ar cr %aropts %t.2.libfoo.a %t.1.add.o
+
+RUN: %link %linkopts -flto %t.1.main.o %t.1.wrap.o %t.2.libfoo.a \
+RUN:   --wrap=add -o %t.2.out -t 2>&1 | %filecheck %s --allow-empty

--- a/test/Common/standalone/WrapSymbolArchive/WrapSymbolWrapInArchive.test
+++ b/test/Common/standalone/WrapSymbolArchive/WrapSymbolWrapInArchive.test
@@ -1,0 +1,57 @@
+#---WrapSymbolWrapInArchive.test---------- Executable ------------------#
+#BEGIN_COMMENT
+# Test that --wrap works when both the wrapper and the original symbol are
+# stored in an archive.
+#END_COMMENT
+#START_TEST
+
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.1.main.o
+RUN: %clang %clangopts -c %p/Inputs/2.c -o %t.1.wrap.o
+RUN: %clang %clangopts -c %p/Inputs/3.c -o %t.1.add.o
+
+# Archive contains both wrapper and original implementation
+RUN: %ar cr %aropts %t.2.libfoo.a %t.1.wrap.o %t.1.add.o
+
+# Link: main.o directly, both wrap and add from archive
+RUN: %link %linkopts %t.1.main.o %t.2.libfoo.a \
+RUN:   --wrap=add -o %t.2.out
+
+# Verify it linked successfully
+RUN: test -f %t.2.out
+
+# Compile inputs with LTO enabled.
+RUN: %clang %clangopts -flto -c %p/Inputs/1.c -o %t.1.main.o
+RUN: %clang %clangopts -flto -c %p/Inputs/2.c -o %t.1.wrap.o
+RUN: %clang %clangopts -flto -c %p/Inputs/3.c -o %t.1.add.o
+
+# Archive contains both wrapper and original implementation
+RUN: %ar cr %aropts %t.2.libfoo.a %t.1.wrap.o %t.1.add.o
+
+# Link: main.o directly, both wrap and add from archive
+RUN: %link %linkopts %t.1.main.o %t.2.libfoo.a -flto\
+RUN:   --wrap=add -o %t.2.out
+
+# Compile inputs with ThinLTO enabled.
+RUN: %clang %clangopts -flto=thin -c %p/Inputs/1.c -o %t.1.main.o
+RUN: %clang %clangopts -flto=thin -c %p/Inputs/2.c -o %t.1.wrap.o
+RUN: %clang %clangopts -flto=thin -c %p/Inputs/3.c -o %t.1.add.o
+
+# Archive contains both wrapper and original implementation
+RUN: %ar cr %aropts %t.2.libfoo.a %t.1.wrap.o %t.1.add.o
+
+# Link: main.o directly, both wrap and add from archive
+RUN: %link %linkopts %t.1.main.o %t.2.libfoo.a -flto=thin\
+RUN:   --wrap=add -o %t.2.out
+
+# Compile inputs with function/data sections enabled for --gc-sections.
+RUN: %clang %clangopts -ffunction-sections -fdata-sections -c %p/Inputs/1.c -o %t.1.main.o
+RUN: %clang %clangopts -ffunction-sections -fdata-sections -c %p/Inputs/2.c -o %t.1.wrap.o
+RUN: %clang %clangopts -ffunction-sections -fdata-sections -c %p/Inputs/3.c -o %t.1.add.o
+
+# Archive contains both wrapper and original implementation
+RUN: %ar cr %aropts %t.2.libfoo.a %t.1.wrap.o %t.1.add.o
+
+# Link with --gc-sections: main.o directly, both wrap and add from archive
+RUN: %link %linkopts %t.1.main.o %t.2.libfoo.a \
+RUN:   --wrap=add --gc-sections -o %t.2.out
+#END_TEST

--- a/test/Common/standalone/WrapSymbolArchive/WrapSymbolWrapNotDefined.test
+++ b/test/Common/standalone/WrapSymbolArchive/WrapSymbolWrapNotDefined.test
@@ -1,0 +1,29 @@
+#---WrapSymbolWrapNotDefined.test---------- Executable ------------------#
+#BEGIN_COMMENT
+# Test that specifying --wrap=<sym> without defining __wrap_<sym> reports a
+# clear undefined reference error.
+#END_COMMENT
+#START_TEST
+
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.1.main.o
+RUN: %clang %clangopts -c %p/Inputs/3.c -o %t.1.add.o
+RUN: %ar cr %aropts %t.2.libfoo.a %t.1.add.o
+
+# Link without wrap.o __wrap_add is never defined.
+# This should fail with a clear undefined reference error.
+RUN: %not %link %linkopts %t.1.main.o %t.2.libfoo.a \
+RUN:   --wrap=add -o %t.2.out 2>&1 | %filecheck %s
+
+# Compile inputs with function/data sections enabled for --gc-sections.
+RUN: %clang %clangopts -ffunction-sections -fdata-sections -c %p/Inputs/1.c -o %t.1.main.o
+RUN: %clang %clangopts -ffunction-sections -fdata-sections -c %p/Inputs/3.c -o %t.1.add.o
+RUN: %ar cr %aropts %t.2.libfoo.a %t.1.add.o
+
+# Link without wrap.o with --gc-sections enabled __wrap_add is still
+# never defined and should still fail with a clear undefined reference
+# error.
+RUN: %not %link %linkopts %t.1.main.o %t.2.libfoo.a \
+RUN:   --wrap=add --gc-sections -o %t.2.out 2>&1 | %filecheck %s
+
+#CHECK: undefined reference to `__wrap_add'
+#END_TEST


### PR DESCRIPTION
Ensure wrapped symbols are pulled from archives when the wrapper references __real_<sym>.

Fix: qualcomm#936