### PR TITLE
[ARM] Add EXIDXSentinelFragment class

### DIFF
--- a/lib/Target/ARM/ARMEXIDXFragment.cpp
+++ b/lib/Target/ARM/ARMEXIDXFragment.cpp
@@ -5,10 +5,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "ARMEXIDXFragment.h"
+#include "eld/Core/Module.h"
 #include "eld/Diagnostics/MsgHandler.h"
 #include "eld/Readers/ELFSection.h"
 #include "eld/Readers/Relocation.h"
 #include "eld/SymbolResolver/ResolveInfo.h"
+#include "llvm/Support/Endian.h"
 #include <cstring>
 
 using namespace eld;
@@ -111,12 +113,13 @@ void EXIDXFragment::dump(llvm::raw_ostream &OS) {
   }
 }
 
-eld::Expected<void> EXIDXFragment::emit(MemoryRegion &Mr, Module &) {
+eld::Expected<void> EXIDXFragment::emit(MemoryRegion &Mr, Module &M) {
   if (Pieces.empty())
     return {};
 
+  DiagnosticEngine *Diag = M.getConfig().getDiagEngine();
   llvm::StringRef Region = getRegion();
-  uint32_t BaseOffset = getOffset();
+  uint32_t BaseOffset = getOffset(Diag);
   uint32_t OutOffset = 0;
   for (const EXIDXPiece &Piece : Pieces) {
     const uint32_t Begin = Piece.InputOffset;
@@ -130,4 +133,30 @@ eld::Expected<void> EXIDXFragment::emit(MemoryRegion &Mr, Module &) {
     OutOffset += PieceSize;
   }
   return {};
+}
+
+// EXIDXSentinelFragment
+
+eld::Expected<void> EXIDXSentinelFragment::emit(MemoryRegion &Mr, Module &M) {
+  DiagnosticEngine *Diag = M.getConfig().getDiagEngine();
+  uint8_t *Buf = Mr.begin() + getOffset(Diag);
+  uint64_t SentinelAddr = getAddr(Diag);
+  uint64_t TargetAddr = 0;
+  if (LinkedSection)
+    TargetAddr = LinkedSection->addr() + LinkedSection->size();
+  // PREL31: (target - place) masked to 31 bits.
+  int32_t Prel31 = static_cast<int32_t>(TargetAddr - SentinelAddr) & 0x7FFFFFFF;
+  llvm::support::endian::write32le(Buf, static_cast<uint32_t>(Prel31));
+  llvm::support::endian::write32le(Buf + 4, 0x00000001u);
+  return {};
+}
+
+void EXIDXSentinelFragment::dump(llvm::raw_ostream &OS) {
+  ELFSection *OutSection = getOutputELFSection();
+  const uint64_t SectionAddr = OutSection ? OutSection->addr() : 0;
+  const uint64_t FragAddr = SectionAddr + (hasOffset() ? getOffset() : 0);
+  OS << "#EXIDX-sentinel";
+  OS << "\taddr=0x";
+  OS.write_hex(FragAddr);
+  OS << "\tsz=0x8\n";
 }

--- a/lib/Target/ARM/ARMEXIDXFragment.h
+++ b/lib/Target/ARM/ARMEXIDXFragment.h
@@ -8,6 +8,7 @@
 #define TARGET_ARM_ARMEXIDXFRAGMENT_H
 
 #include "eld/Fragment/RegionFragment.h"
+#include "eld/Fragment/TargetFragment.h"
 #include "llvm/ADT/SmallVector.h"
 #include <cstdint>
 
@@ -54,6 +55,31 @@ public:
 
 private:
   llvm::SmallVector<EXIDXPiece, 0> Pieces;
+};
+
+// An 8-byte linker-generated CANTUNWIND entry placed at the end of the
+// .ARM.exidx table.  Its first word is a PREL31 offset to the byte
+// immediately past the last covered function; its second word is 0x1
+// (CANTUNWIND compact model entry).  Lives in its own internal section so
+// it is naturally placed last by any *(.ARM.exidx*) linker script rule.
+class EXIDXSentinelFragment : public TargetFragment {
+public:
+  EXIDXSentinelFragment(ELFSection *O)
+      : TargetFragment(TargetFragment::TargetSpecific, O, nullptr, 4, 8) {}
+
+  ~EXIDXSentinelFragment() override = default;
+
+  const std::string name() const override { return "EXIDXSentinel"; }
+  size_t size() const override { return 8; }
+
+  void setLinkedSection(ELFSection *S) { LinkedSection = S; }
+  ELFSection *getLinkedSection() const { return LinkedSection; }
+
+  eld::Expected<void> emit(MemoryRegion &Mr, Module &M) override;
+  void dump(llvm::raw_ostream &OS) override;
+
+private:
+  ELFSection *LinkedSection = nullptr;
 };
 
 } // namespace eld


### PR DESCRIPTION
Introduce EXIDXSentinelFragment, a TargetFragment subclass that emits the 8-byte CANTUNWIND terminator at the end of the .ARM.exidx table.

The first word is a PREL31 offset to the byte immediately past the last covered function (set later via setLinkedSection()); the second word is 0x1 (CANTUNWIND compact model entry).

Also fix EXIDXFragment::emit() to pass the DiagnosticEngine to getOffset() instead of using the argless overload.