### PR TITLE
Address FIXME in FragmentRef.h

### DIFF
--- a/include/eld/Fragment/FragmentRef.h
+++ b/include/eld/Fragment/FragmentRef.h
@@ -15,6 +15,7 @@
 #define ELD_FRAGMENT_FRAGMENTREF_H
 
 #include "eld/Config/Config.h"
+#include "eld/Support/SizeTraits.h"
 #include "llvm/Support/DataTypes.h"
 
 namespace eld {
@@ -32,7 +33,7 @@ class OutputSectionEntry;
  */
 class FragmentRef {
 public:
-  typedef uint64_t Offset; // FIXME: use SizeTraits<T>::Offset
+  typedef SizeTraits<64>::Offset Offset;
 
 public:
   static FragmentRef *null();

--- a/include/eld/Support/SizeTraits.h
+++ b/include/eld/Support/SizeTraits.h
@@ -1,0 +1,28 @@
+//===- SizeTraits.h--------------------------------------------------------===//
+// Part of the eld Project, under the BSD License
+// See https://github.com/qualcomm/eld/LICENSE.txt for license information.
+// SPDX-License-Identifier: BSD-3-Clause
+//===----------------------------------------------------------------------===//
+#ifndef ELD_SUPPORT_SIZETRAITS_H
+#define ELD_SUPPORT_SIZETRAITS_H
+
+#include "llvm/Support/DataTypes.h"
+
+namespace eld {
+
+/// SizeTraits - maps a target bit class (32 or 64, as returned by
+/// TargetOptions::bitclass()) to the integer types wide enough to hold an
+/// address/offset/word for that bit class.
+template <unsigned BitClass> struct SizeTraits;
+
+template <> struct SizeTraits<32> {
+  typedef uint32_t Offset;
+};
+
+template <> struct SizeTraits<64> {
+  typedef uint64_t Offset;
+};
+
+} // namespace eld
+
+#endif


### PR DESCRIPTION
Offset now use SizeTraits<64> instead of uint64_t. Created SizeTraits.h file to reuse similar options that rely on bitwidth.

Fix: qualcomm#1480