### PR TITLE
[ARM] Fix EXIDX sorting when linker script uses per-section rules

### DIFF
--- a/lib/Target/ARM/ARMLDBackend.cpp
+++ b/lib/Target/ARM/ARMLDBackend.cpp
@@ -317,6 +317,12 @@ void ARMGNULDBackend::sortEXIDX() {
     EXIDXFragSet.insert(KV.second);
 
   DiagnosticEngine *Diag = config().getDiagEngine();
+
+  // Setup RuleKeys for linker script rule container sorting
+  llvm::DenseMap<RuleContainer *, uint64_t> RuleKey;
+  for (auto &In : *O)
+    RuleKey[In] = MaxSortKey;
+
   for (auto &In : *O) {
     ELFSection *S = In->getSection();
     if (!S)
@@ -444,8 +450,22 @@ void ARMGNULDBackend::sortEXIDX() {
                        return OriginalFragOffsets.lookup(A) <
                               OriginalFragOffsets.lookup(B);
                      });
+
+    // Record the minimum key for this rule so we can sort rules below.
+    uint64_t RuleMinKey = MaxSortKey;
+    for (const auto &KV : FragSortKeys)
+      RuleMinKey = std::min(RuleMinKey, KV.second);
+    RuleKey[In] = RuleMinKey;
   }
 
+  std::stable_sort(O->begin(), O->end(),
+                   [&](RuleContainer *A, RuleContainer *B) {
+                     const uint64_t KeyA = RuleKey.lookup(A);
+                     const uint64_t KeyB = RuleKey.lookup(B);
+                     if (KeyA != KeyB)
+                       return KeyA < KeyB;
+                     return false;
+                   });
   evaluateAssignments(O);
 
   Fragment *FirstEXIDXFrag = nullptr;

--- a/test/ARM/standalone/EXIDXSorting/EXIDXSortingReverseScript.test
+++ b/test/ARM/standalone/EXIDXSorting/EXIDXSortingReverseScript.test
@@ -1,0 +1,25 @@
+#---EXIDXSortingReverseScript.test------------- Executable ------------------#
+#BEGIN_COMMENT
+# Verify that sortEXIDX() sorts EXIDX entries by function address even when
+# the linker script lists each .ARM.exidx input section as a separate rule
+# in reverse address order.  In this case every RuleContainer holds exactly
+# one fragment, so the intra-rule stable_sort is a no-op.  The inter-rule
+# reordering pass must fix the ordering.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -target arm -c %p/Inputs/exidx.s -o %t1.o
+RUN: %link %linkopts %t1.o -T %p/Inputs/script_reverse_exidx.t -o %t2.out
+RUN: %readelf -u %t2.out | %filecheck %s --check-prefix=UNW
+
+# Entries must appear in ascending function-address order regardless of the
+# reverse rule ordering in the linker script.
+#UNW:      FunctionAddress: 0x11000
+#UNW-NEXT: Model: CantUnwind
+#UNW:      FunctionAddress: 0x11004
+#UNW-NEXT: Model: CantUnwind
+#UNW:      FunctionAddress: 0x11008
+#UNW-NEXT: Model: CantUnwind
+#UNW:      FunctionAddress: 0x1100C
+#UNW-NEXT: Model: CantUnwind
+# No sentinel: all entries are CANTUNWIND so the linker omits it.
+#END_TEST

--- a/test/ARM/standalone/EXIDXSorting/Inputs/script_reverse_exidx.t
+++ b/test/ARM/standalone/EXIDXSorting/Inputs/script_reverse_exidx.t
@@ -1,0 +1,14 @@
+/* Linker script that lists each .ARM.exidx input section as a separate rule
+   in reverse address order.  ld.eld must still sort the output by function
+   address regardless of the rule ordering in the script. */
+SECTIONS {
+  .text (0x11000) : {
+    *(.text.start) *(.text.f1) *(.text.f2) *(.text.f3)
+  }
+  .ARM.exidx : {
+    *(.ARM.exidx.text.f3)
+    *(.ARM.exidx.text.f2)
+    *(.ARM.exidx.text.f1)
+    *(.ARM.exidx.text.start)
+  }
+}


### PR DESCRIPTION
Sort the RuleContainer vector of the OutputSectionEntry by each rule's minimum EXIDX sort key. RuleKey is initialised to UINT64_MAX for every rule so that rules with no EXIDX fragments (including the sentinel rule and empty wildcard rules) always sort to the end, preserving their original relative order. evaluateAssignments() is called once on the OutputSectionEntry after the rule reorder to recompute fragment offsets and addresses.

The sentinel internal section also benefits: because its RuleKey stays at UINT64_MAX, it always ends up after all real EXIDX rules regardless of where the linker script's implicit *(.ARM.exidx) catch-all rule appears.