### PR TITLE
[RISCV] Ignore addend in R_RISCV_GOT_HI20

### DIFF
--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -1422,11 +1422,11 @@ bool RISCVLDBackend::doRelaxationGOT(Relocation &Reloc) {
 
   // Until recently, the calculation for R_RISCV_GOT_HI20 was `G + GOT + A - P`
   // where non-zero addends were allowed. The addend must now be zero and has
-  // been removed from calculation, but not all tools reflect this yet. It's
-  // unclear how this relaxation should work in the presence of a non-zero
-  // addend so avoid doing so to be safe.
-  if (BaseReloc->addend())
-    return false;
+  // been removed from the calculation. eld should ignore any non-zero addends
+  // for the relocations involved here, but assert to be sure as it is unclear
+  // how non-zero addends should be handled in this relaxation.
+  assert(!Reloc->addend() && !BaseReloc->addend() &&
+         "Unexpected non-zero addend!");
 
   ResolveInfo *SymInfo = BaseReloc->symInfo();
   // The psABI only includes "it’s bound at link time to be within the object"

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -1953,18 +1953,19 @@ bool RISCVLDBackend::handleRelocation(ELFSection *pSection,
       m_GroupRelocs.insert(std::make_pair(reloc, offsetToReloc->second));
     return true;
   }
-  // R_RISCV_PCREL_LO* and TLSDESC relocations must have an addend of zero.
-  // Ignore any non-zero addends and warn.
+  // R_RISCV_PCREL_LO*, R_RISCV_GOT_HI20, and TLSDESC relocations must have an
+  // addend of zero. Ignore non-zero addends and warn.
   case llvm::ELF::R_RISCV_PCREL_LO12_I:
   case llvm::ELF::R_RISCV_PCREL_LO12_S:
   case llvm::ELF::R_RISCV_TLSDESC_LOAD_LO12:
   case llvm::ELF::R_RISCV_TLSDESC_ADD_LO12:
-  case llvm::ELF::R_RISCV_TLSDESC_CALL: {
+  case llvm::ELF::R_RISCV_TLSDESC_CALL:
+  case llvm::ELF::R_RISCV_GOT_HI20: {
     if (pAddend) {
       config().raise(Diag::warn_ignore_reloc_addend)
           << pSym.name() << getRISCVRelocName(pType)
           << pSection->originalInput()->getInput()->decoratedPath();
-      pAddend = 0;
+      // pAddend = 0;
     }
     Relocation *reloc = IRBuilder::addRelocation(getRelocator(), pSection,
                                                  pType, pSym, pOffset, pAddend);

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -1965,7 +1965,7 @@ bool RISCVLDBackend::handleRelocation(ELFSection *pSection,
       config().raise(Diag::warn_ignore_reloc_addend)
           << pSym.name() << getRISCVRelocName(pType)
           << pSection->originalInput()->getInput()->decoratedPath();
-      // pAddend = 0;
+      pAddend = 0;
     }
     Relocation *reloc = IRBuilder::addRelocation(getRelocator(), pSection,
                                                  pType, pSym, pOffset, pAddend);

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -1425,7 +1425,7 @@ bool RISCVLDBackend::doRelaxationGOT(Relocation &Reloc) {
   // been removed from the calculation. eld should ignore any non-zero addends
   // for the relocations involved here, but assert to be sure as it is unclear
   // how non-zero addends should be handled in this relaxation.
-  assert(!Reloc->addend() && !BaseReloc->addend() &&
+  assert(!Reloc.addend() && !BaseReloc->addend() &&
          "Unexpected non-zero addend!");
 
   ResolveInfo *SymInfo = BaseReloc->symInfo();

--- a/test/RISCV/standalone/Relaxation/GOT_LOAD_RELAX/GOT_LOAD_RELAX_COMMON.test
+++ b/test/RISCV/standalone/Relaxation/GOT_LOAD_RELAX/GOT_LOAD_RELAX_COMMON.test
@@ -13,10 +13,11 @@ RUN: %link %linkopts --defsym abs_var=5 --no-relax-got %t.common.o -o %t2.out
 RUN: %objdump --no-print-imm-hex -M no-aliases -d %t.out | %filecheck %s --check-prefix=NO-RELAX
 RUN: %objdump --no-print-imm-hex -M no-aliases -d %t2.out | %filecheck %s --check-prefix=NO-RELAX
 
-## Check relaxation isn't performed if there's a non-zero addend on the got_hi.
+## Check non-zero addends on the got_hi are ignored, possibly allowing the
+## relaxation to proceed.
 RUN: %clang %clangopts -c %p/Inputs/addend.s -o %t.addend.o
-RUN: %link %linkopts --defsym abs_var=5 %t.addend.o -o %t.addend.out
-RUN: %objdump --no-print-imm-hex -M no-aliases -d %t.addend.out | %filecheck %s --check-prefix=NO-RELAX
+RUN: %link %linkopts --defsym abs_var=5 %t.addend.o -o %t.addend.out 2>&1 | %filecheck %s --check-prefix=WARN-ADDEND
+RUN: %objdump --no-print-imm-hex -M no-aliases -d %t.addend.out | %filecheck %s --check-prefix=ADDEND-RELAX
 
 ## Check relaxation isn't performed if not all HI/LOs have R_RISCV_RELAX or
 ## if a LO is missing.
@@ -28,6 +29,13 @@ NO-RELAX: auipc a1, 1
 NO-RELAX-NEXT: {{l[wd]}} a1, {{-?[0-9]+}}(a1)
 NO-RELAX: auipc a2, 1
 NO-RELAX-NEXT: {{l[wd]}} a2, {{-?[0-9]+}}(a2)
+
+WARN-ADDEND: ignoring addend for relocation `R_RISCV_GOT_HI20' referring symbol abs_var
+WARN-ADDEND: ignoring addend for relocation `R_RISCV_GOT_HI20' referring symbol rel_var
+
+ADDEND-RELAX: c.li a1, 5
+ADDEND-RELAX: auipc a2, 1
+ADDEND-RELAX-NEXT: addi a2, a2
 
 PARTIAL-NO-RELAX: auipc a1, 1
 PARTIAL-NO-RELAX-NEXT: {{l[wd]}} a1, {{-?[0-9]+}}(a1)

--- a/test/RISCV/standalone/Relocs/IGNORE_RELOC_ADDEND/Inputs/1.s
+++ b/test/RISCV/standalone/Relocs/IGNORE_RELOC_ADDEND/Inputs/1.s
@@ -4,6 +4,7 @@ external:
   auipc sp,%pcrel_hi(external)
   addi sp,sp,%pcrel_lo(external)+0xf000
   sw sp, %pcrel_lo(external)+0xf000(sp)
+  lga a0, external+0xf000
 tlsdesc:
   auipc a0, %tlsdesc_hi(tbss_var)
   lw a1, %tlsdesc_load_lo(tlsdesc)+0xf000(a0)

--- a/test/RISCV/standalone/Relocs/IGNORE_RELOC_ADDEND/ignore_reloc_addend.test
+++ b/test/RISCV/standalone/Relocs/IGNORE_RELOC_ADDEND/ignore_reloc_addend.test
@@ -6,11 +6,18 @@
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/1.s -o %t.1.o
-RUN: %link %linkopts %t.1.o -o %t.1.out 2>&1 | %filecheck %s
+RUN: %link %linkopts --image-base=0x8050000 --section-start .text=0x8052000 \
+RUN: --section-start .got=0x8053000 --no-relax %t.1.o -o %t.1.out 2>&1 | %filecheck %s
+RUN: %objdump -dr %t.1.out | %filecheck %s --check-prefix=DISASM
 #END_TEST
 
 CHECK: {{.*}}: ignoring addend for relocation `R_RISCV_PCREL_LO12_I' referring symbol external
 CHECK: {{.*}}: ignoring addend for relocation `R_RISCV_PCREL_LO12_S' referring symbol external
+CHECK: {{.*}}: ignoring addend for relocation `R_RISCV_GOT_HI20' referring symbol external
 CHECK: {{.*}}: ignoring addend for relocation `R_RISCV_TLSDESC_LOAD_LO12' referring symbol tlsdesc
 CHECK: {{.*}}: ignoring addend for relocation `R_RISCV_TLSDESC_ADD_LO12' referring symbol tlsdesc
 CHECK: {{.*}}: ignoring addend for relocation `R_RISCV_TLSDESC_CALL' referring symbol tlsdesc
+
+# Verify the GOT_HI20 addend was set to zero
+DISASM: auipc a0, 0x1{{$}}
+DISASM-NEXT: R_RISCV_GOT_HI20 external{{$}}


### PR DESCRIPTION
This was recently changed in the psABI to require the addend be non-zero [1].

Handle this similarly to other relocations that must have zero addends by just
ignoring the addend (setting it to zero) and producing a warning.

Note that the calculation in `applyGOT` is left unchanged (the `+ A` is still
there). `applyGOT` is shared with some other GOT-relative relocations that have
no explicit zero addend requirement and eld/lld/bfd all seem to a) accept those
addends b) honor those addends and c) not produce a diagnostic.

So for now, I think it is a bit clearer to keep `R_RISCV_GOT_HI20` using
`applyGOT` and just make sure we zero the addend ahead of time.

Since we're 0-ing the addend ahead of time, switch the GOT relaxations
to asserting on non-0 addends rather than returning. It's a bit unrelated,
but the assert was also extended to cover both the got_hi and pcrel_lo
(as both must have 0 addends).

[1] https://github.com/riscv-non-isa/riscv-elf-psabi-doc/commit/eb794e8ccfabfbb370db2070565b588252c4f8b7

Fixes: #1413