### PR TITLE
[ARM] Honor dot assignments before *(.ARM.exidx*) in sortEXIDX

### DIFF
--- a/lib/Target/ARM/ARMLDBackend.cpp
+++ b/lib/Target/ARM/ARMLDBackend.cpp
@@ -420,6 +420,18 @@ void ARMGNULDBackend::sortEXIDX() {
         exidx->getMatchedLinkerScriptRule());
   exidx->splice(exidx->getFragmentList().end(), Frags);
 
+  // Capture the offset assigned to the first EXIDX fragment during layout. This
+  // offset accounts for any dot assignments (e.g. '. = ALIGN(8)') and symbol
+  // assignments that precede the *(.ARM.exidx*) rule in the output section, so
+  // the reset loop below must resume from it rather than from zero.
+  uint64_t baseOffset = 0;
+  for (auto &F : exidx->getFragmentList()) {
+    if (F->isNull())
+      continue;
+    baseOffset = F->getOffset(config().getDiagEngine());
+    break;
+  }
+
   for (auto &F : exidx->getFragmentList()) {
     for (auto &relocation : F->getOwningSection()->getRelocations()) {
       // bypass the reloc if the symbol is in the discarded input section
@@ -463,7 +475,7 @@ void ARMGNULDBackend::sortEXIDX() {
             });
 
   // Reset offset to real offset
-  uint64_t offset = 0;
+  uint64_t offset = baseOffset;
   for (auto &Frag : exidx->getFragmentList()) {
     if (Frag->isNull())
       continue;

--- a/test/ARM/standalone/EXIDXAlign/EXIDXAlign.test
+++ b/test/ARM/standalone/EXIDXAlign/EXIDXAlign.test
@@ -1,0 +1,33 @@
+#---EXIDXAlign.test--------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# Tests that a dot assignment such as '. = ALIGN(0x8)' appearing before the
+# *(.ARM.exidx*) rule is honored when the linker lays out the EXIDX fragments.
+# sortEXIDX() re-lays out the EXIDX fragments during post-layout; it must
+# resume from the aligned offset produced by the assignment rather than from
+# the output section base. Otherwise __exidx_start (set from the aligned dot)
+# and the first EXIDX fragment end up at different addresses.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -target arm -c %p/Inputs/exidx.s -o %t1.1.o
+RUN: %link -MapStyle txt %linkopts %t1.1.o -T %p/Inputs/script.t -o %t2.out -Map %t2.map \
+RUN:   -u __exidx_start -u __exidx_end
+RUN: %filecheck %s < %t2.map
+RUN: %readelf -s %t2.out | %filecheck %s --check-prefix=SYMS
+
+# The output section is placed at 0x11014 (4-byte aligned, not 8-byte aligned).
+# The '. = ALIGN(0x8)' must pad to 0x11018 before the first EXIDX fragment.
+#CHECK:      .ARM.exidx      0x11014
+#CHECK:      PADDING 0x11014 0x4
+#CHECK:      ALIGN(.(0x11014), 0x8)
+#CHECK:      PROVIDE(__exidx_start(0x11018)
+#CHECK:      .ARM.exidx.text.f2      0x11018 0x8
+#CHECK-NEXT: .ARM.exidx.text.f2      0x11020 0x8
+#CHECK-NEXT: .ARM.exidx.text.f1      0x11028 0x8
+#CHECK-NEXT: .ARM.exidx.text.start   0x11030 0x8
+
+# __exidx_start must match the first EXIDX fragment address (0x11018), and
+# __exidx_end must be one entry past the last fragment (0x11030 + 0x8).
+#SYMS: {{0*}}11018     0 NOTYPE  GLOBAL DEFAULT {{.*}} __exidx_start
+#SYMS: {{0*}}11038     0 NOTYPE  GLOBAL DEFAULT {{.*}} __exidx_end
+
+#END_TEST

--- a/test/ARM/standalone/EXIDXAlign/Inputs/exidx.s
+++ b/test/ARM/standalone/EXIDXAlign/Inputs/exidx.s
@@ -1,0 +1,30 @@
+ .syntax unified
+ .section .text.start, "ax",%progbits
+ .globl _start
+_start:
+ .fnstart
+ bx lr
+ .cantunwind
+ .fnend
+
+ .section .text.f1, "ax", %progbits
+ .globl f1
+f1:
+ .fnstart
+ bx lr
+ .cantunwind
+ .fnend
+
+ .section .text.f2, "ax", %progbits
+ .globl f2
+f2:
+ .fnstart
+ bx lr
+ .cantunwind
+ .fnend
+ .globl f3
+f3:
+ .fnstart
+ bx lr
+ .cantunwind
+ .fnend

--- a/test/ARM/standalone/EXIDXAlign/Inputs/script.t
+++ b/test/ARM/standalone/EXIDXAlign/Inputs/script.t
@@ -1,0 +1,11 @@
+SECTIONS {
+  .text (0x11000) : { *(.text.f2) *(.text.f1) *(.text.start) }
+  /* Place .ARM.exidx at a 4-byte-aligned but not 8-byte-aligned address so
+     that the '. = ALIGN(0x8)' below must shift the exidx fragments by 4. */
+  .ARM.exidx (0x11014) : {
+    . = ALIGN(0x8);
+    PROVIDE(__exidx_start = .);
+    *(.ARM.exidx*)
+    PROVIDE(__exidx_end = .);
+  }
+}


### PR DESCRIPTION
This commit fixes ARMGNULDBackend::sortEXIDX so that a dot assignment such as '. = ALIGN(0x8)' appearing before the `*(.ARM.exidx*)` rule is honored when the EXIDX fragments are laid out.