### PR TITLE
Fix reproduce functionality for shared libraries with sysroot marker

### DIFF
--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -3630,10 +3630,7 @@ void ObjectLinker::addInputFileToTar(InputFile *Ipt, MappingFile::Kind K) {
   if (Ipt->getInput()->isArchiveMember())
     return;
   Input *I = Ipt->getInput();
-  bool UseDecorated =
-      !I->isNamespec() &&
-      Ipt->getKind() == InputFile::InputFileKind::ELFDynObjFileKind;
-  Ipt->setMappedPath(UseDecorated ? I->decoratedPath() : I->getName());
+  Ipt->setMappedPath(I->getName());
   Ipt->setMappingFileKind(K);
   OutputTar->addInputFile(Ipt, /*isLTO*/ false);
 }

--- a/test/Common/standalone/CommandLine/Reproduce/ReproduceSharedLibSoname.test
+++ b/test/Common/standalone/CommandLine/Reproduce/ReproduceSharedLibSoname.test
@@ -1,0 +1,38 @@
+#BEGIN_COMMENT
+# This test verifies that the reproduce functionality works correctly
+# with shared libraries that have soname.
+#END_COMMENT
+RUN: %clang %clangopts -c -fPIC %p/Inputs/1.c -o %t.1.o
+RUN: %clang %clangopts -c %p/Inputs/2.c -o %t.2.o
+RUN: %link %linkopts -shared %t.1.o -o %t.lib1.so -soname LIB1
+RUN: %link %linkopts --dynamic %t.2.o %t.lib1.so \
+RUN:   --reproduce %t.a.tar --dump-mapping-file %t.a.mapping \
+RUN:   --dump-response-file %t.a.response -o %t.a.out
+RUN: %filecheck %s --check-prefix=MAPPING < %t.a.mapping
+# Replaying the response file must succeed.
+RUN: %rm -rf %t.rep && %mkdir %t.rep
+RUN: %tar %gnutaropts -xf %t.a.tar -C %t.rep --strip-components=1
+RUN: cd %t.rep
+RUN: %link @response.txt
+
+RUN: cd ..
+RUN: mkdir %t.libdir
+RUN: %cp %t.lib1.so %t.libdir/lib1.so
+RUN: %link %linkopts --dynamic %t.2.o -l1 -L %t.libdir \
+RUN:   --reproduce %t.b.tar --dump-mapping-file %t.b.mapping \
+RUN:   --dump-response-file %t.b.response -o %t.b.out
+RUN: %filecheck %s --check-prefix=MAPPING_NAMESPEC < %t.b.mapping
+# Replaying the response file must succeed.
+RUN: %rm -rf %t.rep && %mkdir %t.rep
+RUN: %tar %gnutaropts -xf %t.b.tar -C %t.rep --strip-components=1
+RUN: cd %t.rep
+RUN: %link @response.txt
+
+MAPPING: {{.*}}2.o=Object/
+MAPPING: {{.*}}lib1.so=SharedLibrary/
+
+MAPPING_NAMESPEC: {{.*}}2.o=Object/
+MAPPING_NAMESPEC: {{.*}}1=SharedLibrary/
+
+
+

--- a/test/Common/standalone/CommandLine/Reproduce/ReproduceSharedLibSoname.test
+++ b/test/Common/standalone/CommandLine/Reproduce/ReproduceSharedLibSoname.test
@@ -33,6 +33,3 @@ MAPPING: {{.*}}lib1.so=SharedLibrary/
 
 MAPPING_NAMESPEC: {{.*}}2.o=Object/
 MAPPING_NAMESPEC: {{.*}}1=SharedLibrary/
-
-
-

--- a/test/Common/standalone/CommandLine/Reproduce/SysrootMarker.test
+++ b/test/Common/standalone/CommandLine/Reproduce/SysrootMarker.test
@@ -1,0 +1,22 @@
+#BEGIN_COMMENT
+# This test verifies that the reproduce functionality works correctly
+# with shared libraries specified using a sysroot marker (=lib1.so)
+#END_COMMENT
+RUN: %rm -rf %t.sysroot && %mkdir -p %t.sysroot/lib64
+RUN: %clang %clangopts -c -fPIC %p/Inputs/1.c -o %t.sysroot/lib64/lib.o
+RUN: %clang %clangopts -c %p/Inputs/2.c -o %t.sysroot/lib64/main.o
+RUN: %link %linkopts -shared %t.sysroot/lib64/lib.o -o %t.sysroot/lib64/lib.so
+RUN: %link %linkopts --dynamic =/main.o =/lib.so --sysroot %t.sysroot/lib64 \
+RUN:   --reproduce %t.tar --dump-mapping-file %t.mapping \
+RUN:   --dump-response-file %t.response -o %t.out
+# The shared library must be keyed by its marker form, not the resolved path.
+RUN: %filecheck %s --check-prefix=MAPPING < %t.mapping
+
+MAPPING-DAG: =/main.o=Object/
+MAPPING-DAG: =/lib.so=SharedLibrary/
+
+# Replaying the response file must succeed.
+RUN: %rm -rf %t.rep && %mkdir %t.rep
+RUN: %tar %gnutaropts -xf %t.tar -C %t.rep --strip-components=1
+RUN: cd %t.rep
+RUN: %link @response.txt


### PR DESCRIPTION
This commit fixes the --reproduce functionality so that command-line shared libraries specified using a sysroot marker (e.g. =/lib.so) works correctly.

The root cause was incorrect mapped path for non-namespec shared libraries when the shared library was specified using the sysroot marker (=). For a shared library, '=/lib1.so', the mapped path was the expanded path '${SYSROOT}/lib1.so'. However, response.txt file contains the lib1.so entry using 'rewritePath('=lib1.so')'. The rewritePath calls returns 'lib1.so' as fallback because there is no entry for '=lib1.so'. This is because '=lib1.so' entry was never added because we used incorrect mapped path for non-namespec shared libraries (decoratedPath instead of the command-line name used for everything else).

Resolves #972