### PR TITLE
[RISCV] Fix unnecessary .got.plt section creation

### DIFF
--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -2493,16 +2493,13 @@ RISCVGOT *RISCVLDBackend::createGOT(GOT::GOTType T, ELFObjectFile *Obj,
                                     ResolveInfo *R) {
 
   traceGOTCreation(T, R);
-  // If we are creating a GOT, always create a .got.plt.
-  if (!getGOTPLT()->hasFragments()) {
-    LDSymbol *Dynamic = m_Module.getNamePool().findSymbol("_DYNAMIC");
-    // TODO: This should be GOT0, not GOTPLT0.
-    RISCVGOT::CreateGOT0(getGOT(), Dynamic ? Dynamic->resolveInfo() : nullptr,
-                         config().targets().is32Bits());
-    RISCVGOT::CreateGOTPLT0(getGOTPLT(), nullptr,
-                            config().targets().is32Bits());
-  }
-
+  // Create GOT0 in .got when first GOT entry is needed.
+  if (auto *GOTSec = getGOT())
+    if (!GOTSec->hasFragments()) {
+      LDSymbol *Dynamic = m_Module.getNamePool().findSymbol("_DYNAMIC");
+      RISCVGOT::CreateGOT0(GOTSec, Dynamic ? Dynamic->resolveInfo() : nullptr,
+                           config().targets().is32Bits());
+    }
   RISCVGOT *G = nullptr;
   bool GOT = true;
   switch (T) {
@@ -2510,6 +2507,10 @@ RISCVGOT *RISCVLDBackend::createGOT(GOT::GOTType T, ELFObjectFile *Obj,
     G = RISCVGOT::Create(Obj->getGOT(), R, config().targets().is32Bits());
     break;
   case GOT::GOTPLT0:
+    // Create GOTPLT0 in .got.plt only when PLT is actually needed.
+    if (!getGOTPLT()->hasFragments())
+      RISCVGOT::CreateGOTPLT0(getGOTPLT(), nullptr,
+                              config().targets().is32Bits());
     G = llvm::dyn_cast<RISCVGOT>(*getGOTPLT()->getFragmentList().begin());
     GOT = false;
     break;

--- a/test/RISCV/standalone/Relocs/GOT_HI20/reloc_GOT_HI20.test
+++ b/test/RISCV/standalone/Relocs/GOT_HI20/reloc_GOT_HI20.test
@@ -11,5 +11,5 @@ RUN: %readelf -S -W %t1.out | %filecheck %s -check-prefix=GOT
 #CHECK: auipc   a{{.*}}, 1
 #CHECK-DAG: lw  a{{.*}}, {{.*}}(a{{.*}})
 #GOT: .got
-#GOT: .got.plt
+#GOT-NOT: .got.plt
 

--- a/test/RISCV/standalone/UnnecessaryGOTPLT/Inputs/bar.c
+++ b/test/RISCV/standalone/UnnecessaryGOTPLT/Inputs/bar.c
@@ -1,0 +1,1 @@
+int bar() { return 42; }

--- a/test/RISCV/standalone/UnnecessaryGOTPLT/Inputs/got-only.c
+++ b/test/RISCV/standalone/UnnecessaryGOTPLT/Inputs/got-only.c
@@ -1,0 +1,2 @@
+int u = 42;
+int foo() { return u; }

--- a/test/RISCV/standalone/UnnecessaryGOTPLT/Inputs/main.c
+++ b/test/RISCV/standalone/UnnecessaryGOTPLT/Inputs/main.c
@@ -1,0 +1,2 @@
+int foo();
+int main() { return foo() - 1; }

--- a/test/RISCV/standalone/UnnecessaryGOTPLT/Inputs/plt-needed.c
+++ b/test/RISCV/standalone/UnnecessaryGOTPLT/Inputs/plt-needed.c
@@ -1,0 +1,2 @@
+extern int bar();
+int foo() { return bar(); }

--- a/test/RISCV/standalone/UnnecessaryGOTPLT/UnnecessaryGOTPLT.test
+++ b/test/RISCV/standalone/UnnecessaryGOTPLT/UnnecessaryGOTPLT.test
@@ -1,0 +1,29 @@
+#---UnnecessaryGOTPLT.test--------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# Test that ELD does not create unnecessary .got.plt section when only
+# .got section is required.
+# Also verify that .got.plt IS created when PLT entries are needed.
+#END_COMMENT
+#START_TEST
+
+# Test 1: Static executable with only GOT - should have .got but NOT .got.plt
+RUN: %clang %clangopts -target %linuxtarget -o %t1.o %p/Inputs/got-only.c -c -fPIC
+RUN: %link %linkopts -o %t1.static.out %t1.o
+RUN: %readelf -S %t1.static.out | %filecheck %s --check-prefix=STATIC --implicit-check-not=.got.plt
+
+# Test 2: Shared library with no function calls - should have .got but NOT .got.plt
+RUN: %link %linkopts -shared -o %t1.shared.out %t1.o
+RUN: %readelf -S %t1.shared.out | %filecheck %s --check-prefix=STATIC --implicit-check-not=.got.plt
+
+# Test 3: Shared library with external function call - should have both .got AND .got.plt
+RUN: %clang %clangopts -target %linuxtarget -o %t1.plt.o %p/Inputs/plt-needed.c -c -fPIC
+RUN: %clang %clangopts -target %linuxtarget -o %t1.bar.o %p/Inputs/bar.c -c -fPIC
+RUN: %link %linkopts -shared -o %t1.plt.shared.out %t1.plt.o %t1.bar.o
+RUN: %readelf -S %t1.plt.shared.out | %filecheck %s --check-prefix=DYNAMIC
+
+#END_TEST
+
+STATIC: .got
+
+DYNAMIC: .got
+DYNAMIC: .got.plt

--- a/test/RISCV/standalone/UnnecessaryGOTPLT/UnnecessaryGOTPLTRun.test
+++ b/test/RISCV/standalone/UnnecessaryGOTPLT/UnnecessaryGOTPLTRun.test
@@ -1,0 +1,12 @@
+REQUIRES: run_test
+XFAIL: riscv32
+#---UnnecessaryGOTPLTRun.test--------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# Runtime test - verify static executable with GOT runs correctly.
+#END_COMMENT
+#START_TEST
+RUN: %run_cc -o %t1.run.o %p/Inputs/got-only.c -c -fPIC
+RUN: %run_cc -o %t1.main.o %p/Inputs/main.c -c
+RUN: %run_cc -o %t1.run.out %t1.run.o %t1.main.o -static
+RUN: %run %t1.run.out
+#END_TEST


### PR DESCRIPTION
ELD was unnecessarily creating .got.plt section when only .got is required. The .got.plt section should only be created when PLT entries are needed.

Note: Similar fix is needed for AArch64, ARM, Hexagon and x86_64 backends and will be addressed in follow-up PRs.

Part of #1030