### PR TITLE
[Fragment] Convert .dynstr to use a fragment design

### DIFF
--- a/include/eld/Fragment/DynStrFragment.h
+++ b/include/eld/Fragment/DynStrFragment.h
@@ -1,0 +1,47 @@
+//===- DynStrFragment.h----------------------------------------------------===//
+// Part of the eld Project, under the BSD License
+// See https://github.com/qualcomm/eld/LICENSE.txt for license information.
+// SPDX-License-Identifier: BSD-3-Clause
+//===----------------------------------------------------------------------===//
+
+#ifndef ELD_FRAGMENT_DYNSTRFRAGMENT_H
+#define ELD_FRAGMENT_DYNSTRFRAGMENT_H
+
+#include "eld/Fragment/Fragment.h"
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace eld {
+
+/// DynStrFragment holds the content of the .dynstr section.
+///
+/// Strings are appended via addString() and deduplicated. The section starts
+/// with a leading null byte so that offset 0 means "no name", matching the
+/// ELF string-table convention.
+class DynStrFragment : public Fragment {
+public:
+  explicit DynStrFragment(ELFSection *S);
+
+  static bool classof(const Fragment *F) {
+    return F->getKind() == Fragment::Type::DynStr;
+  }
+
+  /// Add \p S to the table if not already present. Returns its byte offset.
+  std::size_t addString(const std::string &S);
+
+  /// Returns the byte offset of \p S, or nullopt if not present.
+  std::optional<std::size_t> getStringOffset(const std::string &S) const;
+
+  size_t size() const override;
+
+  eld::Expected<void> emit(MemoryRegion &Mr, Module &M) override;
+
+private:
+  std::string Contents;
+  std::unordered_map<std::string, std::size_t> Offsets;
+};
+
+} // namespace eld
+
+#endif // ELD_FRAGMENT_DYNSTRFRAGMENT_H

--- a/include/eld/Fragment/Fragment.h
+++ b/include/eld/Fragment/Fragment.h
@@ -51,6 +51,7 @@ public:
     MergeString,
     BuildID,
     SFrame,
+    DynStr,
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
     GNUVerDef,
     GNUVerSym,

--- a/include/eld/Fragment/GNUVerDefFragment.h
+++ b/include/eld/Fragment/GNUVerDefFragment.h
@@ -19,7 +19,7 @@
 
 namespace eld {
 class DiagnosticEngine;
-class ELFFileFormat;
+class DynStrFragment;
 
 /// .gnu.version_d(SHT_GNU_verdef) section contains the symbol version
 /// definitions for the symbols that are defined by the module.
@@ -32,7 +32,7 @@ public:
   }
 
   template <class ELFT>
