### PR TITLE
[X86] Fix RELATIVE relocation addend for merge-string data pointers

### DIFF
--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -4741,6 +4741,9 @@ void GNULDBackend::doPostLayout() {
     for (auto &r : m_RelativeRelocMap) {
       const Relocation *N = r.first;
       Relocation *R = r.second;
+      const FragmentRef *NFragRef = N->targetFragRef();
+      if (!NFragRef || !NFragRef->frag() || !NFragRef->frag()->isMergeStr())
+        continue;
       R->modifyRelocationFragmentRef(N->targetFragRef());
       R->setAddend(N->addend());
     }

--- a/lib/Target/X86/x86_64LDBackend.h
+++ b/lib/Target/X86/x86_64LDBackend.h
@@ -96,10 +96,6 @@ public:
 
   void doPreLayout() override;
 
-  void recordRelativeReloc(Relocation *DynRel, const Relocation *OrigRel) {
-    m_RelativeRelocMap[DynRel] = OrigRel;
-  }
-
   void sortRelocation(ELFSection &pSection) override;
 
   DynRelocType getDynRelocType(const Relocation *X) const override {
@@ -160,7 +156,6 @@ private:
   llvm::DenseMap<ResolveInfo *, x86_64GOT *> m_GOTMap;
   llvm::DenseMap<ResolveInfo *, x86_64GOT *> m_GOTPLTMap;
   llvm::DenseMap<ResolveInfo *, x86_64PLT *> m_PLTMap;
-  llvm::DenseMap<Relocation *, const Relocation *> m_RelativeRelocMap;
 };
 } // namespace eld
 

--- a/test/x86_64/RunTests/MergeStringRelativeReloc/Inputs/main.c
+++ b/test/x86_64/RunTests/MergeStringRelativeReloc/Inputs/main.c
@@ -1,0 +1,31 @@
+/* main.c -- compiled and linked SECOND.
+ *
+ * Its .rodata.str1.1 starts with "a"(2) + "c"(2) + "fF"(3) = 7 bytes, followed
+ * by the escape strings. Those first three strings are duplicates of pad.c's
+ * canonical copies, so they are excluded during string merging. As a result
+ * the first escape string "  \n", input offset 7 in main.o, shifts to output
+ * offset 0 within main.o's surviving fragment.
+ *
+ * The g_* pointers live in .data and, in a PIE, are emitted as
+ * R_X86_64_RELATIVE dynamic relocations whose addend is the escape string's
+ * final address. If the post-merge fixup does not run for x86_64, the addend
+ * keeps the pre-merge input offset (7) and points 7 bytes past "  \n", into
+ * the following string, so g_nl resolves to the wrong string at runtime. */
+#include <stdio.h>
+#include <string.h>
+
+const char *g_a = "a";
+const char *g_c = "c";
+const char *g_fF = "fF";
+const char *g_nl = "  \\n";
+const char *g_cr = "  \\r";
+const char *g_tab = "  \\t";
+const char *g_nul = "  \\0";
+
+int main(void) {
+  printf("nl: %s\n", strcmp(g_nl, "  \\n") == 0 ? "ok" : "wrong");
+  printf("cr: %s\n", strcmp(g_cr, "  \\r") == 0 ? "ok" : "wrong");
+  printf("tab: %s\n", strcmp(g_tab, "  \\t") == 0 ? "ok" : "wrong");
+  printf("nul: %s\n", strcmp(g_nul, "  \\0") == 0 ? "ok" : "wrong");
+  return 0;
+}

--- a/test/x86_64/RunTests/MergeStringRelativeReloc/Inputs/pad.c
+++ b/test/x86_64/RunTests/MergeStringRelativeReloc/Inputs/pad.c
@@ -1,0 +1,26 @@
+/* pad.c -- compiled and linked FIRST.
+ *
+ * Provides the canonical (kept) copies of the short strings "a", "c" and "fF",
+ * plus the escape strings, so that main.c's duplicate copies of "a", "c" and
+ * "fF" are excluded during string merging.
+ *
+ * The unique padding string below ensures pad.o's fragment isn't empty and
+ * gives the escape strings a nonzero output offset in the merged .rodata --
+ * enough to create the mismatch between main.o's small pre-merge input offset
+ * for "  \n" (7) and its true post-merge address, which the doPostLayout
+ * fixup must correct.
+ *
+ * The escape strings are declared before "a"/"c"/"fF" (matching the layout
+ * that triggers the bug): this places the canonical short strings at the end
+ * of pad.o's string table, so that main.o's excluded copies of them shift the
+ * escape strings to a different output offset than their input offset. */
+const char *pad01 = "pad_string_alpha";
+
+const char *p_nl = "  \\n";
+const char *p_cr = "  \\r";
+const char *p_tab = "  \\t";
+const char *p_nul = "  \\0";
+
+const char *p_a = "a";
+const char *p_c = "c";
+const char *p_fF = "fF";

