### PR TITLE
[Layout] Non-alloc sections should use address 0 during layout

### DIFF
--- a/lib/Target/CreateProgramHeaders.hpp
+++ b/lib/Target/CreateProgramHeaders.hpp
@@ -317,13 +317,15 @@ bool GNULDBackend::createProgramHdrs() {
     }
 
     if (curIsDebugSection || (*out)->isDiscard()) {
-      cur->setAddr(dotSymbol->value());
+      // Use addr=0; restore dot after evaluateAssignments resets it to 0.
+      uint64_t SavedDot = dotSymbol->value();
+      cur->setAddr(0);
+      cur->setPaddr(0);
       evaluateAssignments(*out);
+      dotSymbol->setValue(SavedDot);
       evaluateAssignmentsAtEndOfOutputSection(*out);
       cur->setWanted(cur->wantedInOutput() || cur->size());
       ++out;
-      cur->setAddr(0);
-      cur->setPaddr(0);
       continue;
     }
 

--- a/lib/Target/CreateScriptProgramHeaders.hpp
+++ b/lib/Target/CreateScriptProgramHeaders.hpp
@@ -201,11 +201,13 @@ bool GNULDBackend::createScriptProgramHdrs() {
       hasVMARegion = true;
     }
     if (curIsDebugSection || (*out)->isDiscard()) {
-      cur->setAddr(dotSymbol->value());
-      evaluateAssignments(*out);
-      evaluateAssignmentsAtEndOfOutputSection(*out);
+      // Use addr=0; restore dot after evaluateAssignments resets it to 0.
+      uint64_t SavedDot = dotSymbol->value();
       cur->setAddr(0);
       cur->setPaddr(0);
+      evaluateAssignments(*out);
+      dotSymbol->setValue(SavedDot);
+      evaluateAssignmentsAtEndOfOutputSection(*out);
       ++out;
       continue;
     }

--- a/lib/Writers/ELFObjectWriter.cpp
+++ b/lib/Writers/ELFObjectWriter.cpp
@@ -414,7 +414,7 @@ void ELFObjectWriter::emitSectionHeader(
     Shdr[SectIdx].sh_name = Shstridx;
     Shdr[SectIdx].sh_type = LdSect->getType();
     Shdr[SectIdx].sh_flags = LdSect->getFlags();
-    Shdr[SectIdx].sh_addr = (LdSect->isAlloc()) ? LdSect->addr() : 0;
+    Shdr[SectIdx].sh_addr = LdSect->addr();
     Shdr[SectIdx].sh_offset = LdSect->offset();
     if (SectIdx == 0 && ThisModule.size() >= SHN_LORESERVE)
       Shdr[SectIdx].sh_size = ThisModule.size();

--- a/test/Common/standalone/linkerscript/NonAllocAddrZero/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/NonAllocAddrZero/Inputs/1.c
@@ -1,0 +1,3 @@
+int foo() { return 1; }
+int bar() { return 2; }
+int x = 1;

--- a/test/Common/standalone/linkerscript/NonAllocAddrZero/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/NonAllocAddrZero/Inputs/script.t
@@ -1,0 +1,6 @@
+SECTIONS {
+  .text (0x10000) : { *(.text*) }
+  .debug_info : { *(.debug_info*) }
+  after_debug = .;
+  .data : { *(.data*) }
+}

--- a/test/Common/standalone/linkerscript/NonAllocAddrZero/NonAllocAddrZero.test
+++ b/test/Common/standalone/linkerscript/NonAllocAddrZero/NonAllocAddrZero.test
@@ -1,0 +1,20 @@
+#---NonAllocAddrZero.test--------------------- Executable,LS --------------------#
+#BEGIN_COMMENT
+# Verify that non-alloc (debug) sections are laid out with address 0, and that
+# the dot symbol is not advanced by non-alloc sections so subsequent alloc
+# sections and inter-section symbol assignments get the correct VMA.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangg0opts -o %t1.o %p/Inputs/1.c -c -ffunction-sections -fdata-sections -g
+RUN: %link %linkopts -o %t1.out %t1.o -T %p/Inputs/script.t
+RUN: %readelf -Ss %t1.out | %filecheck %s
+
+# Non-alloc debug section must have address 0.
+CHECK: .debug_info PROGBITS {{[0]+}}
+
+# after_debug is assigned with ". =" between the non-alloc and .data sections.
+# It must equal the VMA of .data, proving dot was not advanced by the non-alloc
+# section.
+CHECK: .data PROGBITS [[#%x,DATA_ADDR:]]
+CHECK: {{.*}}: {{0+}}[[#%x,DATA_ADDR]] {{.*}} after_debug
+#END_TEST


### PR DESCRIPTION
During layout non allocatable sections should use 0 for VMA/LMA.