### PR TITLE
[NFC] Resolve trivial FIXME/TODO markers

### DIFF
--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -982,9 +982,9 @@ public:
 
   void setRecordInputfiles() { RecordInputFiles = true; }
 
-  void setCompressTar() { CompressTar = true; }
+  void setCompressReproduceTar() { CompressReproduceTar = true; }
 
-  bool getCompressTar() const { return CompressTar; }
+  bool getCompressReproduceTar() const { return CompressReproduceTar; }
 
   void setHasMappingFile(bool HasMap) { HasMappingFile = HasMap; }
 
@@ -1335,8 +1335,7 @@ private:
   bool ProgressBar = false;                  // Show progressbar.
   bool RecordInputFiles = false;             // --reproduce
   bool RecordInputFilesOnFail = false;       // --reproduce-on-fail
-  // FIXME: Change the name to CompressReproduceTar
-  bool CompressTar = false;         // --reproduce-compressed
+  bool CompressReproduceTar = false;         // --reproduce-compressed
   bool DisplaySummary = false;      // display linker run summary
   bool HasMappingFile = false;      // --Mapping-file
   bool DumpMappings = false;        // --Dump-Mapping-file

--- a/include/eld/LayoutMap/LayoutInfo.h
+++ b/include/eld/LayoutMap/LayoutInfo.h
@@ -232,18 +232,6 @@ public:
 
   void recordOutputFileSize(uint32_t Sz) { LinkStats.OutputFileSize = Sz; }
 
-  // FIXME: Destructor is redundant here.
-  ~LayoutInfo() { destroy(); }
-
-  // FIXME: This function is not required.
-  void destroy() {
-    InputActions.clear();
-    ScriptIncludes.clear();
-    ArchiveRecords.clear();
-    FragmentInfoMap.clear();
-    FragmentInfoVector.clear();
-  }
-
   void recordArchiveMember(Input *Origin, InputFile *Referred,
                            ArchiveFile::Symbol *ArchSym, LDSymbol *Sym);
 

--- a/include/eld/Object/SectionMap.h
+++ b/include/eld/Object/SectionMap.h
@@ -66,18 +66,9 @@ public:
                  std::string Name, uint64_t InputSectionHash,
                  uint64_t InputFileHash, uint64_t NameHash, bool GNUCompatible);
 
-  /// FIXME: this is not used
-  mapping find(std::string PInputFile, std::string CurInputSection,
-               bool IsArchive, std::string Name, uint64_t InputSectionHash,
-               uint64_t InputFileHash, uint64_t InputNameHash,
-               bool GNUCompatible, bool IsCommonSection);
-
   ELFSection *find(std::string EntrySection);
 
   ELFSection *find(uint32_t SectionType);
-
-  /// FIXME: this is not used or implemented
-  ELFSection *findSectionIfNotEmpty(std::string Section);
 
   iterator findIter(std::string EntrySection);
 

--- a/include/eld/SymbolResolver/NamePool.h
+++ b/include/eld/SymbolResolver/NamePool.h
@@ -89,12 +89,12 @@ public:
   size_t getNumGlobalSize() const { return GlobalSymbols.size(); }
 
   /// findSymbol - find the resolved output LDSymbol
-  const LDSymbol *findSymbol(std::string SymbolName) const;
-  LDSymbol *findSymbol(std::string SymbolName);
+  const LDSymbol *findSymbol(const std::string &SymbolName) const;
+  LDSymbol *findSymbol(const std::string &SymbolName);
 
   /// findInfo - find the resolved ResolveInfo
-  const ResolveInfo *findInfo(std::string SymbolName) const;
-  ResolveInfo *findInfo(std::string SymbolName);
+  const ResolveInfo *findInfo(const std::string &SymbolName) const;
+  ResolveInfo *findInfo(const std::string &SymbolName);
 
   // Get Local symbols.
   std::vector<ResolveInfo *> &getLocals() { return LocalSymbols; }

--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -970,9 +970,6 @@ protected:
   /// 'commonSection'.
   std::string getCommonSymbolName(const CommonELFSection *commonSection) const;
 
