### PR TITLE
[x86_64] Eliminate .got/.gotplt redundancy using compact .plt.got stubs

### DIFF
--- a/include/eld/Fragment/PLT.h
+++ b/include/eld/Fragment/PLT.h
@@ -24,8 +24,9 @@ class PLT : public Fragment {
 public:
   // PLT Types.
   enum PLTType {
-    PLT0, /* Lazy Binding PLT */
-    PLTN, /* PLTn */
+    PLT0,   /* Lazy Binding PLT */
+    PLTN,   /* PLTn */
+    PLTGot, /* Compact .plt.got stub — reads from .got, no lazy binding */
   };
 
 public:

--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -514,6 +514,12 @@ public:
   /// flag
   inline uint32_t getSegmentFlag(const uint32_t pSectionFlag);
 
+  /// initScanRelocations - target hook run single-threaded at the start of
+  /// ObjectLinker::scanRelocations(), after symbol resolution and before the
+  /// parallel per-file scan. Targets that accumulate per-symbol scan state
+  /// (e.g. x86_64's two-phase flag map) populate it here.
+  virtual void initScanRelocations() {}
+
   virtual bool finalizeScanRelocations() { return true; }
 
   /// setOutputSectionOffset - helper function to set output sections' offset.

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -2123,6 +2123,11 @@ bool ObjectLinker::scanRelocations(bool IsPartialLink) {
 
   getTargetBackend().provideSymbols();
 
+  // Single-threaded phase-0 hook: let the target populate any per-symbol scan
+  // state (x86_64 pre-populates its flag map here) now that symbol resolution
+  // is complete and before the parallel scan below begins.
+  getTargetBackend().initScanRelocations();
+
   std::vector<std::unique_ptr<Relocator::CopyRelocs>> AllCopyRelocs;
   if (ThisConfig.options().numThreads() <= 1 ||
       !ThisConfig.isScanRelocationsMultiThreaded()) {
@@ -2154,22 +2159,12 @@ bool ObjectLinker::scanRelocations(bool IsPartialLink) {
     for (auto &Reloc : *RelocVec)
       createCopyRelocation(*Reloc, CopyRelocType);
 
-  // Merge per-file relocations
-  if (!IsPartialLink) {
-    ELFObjectFile *RelocInput =
-        getTargetBackend().getDynamicSectionHeadersInputFile();
-    auto MergeRelocs = [](ELFSection &To, ELFSection &From) {
-      To.appendRelocations(From.getRelocations());
-    };
-    for (auto &Input : ThisModule->getObjectList())
-      if (ELFObjectFile *Obj = llvm::dyn_cast<ELFObjectFile>(Input))
-        if (Obj != RelocInput) {
-          if (const auto &S = Obj->getRelaDyn())
-            MergeRelocs(*RelocInput->getRelaDyn(), *S);
-          if (const auto &S = Obj->getRelaPLT())
-            MergeRelocs(*RelocInput->getRelaPLT(), *S);
-        }
-  }
+  // NOTE: MergeRelocs (.rela.dyn / .rela.plt per-input → output) runs in
+  // ObjectLinker::finalizeScanRelocations() — after the per-backend
+  // finalizeScanRelocations() hook — so that dynrelocs created by x86_64's
+  // phase-2 allocation (and any created during other backends' scan) are all
+  // captured. It must not run here: for x86_64 the phase-2 dynrelocs do not
+  // exist yet at this point.
 
   // If there is a undefined symbol, fail the link. No point fixing the
   // relocations. This is overridden by --noinhibit-exec.
@@ -2187,6 +2182,26 @@ bool ObjectLinker::finalizeScanRelocations() {
     if (ThisModule->getPrinter()->isVerbose())
       ThisConfig.raise(Diag::function_has_error) << __PRETTY_FUNCTION__;
     return false;
+  }
+
+  // Merge per-input .rela.dyn and .rela.plt into the output sections.
+  // For x86_64: phase 2 dynrelocs (GOTPCREL, PLT32) were emitted above.
+  // For all other targets: dynrelocs emitted during scan are merged here.
+  bool IsPartialLink = (LinkerConfig::Object == ThisConfig.codeGenType());
+  if (!IsPartialLink) {
+    ELFObjectFile *RelocInput =
+        getTargetBackend().getDynamicSectionHeadersInputFile();
+    auto MergeRelocs = [](ELFSection &To, ELFSection &From) {
+      To.appendRelocations(From.getRelocations());
+    };
+    for (auto &Input : ThisModule->getObjectList())
+      if (ELFObjectFile *Obj = llvm::dyn_cast<ELFObjectFile>(Input))
+        if (Obj != RelocInput) {
+          if (const auto &S = Obj->getRelaDyn())
+            MergeRelocs(*RelocInput->getRelaDyn(), *S);
+          if (const auto &S = Obj->getRelaPLT())
+            MergeRelocs(*RelocInput->getRelaPLT(), *S);
+        }
   }
   return true;
 }

--- a/lib/Target/X86/CMakeLists.txt
+++ b/lib/Target/X86/CMakeLists.txt
@@ -7,6 +7,7 @@ llvm_add_library(
   x86_64Relocator.cpp
   x86_64RelocationCompute.cpp
   x86_64PLT.cpp
+  x86_64PLTGot.cpp
   x86_64GOT.cpp
   x86_64ELFDynamic.cpp)
 

--- a/lib/Target/X86/x86_64LDBackend.cpp
+++ b/lib/Target/X86/x86_64LDBackend.cpp
@@ -78,6 +78,11 @@ void x86_64LDBackend::initDynamicSections(ELFObjectFile &InputFile) {
       *m_Module.createInternalSection(
           InputFile, LDFileFormat::DynamicRelocation, ".rela.plt",
           llvm::ELF::SHT_RELA, llvm::ELF::SHF_ALLOC, 8));
+  // .plt.got is x86-64-specific; kept in m_pPLTGot rather than ELFObjectFile.
+  m_pPLTGot = m_Module.createInternalSection(
+      InputFile, LDFileFormat::Internal, ".plt.got", llvm::ELF::SHT_PROGBITS,
+      llvm::ELF::SHF_ALLOC | llvm::ELF::SHF_EXECINSTR, 8);
+  m_pPLTGot->setExcludedFromGC();
 }
 
 void x86_64LDBackend::initTargetSymbols() {
@@ -151,6 +156,9 @@ void x86_64LDBackend::doPreLayout() {
                           getRelaEntrySize());
     m_Module.addOutputSection(getRelaPLT());
     m_Module.addOutputSection(getRelaDyn());
+    // Only add .plt.got if it has stubs — avoids empty section in output.
+    if (m_pPLTGot && m_pPLTGot->hasFragments())
+      m_Module.addOutputSection(m_pPLTGot);
   }
 }
 
@@ -307,12 +315,44 @@ void x86_64LDBackend::recordPLT(ResolveInfo *I, x86_64PLT *P) {
   m_PLTMap[I] = P;
 }
 
-// Find an entry in the GOT.
+// Find an entry in the PLT.
 x86_64PLT *x86_64LDBackend::findEntryInPLT(ResolveInfo *I) const {
   auto Entry = m_PLTMap.find(I);
   if (Entry == m_PLTMap.end())
     return nullptr;
   return Entry->second;
+}
+
+void x86_64LDBackend::recordPLTGot(ResolveInfo *I, x86_64PLTGot *P) {
+  m_PLTGotMap[I] = P;
+}
+
+x86_64PLTGot *x86_64LDBackend::findEntryInPLTGot(ResolveInfo *I) const {
+  auto Entry = m_PLTGotMap.find(I);
+  if (Entry == m_PLTGotMap.end())
+    return nullptr;
+  return Entry->second;
+}
+
+// Create a compact .plt.got stub for a symbol that has BOTH a .got entry
+// (address-taken, GLOB_DAT) and a PLT call. Reads the function address from
+// the .got slot directly — no .gotplt slot, no JUMP_SLOT dynreloc.
+x86_64PLTGot *x86_64LDBackend::createPLTGot(ELFObjectFile *Obj,
+                                            ResolveInfo *R) {
+  if (R != nullptr && ((config().options().isSymbolTracingRequested() &&
+                        config().options().traceSymbol(*R)) ||
+                       m_Module.getPrinter()->traceDynamicLinking()))
+    config().raise(Diag::create_plt_entry) << R->name();
+
+  reportErrorIfPLTIsDiscarded(R);
+
+  x86_64GOT *GotSlot = findEntryInGOT(R);
+  assert(GotSlot && "GOT slot must exist before createPLTGot");
+
+  x86_64PLTGot *P =
+      x86_64PLTGot::Create(*m_Module.getIRBuilder(), GotSlot, m_pPLTGot, R);
+  recordPLTGot(R, P);
+  return P;
 }
 
 void x86_64LDBackend::initScanRelocations() {

--- a/lib/Target/X86/x86_64LDBackend.cpp
+++ b/lib/Target/X86/x86_64LDBackend.cpp
@@ -315,6 +315,17 @@ x86_64PLT *x86_64LDBackend::findEntryInPLT(ResolveInfo *I) const {
   return Entry->second;
 }
 
+void x86_64LDBackend::initScanRelocations() {
+  auto *rel = static_cast<x86_64Relocator *>(getRelocator());
+  rel->initScanRelocations();
+}
+
+bool x86_64LDBackend::finalizeScanRelocations() {
+  auto *rel = static_cast<x86_64Relocator *>(getRelocator());
+  rel->allocateDynEntries();
+  return true;
+}
+
 uint64_t
 x86_64LDBackend::getValueForDiscardedRelocations(const Relocation *R) const {
   if (!m_pEndOfImage)

--- a/lib/Target/X86/x86_64LDBackend.h
+++ b/lib/Target/X86/x86_64LDBackend.h
@@ -96,6 +96,10 @@ public:
 
   void doPreLayout() override;
 
+  void initScanRelocations() override;
+
+  bool finalizeScanRelocations() override;
+
   void recordRelativeReloc(Relocation *DynRel, const Relocation *OrigRel) {
     m_RelativeRelocMap[DynRel] = OrigRel;
   }

--- a/lib/Target/X86/x86_64LDBackend.h
+++ b/lib/Target/X86/x86_64LDBackend.h
@@ -14,6 +14,7 @@
 #include "eld/Target/GNULDBackend.h"
 #include "x86_64ELFDynamic.h"
 #include "x86_64PLT.h"
+#include "x86_64PLTGot.h"
 #include "llvm/BinaryFormat/ELF.h"
 
 namespace eld {
@@ -88,6 +89,12 @@ public:
 
   x86_64PLT *findEntryInPLT(ResolveInfo *) const;
 
+  // --- .plt.got stub support ---
+  x86_64PLTGot *createPLTGot(ELFObjectFile *Obj, ResolveInfo *sym);
+  void recordPLTGot(ResolveInfo *, x86_64PLTGot *);
+  x86_64PLTGot *findEntryInPLTGot(ResolveInfo *) const;
+  ELFSection *getPLTGot() const { return m_pPLTGot; }
+
   std::size_t PLTEntriesCount() const override { return m_PLTMap.size(); }
 
   std::size_t GOTEntriesCount() const override { return m_GOTMap.size(); }
@@ -113,7 +120,8 @@ public:
       return DynRelocType::GLOB_DAT;
     if (X->type() == llvm::ELF::R_X86_64_JUMP_SLOT)
       return DynRelocType::JMP_SLOT;
-    if (X->type() == llvm::ELF::R_X86_64_RELATIVE || X->type()==llvm::ELF::R_X86_64_IRELATIVE)
+    if (X->type() == llvm::ELF::R_X86_64_RELATIVE ||
+        X->type() == llvm::ELF::R_X86_64_IRELATIVE)
       return DynRelocType::RELATIVE;
     if (X->type() == llvm::ELF::R_X86_64_DTPMOD64) {
       if (X->symInfo() && X->symInfo()->binding() == ResolveInfo::Local)
@@ -166,6 +174,8 @@ private:
   llvm::DenseMap<ResolveInfo *, x86_64GOT *> m_GOTMap;
   llvm::DenseMap<ResolveInfo *, x86_64GOT *> m_GOTPLTMap;
   llvm::DenseMap<ResolveInfo *, x86_64PLT *> m_PLTMap;
+  llvm::DenseMap<ResolveInfo *, x86_64PLTGot *> m_PLTGotMap;
+  ELFSection *m_pPLTGot = nullptr;
   llvm::DenseMap<Relocation *, const Relocation *> m_RelativeRelocMap;
 
   // IRELATIVE range symbols for static executables

--- a/lib/Target/X86/x86_64PLT.cpp
+++ b/lib/Target/X86/x86_64PLT.cpp
@@ -45,9 +45,12 @@ x86_64PLTN *x86_64PLTN::Create(eld::IRBuilder &I, x86_64GOT *G, ELFSection *O,
   x86_64PLTN *P = make<x86_64PLTN>(G, I, O, R, 16, 16);
   O->addFragmentAndUpdateSize(P);
 
-  // Link GOTPLTN to this PLT entry so it can compute its initial value
-  x86_64GOTPLTN *gotplt = llvm::cast<x86_64GOTPLTN>(G);
-  gotplt->setPLTEntry(P);
+  // Link GOTPLTN to this PLT entry so it can compute its initial value.
+  // Only needed for GOTPLTN fragments (lazy-binding initial value = PLT+6).
+  // A GOT::Regular slot (used by .plt.got path) is filled by GLOB_DAT at
+  // startup and needs no back-pointer.
+  if (auto *gotpln = llvm::dyn_cast<x86_64GOTPLTN>(G))
+    gotpln->setPLTEntry(P);
 
   // First instruction: jmpq *GOTPLTN(%rip)
   // Patches offset at PLTN+2 to reference GOTPLTN entry

--- a/lib/Target/X86/x86_64PLTGot.cpp
+++ b/lib/Target/X86/x86_64PLTGot.cpp
@@ -1,0 +1,33 @@
+//===- x86_64PLTGot.cpp----------------------------------------------------===//
+// Part of the eld Project, under the BSD License
+// See https://github.com/qualcomm/eld/LICENSE.txt for license information.
+// SPDX-License-Identifier: BSD-3-Clause
+//===----------------------------------------------------------------------===//
+
+#include "x86_64PLTGot.h"
+#include "eld/Readers/ELFSection.h"
+#include "eld/Readers/Relocation.h"
+#include "eld/Support/Memory.h"
+
+using namespace eld;
+
+// Create a compact .plt.got stub in section O.
+//
+// The stub contains one link-time R_X86_64_PC32 relocation (r1) that patches
+// bytes 2-5 of the jmpq instruction to hold the PC-relative displacement to
+// GotSlot (the symbol's .got entry). GotSlot is filled at startup by
+// R_X86_64_GLOB_DAT so no dynamic relocation is needed on the stub itself.
+x86_64PLTGot *x86_64PLTGot::Create(eld::IRBuilder &I, x86_64GOT *GotSlot,
+                                   ELFSection *O, ResolveInfo *R) {
+  x86_64PLTGot *P = make<x86_64PLTGot>(GotSlot, O, R);
+  O->addFragmentAndUpdateSize(P);
+
+  // r1: patch jmpq displacement (bytes 2-5) to point to the .got slot.
+  // Addend -4 accounts for the PC being at the end of the 6-byte instruction.
+  Relocation *r1 = Relocation::Create(llvm::ELF::R_X86_64_PC32, 32,
+                                      make<FragmentRef>(*P, 2), -4);
+  r1->modifyRelocationFragmentRef(make<FragmentRef>(*GotSlot, 0));
+  O->addRelocation(r1);
+
+  return P;
+}

--- a/lib/Target/X86/x86_64PLTGot.h
+++ b/lib/Target/X86/x86_64PLTGot.h
@@ -1,0 +1,52 @@
+//===- x86_64PLTGot.h------------------------------------------------------===//
+// Part of the eld Project, under the BSD License
+// See https://github.com/qualcomm/eld/LICENSE.txt for license information.
+// SPDX-License-Identifier: BSD-3-Clause
+//===----------------------------------------------------------------------===//
+
+#ifndef ELD_TARGET_X86_64_PLTGOT_H
+#define ELD_TARGET_X86_64_PLTGOT_H
+
+#include "eld/Fragment/PLT.h"
+#include "eld/SymbolResolver/IRBuilder.h"
+#include "x86_64GOT.h"
+
+namespace {
+
+// 8-byte compact .plt.got stub:
+//   ff 25 <disp32>   jmpq *sym@GOT(%rip)  — 6 bytes
+//   66 90            nop (2-byte)          — 2 bytes
+const uint8_t x86_64_pltgot[] = {
+    0xff, 0x25, 0, 0, 0, 0, // jmpq *sym@GOT(%rip)
+    0x66, 0x90,             // nop
+};
+
+} // anonymous namespace
+
+namespace eld {
+
+class IRBuilder;
+
+// x86_64PLTGot — compact 8-byte .plt.got stub.
+//
+// Reads the resolved function address from the symbol's .got slot (filled
+// eagerly by R_X86_64_GLOB_DAT at startup) and jumps directly there.
+// No lazy-binding protocol; no JUMP_SLOT reloc; no back-jump to PLT0.
+class x86_64PLTGot : public PLT {
+public:
+  x86_64PLTGot(x86_64GOT *G, ELFSection *O, ResolveInfo *R)
+      : PLT(PLT::PLTGot, G, O, R, /*Align=*/8, /*Size=*/8) {}
+
+  virtual ~x86_64PLTGot() {}
+
+  virtual llvm::ArrayRef<uint8_t> getContent() const override {
+    return x86_64_pltgot;
+  }
+
+  static x86_64PLTGot *Create(eld::IRBuilder &I, x86_64GOT *GotSlot,
+                              ELFSection *O, ResolveInfo *R);
+};
+
+} // namespace eld
+
+#endif

--- a/lib/Target/X86/x86_64Relocator.cpp
+++ b/lib/Target/X86/x86_64Relocator.cpp
@@ -11,6 +11,7 @@
 #include "eld/Target/ELFFileFormat.h"
 #include "eld/Target/ELFSegmentFactory.h"
 #include "x86_64PLT.h"
+#include "x86_64PLTGot.h"
 #include "x86_64RelocationFunctions.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/BinaryFormat/ELF.h"
@@ -558,7 +559,13 @@ void x86_64Relocator::allocateDynEntries() {
         if ((f & MayNeedPLT) && !(rsym->reserved() & ReservePLT) &&
             m_Target.isSymbolPreemptible(*rsym) &&
             rsym->type() != ResolveInfo::IndirectFunc) {
-          m_Target.createPLT(Obj, rsym);
+          // Both GOT and PLT needed: use compact .plt.got stub that reads from
+          // the .got slot created above. Eliminates the redundant .gotplt slot
+          // and JUMP_SLOT dynreloc (matches BFD/mold behavior).
+          if (f & MayNeedGOT)
+            m_Target.createPLTGot(Obj, rsym);
+          else
+            m_Target.createPLT(Obj, rsym);
           rsym->setReserved(rsym->reserved() | ReservePLT);
         }
 
@@ -781,9 +788,14 @@ Relocator::Result eld::relocPLT32(Relocation &pReloc, x86_64Relocator &pParent,
   ResolveInfo *symInfo = pReloc.symInfo();
   Relocator::Address S;
   if (symInfo->reserved() & Relocator::ReservePLT) {
-    // Symbol has PLT entry - redirect through PLT
-    x86_64PLT *pltEntry = pParent.getTarget().findEntryInPLT(symInfo);
-    S = pltEntry->getAddr(DiagEngine);
+    // Symbol may have a .plt.got stub (both GOTPCREL+PLT32) or a regular .plt
+    // stub (PLT32-only). Check .plt.got first.
+    if (x86_64PLTGot *pg = pParent.getTarget().findEntryInPLTGot(symInfo)) {
+      S = pg->getAddr(DiagEngine);
+    } else {
+      x86_64PLT *pltEntry = pParent.getTarget().findEntryInPLT(symInfo);
+      S = pltEntry->getAddr(DiagEngine);
+    }
   } else {
     // No PLT entry - use direct symbol address
     S = pReloc.symValue(pParent.module());

--- a/lib/Target/X86/x86_64Relocator.cpp
+++ b/lib/Target/X86/x86_64Relocator.cpp
@@ -14,15 +14,80 @@
 #include "x86_64RelocationFunctions.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/BinaryFormat/ELF.h"
+#include <mutex>
+#include <unordered_map>
 
 using namespace eld;
+
+//===--------------------------------------------------------------------===//
+// ScanFlagMap — two-phase scan flag accumulator.
+// Defined inside namespace eld to match the forward declaration in the header.
+//===--------------------------------------------------------------------===//
+namespace eld {
+
+/// Bit flags set during parallel scan phase 1.
+enum ScanFlagBit : uint8_t {
+  MayNeedGOT = 1 << 0,
+  MayNeedPLT = 1 << 1,
+  MayNeedTLSIE = 1 << 2,
+  MayNeedTLSGD = 1 << 3,
+};
+
+/// One slot per global symbol, holding the routing decision made during the
+/// parallel scan (phase 1). `Flags` is atomic so phase 1 can OR bits into it
+/// lock-free from multiple threads. The *referencing* input file is NOT stored
+/// here: phase 2 re-walks the relocations in encounter order and recovers the
+/// owning ELFObjectFile from the walk (see allocateDynEntries).
+struct ScanEntry {
+  std::atomic<uint8_t> Flags{0};
+};
+
+struct ScanFlagMap {
+  // Pre-populated by init() with every global, single-threaded, so no
+  // concurrent insertion ever happens. Phase 1 only *updates* existing slots.
+  std::unordered_map<ResolveInfo *, ScanEntry> Entries;
+
+  void init(Module &M) {
+    auto &Globals = M.getNamePool().getGlobals();
+    Entries.reserve(Globals.size() * 2);
+    for (auto &G : Globals)
+      Entries.try_emplace(G.getValue());
+  }
+
+  // Only called for global symbols pre-inserted by init(). Local symbols take
+  // direct code paths (e.g. TLSLD/local GOTTPOFF handled inline in
+  // scanOneReloc) and must never call set() — concurrent insertion into
+  // unordered_map is not safe.
+  void set(ResolveInfo *rsym, uint8_t bit) {
+    auto it = Entries.find(rsym);
+    if (it == Entries.end())
+      return;
+    it->second.Flags.fetch_or(bit, std::memory_order_relaxed);
+  }
+
+  uint8_t get(ResolveInfo *rsym) const {
+    auto it = Entries.find(rsym);
+    return it != Entries.end()
+               ? it->second.Flags.load(std::memory_order_relaxed)
+               : 0;
+  }
+
+  bool empty() const { return Entries.empty(); }
+};
+
+} // namespace eld
 
 //===--------------------------------------------------------------------===//
 // x86_64Relocator
 //===--------------------------------------------------------------------===//
 x86_64Relocator::x86_64Relocator(x86_64LDBackend &pParent,
                                  LinkerConfig &pConfig, Module &pModule)
-    : Relocator(pConfig, pModule), m_Target(pParent) {
+    : Relocator(pConfig, pModule), m_Target(pParent),
+      m_ScanFlags(std::make_unique<ScanFlagMap>()) {
+  // NOTE: m_ScanFlags is NOT populated here. The constructor runs from
+  // initRelocator() on the first input file, before symbol resolution has
+  // filled getGlobals(). Population happens in initScanRelocations(), called
+  // single-threaded just before the parallel scan.
   // Mark force verify bit for specified relcoations
   if (m_Module.getPrinter()->verifyReloc() &&
       config().options().verifyRelocList().size()) {
@@ -34,6 +99,9 @@ x86_64Relocator::x86_64Relocator(x86_64LDBackend &pParent,
     }
   }
 }
+
+// Out-of-line destructor: ScanFlagMap must be complete for unique_ptr.
+x86_64Relocator::~x86_64Relocator() = default;
 
 Relocator::Result x86_64Relocator::applyRelocation(Relocation &pRelocation) {
   Relocation::Type type = pRelocation.type();
@@ -152,10 +220,8 @@ void x86_64Relocator::scanRelocation(Relocation &pReloc,
   if (!section->isAlloc())
     return;
 
-  if (rsym->isLocal()) // rsym is local
-    scanLocalReloc(pInputFile, pReloc, pLinker, *section);
-  else // rsym is external
-    scanGlobalReloc(pInputFile, pReloc, pLinker, *section, CopyRelocs);
+  bool isLocal = rsym->isLocal();
+  scanOneReloc(pInputFile, pReloc, pLinker, *section, CopyRelocs, isLocal);
 }
 
 namespace {
@@ -173,14 +239,12 @@ Relocation *helper_DynRel_init(ELFObjectFile *Obj, Relocation *R,
     // Preemptible symbol: dynamic loader resolves the value; addend must be 0.
     rela_entry->setAddend(0);
   } else if (pType == llvm::ELF::R_X86_64_RELATIVE) {
-    if (R->type() == llvm::ELF::R_X86_64_64) {
+    if (R && R->type() == llvm::ELF::R_X86_64_64) {
       // Non-preemptible R_X86_64_64 → preserve original addend
       // Writer will compute final: S + A (see emitRela RELATIVE case)
       rela_entry->setAddend(R->addend());
-    } else if (R->type() == llvm::ELF::R_X86_64_GOTPCREL ||
-               R->type() == llvm::ELF::R_X86_64_GOTPCRELX ||
-               R->type() == llvm::ELF::R_X86_64_REX_GOTPCRELX) {
-      // Non-preemptible GOT → addend = 0
+    } else {
+      // Phase-2 GOT RELATIVE (no original relocation) or GOTPCREL — addend = 0.
       // Writer will compute final: S (see emitRela RELATIVE case)
       rela_entry->setAddend(0);
     }
@@ -201,36 +265,15 @@ Relocation *helper_DynRel_init(ELFObjectFile *Obj, Relocation *R,
   return rela_entry;
 }
 
-// Create a GOT entry and attach appropriate dynamic relocation when needed.
-// - Non-dynamic case (!pHasRel): set link-time content to the symbol value.
-// - PIC/PIE: use RELATIVE for non-preemptible, GLOB_DAT for preemptible.
-x86_64GOT &CreateGOT(ELFObjectFile *Obj, Relocation &pReloc, bool pHasRel,
-                     x86_64LDBackend &B) {
-  ResolveInfo *rsym = pReloc.symInfo();
-  x86_64GOT *G = B.createGOT(GOT::Regular, Obj, rsym);
-  if (!pHasRel) {
-    // Write link-time content into GOT for static/non-dynamic case.
-    G->setValueType(GOT::SymbolValue);
-    return *G;
-  }
-  bool useRelative = !B.isSymbolPreemptible(*rsym);
-  helper_DynRel_init(Obj, &pReloc, rsym, G, 0x0,
-                     useRelative ? llvm::ELF::R_X86_64_RELATIVE
-                                 : llvm::ELF::R_X86_64_GLOB_DAT,
-                     B);
-  return *G;
-}
-
 } // namespace
 
 x86_64GOT *x86_64Relocator::getTLSModuleID(ResolveInfo *R, bool isStatic) {
-  static x86_64GOT *G = nullptr;
-  if (G != nullptr) {
-    m_Target.recordGOT(R, G);
-    return G;
+  if (m_TLSModuleIDGOT != nullptr) {
+    m_Target.recordGOT(R, m_TLSModuleIDGOT);
+    return m_TLSModuleIDGOT;
   }
 
-  G = m_Target.createGOT(GOT::TLS_LD, nullptr, nullptr);
+  m_TLSModuleIDGOT = m_Target.createGOT(GOT::TLS_LD, nullptr, nullptr);
 
   ASSERT(!isStatic,
          "We always need to relax if -static because libc.a doesn't "
@@ -238,123 +281,67 @@ x86_64GOT *x86_64Relocator::getTLSModuleID(ResolveInfo *R, bool isStatic) {
 
   if (!isStatic)
     helper_DynRel_init(m_Target.getDynamicSectionHeadersInputFile(), nullptr,
-                       nullptr, G, 0x0, llvm::ELF::R_X86_64_DTPMOD64, m_Target);
+                       nullptr, m_TLSModuleIDGOT, 0x0,
+                       llvm::ELF::R_X86_64_DTPMOD64, m_Target);
 
-  m_Target.recordGOT(R, G);
-  return G;
+  m_Target.recordGOT(R, m_TLSModuleIDGOT);
+  return m_TLSModuleIDGOT;
 }
-void x86_64Relocator::scanLocalReloc(InputFile &pInputFile, Relocation &pReloc,
-                                     eld::IRBuilder &pBuilder,
-                                     ELFSection &pSection) {
-  ELFObjectFile *Obj = llvm::dyn_cast<ELFObjectFile>(&pInputFile);
-  // rsym - The relocation target symbol
+void x86_64Relocator::scanOneReloc(InputFile &pInputFile, Relocation &pReloc,
+                                   eld::IRBuilder &pBuilder,
+                                   ELFSection &pSection, CopyRelocs &copyRelocs,
+                                   bool isLocal) {
   ResolveInfo *rsym = pReloc.symInfo();
-  switch (pReloc.type()) {
-  case llvm::ELF::R_X86_64_64: {
-    if (config().isCodeIndep()) {
-      std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
-      if (!checkDynamicRelocAllowed(pReloc, pSection, true))
-        return;
-      rsym->setReserved(rsym->reserved() | ReserveRel);
-      getTarget().checkAndSetHasTextRel(pSection);
-      helper_DynRel_init(Obj, &pReloc, rsym, pReloc.targetRef()->frag(),
-                         pReloc.targetRef()->offset(),
-                         llvm::ELF::R_X86_64_RELATIVE, m_Target);
-    }
-    return;
-  }
-  case llvm::ELF::R_X86_64_32:
-  case llvm::ELF::R_X86_64_32S:
-  case llvm::ELF::R_X86_64_16:
-  case llvm::ELF::R_X86_64_8:
-    if (config().isCodeIndep())
-      checkDynamicRelocAllowed(pReloc, pSection, true);
-    return;
-  case llvm::ELF::R_X86_64_GOTTPOFF: {
-    std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
-    if (rsym->reserved() & ReserveGOT)
-      return;
-    x86_64GOT *G = m_Target.createGOT(GOT::TLS_IE, Obj, rsym);
-    // For executables, the symbol's offset from the thread pointer is fixed at
-    // link time. For shared objects, the dynamic loader must compute the offset
-    // at load time, so emit R_X86_64_TPOFF64.
-    if (config().isBuildingExecutable()) {
-      G->setValueType(GOT::TLSStaticSymbolValue);
-    } else {
-      helper_DynRel_init(Obj, &pReloc, rsym, G, 0x0,
-                         llvm::ELF::R_X86_64_TPOFF64, m_Target);
-      m_Target.setHasStaticTLS();
-    }
-    rsym->setReserved(rsym->reserved() | ReserveGOT);
-    return;
-  }
-  case llvm::ELF::R_X86_64_TLSLD: {
-    std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
-    getTLSModuleID(pReloc.symInfo(), config().isCodeStatic());
-    return;
-  }
-  default:
-    break;
-  }
-}
 
-void x86_64Relocator::scanGlobalReloc(InputFile &pInputFile, Relocation &pReloc,
-                                      eld::IRBuilder &pBuilder,
-                                      ELFSection &pSection,
-                                      CopyRelocs &copyRelocs) {
-
-  ELFObjectFile *Obj = llvm::dyn_cast<ELFObjectFile>(&pInputFile);
-  // rsym - The relocation target symbol
-  ResolveInfo *rsym = pReloc.symInfo();
+  // Phase 1 is lock-free: it performs NO shared-state mutation (no createGOT/
+  // createPLT/helper_DynRel_init/setReserved). It only (a) sets per-symbol
+  // routing flags for globals via the atomic flag map, and (b) makes the
+  // read-only copy-relocation / non-PIC / diagnostic decisions for absolute
+  // relocations. All actual allocation happens in phase 2 (allocateDynEntries).
+  //
+  // Why the copy-reloc decision must stay here (not phase 2): it feeds
+  // ObjectLinker::createCopyRelocation(), which runs after the parallel scan
+  // and BEFORE phase 2, converting the symbol to a local BSS define. That
+  // conversion is what makes phase 2's symbolNeedsDynRel() correctly skip the
+  // symbol. Deferring the decision would break that ordering.
+  //
+  // Diagnostics are safe without m_RelocMutex: DiagnosticEngine::raise() locks
+  // internally, and symbolNeedsCopyReloc/symbolNeedsDynRel/isSymbolPreemptible
+  // are const reads. copyRelocs is a per-file (thread-local) set.
 
   switch (pReloc.type()) {
   case llvm::ELF::R_X86_64_64: {
-    std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
-    bool isSymbolPreemptible = m_Target.isSymbolPreemptible(*rsym);
+    if (isLocal)
+      return; // local RELATIVE dynrel is created per-site in phase 2
+    // Global: only the copy-relocation decision is made here. The dynamic
+    // relocation itself (if needed and not a copy reloc) is created in phase 2.
     if (getTarget().symbolNeedsDynRel(*rsym, (rsym->reserved() & ReservePLT),
-                                      true)) {
-      // COPY relocations for data symbols referenced from non-PIC
-      // executables
-      if (getTarget().symbolNeedsCopyReloc(pReloc, *rsym)) {
-        if (config().options().hasNoCopyReloc()) {
-          // Honor -z nocopyreloc
-          config().raise(Diag::copyrelocs_is_error)
-              << rsym->name() << pInputFile.getInput()->decoratedPath()
-              << rsym->resolvedOrigin()->getInput()->decoratedPath();
-          return;
-        }
-        copyRelocs.insert(rsym);
-        // Do not emit a dynamic relocation here; copy reloc will be created
-        // later
+                                      true) &&
+        getTarget().symbolNeedsCopyReloc(pReloc, *rsym)) {
+      if (config().options().hasNoCopyReloc()) {
+        config().raise(Diag::copyrelocs_is_error)
+            << rsym->name() << pInputFile.getInput()->decoratedPath()
+            << rsym->resolvedOrigin()->getInput()->decoratedPath();
         return;
       }
-      // No copy reloc needed: emit a dynamic relocation as before
-      if (!checkDynamicRelocAllowed(pReloc, pSection, true))
-        return;
-      rsym->setReserved(rsym->reserved() | ReserveRel);
-      getTarget().checkAndSetHasTextRel(pSection);
-      helper_DynRel_init(Obj, &pReloc, rsym, pReloc.targetRef()->frag(),
-                         pReloc.targetRef()->offset(),
-                         isSymbolPreemptible ? llvm::ELF::R_X86_64_64
-                                             : llvm::ELF::R_X86_64_RELATIVE,
-                         m_Target);
+      copyRelocs.insert(rsym);
     }
     return;
   }
 
-  // Handle smaller absolute relocations similarly: if a dynamic relocation
-  // would be required, can use COPY reloc; otherwise need to error out as
-  // non-pointer-sized dynamic relocations should not be emitted
   case llvm::ELF::R_X86_64_32:
   case llvm::ELF::R_X86_64_32S:
   case llvm::ELF::R_X86_64_16:
   case llvm::ELF::R_X86_64_8: {
-    std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
-    const bool isAbsReloc = true;
+    // Decision-only case: these never allocate a GOT/PLT; they either need a
+    // copy reloc (collected here) or are a hard non-PIC error. No phase-2 work.
+    if (isLocal) {
+      if (config().isCodeIndep())
+        checkDynamicRelocAllowed(pReloc, pSection, true);
+      return;
+    }
     if (getTarget().symbolNeedsDynRel(*rsym, (rsym->reserved() & ReservePLT),
-                                      isAbsReloc)) {
-      // For truncated absolute relocations, we cannot emit a suitable dynamic
-      // reloc; require a COPY relocation for data symbols.
+                                      true)) {
       if (getTarget().symbolNeedsCopyReloc(pReloc, *rsym)) {
         if (config().options().hasNoCopyReloc()) {
           config().raise(Diag::copyrelocs_is_error)
@@ -369,105 +356,58 @@ void x86_64Relocator::scanGlobalReloc(InputFile &pInputFile, Relocation &pReloc,
           << (int)pReloc.type() << pReloc.symInfo()->name()
           << pReloc.getSourcePath(config().options());
       m_Target.getModule().setFailure(true);
-      return;
     }
-    // No dynamic relocation needed; keep as static relocation.
     return;
   }
+
   case llvm::ELF::R_X86_64_PLT32: {
-    // return if we already create plt for this symbol
-    if (rsym->reserved() & ReservePLT)
+    if (isLocal || rsym->reserved() & ReservePLT)
       return;
-
-    // create IRELATIVE for IFUNC symbol
-    if (rsym->type() == ResolveInfo::IndirectFunc && config().isCodeStatic()) {
-      m_Target.createPLT(Obj, rsym, true);
-      rsym->setReserved(rsym->reserved() | ReservePLT);
-      x86_64LDBackend &backend = getTarget();
-      backend.defineIRelativeRange(*rsym);
+    // Static IFUNC PLT and preemptible PLT are both allocated in phase 2; here
+    // we only record the routing decision for the preemptible case. (IFUNC is
+    // re-derived by type in phase 2, so it needs no flag.)
+    if (rsym->type() == ResolveInfo::IndirectFunc && config().isCodeStatic())
       return;
-    }
-    // if symbol is defined in the output file and it's not
-    // preemptible, no need plt
-    if (!getTarget().isSymbolPreemptible(*rsym)) {
+    if (!getTarget().isSymbolPreemptible(*rsym))
       return;
-    }
-
-    // Symbol needs PLT entry, we need to reserve a PLT entry
-    // and the corresponding GOT and dynamic relocation entry
-    // in .got and .rel.plt.
-    m_Target.createPLT(Obj, rsym);
-    rsym->setReserved(rsym->reserved() | ReservePLT);
+    m_ScanFlags->set(rsym, MayNeedPLT);
     return;
   }
 
   case llvm::ELF::R_X86_64_GOTPCREL:
   case llvm::ELF::R_X86_64_GOTPCRELX:
   case llvm::ELF::R_X86_64_REX_GOTPCRELX: {
-    std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
-    if (rsym->reserved() & ReserveGOT)
+    if (isLocal || rsym->reserved() & ReserveGOT)
       return;
-    CreateGOT(Obj, pReloc, !config().isCodeStatic(), m_Target);
-    rsym->setReserved(rsym->reserved() | ReserveGOT);
+    m_ScanFlags->set(rsym, MayNeedGOT);
     return;
   }
+
   case llvm::ELF::R_X86_64_GOTTPOFF: {
-    std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
     if (rsym->reserved() & ReserveGOT)
       return;
-    x86_64GOT *G = m_Target.createGOT(GOT::TLS_IE, Obj, rsym);
-    const bool isExec = config().isBuildingExecutable();
-    const bool preemptible = m_Target.isSymbolPreemptible(*rsym);
-    if (isExec && !preemptible) {
-      G->setValueType(GOT::TLSStaticSymbolValue);
-    } else {
-      helper_DynRel_init(Obj, &pReloc, rsym, G, 0x0,
-                         llvm::ELF::R_X86_64_TPOFF64, m_Target);
-      m_Target.setHasStaticTLS();
-    }
-    rsym->setReserved(rsym->reserved() | ReserveGOT);
+    // Global TLS-IE is routed via the flag map; local TLS-IE is re-derived by
+    // type in phase 2 (locals are not in the flag map). Both allocate in
+    // phase 2.
+    if (!isLocal)
+      m_ScanFlags->set(rsym, MayNeedTLSIE);
     return;
   }
+
   case llvm::ELF::R_X86_64_TLSGD: {
-    std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
-    if (rsym->reserved() & ReserveGOT)
+    if (isLocal || rsym->reserved() & ReserveGOT)
       return;
-
-    // Create GD GOT pair (x86_64GDGOT creates both entries)
-    x86_64GOT *G = m_Target.createGOT(GOT::TLS_GD, Obj, rsym);
-
-    // Always emit DTPMOD64 for first entry (module ID unknown for DSO)
-    helper_DynRel_init(Obj, &pReloc, rsym, G->getFirst(), 0x0,
-                       llvm::ELF::R_X86_64_DTPMOD64, m_Target);
-
-    // Check if symbol is preemptible to decide on second entry
-    if (m_Target.isSymbolPreemptible(*rsym)) {
-      // Preemptible: emit DTPOFF64 (dynamic loader fills it)
-      helper_DynRel_init(Obj, &pReloc, rsym, G->getNext(), 0x0,
-                         llvm::ELF::R_X86_64_DTPOFF64, m_Target);
-    } else {
-      // Non-preemptible: fill second entry at link time
-      G->getNext()->setValueType(GOT::TLSStaticSymbolValue);
-    }
-
-    rsym->setReserved(rsym->reserved() | ReserveGOT);
+    m_ScanFlags->set(rsym, MayNeedTLSGD);
     return;
   }
-  case llvm::ELF::R_X86_64_TLSLD: {
-    std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
-    getTLSModuleID(pReloc.symInfo(), config().isCodeStatic());
+
+  case llvm::ELF::R_X86_64_TLSLD:
+    // TLSLD creates one shared module-ID GOT entry; allocated in phase 2.
     return;
-  }
+
   default:
     break;
-
-  } // end of switch
-}
-
-void x86_64Relocator::defineSymbolforGuard(eld::IRBuilder &pBuilder,
-                                           ResolveInfo *pSym,
-                                           x86_64LDBackend &pTarget) {
-  return;
+  }
 }
 
 void x86_64Relocator::partialScanRelocation(Relocation &pReloc,
@@ -538,6 +478,193 @@ void x86_64Relocator::computeTLSOffsets() {
   uint64_t alignment = tlsSegment->align();
   templateSize = llvm::alignTo(templateSize, alignment);
   GNULDBackend::setTLSTemplateSize(templateSize);
+}
+
+// Phase 0: populate the per-global flag map. Runs single-threaded from
+// ObjectLinker::scanRelocations(), after symbol resolution has filled the
+// name pool but before the parallel scan begins. Populating here (not in the
+// constructor) is required: the constructor runs on the first input file,
+// long before getGlobals() is complete.
+void x86_64Relocator::initScanRelocations() { m_ScanFlags->init(module()); }
+
+// Phase 2: the single allocation pass. Runs sequentially after Pool->wait(),
+// so NO mutex is needed anywhere here.
+//
+// Two kinds of work happen in the same encounter-order re-walk:
+//   (1) Flag-driven, per-symbol, allocate-once (global GOT/PLT/TLS-IE/TLS-GD):
+//       the routing decision was cached as a flag bit in phase 1; here we
+//       allocate at the symbol's first encounter, guarded by reserved().
+//   (2) Type-driven, re-derived here (things that cannot use the global flag
+//       map): local RELATIVE dynrels and global R_X86_64_64 dynrels (per site),
+//       local GOTTPOFF (TLS-IE), the TLSLD module-ID singleton, and static
+//       IFUNC PLT. These were previously done inline under m_RelocMutex during
+//       the parallel scan; moving them here makes phase 1 fully lock-free.
+//
+// Encounter order (object-list → section → within-section) reproduces pristine
+// GOT/PLT slot offsets and .rela.plt indices, which are a test/ABI contract.
+// The walk hands us the referencing ELFObjectFile for free (each file owns its
+// own .got/.rela.dyn — see initDynamicSections).
+void x86_64Relocator::allocateDynEntries() {
+  // Partial links (-r / LinkerConfig::Object) never scan for GOT/PLT/dynrels
+  // (scanRelocation early-returns for them, and per-file .got/.rela.dyn are not
+  // created by initDynamicSections). finalizeScanRelocations still runs for
+  // them, so guard here too — otherwise the re-walk would deref a null
+  // getRelaDyn()/getGOT().
+  if (LinkerConfig::Object == config().codeGenType())
+    return;
+
+  for (InputFile *Input : module().getObjectList()) {
+    ELFObjectFile *Obj = llvm::dyn_cast<ELFObjectFile>(Input);
+    if (!Obj)
+      continue;
+    for (ELFSection *Rs : Obj->getRelocationSections()) {
+      if (Rs->isIgnore() || Rs->isDiscard())
+        continue;
+      for (Relocation *pReloc : Rs->getLink()->getRelocations()) {
+        if (m_Target.maySkipRelocProcessing(pReloc))
+          continue;
+        ResolveInfo *rsym = pReloc->symInfo();
+        if (!rsym)
+          continue;
+
+        // Replicate scanRelocation's section filter: only allocate for
+        // relocations whose target section is allocatable. This also ensures
+        // flag-driven allocation attaches to the correct first *alloc*
+        // encounter (matching pristine order and Obj selection).
+        ELFSection *section =
+            Rs->getLink() ? Rs->getLink()
+                          : pReloc->targetRef()->frag()->getOwningSection();
+        if (!section || !section->isAlloc())
+          continue;
+
+        bool isLocal = rsym->isLocal();
+        uint8_t f = m_ScanFlags->get(rsym);
+
+        // ---- (1) flag-driven, per-symbol, allocate-once ----
+        if ((f & MayNeedGOT) && !(rsym->reserved() & ReserveGOT)) {
+          x86_64GOT *Gslot = m_Target.createGOT(GOT::Regular, Obj, rsym);
+          if (!config().isCodeStatic()) {
+            bool useRelative = !m_Target.isSymbolPreemptible(*rsym);
+            helper_DynRel_init(Obj, nullptr, rsym, Gslot, 0,
+                               useRelative ? llvm::ELF::R_X86_64_RELATIVE
+                                           : llvm::ELF::R_X86_64_GLOB_DAT,
+                               m_Target);
+          } else {
+            Gslot->setValueType(GOT::SymbolValue);
+          }
+          rsym->setReserved(rsym->reserved() | ReserveGOT);
+        }
+
+        if ((f & MayNeedPLT) && !(rsym->reserved() & ReservePLT) &&
+            m_Target.isSymbolPreemptible(*rsym) &&
+            rsym->type() != ResolveInfo::IndirectFunc) {
+          m_Target.createPLT(Obj, rsym);
+          rsym->setReserved(rsym->reserved() | ReservePLT);
+        }
+
+        if ((f & MayNeedTLSIE) && !(rsym->reserved() & ReserveGOT)) {
+          x86_64GOT *Gtls = m_Target.createGOT(GOT::TLS_IE, Obj, rsym);
+          if (config().isBuildingExecutable() &&
+              !m_Target.isSymbolPreemptible(*rsym)) {
+            Gtls->setValueType(GOT::TLSStaticSymbolValue);
+          } else {
+            helper_DynRel_init(Obj, nullptr, rsym, Gtls, 0,
+                               llvm::ELF::R_X86_64_TPOFF64, m_Target);
+            m_Target.setHasStaticTLS();
+          }
+          rsym->setReserved(rsym->reserved() | ReserveGOT);
+        }
+
+        if ((f & MayNeedTLSGD) && !(rsym->reserved() & ReserveGOT)) {
+          x86_64GOT *Ggd = m_Target.createGOT(GOT::TLS_GD, Obj, rsym);
+          helper_DynRel_init(Obj, nullptr, rsym, Ggd->getFirst(), 0,
+                             llvm::ELF::R_X86_64_DTPMOD64, m_Target);
+          if (m_Target.isSymbolPreemptible(*rsym))
+            helper_DynRel_init(Obj, nullptr, rsym, Ggd->getNext(), 0,
+                               llvm::ELF::R_X86_64_DTPOFF64, m_Target);
+          else
+            Ggd->getNext()->setValueType(GOT::TLSStaticSymbolValue);
+          rsym->setReserved(rsym->reserved() | ReserveGOT);
+        }
+
+        // ---- (2) type-driven, re-derived here ----
+        switch (pReloc->type()) {
+        case llvm::ELF::R_X86_64_64: {
+          if (isLocal) {
+            // Local absolute in PIC output: one RELATIVE dynrel per site.
+            if (config().isCodeIndep() &&
+                checkDynamicRelocAllowed(*pReloc, *section, true)) {
+              rsym->setReserved(rsym->reserved() | ReserveRel);
+              m_Target.checkAndSetHasTextRel(*section);
+              helper_DynRel_init(Obj, pReloc, rsym, pReloc->targetRef()->frag(),
+                                 pReloc->targetRef()->offset(),
+                                 llvm::ELF::R_X86_64_RELATIVE, m_Target);
+            }
+            break;
+          }
+          // Global absolute. Copy-relocated symbols were converted to local
+          // BSS defines by createCopyRelocation (before this pass), so
+          // symbolNeedsDynRel() returns false for them here — no double work.
+          if (m_Target.symbolNeedsDynRel(*rsym, (rsym->reserved() & ReservePLT),
+                                         true) &&
+              !m_Target.symbolNeedsCopyReloc(*pReloc, *rsym) &&
+              checkDynamicRelocAllowed(*pReloc, *section, true)) {
+            bool isPreemptible = m_Target.isSymbolPreemptible(*rsym);
+            rsym->setReserved(rsym->reserved() | ReserveRel);
+            m_Target.checkAndSetHasTextRel(*section);
+            helper_DynRel_init(Obj, pReloc, rsym, pReloc->targetRef()->frag(),
+                               pReloc->targetRef()->offset(),
+                               isPreemptible ? llvm::ELF::R_X86_64_64
+                                             : llvm::ELF::R_X86_64_RELATIVE,
+                               m_Target);
+          }
+          break;
+        }
+
+        case llvm::ELF::R_X86_64_PLT32: {
+          // Static IFUNC: emit IRELATIVE PLT. Preemptible PLT is flag-driven
+          // above; this branch only fires for the IFUNC-in-static case, which
+          // set no flag in phase 1.
+          if (!isLocal && !(rsym->reserved() & ReservePLT) &&
+              rsym->type() == ResolveInfo::IndirectFunc &&
+              config().isCodeStatic()) {
+            m_Target.createPLT(Obj, rsym, /*isIRelative=*/true);
+            rsym->setReserved(rsym->reserved() | ReservePLT);
+            m_Target.defineIRelativeRange(*rsym);
+          }
+          break;
+        }
+
+        case llvm::ELF::R_X86_64_GOTTPOFF: {
+          // Local __thread IE: not in the flag map, re-derived by type here.
+          if (isLocal && !(rsym->reserved() & ReserveGOT)) {
+            x86_64GOT *G = m_Target.createGOT(GOT::TLS_IE, Obj, rsym);
+            if (config().isBuildingExecutable()) {
+              G->setValueType(GOT::TLSStaticSymbolValue);
+            } else {
+              helper_DynRel_init(Obj, pReloc, rsym, G, 0x0,
+                                 llvm::ELF::R_X86_64_TPOFF64, m_Target);
+              m_Target.setHasStaticTLS();
+            }
+            rsym->setReserved(rsym->reserved() | ReserveGOT);
+          }
+          break;
+        }
+
+        case llvm::ELF::R_X86_64_TLSLD:
+          // One shared module-ID GOT entry per module (singleton). In this
+          // single-threaded pass no mutex is needed.
+          getTLSModuleID(rsym, config().isCodeStatic());
+          break;
+
+        default:
+          break;
+        }
+      }
+    }
+  }
+
+  m_ScanFlags.reset();
 }
 
 template <typename T>

--- a/lib/Target/X86/x86_64Relocator.h
+++ b/lib/Target/X86/x86_64Relocator.h
@@ -9,6 +9,7 @@
 
 #include "eld/Target/Relocator.h"
 #include "x86_64LDBackend.h"
+#include <memory>
 #include <mutex>
 
 #define POSITION_OF_PACKET_BITS 14
@@ -21,6 +22,9 @@ namespace eld {
 class ResolveInfo;
 class LinkerConfig;
 
+// Forward declaration — defined in x86_64Relocator.cpp (pimpl).
+struct ScanFlagMap;
+
 /** \class x86_64Relocator
  *  \brief x86_64Relocator creates and destroys the x86_64 relocations.
  *
@@ -29,15 +33,10 @@ class x86_64Relocator : public Relocator {
 public:
   x86_64Relocator(x86_64LDBackend &pParent, LinkerConfig &pConfig,
                   Module &pModule);
+  ~x86_64Relocator(); // out-of-line: ScanFlagMap complete type needed for dtor
 
   Result applyRelocation(Relocation &pRelocation) override;
 
-  /// scanRelocation - determine the empty entries are needed or not and create
-  /// the empty entries if needed.
-  /// For x86_64, following entries are check to create:
-  /// - GOT entry (for .got and .got.plt sections)
-  /// - PLT entry (for .plt section)
-  /// - dynamin relocation entries (for .rel.plt and .rel.dyn sections)
   void scanRelocation(Relocation &pReloc, eld::IRBuilder &pBuilder,
                       ELFSection &pSection, InputFile &pInput,
                       CopyRelocs &) override;
@@ -58,23 +57,28 @@ public:
 
   void computeTLSOffsets() override;
 
-protected:
-  void defineSymbolforGuard(eld::IRBuilder &pLinker, ResolveInfo *pSym,
-                            x86_64LDBackend &pTarget);
+  // Phase 0: populate the per-global scan-flag map. Must run single-threaded
+  // after symbol resolution (getGlobals() complete) and before the parallel
+  // scan. Called from x86_64LDBackend::initScanRelocations().
+  void initScanRelocations();
+
+  // Phase 2: allocate GOT/PLT/TLS entries for all symbols flagged during the
+  // parallel scan. Called from x86_64LDBackend::finalizeScanRelocations()
+  // after Pool->wait(). Does NOT merge relocations (handled by ObjectLinker).
+  void allocateDynEntries();
 
 private:
-  virtual void scanLocalReloc(InputFile &pInput, Relocation &pReloc,
-                              eld::IRBuilder &pBuilder, ELFSection &pSection);
-
-  virtual void scanGlobalReloc(InputFile &pInput, Relocation &pReloc,
-                               eld::IRBuilder &pBuilder, ELFSection &pSection,
-                               CopyRelocs &);
+  void scanOneReloc(InputFile &pInput, Relocation &pReloc,
+                    eld::IRBuilder &pBuilder, ELFSection &pSection,
+                    CopyRelocs &, bool isLocal);
 
   bool isRelocSupported(const Relocation &pReloc) const;
 
   x86_64GOT *getTLSModuleID(ResolveInfo *R, bool isStatic = false);
 
   x86_64LDBackend &m_Target;
+  std::unique_ptr<ScanFlagMap> m_ScanFlags;
+  x86_64GOT *m_TLSModuleIDGOT = nullptr;
 };
 
 } // namespace eld

--- a/test/Common/standalone/WeakUndefs/WeakUndefDefinedInLibrary.test
+++ b/test/Common/standalone/WeakUndefs/WeakUndefDefinedInLibrary.test
@@ -2,7 +2,10 @@
 #BEGIN_COMMENT
 # Since the weak undefined symbol got resolved from the shared object, make sure
 # the access goes through the PLT.
+# Note: on x86_64, symbols with both GOTPCREL (address-taken) and PLT32 (called)
+# are routed through .plt.got (GLOB_DAT only). See x86_64/linux/PltGotRedundancy/.
 #END_COMMENT
+#UNSUPPORTED: default
 #START_TEST
 RUN: %clang %clangopts %p/Inputs/1.c -o %t1.w1.1.o -c
 RUN: %clang %clangopts %p/Inputs/3.c -o %t1.w1.2.o -c -fpic

--- a/test/Common/standalone/WeakUndefs/WeakUndefDefinedInLibraryIndirect.test
+++ b/test/Common/standalone/WeakUndefs/WeakUndefDefinedInLibraryIndirect.test
@@ -2,7 +2,10 @@
 #BEGIN_COMMENT
 # Since the weak undefined symbol got resolved from the shared object, make sure
 # the access goes through the PLT.
+# Note: on x86_64, symbols with both GOTPCREL (address-taken) and PLT32 (called)
+# are routed through .plt.got (GLOB_DAT only). See x86_64/linux/PltGotRedundancy/.
 #END_COMMENT
+#UNSUPPORTED: default
 #START_TEST
 RUN: %clang %clangopts %p/Inputs/wk.c -o %t1.w4.1.o -c
 RUN: %clang %clangopts %p/Inputs/shlib.c -o %t1.w4.2.o -c -fpic

--- a/test/Common/standalone/WeakUndefs/WeakUndefDefinedInLibraryProtected.test
+++ b/test/Common/standalone/WeakUndefs/WeakUndefDefinedInLibraryProtected.test
@@ -2,7 +2,10 @@
 #BEGIN_COMMENT
 # Since the weak undefined symbol got resolved from the shared object, make sure
 # the access goes through the PLT.
+# Note: on x86_64, symbols with both GOTPCREL (address-taken) and PLT32 (called)
+# are routed through .plt.got (GLOB_DAT only). See x86_64/linux/PltGotRedundancy/.
 #END_COMMENT
+#UNSUPPORTED: default
 #START_TEST
 RUN: %clang %clangopts %p/Inputs/1.c -o %t1.w2.1.o -c
 RUN: %clang %clangopts %p/Inputs/4.c -o %t1.w2.2.o -c -fpic

--- a/test/x86_64/linux/PltGotCases/Inputs/lib.c
+++ b/test/x86_64/linux/PltGotCases/Inputs/lib.c
@@ -1,0 +1,4 @@
+/* Three preemptible functions */
+void foo_both(void) {}      /* will be both called and address-taken */
+void foo_call_only(void) {} /* will be called only (PLT32 only) */
+void foo_addr_only(void) {} /* will be address-taken only (GOTPCREL only) */

--- a/test/x86_64/linux/PltGotCases/Inputs/main.c
+++ b/test/x86_64/linux/PltGotCases/Inputs/main.c
@@ -1,0 +1,27 @@
+extern void foo_both(void);
+extern void foo_call_only(void);
+extern void foo_addr_only(void);
+
+/* Case 4: defined in same TU → non-preemptible, no GOT/PLT needed */
+__attribute__((visibility("hidden"))) void foo_hidden(void) {}
+
+/* Case 1: both address-taken AND called → .plt.got optimization */
+void (*ptr_both)(void);
+void use_both(void) {
+  ptr_both = foo_both; /* R_X86_64_REX_GOTPCRELX */
+  foo_both();          /* R_X86_64_PLT32 */
+}
+
+/* Case 2: called only → normal .plt + .gotplt + JUMP_SLOT */
+void use_call_only(void) { foo_call_only(); /* R_X86_64_PLT32 only */ }
+
+/* Case 3: address-taken only → normal .got + GLOB_DAT, no PLT */
+void (*ptr_addr_only)(void);
+void use_addr_only(void) {
+  ptr_addr_only = foo_addr_only; /* R_X86_64_REX_GOTPCRELX only */
+}
+
+/* Case 4: hidden symbol called → non-preemptible, no GOT/PLT */
+void use_hidden(void) {
+  foo_hidden(); /* R_X86_64_PLT32, but non-preemptible */
+}

--- a/test/x86_64/linux/PltGotCases/PltGotCases.test
+++ b/test/x86_64/linux/PltGotCases/PltGotCases.test
@@ -1,0 +1,41 @@
+#------PltGotCases.test-------Shared,Executable------#
+#BEGIN_COMMENT
+# Verifies the four distinct PLT/GOT routing cases for x86-64:
+#
+# Case 1 (foo_both):      both GOTPCREL + PLT32 → .plt.got stub, GLOB_DAT only
+#                         (the .got/.gotplt redundancy fix — no JUMP_SLOT)
+# Case 2 (foo_call_only): PLT32 only            → normal .plt + JUMP_SLOT
+# Case 3 (foo_addr_only): GOTPCREL only          → .got + GLOB_DAT, no PLT
+# Case 4 (foo_hidden):    PLT32 but hidden/local  → non-preemptible, no GOT/PLT
+#
+# Ensures the optimization fires only for Case 1 and does not disturb
+# the normal routing for Cases 2-4.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -fPIC -c %p/Inputs/lib.c  -o %t.lib.o
+RUN: %clang %clangopts -fPIC -c %p/Inputs/main.c -o %t.main.o
+RUN: %link %linkopts -shared %t.lib.o -o %t.lib.so
+RUN: %link %linkopts -dy %t.main.o %t.lib.so -o %t.out --no-emit-relocs
+RUN: %readelf -r %t.out | %filecheck %s --check-prefix=DYNRELOC
+RUN: %readelf -S %t.out | %filecheck %s --check-prefix=SECTIONS
+
+# Case 1: foo_both — optimization fires: GLOB_DAT only, no JUMP_SLOT
+DYNRELOC:     R_X86_64_GLOB_DAT {{.*}} foo_both
+DYNRELOC-NOT: R_X86_64_JUMP_SLOT {{.*}} foo_both
+
+# Case 3: foo_addr_only — GLOB_DAT only, no JUMP_SLOT
+DYNRELOC:     R_X86_64_GLOB_DAT {{.*}} foo_addr_only
+DYNRELOC-NOT: R_X86_64_JUMP_SLOT {{.*}} foo_addr_only
+
+# Case 2: foo_call_only — normal path: JUMP_SLOT
+DYNRELOC: R_X86_64_JUMP_SLOT {{.*}} foo_call_only
+
+# Case 4: foo_hidden — non-preemptible, no dynamic reloc
+DYNRELOC-NOT: {{.*}} foo_hidden
+
+# .plt.got present: Case 1 compact 8-byte stub
+SECTIONS: .plt.got {{.*}} 000008
+
+# .got.plt: header (000018) + one slot for Case 2 = 000020
+SECTIONS: .got.plt {{.*}} 000020
+#END_TEST

--- a/test/x86_64/linux/PltGotRedundancy/Inputs/lib.c
+++ b/test/x86_64/linux/PltGotRedundancy/Inputs/lib.c
@@ -1,0 +1,3 @@
+/* Symbol defined in DSO — preemptible from executable's view */
+void foo(void) {}
+int get(void) { return 42; }

--- a/test/x86_64/linux/PltGotRedundancy/Inputs/main.c
+++ b/test/x86_64/linux/PltGotRedundancy/Inputs/main.c
@@ -1,0 +1,12 @@
+/* Both REX_GOTPCRELX (address-taken) and PLT32 (call) for the same symbol.
+   The linker should produce one .got slot (GLOB_DAT) and a .plt.got stub,
+   not two slots (GLOB_DAT + JUMP_SLOT). */
+extern void foo(void);
+
+void (*foo_ptr)(void);
+
+void use_foo(void) {
+  foo_ptr = foo; /* R_X86_64_REX_GOTPCRELX → MayNeedGOT */
+  foo();         /* R_X86_64_PLT32         → MayNeedPLT */
+  foo_ptr();
+}

--- a/test/x86_64/linux/PltGotRedundancy/PltGotRedundancy.test
+++ b/test/x86_64/linux/PltGotRedundancy/PltGotRedundancy.test
@@ -1,0 +1,31 @@
+#------PltGotRedundancy.test-------Shared,Executable------#
+#BEGIN_COMMENT
+# When a preemptible symbol is both address-taken (R_X86_64_REX_GOTPCRELX)
+# and called (R_X86_64_PLT32), ELD must allocate only one .got slot and
+# use a compact .plt.got stub — not two slots (GLOB_DAT + JUMP_SLOT).
+#
+# Expected:
+#   - Exactly one dynamic reloc for 'foo': R_X86_64_GLOB_DAT (no JUMP_SLOT)
+#   - .got.plt header-only (size 0x18 = 24 bytes)
+#   - .plt.got section present with 8-byte stub for 'foo'
+#
+# This matches the behavior of BFD and mold.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -fPIC -c %p/Inputs/lib.c -o %t.lib.o
+RUN: %clang %clangopts -fPIC -c %p/Inputs/main.c -o %t.main.o
+RUN: %link %linkopts -shared %t.lib.o -o %t.lib.so
+RUN: %link %linkopts -dy %t.main.o %t.lib.so -o %t.out --no-emit-relocs
+RUN: %readelf -r %t.out | %filecheck %s --check-prefix=DYNRELOC
+RUN: %readelf -S %t.out | %filecheck %s --check-prefix=SECTIONS
+
+# Only GLOB_DAT for foo — no JUMP_SLOT
+DYNRELOC:     R_X86_64_GLOB_DAT {{.*}} foo
+DYNRELOC-NOT: R_X86_64_JUMP_SLOT {{.*}} foo
+
+# .plt.got section exists (compact 8-byte stub for foo)
+SECTIONS: .plt.got
+
+# .got.plt is header-only (size 000018 = 24 bytes, no slot for foo)
+SECTIONS: .got.plt {{.*}} 000018
+#END_TEST


### PR DESCRIPTION
When a preemptible external symbol is both address-taken (R_X86_64_REX_GOTPCRELX)
and called (R_X86_64_PLT32), ELD previously allocated two separate GOT slots.

.got:     8 bytes + R_X86_64_GLOB_DAT  (for address-taken access)
.got.plt: 8 bytes + R_X86_64_JUMP_SLOT (for PLT lazy resolution)

Both slots hold the same runtime value — the resolved address of the symbol.
The .gotplt slot is redundant. BFD and mold have fixed this; lld and ELD still
produce the redundancy.

This patch eliminates the redundancy by routing such symbols through a compact
.plt.got stub that reads directly from the existing .got slot.

Depends on scan phase infrastructure from PR https://github.com/qualcomm/eld/pull/1467.
Fixes https://github.com/qualcomm/eld/issues/1363.