--- a/test/x86_64/RunTests/MergeStringRelativeReloc/MergeStringRelativeReloc_RUN.test
+++ b/test/x86_64/RunTests/MergeStringRelativeReloc/MergeStringRelativeReloc_RUN.test
@@ -1,0 +1,28 @@
+REQUIRES: run_test
+#--MergeStringRelativeReloc_RUN.test-------------Executable--------#
+#BEGIN_COMMENT
+# Run test: x86_64 merge-string R_X86_64_RELATIVE relocation addend.
+#
+# When a PIE stores a pointer to a string literal that lives in a merged
+# SHF_MERGE|SHF_STRINGS section (.rodata.str1.1), the linker emits an
+# R_X86_64_RELATIVE dynamic relocation whose addend must be the string's final,
+# post-merge address. String merging runs after relocation scanning, so the
+# post-merge fragment reference and addend are propagated to the dynamic
+# relocation by GNULDBackend::doPostLayout().
+#
+# Inputs (pad.c linked first, main.c second): main.o's copies of "a"/"c"/"fF"
+# are excluded during merging, shifting its first escape string "  \n" from
+# input offset 7 to output offset 0. Runs the linked binary and checks that
+# every merged string pointer's content matches the expected string.
+#END_COMMENT
+#START_TEST
+RUN: %run_cc -c %p/Inputs/pad.c -o %t.pad.o
+RUN: %run_cc -c %p/Inputs/main.c -o %t.main.o
+RUN: %run_cc -pie %t.pad.o %t.main.o -o %t.out
+RUN: %run %t.out | %filecheck %s
+#END_TEST
+
+CHECK: nl: ok
+CHECK: cr: ok
+CHECK: tab: ok
+CHECK: nul: ok

--- a/test/x86_64/linux/MergeStringRelativeRelocAddend/Inputs/main.c
+++ b/test/x86_64/linux/MergeStringRelativeRelocAddend/Inputs/main.c
@@ -1,0 +1,34 @@
+/* main.c -- compiled and linked SECOND.
+ *
+ * Its .rodata.str1.1 starts with "a"(2) + "c"(2) + "fF"(3) = 7 bytes, followed
+ * by the escape strings. Those first three strings are duplicates of pad.c's
+ * canonical copies, so they are excluded during string merging. As a result
+ * the first escape string "  \n", input offset 7 in main.o, shifts to output
+ * offset 0 within main.o's surviving fragment.
+ *
+ * The g_* pointers live in .data and, in a PIE, are emitted as
+ * R_X86_64_RELATIVE dynamic relocations whose addend is the escape string's
+ * final address. This is the merge-string RELATIVE case:
+ * GNULDBackend::doPostLayout() must propagate the post-merge fragment
+ * reference and addend onto each of them.
+ *
+ * global_var_non_premp is a non-preemptible global read through a GOT entry
+ * (clang emits R_X86_64_REX_GOTPCRELX with addend -4, the RIP
+ * end-of-instruction bias, for the access in read_it()). The GOT slot itself
+ * gets its own R_X86_64_RELATIVE dynamic relocation, whose addend must be the
+ * symbol's own address (0 relative to it) -- NOT the -4 from the GOTPCRELX
+ * access. This is the GOT RELATIVE case that doPostLayout() must leave
+ * untouched: the isMergeStr() guard exists so that copying the merge-string
+ * fixup does not also overwrite this GOT slot's addend with -4. */
+const char *g_a = "a";
+const char *g_c = "c";
+const char *g_fF = "fF";
+const char *g_nl = "  \\n";
+const char *g_cr = "  \\r";
+const char *g_tab = "  \\t";
+const char *g_nul = "  \\0";
+
+long global_var_non_premp = 42;
+long read_it(void) { return global_var_non_premp; }
+
+int main(void) { return 0; }

