### PR TITLE
Add iplt_(start|end) symbols, if referenced, in initStandardSymbols

### DIFF
--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -196,6 +196,16 @@ public:
   /// finalizeTargetSymbols - set the value of target symbols
   virtual bool finalizeTargetSymbols() = 0;
 
+  /// defineIRelativeRange - define the __rel[a]_iplt_start/__rel[a]_iplt_end
+  /// range symbols. This must run before scanRelocations so
+  /// that any GOT entries created for these symbols are populated with the
+  /// correct symbol values.
+  void defineIRelativeRange();
+
+  /// finalizeIRelativeRange - set the values of the __rel[a]_iplt range symbols
+  /// to bound the PLT relocation output section.
+  void finalizeIRelativeRange();
+
   /// finalizeTLSSymbol - set the value of a TLS symbol
   virtual uint64_t finalizeTLSSymbol(LDSymbol *pSymbol);
 
@@ -1217,6 +1227,11 @@ protected:
   ELFObjectFile *m_DynamicSectionHeadersInputFile = nullptr;
   LDSymbol *m_pGOTSymbol = nullptr;
   llvm::DenseMap<const Relocation *, Relocation *> m_RelativeRelocMap;
+
+  // __rel[a]_iplt_start / __rel[a]_iplt_end range symbols for static IFunc
+  // (R_*_IRELATIVE) support.
+  LDSymbol *m_pIRelativeStart = nullptr;
+  LDSymbol *m_pIRelativeEnd = nullptr;
 
   // Patching.
   llvm::DenseMap<ResolveInfo *, const ResolveInfo *> m_AbsolutePLTMap;

--- a/lib/Target/AArch64/AArch64LDBackend.cpp
+++ b/lib/Target/AArch64/AArch64LDBackend.cpp
@@ -54,12 +54,10 @@ using namespace llvm;
 //===----------------------------------------------------------------------===//
 // AArch64LDBackend
 //===----------------------------------------------------------------------===//
-AArch64LDBackend::AArch64LDBackend(eld::Module &pModule,
-                                                 TargetInfo *pInfo)
+AArch64LDBackend::AArch64LDBackend(eld::Module &pModule, TargetInfo *pInfo)
     : GNULDBackend(pModule, pInfo), m_pErrata843419Factory(nullptr),
       m_pAArch64ErrataIslandFactory(nullptr), m_pRelocator(nullptr),
-      m_pDynamic(nullptr), m_pIRelativeStart(nullptr), m_pIRelativeEnd(nullptr),
-      m_ptdata(nullptr), m_ptbss(nullptr) {}
+      m_pDynamic(nullptr), m_ptdata(nullptr), m_ptbss(nullptr) {}
 
 AArch64LDBackend::~AArch64LDBackend() {}
 
@@ -520,54 +518,7 @@ void AArch64LDBackend::createErratum843419Stub(Fragment *frag,
   } // for all relocation section
 }
 