-  eld::Expected<void> computeVersionDefs(Module &M, ELFFileFormat *FileFormat,
+  eld::Expected<void> computeVersionDefs(Module &M, DynStrFragment *DynStr,
                                          DiagnosticEngine &DE);
 
   eld::Expected<void> emit(MemoryRegion &Mr, Module &M) override;

--- a/include/eld/Fragment/GNUVerNeedFragment.h
+++ b/include/eld/Fragment/GNUVerNeedFragment.h
@@ -19,9 +19,9 @@
 
 namespace eld {
 class DiagnosticEngine;
+class DynStrFragment;
 class ELFSection;
 class InputFile;
-class ELFFileFormat;
 
 /** \class VerNeedFragment
  *  \brief VerNeedFragment is a kind of Fragment containing input memory region
@@ -38,7 +38,7 @@ public:
   template <class ELFT>
   eld::Expected<void>
   computeVersionNeeds(const std::vector<InputFile *> &DynamicObjectFiles,
-                      ELFFileFormat *FileFormat, DiagnosticEngine &DE);
+                      DynStrFragment *DynStr, DiagnosticEngine &DE);
 
   eld::Expected<void> emit(MemoryRegion &Mr, Module &M) override;
 

--- a/include/eld/Target/ELFDynamic.h
+++ b/include/eld/Target/ELFDynamic.h
@@ -26,6 +26,7 @@
 
 namespace eld {
 
+class DynStrFragment;
 class ELFFileFormat;
 class GNULDBackend;
 class LinkerConfig;
@@ -141,13 +142,13 @@ public:
   size_t numOfBytes() const;
 
   /// reserveEntries - reserve entries
-  void reserveEntries(ELFFileFormat &pFormat, Module &pModule);
+  void reserveEntries(DynStrFragment *DynStr, Module &pModule);
 
   /// reserveNeedEntry - reserve on DT_NEED entry.
   elf_dynamic::EntryIF *reserveNeedEntry();
 
   /// applyEntries - apply entries
-  void applyEntries(const ELFFileFormat &pFormat, const Module &pModule);
+  void applyEntries(const ELFSection *DynStrSect, const Module &pModule);
 
   void applySoname(uint64_t pStrTabIdx);
 

--- a/include/eld/Target/ELFFileFormat.h
+++ b/include/eld/Target/ELFFileFormat.h
@@ -25,8 +25,6 @@ public:
 
   ELFSection *getDynamic() const { return f_pDynamic; }
 
-  ELFSection *getDynStrTab() const { return f_pDynStrTab; }
-
   ELFSection *getDynSymTab() const { return f_pDynSymTab; }
 
   ELFSection *getShStrTab() const { return f_pShStrTab; }
@@ -38,10 +36,6 @@ public:
   ELFSection *getSymTabShndxr() const { return f_pSymTabShndxr; }
 
   bool hasDynamic() const { return (f_pDynamic) && (!f_pDynamic->isIgnore()); }
-
-  bool hasDynStrTab() const {
-    return (f_pDynStrTab) && (!f_pDynStrTab->isIgnore());
-  }
 
   bool hasDynSymTab() const {
     return (f_pDynSymTab) && (!f_pDynSymTab->isIgnore());
@@ -61,52 +55,11 @@ public:
 
   std::vector<ELFSection *> &getSections() { return f_pSections; }
 
-  std::size_t addStringToDynStrTab(const std::string &S) {
-    return DynamicStringTableContents.addString(S);
-  }
-
-  std::size_t getDynStrTabSize() const {
-    return DynamicStringTableContents.size();
-  }
-
-  std::optional<std::size_t> getOffsetInDynStrTab(const std::string &S) const {
-    return DynamicStringTableContents.getOffset(S);
-  }
-
-  const std::string &getDynStrTabContents() const {
-    return DynamicStringTableContents.Strings;
-  }
-
-private:
-  struct StringTableContents {
-    std::string Strings = std::string(1, '\0');
-    std::unordered_map<std::string, std::size_t> StringOffsets;
-
-    std::size_t addString(const std::string &S) {
-      auto iter = StringOffsets.find(S);
-      if (iter != StringOffsets.end())
-        return iter->second;
-      std::size_t Offset = Strings.size();
-      Strings += S + std::string(1, '\0');
-      return StringOffsets[S] = Offset;
-    }
-
-    std::size_t size() const { return Strings.size(); }
-
-    std::optional<std::size_t> getOffset(const std::string &S) const {
-      auto iter = StringOffsets.find(S);
-      if (iter != StringOffsets.end())
-        return iter->second;
-      return std::nullopt;
-    }
-  };
-
 private:
   ELFSection *createFileFormatSection(Module &pModule, llvm::StringRef pName,
                                       LDFileFormat::Kind pKind, uint32_t pType,
                                       uint32_t pFlag, uint32_t pAlign);
   ELFSection *f_pDynamic;      // .dynamic
-  ELFSection *f_pDynStrTab;    // .dynstr
   ELFSection *f_pDynSymTab;    // .dynsym
   ELFSection *f_pShStrTab;     // .shstrtab
   ELFSection *f_pStrTab;       // .strtab
@@ -115,7 +68,6 @@ private:
 
   // House all the sections in this vector for convenient iteration
   std::vector<ELFSection *> f_pSections;
-  StringTableContents DynamicStringTableContents;
 };
 
 } // namespace eld

--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -42,6 +42,7 @@
 namespace eld {
 
 class BuildIDFragment;
+class DynStrFragment;
 class BinaryFileParser;
 class BitcodeReader;
 class BranchIslandFactory;
@@ -171,6 +172,10 @@ public:
   void insertTimingFragmentStub();
 
   TimingFragment *getTimingFragment() const { return m_pTimingFragment; }
+
+  DynStrFragment *getDynStrFragment() const { return m_pDynStrFrag; }
+
+  ELFSection *getDynStrSection() const { return m_pDynStrSection; }
 
   // -----  target symbols ----- //
   /// initStandardSymbols - initialize standard symbols.
@@ -1185,6 +1190,10 @@ protected:
   // Build ID Section
   ELFSection *m_pBuildIDSection = nullptr;
   BuildIDFragment *m_pBuildIDFragment = nullptr;
+
+  // Dynamic string table
+  ELFSection *m_pDynStrSection = nullptr;
+  DynStrFragment *m_pDynStrFrag = nullptr;
 
   // Start Offset.
   int64_t m_StartOffset = 0;

--- a/lib/Fragment/CMakeLists.txt
+++ b/lib/Fragment/CMakeLists.txt
@@ -2,6 +2,7 @@ llvm_add_library(
   ELDFragment
   STATIC
   BuildIDFragment.cpp
+  DynStrFragment.cpp
   EhFrameFragment.cpp
   EhFrameHdrFragment.cpp
   FillFragment.cpp

--- a/lib/Fragment/DynStrFragment.cpp
+++ b/lib/Fragment/DynStrFragment.cpp
@@ -1,0 +1,39 @@
+//===- DynStrFragment.cpp--------------------------------------------------===//
+// Part of the eld Project, under the BSD License
+// See https://github.com/qualcomm/eld/LICENSE.txt for license information.
+// SPDX-License-Identifier: BSD-3-Clause
+//===----------------------------------------------------------------------===//
+
+#include "eld/Fragment/DynStrFragment.h"
+#include "eld/Core/Module.h"
+
+using namespace eld;
+
+DynStrFragment::DynStrFragment(ELFSection *S)
+    : Fragment(Fragment::Type::DynStr, S), Contents(1, '\0') {}
+
+std::size_t DynStrFragment::addString(const std::string &S) {
+  auto It = Offsets.find(S);
+  if (It != Offsets.end())
+    return It->second;
+  std::size_t Offset = Contents.size();
+  Contents += S;
+  Contents += '\0';
+  return Offsets[S] = Offset;
+}
+
+std::optional<std::size_t>
+DynStrFragment::getStringOffset(const std::string &S) const {
+  auto It = Offsets.find(S);
+  if (It != Offsets.end())
+    return It->second;
+  return std::nullopt;
+}
+
+size_t DynStrFragment::size() const { return Contents.size(); }
+
+eld::Expected<void> DynStrFragment::emit(MemoryRegion &Mr, Module &M) {
+  memcpy(Mr.begin() + getOffset(M.getConfig().getDiagEngine()), Contents.data(),
+         Contents.size());
+  return {};
+}

--- a/lib/Fragment/GNUVerDefFragment.cpp
+++ b/lib/Fragment/GNUVerDefFragment.cpp
@@ -14,8 +14,8 @@
 #include "eld/Config/GeneralOptions.h"
 #include "eld/Core/Module.h"
 #include "eld/Diagnostics/DiagnosticEngine.h"
+#include "eld/Fragment/DynStrFragment.h"
 #include "eld/SymbolResolver/ResolveInfo.h"
-#include "eld/Target/ELFFileFormat.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/Object/ELF.h"
@@ -29,7 +29,7 @@ GNUVerDefFragment::GNUVerDefFragment(ELFSection *S)
 
 template <class ELFT>
 eld::Expected<void>
-GNUVerDefFragment::computeVersionDefs(Module &M, ELFFileFormat *FileFormat,
+GNUVerDefFragment::computeVersionDefs(Module &M, DynStrFragment *DynStr,
                                       DiagnosticEngine &DE) {
   const auto &VSNodes = M.getVersionScriptNodes();
   if (VSNodes.empty())
@@ -47,7 +47,7 @@ GNUVerDefFragment::computeVersionDefs(Module &M, ELFFileFormat *FileFormat,
     std::string outputFileName = options.outputFileName();
     baseVersion = std::string(llvm::sys::path::filename(outputFileName));
   }
-  std::size_t baseVersionOffset = FileFormat->addStringToDynStrTab(baseVersion);
+  std::size_t baseVersionOffset = DynStr->addString(baseVersion);
   VersionDefs.push_back(VerDefInfo{1, static_cast<uint32_t>(baseVersionOffset),
                                    llvm::object::hashSysV(baseVersion)});
 
@@ -57,7 +57,7 @@ GNUVerDefFragment::computeVersionDefs(Module &M, ELFFileFormat *FileFormat,
     if (!Node || Node->isAnonymous())
       continue;
     llvm::StringRef VerName = Node->getName();
-    std::size_t NameOffset = FileFormat->addStringToDynStrTab(VerName.str());
+    std::size_t NameOffset = DynStr->addString(VerName.str());
     VersionDefs.push_back(VerDefInfo{VerID, static_cast<uint32_t>(NameOffset),
                                      llvm::object::hashSysV(VerName)});
     ++VerID;
@@ -112,10 +112,10 @@ eld::Expected<void> GNUVerDefFragment::emitImpl(uint8_t *Buf, Module &M) {
 // Explicit instantiations
 template eld::Expected<void>
 GNUVerDefFragment::computeVersionDefs<llvm::object::ELF32LE>(
-    Module &M, ELFFileFormat *FileFormat, DiagnosticEngine &DE);
+    Module &M, DynStrFragment *DynStr, DiagnosticEngine &DE);
 template eld::Expected<void>
 GNUVerDefFragment::computeVersionDefs<llvm::object::ELF64LE>(
-    Module &M, ELFFileFormat *FileFormat, DiagnosticEngine &DE);
+    Module &M, DynStrFragment *DynStr, DiagnosticEngine &DE);
 template eld::Expected<void>
 GNUVerDefFragment::emitImpl<llvm::object::ELF32LE>(uint8_t *Buf, Module &M);
 template eld::Expected<void>

--- a/lib/Fragment/GNUVerNeedFragment.cpp
+++ b/lib/Fragment/GNUVerNeedFragment.cpp
@@ -13,9 +13,9 @@
 #include "eld/Fragment/GNUVerNeedFragment.h"
 #include "eld/Core/Module.h"
 #include "eld/Diagnostics/DiagnosticEngine.h"
+#include "eld/Fragment/DynStrFragment.h"
 #include "eld/Input/ELFDynObjectFile.h"
 #include "eld/Input/InputFile.h"
-#include "eld/Target/ELFFileFormat.h"
 #include "llvm/Object/ELF.h"
 #include <cstdint>
 
@@ -26,8 +26,8 @@ GNUVerNeedFragment::GNUVerNeedFragment(ELFSection *S)
 
 template <class ELFT>
 eld::Expected<void> GNUVerNeedFragment::computeVersionNeeds(
-    const std::vector<InputFile *> &DynamicObjectFiles,
-    ELFFileFormat *FileFormat, DiagnosticEngine &DE) {
+    const std::vector<InputFile *> &DynamicObjectFiles, DynStrFragment *DynStr,
+    DiagnosticEngine &DE) {
   VerNeedEntrySize = sizeof(typename ELFT::Verneed);
   VernAuxEntrySize = sizeof(typename ELFT::Vernaux);
   bool traceSV = DE.getPrinter()->traceSymbolVersioning();
@@ -35,8 +35,7 @@ eld::Expected<void> GNUVerNeedFragment::computeVersionNeeds(
     auto *DynObjFile = llvm::cast<ELFDynObjectFile>(IF);
     const auto &VernAuxIDMap = DynObjFile->getOutputVernAuxIDMap();
     VerNeedInfo VNI;
-    VNI.SONameOffset =
-        FileFormat->addStringToDynStrTab(DynObjFile->getSOName());
+    VNI.SONameOffset = DynStr->addString(DynObjFile->getSOName());
     for (std::size_t i = 0; i < VernAuxIDMap.size(); ++i) {
       if (VernAuxIDMap[i] == 0)
         continue;
@@ -45,8 +44,7 @@ eld::Expected<void> GNUVerNeedFragment::computeVersionNeeds(
       llvm::StringRef VerName = DynObjFile->getDynStringTable().data() +
                                 static_cast<size_t>(verdef->getAux()->vda_name);
       VernAuxInfo AuxInfo = {
-          static_cast<uint32_t>(
-              FileFormat->addStringToDynStrTab(VerName.str())),
+          static_cast<uint32_t>(DynStr->addString(VerName.str())),
           VernAuxIDMap[i], verdef->vd_hash};
       if (traceSV)
         DE.raise(Diag::trace_adding_verneed_entry)
@@ -108,9 +106,9 @@ eld::Expected<void> GNUVerNeedFragment::emitImpl(uint8_t *Buf, Module &M) {
 
 template eld::Expected<void>
 GNUVerNeedFragment::computeVersionNeeds<llvm::object::ELF32LE>(
-    const std::vector<InputFile *> &DynamicObjectFiles,
-    ELFFileFormat *FileFormat, DiagnosticEngine &DE);
+    const std::vector<InputFile *> &DynamicObjectFiles, DynStrFragment *DynStr,
+    DiagnosticEngine &DE);
 template eld::Expected<void>
 GNUVerNeedFragment::computeVersionNeeds<llvm::object::ELF64LE>(
-    const std::vector<InputFile *> &DynamicObjectFiles,
-    ELFFileFormat *FileFormat, DiagnosticEngine &DE);
+    const std::vector<InputFile *> &DynamicObjectFiles, DynStrFragment *DynStr,
+    DiagnosticEngine &DE);

--- a/lib/Target/ELFDynamic.cpp
+++ b/lib/Target/ELFDynamic.cpp
@@ -16,6 +16,7 @@
 #include "eld/Config/LinkerConfig.h"
 #include "eld/Core/Module.h"
 #include "eld/Diagnostics/DiagnosticPrinter.h"
+#include "eld/Fragment/DynStrFragment.h"
 #include "eld/Support/MsgHandling.h"
 #include "eld/SymbolResolver/LDSymbol.h"
 #include "eld/Target/ELFFileFormat.h"
@@ -133,12 +134,12 @@ void ELFDynamic::applyOne(uint64_t pTag, uint64_t pValue) {
 }
 
 /// reserveEntries - reserve entries
-void ELFDynamic::reserveEntries(ELFFileFormat &pFormat, Module &pModule) {
+void ELFDynamic::reserveEntries(DynStrFragment *DynStr, Module &pModule) {
   if (LinkerConfig::DynObj == m_Config.codeGenType()) {
     // DT_SONAME is the 0th entry in the dynamic section.
-    if (pModule.getSection(".dynstr") && !m_Config.options().soname().empty()) {
+    if (DynStr && !m_Config.options().soname().empty()) {
       reserveOne(llvm::ELF::DT_SONAME); // DT_SONAME
-      applySoname(pFormat.addStringToDynStrTab(m_Config.options().soname()));
+      applySoname(DynStr->addString(m_Config.options().soname()));
     }
 
     if (m_Config.options().bsymbolic())
@@ -178,7 +179,7 @@ void ELFDynamic::reserveEntries(ELFFileFormat &pFormat, Module &pModule) {
     reserveOne(llvm::ELF::DT_SYMENT); // DT_SYMENT
   }
 
-  if (pModule.getSection(".dynstr")) {
+  if (DynStr) {
     reserveOne(llvm::ELF::DT_STRTAB); // DT_STRTAB
     reserveOne(llvm::ELF::DT_STRSZ);  // DT_STRSZ
   }
@@ -265,7 +266,7 @@ void ELFDynamic::reserveEntries(ELFFileFormat &pFormat, Module &pModule) {
 }
 
 /// applyEntries - apply entries
-void ELFDynamic::applyEntries(const ELFFileFormat &pFormat,
+void ELFDynamic::applyEntries(const ELFSection *DynStrSect,
                               const Module &pModule) {
   if (LinkerConfig::DynObj == m_Config.codeGenType() &&
       m_Config.options().bsymbolic()) {
@@ -333,11 +334,13 @@ void ELFDynamic::applyEntries(const ELFFileFormat &pFormat,
     applyOne(llvm::ELF::DT_SYMENT, symbolSize());    // DT_SYMENT
   }
 
-  if (pModule.getSection(".dynstr")) {
-    applyOne(llvm::ELF::DT_STRTAB,
-             pModule.getSection(".dynstr")->addr()); // DT_STRTAB
-    applyOne(llvm::ELF::DT_STRSZ,
-             pModule.getSection(".dynstr")->size()); // DT_STRSZ
+  if (DynStrSect) {
+    ELFSection *DynStrOut = DynStrSect->getOutputELFSection();
+    uint64_t DynStrAddr = DynStrOut ? (DynStrOut->addr() + DynStrSect->offset())
+                                    : DynStrSect->addr();
+    uint64_t DynStrSize = DynStrSect->size();
+    applyOne(llvm::ELF::DT_STRTAB, DynStrAddr); // DT_STRTAB
+    applyOne(llvm::ELF::DT_STRSZ, DynStrSize);  // DT_STRSZ
   }
 
   if (const ELFSection *GOTPLT = m_Backend.getGOTPLT())

--- a/lib/Target/ELFFileFormat.cpp
+++ b/lib/Target/ELFFileFormat.cpp
@@ -17,8 +17,8 @@
 using namespace eld;
 
 ELFFileFormat::ELFFileFormat()
-    : f_pDynamic(nullptr), f_pDynStrTab(nullptr), f_pDynSymTab(nullptr),
-      f_pShStrTab(nullptr), f_pStrTab(nullptr), f_pSymTab(nullptr) {}
+    : f_pDynamic(nullptr), f_pDynSymTab(nullptr), f_pShStrTab(nullptr),
+      f_pStrTab(nullptr), f_pSymTab(nullptr) {}
 
 void ELFFileFormat::initStdSections(Module &pModule, unsigned int pBitClass) {
   ELFSection *NullSection = createFileFormatSection(
@@ -31,10 +31,6 @@ void ELFFileFormat::initStdSections(Module &pModule, unsigned int pBitClass) {
     f_pDynSymTab = createFileFormatSection(
         pModule, ".dynsym", LDFileFormat::NamePool, llvm::ELF::SHT_DYNSYM,
         llvm::ELF::SHF_ALLOC, pBitClass / 8);
-
-    f_pDynStrTab = createFileFormatSection(
-        pModule, ".dynstr", LDFileFormat::NamePool, llvm::ELF::SHT_STRTAB,
-        llvm::ELF::SHF_ALLOC, 0x1);
 
     f_pDynamic = createFileFormatSection(
         pModule, ".dynamic", LDFileFormat::NamePool, llvm::ELF::SHT_DYNAMIC,

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -21,6 +21,7 @@
 #include "eld/Diagnostics/DiagnosticEngine.h"
 #include "eld/Diagnostics/DiagnosticInfos.h"
 #include "eld/Fragment/BuildIDFragment.h"
+#include "eld/Fragment/DynStrFragment.h"
 #include "eld/Fragment/EhFrameFragment.h"
 #include "eld/Fragment/FillFragment.h"
 #include "eld/Fragment/GNUHashFragment.h"
@@ -209,6 +210,17 @@ eld::Expected<void> GNULDBackend::initStdSections() {
   m_pFileFormat = make<ELFFileFormat>();
 
   m_pFileFormat->initStdSections(m_Module, config().targets().bitclass());
+
+  if (!config().isCodeStatic() || config().options().isPIE() ||
+      config().options().forceDynamic()) {
+    ELFSection *DynStrSection = m_Module.createInternalSection(
+        Module::InternalInputType::DynamicSections, LDFileFormat::Internal,
+        ".dynstr", llvm::ELF::SHT_STRTAB, llvm::ELF::SHF_ALLOC, 1);
+    m_pDynStrFrag = make<DynStrFragment>(DynStrSection);
+    DynStrSection->addFragmentAndUpdateSize(m_pDynStrFrag);
+    m_pDynStrSection = DynStrSection;
+    m_pFileFormat->getSections().push_back(DynStrSection);
+  }
 
   ELFSection *interp = nullptr;
 
@@ -946,10 +958,10 @@ void GNULDBackend::sizeDynNamePools() {
     GNUVerDefFragment *F = make<GNUVerDefFragment>(GNUVerDefSection);
     bool is32Bits = config().targets().is32Bits();
     if (is32Bits)
-      F->computeVersionDefs<llvm::object::ELF32LE>(m_Module, getOutputFormat(),
+      F->computeVersionDefs<llvm::object::ELF32LE>(m_Module, m_pDynStrFrag,
                                                    *DE);
     else
-      F->computeVersionDefs<llvm::object::ELF64LE>(m_Module, getOutputFormat(),
+      F->computeVersionDefs<llvm::object::ELF64LE>(m_Module, m_pDynStrFrag,
                                                    *DE);
     GNUVerDefSection->addFragmentAndUpdateSize(F);
     GNUVerDefFrag = F;
@@ -964,10 +976,10 @@ void GNULDBackend::sizeDynNamePools() {
     bool is32Bits = config().targets().is32Bits();
     if (is32Bits)
       F->computeVersionNeeds<llvm::object::ELF32LE>(
-          m_Module.getDynLibraryList(), getOutputFormat(), *DE);
+          m_Module.getDynLibraryList(), m_pDynStrFrag, *DE);
     else
       F->computeVersionNeeds<llvm::object::ELF64LE>(
-          m_Module.getDynLibraryList(), getOutputFormat(), *DE);
+          m_Module.getDynLibraryList(), m_pDynStrFrag, *DE);
     GNUVerNeedSection->addFragmentAndUpdateSize(F);
     GNUVerNeedFrag = F;
     GNUVerNeedSection->setInfo(F->getNeedCount());
@@ -1025,8 +1037,6 @@ void GNULDBackend::sizeDynamic() {
   if (config().isCodeStatic() && !config().options().forceDynamic()) {
     return;
   }
-  ELFFileFormat *FileFormat = getOutputFormat();
-  ASSERT(FileFormat, "Must not be null!");
   size_t symIdx = 0;
   for (auto &DynSym : DynamicSymbols) {
     m_pDynSymIndexMap[DynSym->outSymbol()] = symIdx;
@@ -1035,12 +1045,12 @@ void GNULDBackend::sizeDynamic() {
 #else
     std::string symName = std::string(DynSym->name());
 #endif
-    FileFormat->addStringToDynStrTab(symName);
+    m_pDynStrFrag->addString(symName);
     ++symIdx;
   }
   if (config().codeGenType() == LinkerConfig::DynObj) {
     if (!config().options().soname().empty())
-      FileFormat->addStringToDynStrTab(config().options().soname());
+      m_pDynStrFrag->addString(config().options().soname());
   }
 
   // add DT_NEEDED
@@ -1052,7 +1062,7 @@ void GNULDBackend::sizeDynamic() {
         continue;
       addedLibs.insert(dynObjFile->getInput()->getMemArea());
       std::size_t SONameOffset =
-          FileFormat->addStringToDynStrTab(dynObjFile->getSOName());
+          m_pDynStrFrag->addString(dynObjFile->getSOName());
       auto DTEntry = dynamic()->reserveNeedEntry();
       DTEntry->setValue(llvm::ELF::DT_NEEDED, SONameOffset);
     }
@@ -1069,7 +1079,7 @@ void GNULDBackend::sizeDynamic() {
       if (rpath + 1 != rpathEnd)
         RunPath += ":";
     }
-    std::size_t RunPathOffset = FileFormat->addStringToDynStrTab(RunPath);
+    std::size_t RunPathOffset = m_pDynStrFrag->addString(RunPath);
     DTEntry->setValue(llvm::ELF::DT_RUNPATH, RunPathOffset);
   }
   // set size
@@ -1080,8 +1090,8 @@ void GNULDBackend::sizeDynamic() {
     getOutputFormat()->getDynSymTab()->setSize((DynamicSymbols.size()) *
                                                sizeof(llvm::ELF::Elf64_Sym));
   }
-  dynamic()->reserveEntries(*getOutputFormat(), m_Module);
-  getOutputFormat()->getDynStrTab()->setSize(FileFormat->getDynStrTabSize());
+  dynamic()->reserveEntries(m_pDynStrFrag, m_Module);
+  m_pDynStrSection->setSize(m_pDynStrFrag->size());
   getOutputFormat()->getDynamic()->setSize(dynamic()->numOfBytes());
 }
 
@@ -1190,7 +1200,7 @@ void GNULDBackend::emitSymbol32(llvm::ELF::Elf32_Sym &pSym, LDSymbol *pSymbol,
 #else
       std::string name = std::string(pSymbol->name());
 #endif
-      auto optSymNameOffset = getOutputFormat()->getOffsetInDynStrTab(name);
+      auto optSymNameOffset = m_pDynStrFrag->getStringOffset(name);
       ASSERT(optSymNameOffset.has_value(),
              "Symbol name must be present in .dynstr!");
       pSym.st_name = optSymNameOffset.value();
@@ -1222,7 +1232,7 @@ void GNULDBackend::emitSymbol64(llvm::ELF::Elf64_Sym &pSym, LDSymbol *pSymbol,
 #else
       std::string name = std::string(pSymbol->name());
 #endif
-      auto optSymNameOffset = getOutputFormat()->getOffsetInDynStrTab(name);
+      auto optSymNameOffset = m_pDynStrFrag->getStringOffset(name);
       ASSERT(optSymNameOffset.has_value(),
              "Symbol name (" + name + ") must be present in .dynstr!");
       pSym.st_name = optSymNameOffset.value();
@@ -1356,7 +1366,7 @@ GNULDBackend::emitRegNamePools(llvm::FileOutputBuffer &pOutput) {
 /// layout should computes the start offset of these tables
 bool GNULDBackend::emitDynNamePools(llvm::FileOutputBuffer &pOutput) {
   ELFSection *symtab_sect = m_Module.getSection(".dynsym");
-  ELFSection *strtab_sect = m_Module.getSection(".dynstr");
+  ELFSection *strtab_sect = m_pDynStrSection;
   ELFSection *dyn_sect = m_Module.getSection(".dynamic");
 
   bool BuildDynSym = false;
@@ -1400,18 +1410,11 @@ bool GNULDBackend::emitDynNamePools(llvm::FileOutputBuffer &pOutput) {
       config().raise(Diag::section_ignored) << ".dynstr";
       return false;
     }
+    ELFSection *StrtabOutSect = strtab_sect->getOutputELFSection();
+    ASSERT(StrtabOutSect, ".dynstr must be placed in an output section!");
     MemoryRegion strtab_region = getFileOutputRegion(
-        pOutput, strtab_sect->offset(), strtab_sect->size());
+        pOutput, StrtabOutSect->offset(), StrtabOutSect->size());
     strtab = (char *)strtab_region.begin();
-  }
-
-  if (strtab) {
-    ELFFileFormat *FileFormat = getOutputFormat();
-    ASSERT(FileFormat, "Must not be null!");
-    const std::string &DynStrTabContents = FileFormat->getDynStrTabContents();
-    ASSERT(strtab_sect->size() == DynStrTabContents.size(),
-           "Size must be same!");
-    memcpy(strtab, DynStrTabContents.c_str(), DynStrTabContents.size());
   }
   size_t symIdx = 0;
   size_t strtabsize = 0;
@@ -1436,7 +1439,7 @@ bool GNULDBackend::emitDynNamePools(llvm::FileOutputBuffer &pOutput) {
   if (firstNonLocal)
     symtab_sect->setInfo(*firstNonLocal);
 
-  dynamic()->applyEntries(*getOutputFormat(), m_Module);
+  dynamic()->applyEntries(m_pDynStrSection, m_Module);
 
   if (dyn_sect->getKind() != LDFileFormat::Null) {
     MemoryRegion dyn_region =
@@ -1480,6 +1483,9 @@ unsigned int GNULDBackend::getSectionOrder(const ELFSection &pSectHdr) const {
     return SHO_NAMEPOOL;
 
   if (pSectHdr.name() == ".gnu.hash")
+    return SHO_NAMEPOOL;
+
+  if (pSectHdr.name() == ".dynstr")
     return SHO_NAMEPOOL;
 
   // if the section is not ALLOC, lay it out until the last possible moment
@@ -5375,7 +5381,7 @@ void GNULDBackend::initSymbolVersioningSections() {
       LDFileFormat::Kind::SymbolVersion, ".gnu.version_d",
       llvm::ELF::SHT_GNU_verdef, llvm::ELF::SHF_ALLOC,
       /*Align=*/sizeof(uint32_t));
-  GNUVerDefSection->setLink(getOutputFormat()->getDynStrTab());
+  GNUVerDefSection->setLink(m_pDynStrSection);
 
   if (DP->traceSymbolVersioning())
     config().raise(Diag::trace_creating_symbol_versioning_section)
@@ -5385,7 +5391,7 @@ void GNULDBackend::initSymbolVersioningSections() {
       LDFileFormat::Kind::SymbolVersion, ".gnu.version_r",
       llvm::ELF::SHT_GNU_verneed, llvm::ELF::SHF_ALLOC,
       /*Align=*/sizeof(uint32_t));
-  GNUVerNeedSection->setLink(getOutputFormat()->getDynStrTab());
+  GNUVerNeedSection->setLink(m_pDynStrSection);
 }
 #endif
 