--- a/test/x86_64/linux/MergeStringRelativeRelocAddend/Inputs/pad.c
+++ b/test/x86_64/linux/MergeStringRelativeRelocAddend/Inputs/pad.c
@@ -1,0 +1,25 @@
+/* pad.c -- compiled and linked FIRST.
+ *
+ * Provides the canonical (kept) copies of the short strings "a", "c" and "fF",
+ * plus the escape strings, so that main.c's duplicate copies of "a", "c" and
+ * "fF" are excluded during string merging.
+ *
+ * The unique padding string below ensures pad.o's fragment isn't empty and
+ * gives the escape strings a nonzero output offset in the merged .rodata --
+ * enough to create the mismatch between main.o's small pre-merge input offset
+ * for "  \n" (7) and its true post-merge address, which the doPostLayout
+ * fixup must correct. */
+const char *pad01 = "pad_string_alpha";
+
+/* The escape strings are declared before "a"/"c"/"fF" (matching the layout
+ * that triggers the bug): this places the canonical short strings at the end
+ * of pad.o's string table, so that main.o's excluded copies of them shift the
+ * escape strings to a different output offset than their input offset. */
+const char *p_nl = "  \\n";
+const char *p_cr = "  \\r";
+const char *p_tab = "  \\t";
+const char *p_nul = "  \\0";
+
+const char *p_a = "a";
+const char *p_c = "c";
+const char *p_fF = "fF";