-void AArch64LDBackend::defineIRelativeRange(ResolveInfo &pSym) {
-  // It is up to linker script to define those symbols.
-  if (m_Module.getScript().linkerScriptHasSectionsCommand())
-    return;
-
-  // Define the copy symbol in the bss section and resolve it
-  auto SymbolName = "__rela_iplt_start";
-  if (!m_pIRelativeStart && !m_pIRelativeEnd) {
-    m_pIRelativeStart =
-        m_Module.getIRBuilder()
-            ->addSymbol<IRBuilder::Force, IRBuilder::Resolve>(
-                m_Module.getInternalInput(Module::Script), SymbolName,
-                ResolveInfo::Object, ResolveInfo::Define,
-                (ResolveInfo::Binding)pSym.binding(),
-                0,   // size
-                0x0, // value
-                FragmentRef::null(), (ResolveInfo::Visibility)pSym.other());
-    if (m_Module.getConfig().options().isSymbolTracingRequested() &&
-        m_Module.getConfig().options().traceSymbol(SymbolName)) {
-      config().raise(Diag::target_specific_symbol) << SymbolName;
-    }
-    m_pIRelativeStart->setShouldIgnore(false);
-    SymbolName = "__rela_iplt_end";
-    m_pIRelativeEnd =
-        m_Module.getIRBuilder()
-            ->addSymbol<IRBuilder::Force, IRBuilder::Resolve>(
-                m_Module.getInternalInput(Module::Script), SymbolName,
-                ResolveInfo::Object, ResolveInfo::Define,
-                (ResolveInfo::Binding)pSym.binding(),
-                pSym.size(), // size
-                0x0,         // value
-                FragmentRef::null(), (ResolveInfo::Visibility)pSym.other());
-    if (m_Module.getConfig().options().isSymbolTracingRequested() &&
-        m_Module.getConfig().options().traceSymbol(SymbolName)) {
-      config().raise(Diag::target_specific_symbol) << SymbolName;
-    }
-    m_pIRelativeEnd->setShouldIgnore(false);
-  }
-}
-
 bool AArch64LDBackend::finalizeTargetSymbols() {
-  if (m_pIRelativeStart && m_pIRelativeEnd) {
-    m_pIRelativeStart->setValue(
-        getRelaPLT()->getOutputSection()->getSection()->addr());
-    m_pIRelativeEnd->setValue(
-        getRelaPLT()->getOutputSection()->getSection()->addr() +
-        getRelaPLT()->getOutputSection()->getSection()->size());
-  }
   if (m_pGOTSymbol) {
     m_pGOTSymbol->setValue(getGOT()->getOutputSection()->getSection()->addr());
   }

--- a/lib/Target/AArch64/AArch64LDBackend.h
+++ b/lib/Target/AArch64/AArch64LDBackend.h
@@ -86,8 +86,6 @@ public:
 
   ELFSection *getTBSS() const { return m_ptbss; }
 
-  void defineIRelativeRange(ResolveInfo &pSym);
-
   bool scanErrata843419();
 
   Relocation::Type getCopyRelType() const override;
@@ -220,8 +218,6 @@ private:
   Relocator *m_pRelocator;
 
   AArch64ELFDynamic *m_pDynamic;
-  LDSymbol *m_pIRelativeStart;
-  LDSymbol *m_pIRelativeEnd;
   ELFSection *m_ptdata;
   ELFSection *m_ptbss;
   /// GNU Property section

--- a/lib/Target/AArch64/AArch64Relocator.cpp
+++ b/lib/Target/AArch64/AArch64Relocator.cpp
@@ -1378,7 +1378,6 @@ void AArch64Relocator::handleScanForNonPreemptibleIFunc(Relocation &R,
   if (RI->reserved() & Relocator::ReservePLT)
     return;
   m_Target.createPLT(Obj, RI, /*isIRelative=*/true);
-  m_Target.defineIRelativeRange(*RI);
   RI->setReserved(RI->reserved() | Relocator::ReservePLT);
 }
 

--- a/lib/Target/ARM/ARMLDBackend.cpp
+++ b/lib/Target/ARM/ARMLDBackend.cpp
@@ -58,10 +58,9 @@ using namespace llvm;
 //===----------------------------------------------------------------------===//
 ARMGNULDBackend::ARMGNULDBackend(eld::Module &pModule, TargetInfo *pInfo)
     : GNULDBackend(pModule, pInfo), m_pRelocator(nullptr), m_pDynamic(nullptr),
-      m_pEXIDXStart(nullptr), m_pEXIDXEnd(nullptr), m_pIRelativeStart(nullptr),
-      m_pIRelativeEnd(nullptr), m_pEXIDX(nullptr), m_pRWPIBase(nullptr),
-      m_pSBRELSegment(nullptr), m_pARMAttributeSection(nullptr),
-      AttributeFragment(nullptr) {}
+      m_pEXIDXStart(nullptr), m_pEXIDXEnd(nullptr), m_pEXIDX(nullptr),
+      m_pRWPIBase(nullptr), m_pSBRELSegment(nullptr),
+      m_pARMAttributeSection(nullptr), AttributeFragment(nullptr) {}
 
 ARMGNULDBackend::~ARMGNULDBackend() {}
 
@@ -642,60 +641,8 @@ ARMGNULDBackend::emitSection(ELFSection *pSection,
   return GNULDBackend::emitSection(pSection, pRegion);
 }
 
-void ARMGNULDBackend::defineIRelativeRange(ResolveInfo &pSym) {
-  // It is up to linker script to define those symbols.
-  if (m_Module.getScript().linkerScriptHasSectionsCommand())
-    return;
-
-  if (!m_pIRelativeStart && !m_pIRelativeEnd) {
-    auto SymbolName = "__rel_iplt_start";
-    m_pIRelativeStart =
-        m_Module.getIRBuilder()
-            ->addSymbol<IRBuilder::AsReferred, IRBuilder::Resolve>(
-                m_Module.getInternalInput(Module::Script), SymbolName,
-                ResolveInfo::Type::NoType, ResolveInfo::Define,
-                ResolveInfo::Binding::Local,
-                0,   // size
-                0x0, // value
-                FragmentRef::null(), ResolveInfo::Visibility::Default);
-    if (m_pIRelativeStart) {
-      m_pIRelativeStart->setShouldIgnore(false);
-      if (m_Module.getConfig().options().isSymbolTracingRequested() &&
-          m_Module.getConfig().options().traceSymbol(SymbolName))
-        config().raise(Diag::target_specific_symbol) << SymbolName;
-    }
-    SymbolName = "__rel_iplt_end";
-    m_pIRelativeEnd =
-        m_Module.getIRBuilder()
-            ->addSymbol<IRBuilder::AsReferred, IRBuilder::Resolve>(
-                m_Module.getInternalInput(Module::Script), SymbolName,
-                ResolveInfo::Type::NoType, ResolveInfo::Define,
-                ResolveInfo::Binding::Local,
-                0,   // size
-                0x0, // value
-                FragmentRef::null(), ResolveInfo::Visibility::Default);
-    if (m_pIRelativeEnd) {
-      m_pIRelativeEnd->setShouldIgnore(false);
-      if (m_Module.getConfig().options().isSymbolTracingRequested() &&
-          m_Module.getConfig().options().traceSymbol(SymbolName))
-        config().raise(Diag::target_specific_symbol) << SymbolName;
-    }
-  }
-}
-
 /// finalizeSymbol - finalize the symbol value
-bool ARMGNULDBackend::finalizeTargetSymbols() {
-  if (m_pIRelativeStart && m_pIRelativeEnd) {
-    m_pIRelativeStart->setValue(
-        getRelaPLT()->getOutputSection()->getSection()->addr());
-    m_pIRelativeEnd->setValue(
-        getRelaPLT()->getOutputSection()->getSection()->addr() +
-        getRelaPLT()->getOutputSection()->getSection()->size());
-    addSectionInfo(m_pIRelativeStart, getRelaPLT());
-    addSectionInfo(m_pIRelativeEnd, getRelaPLT());
-  }
-  return true;
-}
+bool ARMGNULDBackend::finalizeTargetSymbols() { return true; }
 
 void ARMGNULDBackend::finalizeBeforeWrite() {
   // Update __RWPI_BASE__

--- a/lib/Target/ARM/ARMLDBackend.h
+++ b/lib/Target/ARM/ARMLDBackend.h
@@ -117,8 +117,6 @@ public:
                                 std::string RelocModel,
                                 const std::string &Output) override;
 
-  void defineIRelativeRange(ResolveInfo &pSym);
-
   uint64_t getSectLink(const ELFSection *S) const override;
 
   Relocation::Type getCopyRelType() const override;
@@ -246,8 +244,6 @@ private:
   ARMELFDynamic *m_pDynamic;
   LDSymbol *m_pEXIDXStart;
   LDSymbol *m_pEXIDXEnd;
-  LDSymbol *m_pIRelativeStart;
-  LDSymbol *m_pIRelativeEnd;
 
   //     variable name           :  ELF
   ELFSection *m_pEXIDX;        // .ARM.exidx

--- a/lib/Target/ARM/ARMRelocator.cpp
+++ b/lib/Target/ARM/ARMRelocator.cpp
@@ -855,7 +855,6 @@ void ARMRelocator::handleScanForNonPreemptibleIFunc(Relocation &R,
   if (RI->reserved() & ReservePLT)
     return;
   m_Target.createPLT(Obj, RI, /*isIRelative=*/true);
-  m_Target.defineIRelativeRange(*RI);
   RI->setReserved(RI->reserved() | ReservePLT);
 }
 

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -365,6 +365,13 @@ bool GNULDBackend::initStandardSymbols() {
   InitStandardSym("", "_end", m_Module.getSection(".bss"));
   MayDefineStandardSym("__ehdr_start");
   MayDefineStandardSym("__dso_handle");
+
+  // Define __rel[a]_iplt_start/__rel[a]_iplt_end (used by glibc to process
+  // R_*_IRELATIVE entries in static executables) if they are referenced. This
+  // must run before scanRelocations creates GOT entries for them, so that the
+  // GOT slots are populated with the correct symbol values.
+  if (config().isCodeStatic())
+    defineIRelativeRange();
   return true;
 }
 
@@ -468,6 +475,7 @@ bool GNULDBackend::finalizeStandardSymbols() {
                                llvm::ELF::PF_X, 8, true, true);
   DefineStandardSymFromSegment("", "_end", llvm::ELF::PF_W, llvm::ELF::PF_X, 8,
                                true, true);
+  finalizeIRelativeRange();
   return true;
 }
 