--- a/lib/Writers/ELFObjectWriter.cpp
+++ b/lib/Writers/ELFObjectWriter.cpp
@@ -723,9 +723,9 @@ uint64_t ELFObjectWriter::getSectLink(const ELFSection *S) const {
   if (llvm::ELF::SHT_SYMTAB_SHNDX == S->getType())
     Link = ThisModule.getBackend().getOutputFormat()->getSymTab();
   if (llvm::ELF::SHT_DYNSYM == S->getType())
-    Link = ThisModule.getBackend().getOutputFormat()->getDynStrTab();
+    Link = ThisModule.getBackend().getDynStrSection();
   if (llvm::ELF::SHT_DYNAMIC == S->getType())
-    Link = ThisModule.getBackend().getOutputFormat()->getDynStrTab();
+    Link = ThisModule.getBackend().getDynStrSection();
   if (llvm::ELF::SHT_HASH == S->getType() ||
       llvm::ELF::SHT_GNU_HASH == S->getType())
     Link = ThisModule.getBackend().getOutputFormat()->getDynSymTab();
@@ -733,9 +733,9 @@ uint64_t ELFObjectWriter::getSectLink(const ELFSection *S) const {
   if (llvm::ELF::SHT_GNU_versym == S->getType())
     Link = ThisModule.getBackend().getOutputFormat()->getDynSymTab();
   if (llvm::ELF::SHT_GNU_verdef == S->getType())
-    Link = ThisModule.getBackend().getOutputFormat()->getDynStrTab();
+    Link = ThisModule.getBackend().getDynStrSection();
   if (llvm::ELF::SHT_GNU_verneed == S->getType())
-    Link = ThisModule.getBackend().getOutputFormat()->getDynStrTab();
+    Link = ThisModule.getBackend().getDynStrSection();
 #endif
   if (ThisModule.getConfig().isLinkPartial() &&
       llvm::ELF::SHF_LINK_ORDER & S->getFlags() && S->getLink())
@@ -751,6 +751,9 @@ uint64_t ELFObjectWriter::getSectLink(const ELFSection *S) const {
 
   if (Link->isIgnore() || Link->isDiscard())
     return 0;
+  // For internal (input) sections, return the output section index.
+  if (ELFSection *OutSect = Link->getOutputELFSection())
+    return OutSect->getIndex();
   return Link->getIndex();
 }
 


### PR DESCRIPTION
Convert .dynstr from an ELFFileFormat section to a dedicated fragment so that linker script rules are handled correctly.

Add a DynStrFragment to manage dynamic strings and support string deduplication.