--- a/test/x86_64/linux/MergeStringRelativeRelocAddend/MergeStringRelativeRelocAddend.test
+++ b/test/x86_64/linux/MergeStringRelativeRelocAddend/MergeStringRelativeRelocAddend.test
@@ -1,0 +1,65 @@
+#--MergeStringAndGOTRelativeReloc.test-----------Executable--------#
+#BEGIN_COMMENT
+# Test: x86_64 merge-string R_X86_64_RELATIVE relocation addend, and the
+# isMergeStr() guard in GNULDBackend::doPostLayout() that must fix up
+# merge-string RELATIVE addends while leaving GOT-related RELATIVE addends
+# untouched.
+#
+# When a PIE stores a pointer to a string literal that lives in a merged
+# SHF_MERGE|SHF_STRINGS section (.rodata.str1.1), the linker emits an
+# R_X86_64_RELATIVE dynamic relocation whose addend must be the string's final,
+# post-merge address. String merging runs after relocation scanning, so the
+# post-merge fragment reference and addend are propagated to the dynamic
+# relocation by GNULDBackend::doPostLayout().
+#
+# doPostLayout() walks m_RelativeRelocMap and, for each dynamic RELATIVE
+# relocation R paired with its original relocation N, copies N's post-merge
+# fragment reference and addend onto R -- but only when N's target is a
+# merge-string fragment (isMergeStr()). Without that guard, the copy would
+# also run for GOT-related RELATIVE relocations, whose original relocation
+# (R_X86_64_(REX_)?GOTPCRELX) carries addend -4 (the RIP end-of-instruction
+# bias for the 4-byte displacement field) -- overwriting the GOT slot's
+# correct addend (the symbol's own address) with a corrupted, off-by-4 value.
+#
+# Inputs (pad.c linked first, main.c second): main.o's copies of "a"/"c"/"fF"
+# are excluded during merging, shifting its four escape strings from their
+# pre-merge input offsets to different post-merge output offsets -- this is
+# the merge-string RELATIVE case. main.c also reads a non-preemptible global
+# through a GOT entry, which gets its own GOT-related RELATIVE relocation --
+# this is the case the guard must leave alone.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/pad.c -o %t.pad.o -fPIC
+RUN: %clang %clangopts -c %p/Inputs/main.c -o %t.main.o -fPIC
+RUN: %clang %clangopts -fuse-ld=%link -pie %t.pad.o %t.main.o -o %t.out
+RUN: %readelf -sr -W %t.out | %filecheck %s
+#END_TEST
+
+# p_nl/p_cr/p_tab/p_nul (canonical) and g_nl/g_cr/g_tab/g_nul (duplicates,
+# excluded+shifted at merge) must each resolve to the identical post-merge
+# string address: the merge-string fixup must have run.
+CHECK-DAG: {{[0-9]+}}: [[#%x,PNL_ADDR:]]{{.*}} p_nl
+CHECK-DAG: [[#PNL_ADDR]]{{.*}}R_X86_64_RELATIVE{{.*}}[[#%x,NL_STR:]]
+CHECK-DAG: {{[0-9]+}}: [[#%x,GNL_ADDR:]]{{.*}} g_nl
+CHECK-DAG: [[#GNL_ADDR]]{{.*}}R_X86_64_RELATIVE{{.*}}[[#NL_STR]]
+
+CHECK-DAG: {{[0-9]+}}: [[#%x,PCR_ADDR:]]{{.*}} p_cr
+CHECK-DAG: [[#PCR_ADDR]]{{.*}}R_X86_64_RELATIVE{{.*}}[[#%x,CR_STR:]]
+CHECK-DAG: {{[0-9]+}}: [[#%x,GCR_ADDR:]]{{.*}} g_cr
+CHECK-DAG: [[#GCR_ADDR]]{{.*}}R_X86_64_RELATIVE{{.*}}[[#CR_STR]]
+
+CHECK-DAG: {{[0-9]+}}: [[#%x,PTAB_ADDR:]]{{.*}} p_tab
+CHECK-DAG: [[#PTAB_ADDR]]{{.*}}R_X86_64_RELATIVE{{.*}}[[#%x,TAB_STR:]]
+CHECK-DAG: {{[0-9]+}}: [[#%x,GTAB_ADDR:]]{{.*}} g_tab
+CHECK-DAG: [[#GTAB_ADDR]]{{.*}}R_X86_64_RELATIVE{{.*}}[[#TAB_STR]]
+
+CHECK-DAG: {{[0-9]+}}: [[#%x,PNUL_ADDR:]]{{.*}} p_nul
+CHECK-DAG: [[#PNUL_ADDR]]{{.*}}R_X86_64_RELATIVE{{.*}}[[#%x,NUL_STR:]]
+CHECK-DAG: {{[0-9]+}}: [[#%x,GNUL_ADDR:]]{{.*}} g_nul
+CHECK-DAG: [[#GNUL_ADDR]]{{.*}}R_X86_64_RELATIVE{{.*}}[[#NUL_STR]]
+
+# global_var_non_premp's GOT-slot RELATIVE relocation must have an addend
+# equal to global_var_non_premp's OWN address -- not shifted by -4. If the
+# guard were missing, this addend would instead read [[#GV_ADDR-4]].
+CHECK-DAG: {{[0-9]+}}: [[#%x,GV_ADDR:]]{{.*}} global_var_non_premp
+CHECK-DAG: {{[0-9a-f]+}}{{.*}}R_X86_64_RELATIVE{{.*}}[[#GV_ADDR]]


### PR DESCRIPTION
### Problem

In a PIE, a pointer into a merged `SHF_MERGE|SHF_STRINGS` section (`.rodata.str1.1`) is emitted as an `R_X86_64_RELATIVE` dynamic relocation whose addend must be the string's final, post-merge address. Since relocation scanning runs before string merging, the dynamic relocation's target fragment and addend must be corrected afterwards, once the surviving string's real location is known.

`x86_64LDBackend` used to shadow the non-virtual `GNULDBackend::recordRelativeReloc()` with its own version writing into its own `m_RelativeRelocMap`, so x86_64's relative relocations never reached `GNULDBackend::doPostLayout()`'s shared fixup loop, which iterates `GNULDBackend::m_RelativeRelocMap`. That map stayed empty for x86_64, so the fixup never ran and merge-string RELATIVE addends kept their pre-merge input offset.

### Fix

Removes x86_64's shadow `recordRelativeReloc()`/`m_RelativeRelocMap` entirely, so x86_64's relative relocations flow through the shared `GNULDBackend::recordRelativeReloc()` into `GNULDBackend::m_RelativeRelocMap` like every other backend, and are corrected by `GNULDBackend::doPostLayout()` like every other backend.

`GNULDBackend::doPostLayout()`'s fixup loop now needs a `isMergeStr()` guard: once x86_64's relative relocations reach this shared map, it also holds x86_64's GOT-related RELATIVE relocations. Those are recorded with a deliberately different addend (0, since the writer computes the final value as just `S`) than the addend already on the original `R_X86_64_GOTPCREL(X)` relocation (`-4`, the RIP end-of-instruction bias for the 4-byte displacement field). Copying that `-4` onto the GOT slot's RELATIVE relocation unconditionally would corrupt it. The guard restricts the fixup to relocations whose target is an actual merge-string fragment, leaving GOT-related relocations on every backend untouched.