-  /// FIXME: This is not implemented anywhere
-  bool evaluateOutputSectionDataCmds();
-
 private:
   uint32_t getOneEhdrSize() const;
 

--- a/lib/Diagnostics/DiagnosticEngine.cpp
+++ b/lib/Diagnostics/DiagnosticEngine.cpp
@@ -75,8 +75,7 @@ bool DiagnosticEngine::diagnose() {
       return false;
   }
 
-  // FIXME: Remove redundant '&& true'
-  return !Printer->getNumFatalErrors() && true;
+  return !Printer->getNumFatalErrors();
 }
 
 void DiagnosticEngine::finalize() {

--- a/lib/Fragment/OutputSectDataFragment.cpp
+++ b/lib/Fragment/OutputSectDataFragment.cpp
@@ -30,8 +30,7 @@ eld::Expected<void> OutputSectDataFragment::emit(MemoryRegion &Mr, Module &M) {
   uint64_t Value = ExpVal.value();
   if (M.getConfig().showLinkerScriptWarnings()) {
     std::size_t DataSizeBits = 8 * size();
-    // FIXME: 'size() < sizeof(value)' is redundant.
-    if (size() < sizeof(Value) && !llvm::isIntN(DataSizeBits, Value) &&
+    if (!llvm::isIntN(DataSizeBits, Value) &&
         !llvm::isUIntN(DataSizeBits, Value)) {
       M.getConfig().raise(Diag::warn_output_data_truncated)
           << llvm::utohexstr(Value, true) << DataSizeBits

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -1169,7 +1169,7 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
   // --reproduce-compressed
   if (llvm::opt::Arg *arg = Args.getLastArg(T::reproduce_compressed)) {
     Config.options().setRecordInputfiles();
-    Config.options().setCompressTar();
+    Config.options().setCompressReproduceTar();
     reproduceFileName = arg->getValue();
   }
 

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -998,8 +998,6 @@ bool ObjectLinker::createOutputSection(ObjectBuilder &Builder,
       OutSect->setAddrAlign(OutAlign);
   }
 
-  /// FIXME: this vector is unused?
-  std::vector<RuleContainer *> InputsWithNoData;
   RuleContainer *FirstNonEmptyRule = nullptr;
 
   for (In = InBegin; In != InEnd; ++In) {

--- a/lib/Object/SectionMap.cpp
+++ b/lib/Object/SectionMap.cpp
@@ -52,31 +52,6 @@ SectionMap::~SectionMap() {
   MEntrySections.clear();
 }
 
-SectionMap::mapping SectionMap::find(std::string PInputFile,
-                                     std::string CurInputSection,
-                                     bool IsArchive, std::string Name,
-                                     uint64_t InputSectionHash,
-                                     uint64_t InputFileHash, uint64_t NameHash,
-                                     bool GNUCompatible, bool IsCommonSection) {
-  iterator Out, OutBegin = begin(), OutEnd = end();
-  for (Out = OutBegin; Out != OutEnd; ++Out) {
-    OutputSectionEntry::iterator In, InBegin = (*Out)->begin(),
-                                     InEnd = (*Out)->end();
-    for (In = InBegin; In != InEnd; ++In) {
-      if ((*In)->isSpecial())
-        continue;
-      if (matched(**In, nullptr, PInputFile, CurInputSection, IsArchive, Name,
-                  InputSectionHash, InputFileHash, NameHash, GNUCompatible,
-                  IsCommonSection))
-        return std::make_pair(*Out, *In);
-    }
-  }
-  auto Sp = SpecialSections.find(CurInputSection);
-  if (Sp != SpecialSections.end())
-    return std::make_pair(Sp->second.first, Sp->second.second);
-  return std::make_pair(nullptr, nullptr);
-}
-
 // Find section by name.
 ELFSection *SectionMap::find(std::string POutputSection) {
   iterator Out, OutBegin = begin(), OutEnd = end();

--- a/lib/Support/OutputTarWriter.cpp
+++ b/lib/Support/OutputTarWriter.cpp
@@ -25,7 +25,8 @@ using namespace eld;
 /// \param OutputPath where the tarball should be written
 /// \param BaseDir base directory
 OutputTarWriter::OutputTarWriter(LinkerConfig &Config)
-    : m_Config(Config), m_Compress(m_Config.options().getCompressTar()),
+    : m_Config(Config),
+      m_Compress(m_Config.options().getCompressReproduceTar()),
       m_Verbose(m_Config.getPrinter()->isVerbose()) {}
 
 bool OutputTarWriter::createOutput() {

--- a/lib/SymbolResolver/NamePool.cpp
+++ b/lib/SymbolResolver/NamePool.cpp
@@ -228,7 +228,7 @@ bool NamePool::getSymbolTracingRequested() const {
   return IsSymbolTracingRequested;
 }
 /// findInfo - find the resolved ResolveInfo
-ResolveInfo *NamePool::findInfo(std::string SymbolName) {
+ResolveInfo *NamePool::findInfo(const std::string &SymbolName) {
   auto I = GlobalSymbols.find(SymbolName);
   if (I == GlobalSymbols.end())
     return nullptr;
@@ -236,8 +236,7 @@ ResolveInfo *NamePool::findInfo(std::string SymbolName) {
 }
 
 /// findInfo - find the resolved ResolveInfo
-// FIXME: Pass name by const reference, or use llvm::StringRef
-const ResolveInfo *NamePool::findInfo(std::string SymbolName) const {
+const ResolveInfo *NamePool::findInfo(const std::string &SymbolName) const {
   auto I = GlobalSymbols.find(SymbolName);
   if (I == GlobalSymbols.end())
     return nullptr;
@@ -245,8 +244,7 @@ const ResolveInfo *NamePool::findInfo(std::string SymbolName) const {
 }
 
 /// findSymbol - find the resolved output LDSymbol
-// FIXME: Pass name by const reference, or use llvm::StringRef
-LDSymbol *NamePool::findSymbol(std::string SymbolName) {
+LDSymbol *NamePool::findSymbol(const std::string &SymbolName) {
   ResolveInfo *Info = findInfo(SymbolName);
   if (nullptr == Info)
     return nullptr;
@@ -254,8 +252,7 @@ LDSymbol *NamePool::findSymbol(std::string SymbolName) {
 }
 
 /// findSymbol - find the resolved output LDSymbol
-// FIXME: Pass name by const reference, or use llvm::StringRef
-const LDSymbol *NamePool::findSymbol(std::string SymbolName) const {
+const LDSymbol *NamePool::findSymbol(const std::string &SymbolName) const {
   const ResolveInfo *Info = findInfo(SymbolName);
   if (nullptr == Info)
     return nullptr;

--- a/lib/Target/ELFDynamic.cpp
+++ b/lib/Target/ELFDynamic.cpp
@@ -180,9 +180,8 @@ void ELFDynamic::reserveEntries(GNULDBackend &pBackend, DynStrFragment *DynStr,
   if (pModule.getSection(".hash"))
     reserveOne(llvm::ELF::DT_HASH); // DT_HASH
 
-  // FIXME: use llvm enum constant
   if (pModule.getSection(".gnu.hash"))
-    reserveOne(0x6ffffef5); // DT_GNU_HASH
+    reserveOne(llvm::ELF::DT_GNU_HASH);
 
   if (pModule.getSection(".dynsym")) {
     reserveOne(llvm::ELF::DT_SYMTAB); // DT_SYMTAB
@@ -339,8 +338,7 @@ void ELFDynamic::applyEntries(GNULDBackend &pBackend,
              pModule.getSection(".hash")->addr()); // DT_HASH
 
   if (pModule.getSection(".gnu.hash"))
-    applyOne(0x6ffffef5,
-             pModule.getSection(".gnu.hash")->addr()); // DT_GNU_HASH
+    applyOne(llvm::ELF::DT_GNU_HASH, pModule.getSection(".gnu.hash")->addr());
 
   if (pModule.getSection(".dynsym")) {
     applyOne(llvm::ELF::DT_SYMTAB,


### PR DESCRIPTION
Clear the mechanical, self-contained FIXME/TODO markers whose fix is purely NFC. Each marker is resolved by doing what it says, not by deleting the annotation.

Assisted-by: Claude