@@ -581,6 +589,64 @@ bool GNULDBackend::defineStandardAndSectionMagicSymbols() {
       canProvideSymbol(R);
   }
   return true;
+}
+
+void GNULDBackend::defineIRelativeRange() {
+  // It is up to the linker script to define these symbols when a SECTIONS
+  // command is present.
+  if (m_Module.getScript().linkerScriptHasSectionsCommand())
+    return;
+
+  if (m_pIRelativeStart || m_pIRelativeEnd)
+    return;
+
+  // The relocation section that holds R_*_IRELATIVE entries is `.rela.plt` on
+  // RELA targets and `.rel.plt` on REL targets; the range symbols are named to
+  // match.
+  const bool IsRela = getRelocator()->relocType() == llvm::ELF::SHT_RELA;
+  llvm::StringRef StartName = IsRela ? "__rela_iplt_start" : "__rel_iplt_start";
+  llvm::StringRef EndName = IsRela ? "__rela_iplt_end" : "__rel_iplt_end";
+
+  m_pIRelativeStart =
+      m_Module.getIRBuilder()
+          ->addSymbol<IRBuilder::AsReferred, IRBuilder::Resolve>(
+              m_Module.getInternalInput(Module::Script), StartName.str(),
+              ResolveInfo::NoType, ResolveInfo::Define, ResolveInfo::Global,
+              0,   // size
+              0x0, // value
+              FragmentRef::null(), ResolveInfo::Hidden);
+  if (m_pIRelativeStart) {
+    m_pIRelativeStart->setShouldIgnore(false);
+    if (m_Module.getConfig().options().isSymbolTracingRequested() &&
+        m_Module.getConfig().options().traceSymbol(StartName.str()))
+      config().raise(Diag::target_specific_symbol) << StartName;
+  }
+
+  m_pIRelativeEnd =
+      m_Module.getIRBuilder()
+          ->addSymbol<IRBuilder::AsReferred, IRBuilder::Resolve>(
+              m_Module.getInternalInput(Module::Script), EndName.str(),
+              ResolveInfo::NoType, ResolveInfo::Define, ResolveInfo::Global,
+              0,   // size
+              0x0, // value
+              FragmentRef::null(), ResolveInfo::Hidden);
+  if (m_pIRelativeEnd) {
+    m_pIRelativeEnd->setShouldIgnore(false);
+    if (m_Module.getConfig().options().isSymbolTracingRequested() &&
+        m_Module.getConfig().options().traceSymbol(EndName.str()))
+      config().raise(Diag::target_specific_symbol) << EndName;
+  }
+}
+
+void GNULDBackend::finalizeIRelativeRange() {
+  if (m_pIRelativeStart && m_pIRelativeEnd && getRelaPLT() &&
+      getRelaPLT()->getOutputSection()) {
+    ELFSection *relaPltSec = getRelaPLT()->getOutputSection()->getSection();
+    m_pIRelativeStart->setValue(relaPltSec->addr());
+    m_pIRelativeEnd->setValue(relaPltSec->addr() + relaPltSec->size());
+    addSectionInfo(m_pIRelativeStart, getRelaPLT());
+    addSectionInfo(m_pIRelativeEnd, getRelaPLT());
+  }
 }
 
 void GNULDBackend::provideSymbols() {

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -198,6 +198,7 @@ void RISCVLDBackend::initTargetSymbols() {
   // Do not create another __global_pointer$ when linking a patch.
   if (config().options().getPatchBase())
     return;
+
   if (m_Module.getScript().linkerScriptHasSectionsCommand()) {
     m_pGlobalPointer = m_Module.getNamePool().findSymbol("__global_pointer$");
     return;
@@ -1846,16 +1847,6 @@ void RISCVLDBackend::mayBeRelax(int relaxation_pass, bool &pFinished) {
 
 /// finalizeSymbol - finalize the symbol value
 bool RISCVLDBackend::finalizeTargetSymbols() {
-  if (m_pIRelativeStart && m_pIRelativeEnd) {
-    m_pIRelativeStart->setValue(
-        getRelaPLT()->getOutputSection()->getSection()->addr());
-    m_pIRelativeEnd->setValue(
-        getRelaPLT()->getOutputSection()->getSection()->addr() +
-        getRelaPLT()->getOutputSection()->getSection()->size());
-    addSectionInfo(m_pIRelativeStart, getRelaPLT());
-    addSectionInfo(m_pIRelativeEnd, getRelaPLT());
-  }
-
   for (auto &I : m_LabeledSymbols)
     m_Module.getLinker()->getObjLinker()->finalizeSymbolValue(I);
 
@@ -2330,44 +2321,6 @@ void RISCVLDBackend::defineGOTSymbol(Fragment &pFrag) {
   if (m_Module.getConfig().options().isSymbolTracingRequested() &&
       m_Module.getConfig().options().traceSymbol(SymbolName))
     config().raise(Diag::target_specific_symbol) << SymbolName;
-}
-
-void RISCVLDBackend::defineIRelativeRange(ResolveInfo &pSym) {
-  if (m_Module.getScript().linkerScriptHasSectionsCommand())
-    return;
-
-  if (!m_pIRelativeStart && !m_pIRelativeEnd) {
-    auto SymbolName = "__rela_iplt_start";
-    m_pIRelativeStart =
-        m_Module.getIRBuilder()
-            ->addSymbol<IRBuilder::Force, IRBuilder::Resolve>(
-                m_Module.getInternalInput(Module::Script), SymbolName,
-                ResolveInfo::Type::NoType, ResolveInfo::Define,
-                ResolveInfo::Binding::Local,
-                0,   // size
-                0x0, // value
-                FragmentRef::null(), ResolveInfo::Visibility::Default);
-    if (m_Module.getConfig().options().isSymbolTracingRequested() &&
-        m_Module.getConfig().options().traceSymbol(SymbolName)) {
-      config().raise(Diag::target_specific_symbol) << SymbolName;
-    }
-    m_pIRelativeStart->setShouldIgnore(false);
-    SymbolName = "__rela_iplt_end";
-    m_pIRelativeEnd =
-        m_Module.getIRBuilder()
-            ->addSymbol<IRBuilder::Force, IRBuilder::Resolve>(
-                m_Module.getInternalInput(Module::Script), SymbolName,
-                ResolveInfo::Type::NoType, ResolveInfo::Define,
-                ResolveInfo::Binding::Local,
-                0x0, // size
-                0x0, // value
-                FragmentRef::null(), ResolveInfo::Visibility::Default);
-    if (m_Module.getConfig().options().isSymbolTracingRequested() &&
-        m_Module.getConfig().options().traceSymbol(SymbolName)) {
-      config().raise(Diag::target_specific_symbol) << SymbolName;
-    }
-    m_pIRelativeEnd->setShouldIgnore(false);
-  }
 }
 
 bool RISCVLDBackend::finalizeScanRelocations() {

--- a/lib/Target/RISCV/RISCVLDBackend.h
+++ b/lib/Target/RISCV/RISCVLDBackend.h
@@ -125,10 +125,6 @@ public:
 
   void recordPLT(ResolveInfo *, RISCVPLT *);
 
-  /// defineIRelativeRange - define __rela_iplt_start/__rela_iplt_end symbols
-  /// for IFunc support in static linking
-  void defineIRelativeRange(ResolveInfo &pSym);
-
   RISCVPLT *findEntryInPLT(ResolveInfo *) const;
 
   // ---------------------  Dynamic relocation support ------------
@@ -368,9 +364,6 @@ private:
   RISCVTableJumpFragment *TableJumpFragment = nullptr;
   bool TableJumpInitialized = false;
   LDSymbol *m_pJvtBase = nullptr;
-
-  LDSymbol *m_pIRelativeStart = nullptr;
-  LDSymbol *m_pIRelativeEnd = nullptr;
 
   llvm::DenseMap<ResolveInfo *, RISCVGOT *> m_GOTMap;
   llvm::DenseMap<ResolveInfo *, RISCVGOT *> m_GOTPLTMap;

--- a/lib/Target/RISCV/RISCVRelocator.cpp
+++ b/lib/Target/RISCV/RISCVRelocator.cpp
@@ -1224,7 +1224,6 @@ void RISCVRelocator::handleScanForNonPreemptibleIFunc(Relocation &R,
     return;
 
   m_Target.createPLT(Obj, RI, /*isIRelative=*/true);
-  m_Target.defineIRelativeRange(*RI);
   RI->setReserved(RI->reserved() | Relocator::ReservePLT);
 }
 

--- a/lib/Target/X86/x86_64LDBackend.cpp
+++ b/lib/Target/X86/x86_64LDBackend.cpp
@@ -33,8 +33,7 @@ using namespace llvm;
 //===----------------------------------------------------------------------===//
 x86_64LDBackend::x86_64LDBackend(Module &pModule, x86_64Info *pInfo)
     : GNULDBackend(pModule, pInfo), m_pRelocator(nullptr), m_pDynamic(nullptr),
-      m_pEndOfImage(nullptr), m_pIRelativeStart(nullptr),
-      m_pIRelativeEnd(nullptr) {}
+      m_pEndOfImage(nullptr) {}
 
 x86_64LDBackend::~x86_64LDBackend() {}
 
@@ -118,24 +117,6 @@ bool x86_64LDBackend::finalizeTargetSymbols() {
     m_pEndOfImage->setValue(imageEnd + 1);
   }
 
-  // Finalize __rela_iplt range symbols for static executables when
-  // output sections are available.
-  if (config().isCodeStatic() && m_pIRelativeStart && m_pIRelativeEnd &&
-      getRelaPLT()->getOutputSection()) {
-    ELFSection *relaPltSec = getRelaPLT()->getOutputSection()->getSection();
-
-    m_pIRelativeStart->setValue(relaPltSec->addr());
-    m_pIRelativeEnd->setValue(relaPltSec->addr() + relaPltSec->size());
-
-    // Associate symbols with the .rela.plt section
-    if (relaPltSec->hasFragments()) {
-      Fragment *firstFrag = *relaPltSec->getFragmentList().begin();
-      m_pIRelativeStart->setFragmentRef(make<FragmentRef>(*firstFrag, 0));
-      m_pIRelativeEnd->setFragmentRef(
-          make<FragmentRef>(*firstFrag, relaPltSec->size()));
-    }
-  }
-
   return true;
 }
 
@@ -151,35 +132,6 @@ void x86_64LDBackend::doPreLayout() {
                           getRelaEntrySize());
     m_Module.addOutputSection(getRelaPLT());
     m_Module.addOutputSection(getRelaDyn());
-  }
-}
-
-// Define synthetic range symbols for IRELATIVE processing in static
-// executables. Values are finalized to bound the .rela.plt output section.
-void x86_64LDBackend::defineIRelativeRange(ResolveInfo &pSym) {
-  if (m_Module.getScript().linkerScriptHasSectionsCommand())
-    return;
-  auto SymbolName = "__rela_iplt_start";
-  if (!m_pIRelativeStart && !m_pIRelativeEnd) {
-    m_pIRelativeStart =
-        m_Module.getIRBuilder()
-            ->addSymbol<IRBuilder::Force, IRBuilder::Resolve>(
-                m_Module.getInternalInput(Module::Script), SymbolName,
-                ResolveInfo::Object, ResolveInfo::Define,
-                ResolveInfo::Local, //
-                0,                  // size
-                0x0,                // value
-                FragmentRef::null(), ResolveInfo::Hidden);
-
-    m_pIRelativeEnd =
-        m_Module.getIRBuilder()
-            ->addSymbol<IRBuilder::Force, IRBuilder::Resolve>(
-                m_Module.getInternalInput(Module::Script), "__rela_iplt_end",
-                ResolveInfo::Object, ResolveInfo::Define,
-                ResolveInfo::Local, //
-                0,                  // size
-                0x0,                // value
-                FragmentRef::null(), ResolveInfo::Hidden);
   }
 }
 

--- a/lib/Target/X86/x86_64LDBackend.h
+++ b/lib/Target/X86/x86_64LDBackend.h
@@ -100,8 +100,6 @@ public:
     m_RelativeRelocMap[DynRel] = OrigRel;
   }
 
-  void defineIRelativeRange(ResolveInfo &pSym);
-
   void sortRelocation(ELFSection &pSection) override;
 
   DynRelocType getDynRelocType(const Relocation *X) const override {
@@ -163,10 +161,6 @@ private:
   llvm::DenseMap<ResolveInfo *, x86_64GOT *> m_GOTPLTMap;
   llvm::DenseMap<ResolveInfo *, x86_64PLT *> m_PLTMap;
   llvm::DenseMap<Relocation *, const Relocation *> m_RelativeRelocMap;
-
-  // IRELATIVE range symbols for static executables
-  LDSymbol *m_pIRelativeStart = nullptr;
-  LDSymbol *m_pIRelativeEnd = nullptr;
 };
 } // namespace eld
 

--- a/lib/Target/X86/x86_64Relocator.cpp
+++ b/lib/Target/X86/x86_64Relocator.cpp
@@ -383,8 +383,6 @@ void x86_64Relocator::scanGlobalReloc(InputFile &pInputFile, Relocation &pReloc,
     if (rsym->type() == ResolveInfo::IndirectFunc && config().isCodeStatic()) {
       m_Target.createPLT(Obj, rsym, true);
       rsym->setReserved(rsym->reserved() | ReservePLT);
-      x86_64LDBackend &backend = getTarget();
-      backend.defineIRelativeRange(*rsym);
       return;
     }
     // if symbol is defined in the output file and it's not

--- a/test/AArch64/standalone/IFunc/IFunc.test
+++ b/test/AArch64/standalone/IFunc/IFunc.test
@@ -6,7 +6,8 @@
 #START_TEST
 RUN: %clang %clangopts -target aarch64 -c %p/Inputs/m.c -o %tm.o
 RUN: %clang %clangopts -target aarch64 -c %p/Inputs/t.c -o %tt.o
-RUN: %link %linkopts -march aarch64 %tm.o %tt.o -o %t.out
+RUN: %clang %clangopts -target aarch64 -c %p/Inputs/iplt_range.s -o %tr.o
+RUN: %link %linkopts -march aarch64 %tm.o %tt.o %tr.o -o %t.out
 RUN: %readelf -a %t.out | %filecheck --check-prefix=STANDALONE %s
 RUN: llvm-readobj -r %t.out | %filecheck --check-prefix=STANDALONE2 %s
 RUN: %link %linkopts -march aarch64 %tm.o %tt.o -pie -o %t2.out

--- a/test/AArch64/standalone/IFunc/Inputs/iplt_range.s
+++ b/test/AArch64/standalone/IFunc/Inputs/iplt_range.s
@@ -1,0 +1,8 @@
+// Reference the linker-defined IRELATIVE range symbols (as glibc's crt does)
+// so that they are defined in a static executable. Only linked into the static
+// STANDALONE case.
+	.data
+	.globl	iplt_range
+iplt_range:
+	.xword	__rela_iplt_start
+	.xword	__rela_iplt_end

--- a/test/ARM/standalone/StaticIFunc/StaticIFunc.test
+++ b/test/ARM/standalone/StaticIFunc/StaticIFunc.test
@@ -38,8 +38,8 @@ RUN: %link %linkopts -o %t1.main-local.pic.out %t1.main-local.pic.o \
 RUN:   --trace=symbol=foo 2>&1 | %filecheck %s --check-prefix=CHECK_GOT
 #END_TEST
 
-READELF: 0 NOTYPE  LOCAL  DEFAULT     [[SECT_INDEX:[1-9]]] __rel_iplt_start
-READELF: 0 NOTYPE  LOCAL  DEFAULT     [[SECT_INDEX]] __rel_iplt_end
+READELF: 0 NOTYPE  GLOBAL HIDDEN     [[SECT_INDEX:[1-9]]] __rel_iplt_start
+READELF: 0 NOTYPE  GLOBAL HIDDEN     [[SECT_INDEX]] __rel_iplt_end
 
 CHECK_NO_GOT-NOT: Created GOT Entry for Symbol foo{{$}}
 

--- a/test/Common/RunTests/HelloWorld/HelloWorld.test
+++ b/test/Common/RunTests/HelloWorld/HelloWorld.test
@@ -1,5 +1,4 @@
 REQUIRES: run_test
-XFAIL: riscv32, riscv64
 UNSUPPORTED: x86
 #---HelloWorld.test--------------------- Executable------------------#
 #BEGIN_COMMENT

--- a/test/RISCV/RunTests/GOT_LOAD_RELAX/GOT_LOAD_RELAX_RUN.test
+++ b/test/RISCV/RunTests/GOT_LOAD_RELAX/GOT_LOAD_RELAX_RUN.test
@@ -1,9 +1,4 @@
 REQUIRES: run_test
-# XFAIL'ed for rv64 until https://github.com/qualcomm/eld/issues/1342 is resolved.
-# The accesses to __rela_iplt_start/__rela_iplt_end aren't relaxed in rv64 as
-# they are 0 at the time of relaxation so use the GOT and hit 1342. rv32 can
-# always assume relative accesses will be in range, so sidestep this issue.
-XFAIL: riscv64
 #----------GOT_LOAD_RELAX_RUN.test----------------- Executable------------------#
 #BEGIN_COMMENT
 # Run tests for RISC-V GOT load relaxation. Verifies that the correct runtime

--- a/test/RISCV/standalone/IFunc/IFunc.test
+++ b/test/RISCV/standalone/IFunc/IFunc.test
@@ -28,8 +28,8 @@ RUN: %objdump -dr %t1.pic.auipc-got.out | %filecheck %s --check-prefix=AUIPC_GOT
 #END_TEST
 
 READELF: [[#SECTION_INDEX:]]] .rela.plt
-READELF: 0 NOTYPE LOCAL DEFAULT [[#SECTION_INDEX]] __rela_iplt_start
-READELF: 0 NOTYPE LOCAL DEFAULT [[#SECTION_INDEX]] __rela_iplt_end
+READELF: 0 NOTYPE GLOBAL HIDDEN [[#SECTION_INDEX]] __rela_iplt_start
+READELF: 0 NOTYPE GLOBAL HIDDEN [[#SECTION_INDEX]] __rela_iplt_end
 
 LUI_AND_AUIPC: <main>:
 LUI_AND_AUIPC: lui a0, 0x40

--- a/test/RISCV/standalone/IFunc/Inputs/main-nopic.s
+++ b/test/RISCV/standalone/IFunc/Inputs/main-nopic.s
@@ -31,3 +31,12 @@ main:
   ret
 
   .size main, . - main
+
+  # Reference the linker-defined IRELATIVE range symbols (as glibc's crt does)
+  # so that they are defined in the output. These are absolute data references
+  # and do not create GOT entries, so the .text/.got layout is unchanged.
+  .section .data,"aw",@progbits
+  .global iplt_range
+iplt_range:
+  .word __rela_iplt_start
+  .word __rela_iplt_end


### PR DESCRIPTION
This commit modifies where `__rel(a)_iplt_(start|end)` symbols are added.
Previously, they were added during scan relocation phase on encountering
an ifunc symbol. However, it causes issues when a GOT to
`__rel(a)_iplt_(start|end)` symbol is encountered before an ifunc symbol.
Additionally, these symbols should also be made available for GNU
compatibility even if there is no ifunc symbol.
Now these symbols are added, if referenced, in initStandardSymbolsphase.
This phase happens before scan relocation.

Additionally, this PR refactors creating and defining of rela_iplt
symbols such that it happens in GNULDBackend, instead of separately in
each target.

This PR changes the rela_iplt symbols to have global binding and hidden
visibility. Previously, these properties were not uniform across targets:

- AArch64 used to use the binding and visibility of the IFunc symbol
  which triggered the creation of these symbols.
- ARM and RISCV already used to be GNU-compatible here with local
  binding and default visibility.
- x86-64 used local binding but with hidden visibillity.

Resolves #1342