### PR TITLE
[github-workflow] Gate PR ELD toolset upload on `zephyr-check` label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   pull_request:
+    # `labeled` so adding `zephyr-check` mid-PR triggers a fresh CI upload.
+    types: [opened, synchronize, reopened, labeled]
     paths-ignore:
       - '.github/workflows/sanitize.yml'
       - '.github/workflows/reviter.yml'
@@ -25,6 +27,10 @@ permissions:
   contents: write
 jobs:
   build:
+    # Skip label-triggered runs unless the label is `zephyr-check`.
+    if: |
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'zephyr-check'
     runs-on: self-hosted
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -164,9 +170,13 @@ jobs:
         run: ninja check-eld-summary
 
       # Package the PR-built ld.eld (+ libs) for zephyr-pr.yml. `inst/` layout
-      # matches FetchNightlyToolset (~18MB compressed).
+      # matches FetchNightlyToolset (~27MB compressed). Gated on `zephyr-check`
+      # -- artifact is only consumed by the manual zephyr-pr.yml dispatch, so
+      # uploading on every PR would just fill Actions storage with unread tars.
       - name: Package PR ELD toolset
-        if: steps.file-check.outputs.skip_build == 'false'
+        if: |
+          steps.file-check.outputs.skip_build == 'false' &&
+          contains(github.event.pull_request.labels.*.name, 'zephyr-check')
         working-directory: pr-${{ env.PR_NUMBER }}
         shell: bash
         run: |
@@ -183,13 +193,15 @@ jobs:
 
           XZ_OPT=-T0 tar -Jcf install-pr-toolset.tar.xz inst
 
-      #- name: Upload PR ELD toolset
-      #  if: steps.file-check.outputs.skip_build == 'false'
-      #  uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
-      #  with:
-      #    name: pr-eld-toolset
-      #    retention-days: 1
-      #    path: pr-${{ env.PR_NUMBER }}/install-pr-toolset.tar.xz
+      - name: Upload PR ELD toolset
+        if: |
+          steps.file-check.outputs.skip_build == 'false' &&
+          contains(github.event.pull_request.labels.*.name, 'zephyr-check')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
+        with:
+          name: pr-eld-toolset
+          retention-days: 1
+          path: pr-${{ env.PR_NUMBER }}/install-pr-toolset.tar.xz
 
       - name: Clean up
         if: always()

--- a/.github/workflows/zephyr-pr.yml
+++ b/.github/workflows/zephyr-pr.yml
@@ -1,10 +1,10 @@
 name: Zephyr on ELD PR
 
-# Opt-in: run Zephyr against a PR's *own* ELD build (not nightly). Assumes ci.yml
-# passed for the PR and uploaded the `pr-eld-toolset` artifact. Given a PR number,
-# finds the latest successful ci.yml run for its head commit; ci_run_id overrides.
-# Scope: aarch64 (qemu_cortex_a53), tests/kernel. Add arches later by mirroring
-# zephyr-nightly.yml's matrix.
+# Opt-in: run Zephyr against a PR's own ELD build. Requires the
+# PR to carry the `zephyr-check` label so ci.yml uploads the `pr-eld-toolset`
+# artifact. Given a PR number, finds the latest successful ci.yml run for its
+# head commit; ci_run_id overrides. Scope: aarch64 (qemu_cortex_a53),
+# tests/kernel. Add arches later by mirroring zephyr-nightly.yml's matrix.
 
 on:
   workflow_dispatch:
@@ -89,6 +89,20 @@ jobs:
 
             const run = success[0];
             core.info(`Latest successful ci.yml run: id=${run.id}, run_number=${run.run_number}`);
+
+            // Fail fast with a helpful message if the run predates the label
+            // (otherwise zephyr-run.yml's download-artifact fails cryptically).
+            const { data: { artifacts } } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner, repo, run_id: run.id, per_page: 100,
+            });
+            if (!artifacts.some(a => a.name === 'pr-eld-toolset' && !a.expired)) {
+              core.setFailed(
+                `ci.yml run ${run.id} did not upload a pr-eld-toolset artifact ` +
+                `(or it has expired). Add the \`zephyr-check\` label to PR ` +
+                `#${prNumber} and re-run CI, then dispatch this workflow again.`);
+              return;
+            }
+
             core.setOutput('run_id', String(run.id));
 
   zephyr:


### PR DESCRIPTION
97ea3ddc disabled the upload because it ran on every CI build and the storage utilization ended up being too high (~25 MB * ~30 runs/day at 1 day retention).

Re-enable, gated on a `zephyr-check` PR label.

Requires the `zephyr-check` label to exist on qualcomm/eld.