### PR TITLE
Add zlib::isAvailable() check to readCompressedSection function

### DIFF
--- a/lib/Readers/RelocELFReader.cpp
+++ b/lib/Readers/RelocELFReader.cpp
@@ -209,6 +209,10 @@ eld::Expected<bool> RelocELFReader<ELFT>::readCompressedSection(ELFSection *S) {
   if (hdr->ch_type != llvm::ELF::ELFCOMPRESS_ZLIB)
     return false;
 
+  // Check if zlib is available before calling decompress.
+  if (!llvm::compression::zlib::isAvailable())
+    return false;
+
   size_t uncompressedSize = hdr->ch_size;
   typename ELFReader<ELFT>::uintX_t alignment =
       std::max<typename ELFReader<ELFT>::uintX_t>(hdr->ch_addralign, 1);

--- a/test/Common/standalone/CompressedSectionsNoZlib/Inputs/1.c
+++ b/test/Common/standalone/CompressedSectionsNoZlib/Inputs/1.c
@@ -1,0 +1,4 @@
+int i = 0;
+__attribute__((always_inline)) int foo(int j) { return i + j; }
+__attribute__((always_inline)) int bar(int j) { return i + j; }
+int baz() { return foo(i) + bar(i); }

--- a/test/Common/standalone/CompressedSectionsNoZlib/ReadCompressedSectionsNoZlib.test
+++ b/test/Common/standalone/CompressedSectionsNoZlib/ReadCompressedSectionsNoZlib.test
@@ -1,0 +1,10 @@
+#---ReadCompressedSectionsNoZlib.test---------- Executable --------------------#
+#BEGIN_COMMENT
+#This checks that the linker does not crash when trying to read information in
+#compressed format and zlib is not available
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -gz -g -o %t1.1.o -ffunction-sections
+RUN: %link %linkopts %t1.1.o -o %t2.out
+
+#END_TEST


### PR DESCRIPTION
Add llvm::compression::zlib::isAvailable() check to RelocELFReader::readCompressedSection function to prevent hitting an llvm_unreachable when calling llvm::compression::zlib::decompress

Fix: qualcomm#1399