### PR TITLE
[LinkerScript] Fix orphan section placement with scripts

### DIFF
--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -2732,6 +2732,29 @@ bool GNULDBackend::checkCrossReferences() {
   return true;
 }
 
+// True if a section is bound only to non-PT_LOAD segments. A section with no
+// phdr binding stays in the default PT_LOAD, so it is loadable.
+static bool isInNonLoadSegment(const OutputSectionEntry *Sec,
+                               LinkerScript &Script) {
+  if (Sec->getSection()->isNullKind())
+    return true;
+  if (!Sec->epilog().hasPhdrs())
+    return false;
+  bool sawPhdr = false;
+  for (const StrToken *Tok : Sec->epilog().phdrs()->tokens()) {
+    uint32_t type = llvm::ELF::PT_NULL;
+    for (const auto *Phdr : Script.phdrList())
+      if (Phdr->spec().name() == Tok->name()) {
+        type = Phdr->spec().type();
+        break;
+      }
+    if (type == llvm::ELF::PT_LOAD)
+      return false;
+    sawPhdr = true;
+  }
+  return sawPhdr;
+}
+
 /// placeOutputSections - place output sections based on SectionMap
 bool GNULDBackend::placeOutputSections() {
   typedef std::vector<ELFSection *> Orphans;
@@ -2996,15 +3019,37 @@ bool GNULDBackend::placeOutputSections() {
         // later
         // though. The value is initialized to -1, to skip the Null section
         // inserted.
+        //
+        // With a SECTIONS command sectionMap is in declaration order, not
+        // rank order, so stopping at the first higher ranked entry can insert
+        // the orphan too early. Track the last position it may follow instead.
+        //
+        // An orphan inherits the segment of the section before it. Keep an
+        // alloc orphan out of a non-load segment by preferring the last
+        // loadable segment. Fall back to the last fit if there is none (eg
+        // NONE segment layouts).
         int numSections = -1;
+        SectionMap::iterator lastFit = outEnd, lastLoadFit = outEnd;
         for (out = outBegin; out != outEnd; ++out) {
           if (numSections && (*out)->isDiscard() && (order <= SHO_UNDEFINED))
             break;
           if ((*out)->order() > order) {
-            break;
+            if (!linkerScriptHasSectionsCommand)
+              break;
+          } else if (linkerScriptHasSectionsCommand) {
+            lastFit = out;
+            if (orphan->isAlloc() &&
+                !isInNonLoadSegment(*out, m_Module.getScript()))
+              lastLoadFit = out;
           }
           ++numSections;
         }
+        if (lastLoadFit != outEnd)
+          lastFit = lastLoadFit;
+        // lastFit points at the entry to follow; insert after it. No fit
+        // (outEnd) means the orphan outranks everything, so insert at front.
+        if (linkerScriptHasSectionsCommand)
+          out = (lastFit == outEnd) ? outBegin : ++lastFit;
         if (orphan->getOutputSection())
           out = sectionMap.insert(out, orphan->getOutputSection());
         else {

--- a/test/Common/RunTests/OrphanNoLoadSegmentPhdr/OrphanNoLoadSegmentPhdr.test
+++ b/test/Common/RunTests/OrphanNoLoadSegmentPhdr/OrphanNoLoadSegmentPhdr.test
@@ -1,0 +1,77 @@
+REQUIRES: run_test
+
+## Verify that orphan section placement respects segments. An orphan writable
+## section must not be placed into a non-loadable  segment even when a same rank
+## script mentioned section is bound there; doing so would leave
+## the orphan unmapped at run time.
+
+RUN: split-file %s %t
+RUN: %run_cc %clangopts -c -fPIC %t/orphan.c -o %t.o
+RUN: %run_cc %clangopts -o %t.out %t.o -Wl,-dy -Wl,-z,max-page-size=0x1000 -T %t/script.t
+RUN: %run %t.out | %filecheck %s
+RUN: %readelf -l %t.out | %filecheck %s --check-prefix=PHDRS
+
+CHECK: OK
+
+PHDRS:      LOAD
+PHDRS:      LOAD
+PHDRS:      NULL
+
+#--- orphan.c
+#include <stdio.h>
+
+__attribute__((section(".orphan_data"))) volatile int sentinel = 0xC0FFEE;
+
+/// Force the overlay output section to exist so the orphan placement scan
+/// actually considers it as a candidate anchor.
+__attribute__((section(".overlay"), used)) volatile int overlay_marker;
+
+int main(void) {
+  if (sentinel != 0xC0FFEE) {
+    fprintf(stderr, "orphan stranded: sentinel=0x%x\n", sentinel);
+    return 1;
+  }
+  puts("OK");
+  return 0;
+}
+
+#--- script.t
+PHDRS {
+  ph_phdr    PT_PHDR    PHDRS;
+  ph_interp  PT_INTERP;
+  ph_text    PT_LOAD    FILEHDR PHDRS FLAGS(5);
+  ph_data    PT_LOAD    FLAGS(6);
+  ph_dyn     PT_DYNAMIC;
+  ph_overlay PT_NULL    FLAGS(6);
+}
+SECTIONS {
+  .interp        : { *(.interp) }         :ph_interp :ph_text
+  .note.gnu.build-id : { *(.note.gnu.build-id) } :ph_text
+  .dynsym        : { *(.dynsym) }         :ph_text
+  .dynstr        : { *(.dynstr) }         :ph_text
+  .gnu.version   : { *(.gnu.version) }    :ph_text
+  .gnu.version_r : { *(.gnu.version_r) }  :ph_text
+  .gnu.hash      : { *(.gnu.hash) }       :ph_text
+  .rela.dyn      : { *(.rela.dyn) }       :ph_text
+  .rela.plt      : { *(.rela.plt) }       :ph_text
+  .rel.dyn       : { *(.rel.dyn) }        :ph_text
+  .rel.plt       : { *(.rel.plt) }        :ph_text
+  .init          : { *(.init) }           :ph_text
+  .plt           : { *(.plt*) }           :ph_text
+  . = ALIGN(4K);
+  .text          : { *(.text*) }          :ph_text
+  .fini          : { *(.fini) }           :ph_text
+  .rodata        : { *(.rodata*) }        :ph_text
+  .eh_frame      : { *(.eh_frame*) }      :ph_text
+  . = ALIGN(4K);
+  .init_array : { KEEP(*(.init_array*)) } :ph_data
+  .fini_array : { KEEP(*(.fini_array*)) } :ph_data
+  .dynamic    : { *(.dynamic) }           :ph_data :ph_dyn
+  .got        : { *(.got) }               :ph_data
+  .got.plt    : { *(.got.plt) }           :ph_data
+  __global_pointer$ = .;
+  .mydata     : { *(.mydata) *(.data*) }  :ph_data
+  .bss        : { *(.bss*) *(COMMON) }    :ph_data
+  . = 0x40000000;
+  .overlay (NOLOAD) : { *(.overlay) }     :ph_overlay
+}

--- a/test/Common/standalone/OrphanBeforeLowerRankedSection/OrphanBeforeLowerRankedSection.test
+++ b/test/Common/standalone/OrphanBeforeLowerRankedSection/OrphanBeforeLowerRankedSection.test
@@ -1,0 +1,53 @@
+## When a linker script declares a lower ranked section before a higher ranked
+## one (a WA .vectors before an AX .text), the output section list is not
+## sorted by rank. An executable orphan must still be placed after .text, not
+## spliced in ahead of .vectors.
+
+RUN: split-file %s %t
+RUN: %clang %clangopts -c %t/1.s -o %t.o
+RUN: %link %linkopts %t.o -T %t/script.t -o %t.out
+RUN: %readelf -S %t.out | %filecheck %s
+
+## .vectors (WA) keeps the origin, .text (AX) follows, and the AX orphan should
+## land after .text rather than ahead of .vectors.
+CHECK:      .vectors {{.*}} WA
+CHECK-NEXT: .text {{.*}} AX
+CHECK-NEXT: .orphan_text {{.*}} AX
+
+## When the script declares only a higher ranked section, a lower ranked orphan
+## ranks ahead of everything present. The scan finds no fit and inserts the
+## orphan at the front of the section list.
+RUN: %clang %clangopts -c %t/2.s -o %t2.o
+RUN: %link %linkopts %t2.o -T %t/front.t -o %t.front.out
+RUN: %readelf -S %t.front.out | %filecheck %s -check-prefix=FRONT
+
+FRONT:      .text {{.*}} AX
+FRONT-NEXT: .bss {{.*}} WA
+
+#--- 1.s
+.section .vectors, "aw", %progbits
+.long 0
+
+.section .text, "ax", %progbits
+.long 0
+
+.section .orphan_text, "ax", %progbits
+.long 0
+
+#--- 2.s
+.section .bss, "aw", %nobits
+.long 0
+
+.section .text, "ax", %progbits
+.long 0
+
+#--- script.t
+SECTIONS {
+  .vectors : { *(.vectors) }
+  .text    : { *(.text) }
+}
+
+#--- front.t
+SECTIONS {
+  .bss : { *(.bss) }
+}

--- a/test/Common/standalone/OrphanNoLoadSegmentPhdr/OrphanNoLoadSegmentPhdr.test
+++ b/test/Common/standalone/OrphanNoLoadSegmentPhdr/OrphanNoLoadSegmentPhdr.test
@@ -1,0 +1,43 @@
+## A script can declare PHDRS with a non-loadable segment (e.g. a PT_NULL
+## overlay) and assign a writable section to it after the normal writable
+## data. A writable orphan of the same rank must not end up in that segment:
+## an orphan takes the segment of the section it follows, so landing after the
+## overlay section would leave it unloaded at run time. It should stay after
+## the last loadable section (.mydata) instead.
+
+RUN: split-file %s %t
+RUN: %clang %clangopts -c %t/1.s -o %t.o
+RUN: %link %linkopts %t.o -T %t/script.t -o %t.out
+RUN: %readelf -l %t.out | %filecheck %s
+
+CHECK:      Segment Sections
+CHECK:      {{[0-9]+}} .mydata .orphan_rw {{$}}
+CHECK:      {{[0-9]+}} .overlay {{$}}
+
+#--- 1.s
+.section .text, "ax", %progbits
+.long 0
+
+.section .mydata, "aw", %progbits
+.long 0x11111111
+
+.section .orphan_rw, "aw", %progbits
+.long 0x22222222
+
+.section .overlay, "aw", %progbits
+.long 0x33333333
+
+#--- script.t
+PHDRS {
+  TEXT PT_LOAD;
+  DATA PT_LOAD;
+  OVERLAY PT_NULL;
+}
+SECTIONS {
+  . = 0x1000;
+  .text    : { *(.text) }    :TEXT
+  . = 0x10000;
+  .mydata  : { *(.mydata) }  :DATA
+  . = 0x40000000;
+  .overlay (NOLOAD) : { *(.overlay) } :OVERLAY
+}

--- a/test/Hexagon/standalone/TrampolineMissingSymbol/Inputs/script.t
+++ b/test/Hexagon/standalone/TrampolineMissingSymbol/Inputs/script.t
@@ -1,5 +1,6 @@
 SECTIONS {
   .moo : { *(.text.moo) }
+  .init : { *(.init) }
   .data : { *(.data) }
   . = 0xF0000000;
   .txt.foo : { *(.text.foo) *(.text.coo) *(.text.moo) }

--- a/test/Hexagon/standalone/TrampolineMissingSymbol/TrampolineMissingSymbol.test
+++ b/test/Hexagon/standalone/TrampolineMissingSymbol/TrampolineMissingSymbol.test
@@ -16,8 +16,7 @@ RUN: %clang %clangopts -c -fpic %p/Inputs/5.s -o %t5.o
 RUN: %link %linkopts %t1.o %t2.o %t3.o %t4.o %t5.o -T %p/Inputs/script.t -Map %t.map -o %t.out
 RUN: %objdump -d %t.out | %filecheck %s
 
-CHECK: <bar>:
-CHECK-DAG: <baz>:
-CHECK-DAG: <caz>
-CHECK-DAG: <foo>
-CHECK-DAG: <coo>
+CHECK: <baz>:
+CHECK: call {{.*}} <trampoline_for_coo_from_.init{{.*}}>
+CHECK: <trampoline_for_coo_from_.init{{.*}}>:
+CHECK: jump {{.*}} <coo>


### PR DESCRIPTION
 Orphan insertion scan stopped at the first section with a greater rank than the orphan, placing the orphan before that section. This groups sections with like permissions together when the script is sorted by rank, but when a
  script declares a lower ranked section first, the scan can insert a higher ranked orphan too early:

```ld
  SECTIONS {
      .init : { KEEP((.data.init.enter)) }  /* WA (picolibc) */
      .text : { (.text) }                   /* AX */
  }
```
  Note: AX/.text has a lower rank than WA/.init.

  A third (orphan) section `orphan_code` (AX) is placed before `.init`, the first section with a higher rank, but `.init` is expected to come first. lld/bfd instead group the orphan with its like ranked neighbor (`.text`) rather
  than taking eld's single pass insertion shortcut, so the orphan lands after `.text` and `.init` keeps its place.

  Scan the whole list and insert after the last section with rank `<=` the orphan's. For scripts sorted by rank, this is equivalent. The no linker script path is unchanged.

  Also update Hexagon TrampolineMissingSymbol: the fix moved its orphaned `.init` next to `.txt.foo`, removing the long call. Add an explicit `.init` rule to restore the call distance and check that the expected trampoline is
  emitted.

Fixes #1408