### PR TITLE
Redesign --print-timing-stats as a hierarchical report

### DIFF
--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -878,7 +878,10 @@ public:
   // --print-stats
   bool printTimingStats(const char *TimeRegion = nullptr) const;
 
-  void setPrintTimingStats() { BPrintTimeStats = true; }
+  void setPrintTimingStats() {
+    BPrintTimeStats = true;
+    BPrintAllUserPluginTimeStats = true;
+  }
 
   bool allUserPluginStatsRequested() const {
     return BPrintAllUserPluginTimeStats;

--- a/include/eld/Support/RegisterTimer.h
+++ b/include/eld/Support/RegisterTimer.h
@@ -8,6 +8,7 @@
 #define ELD_SUPPORT_REGISTERTIMER_H
 
 #include "llvm/Support/Timer.h"
+#include "llvm/Support/raw_ostream.h"
 #include <optional>
 
 namespace eld {
@@ -18,17 +19,22 @@ class RegisterTimer {
 public:
   // Params:
   // - Name: timer name (also used as description by default)
-  // - Group: TimerGroup name (also used as group description by default)
+  // - Phase: top-level linker phase
+  // (Initialize/Read/Resolve/Layout/Emit/Plugins)
   // - Enable: if false, the timer is a no-op
-  explicit RegisterTimer(llvm::StringRef Name, llvm::StringRef Group,
+  explicit RegisterTimer(llvm::StringRef Name, llvm::StringRef Phase,
                          bool Enable);
 
   // Like the 3-arg ctor, but allows custom timer/group descriptions.
   RegisterTimer(llvm::StringRef Name, llvm::StringRef Description,
-                llvm::StringRef Group, llvm::StringRef GroupDescription,
+                llvm::StringRef Phase, llvm::StringRef PhaseDescription,
                 bool Enable);
 
   llvm::Timer *getTimer() const { return T; }
+
+  // Print a hierarchical timing report to OS, grouping timers under their
+  // phases in pipeline order (Initialize -> Read -> Resolve -> Layout -> Emit).
+  static void printTimingReport(llvm::raw_ostream &OS);
 
 private:
   llvm::Timer *T = nullptr;

--- a/lib/Core/Linker.cpp
+++ b/lib/Core/Linker.cpp
@@ -79,7 +79,7 @@ bool Linker::prepare(std::vector<InputAction *> &Actions,
   if (ThisModule->getPrinter()->isVerbose())
     ThisConfig->raise(Diag::initializing_linker);
   if (Target) {
-    eld::RegisterTimer F("Initialize Linker", "Link Summary",
+    eld::RegisterTimer F("Initialize Linker", "Initialize",
                          ThisConfig->options().printTimingStats());
     if (!initEmulator(ThisModule->getScript(), Target))
       return false;
@@ -87,7 +87,7 @@ bool Linker::prepare(std::vector<InputAction *> &Actions,
       return false;
   }
   {
-    eld::RegisterTimer F("Initialize Inputs", "Link Summary",
+    eld::RegisterTimer F("Initialize Inputs", "Initialize",
                          ThisConfig->options().printTimingStats());
     if (!initializeInputTree(Actions))
       return false;
@@ -140,7 +140,7 @@ bool Linker::prepare(std::vector<InputAction *> &Actions,
   }
 
   {
-    eld::RegisterTimer F("Read all Input files", "Link Summary",
+    eld::RegisterTimer F("Normalize Inputs", "Initialize",
                          ThisConfig->options().printTimingStats());
     if (!normalize())
       return false;
@@ -163,7 +163,7 @@ bool Linker::link() {
   llvm::sys::fs::current_path(LinkLaunchDirectory);
   ThisConfig->options().setLinkLaunchDirectory(LinkLaunchDirectory.str().str());
   {
-    eld::RegisterTimer F("Apply Linker default sections", "Link Summary",
+    eld::RegisterTimer F("Apply Linker default sections", "Layout",
                          ThisConfig->options().printTimingStats());
     if (!ObjLinker->initStdSections())
       return false;
@@ -180,7 +180,7 @@ bool Linker::link() {
     ThisConfig->raise(Diag::merging_input_sections);
   {
     eld::RegisterTimer F("Merge input sections and prepare for layout",
-                         "Link Summary",
+                         "Initialize",
                          ThisConfig->options().printTimingStats());
     if (!resolve()) {
       // llvm::errs() << "resolve returning false!\n";
@@ -200,7 +200,7 @@ bool Linker::link() {
   }
 
   {
-    eld::RegisterTimer F("Prepare Output file", "Link Summary",
+    eld::RegisterTimer F("Prepare Output file", "Emit",
                          ThisConfig->options().printTimingStats());
     if (!layout()) {
       // llvm::errs() << "layout returning false!\n";
@@ -216,7 +216,7 @@ bool Linker::link() {
     ThisConfig->raise(Diag::emit_output_file)
         << ThisConfig->options().outputFileName();
   {
-    eld::RegisterTimer F("Emit output file", "Link Summary",
+    eld::RegisterTimer F("Emit output file", "Emit",
                          ThisConfig->options().printTimingStats());
     if (ThisConfig->options().getInsertTimingStats()) {
       TimingSectionTimer->stopTimer();
@@ -253,8 +253,6 @@ void Linker::printLayout() {
   }
   LinkTime->clear();
 
-  eld::RegisterTimer F("Emit Map file", "Link Summary",
-                       ThisConfig->options().printTimingStats());
   ObjLinker->printlayout();
 }
 
@@ -342,7 +340,7 @@ bool Linker::normalize() {
 
   {
     LinkerProgress->incrementAndDisplayProgress();
-    eld::RegisterTimer T("Read all Input files", "Read all Input files",
+    eld::RegisterTimer T("Normalize", "Read",
                          ThisConfig->options().printTimingStats());
     if (!ObjLinker->normalize())
       return false;
@@ -383,7 +381,7 @@ bool Linker::normalize() {
   setUnresolvePolicy(ThisConfig->options().reportUndefPolicy());
 
   {
-    eld::RegisterTimer T("Parse External scripts ", "Read all Input files",
+    eld::RegisterTimer T("Parse External scripts ", "Read",
                          ThisConfig->options().printTimingStats());
     LinkerProgress->incrementAndDisplayProgress();
     if (!ObjLinker->parseVersionScript())
@@ -399,7 +397,7 @@ bool Linker::normalize() {
 
     {
       LinkerProgress->incrementAndDisplayProgress();
-      eld::RegisterTimer T("Add Script Symbols", "Symbols from Linker Script",
+      eld::RegisterTimer T("Add Script Symbols", "Resolve",
                            ThisConfig->options().printTimingStats());
       // Add Linker script symbols.
       if (!ObjLinker->addScriptSymbols())
@@ -413,7 +411,7 @@ bool Linker::normalize() {
   if (ThisModule->needLTOToBeInvoked() || ThisConfig->options().hasLTO()) {
     LinkerProgress->addMoreTicks(3);
     LinkerProgress->incrementAndDisplayProgress();
-    eld::RegisterTimer T("Perform LTO", "LTO",
+    eld::RegisterTimer T("Perform LTO", "Read",
                          ThisConfig->options().printTimingStats());
     // a. Create LTO Object file from bitcode inputs
     if (!ObjLinker->createLTOObject())
@@ -457,7 +455,7 @@ bool Linker::resolve() {
 
   {
     LinkerProgress->incrementAndDisplayProgress();
-    eld::RegisterTimer T("Allocate Common Symbols", "Common Symbols",
+    eld::RegisterTimer T("Allocate Common Symbols", "Resolve",
                          ThisConfig->options().printTimingStats());
     if (!ObjLinker->allocateCommonSymbols()) {
       return false;
@@ -506,7 +504,7 @@ bool Linker::resolve() {
   }
 
   {
-    eld::RegisterTimer T("Add Standard Symbols", "Add Default Standard Symbols",
+    eld::RegisterTimer T("Add Standard Symbols", "Resolve",
                          ThisConfig->options().printTimingStats());
     LinkerProgress->incrementAndDisplayProgress();
     // Add all symbols (Standard, Target specific symbols)
@@ -564,7 +562,7 @@ bool Linker::resolve() {
 
   LinkerProgress->incrementAndDisplayProgress();
   if (LinkerConfig::Object != ThisConfig->codeGenType()) {
-    eld::RegisterTimer T("Scan Relocation Processing", "Relocation Processing",
+    eld::RegisterTimer T("Scan Relocation Processing", "Resolve",
                          ThisConfig->options().printTimingStats());
     bool Success = ObjLinker->scanRelocations(false);
     if (!Success)
@@ -573,7 +571,7 @@ bool Linker::resolve() {
 
   LinkerProgress->incrementAndDisplayProgress();
   if (ThisConfig->isCodeDynamic() || ThisConfig->options().forceDynamic()) {
-    eld::RegisterTimer T("Dynamic List Symbols", "Add Dynamic List Symbols",
+    eld::RegisterTimer T("Dynamic List Symbols", "Resolve",
                          ThisConfig->options().printTimingStats());
     if (!ObjLinker->addDynListSymbols())
       return false;
@@ -581,8 +579,7 @@ bool Linker::resolve() {
 
   LinkerProgress->incrementAndDisplayProgress();
   {
-    eld::RegisterTimer T("Finalize Scan Relocation Processing",
-                         "Relocation Processing",
+    eld::RegisterTimer T("Finalize Scan Relocation Processing", "Resolve",
                          ThisConfig->options().printTimingStats());
     if (!ObjLinker->finalizeScanRelocations())
       return false;
@@ -590,7 +587,7 @@ bool Linker::resolve() {
 
   LinkerProgress->incrementAndDisplayProgress();
   {
-    eld::RegisterTimer T("Add Output symbols", "Output Symbols",
+    eld::RegisterTimer T("Add Output symbols", "Layout",
                          ThisConfig->options().printTimingStats());
     // Add symbols that we need to the output.
     if (!ObjLinker->addSymbolsToOutput())
@@ -599,7 +596,7 @@ bool Linker::resolve() {
 
   LinkerProgress->incrementAndDisplayProgress();
   {
-    eld::RegisterTimer T("Add Dynamic Output symbols", "Output Symbols",
+    eld::RegisterTimer T("Add Dynamic Output symbols", "Layout",
                          ThisConfig->options().printTimingStats());
     // To allocate dynamic sections, we need dynamic symbols to be populated
     // properly.
@@ -609,7 +606,7 @@ bool Linker::resolve() {
 
   {
     LinkerProgress->incrementAndDisplayProgress();
-    eld::RegisterTimer T("Size Dynamic Sections", "Perform Layout",
+    eld::RegisterTimer T("Size Dynamic Sections", "Layout",
                          ThisConfig->options().printTimingStats());
     ObjLinker->sizeDynamic();
   }
@@ -617,7 +614,7 @@ bool Linker::resolve() {
   // Merge sections.
   {
     LinkerProgress->incrementAndDisplayProgress();
-    eld::RegisterTimer T("Merge Sections", "Perform Layout",
+    eld::RegisterTimer T("Merge Sections", "Layout",
                          ThisConfig->options().printTimingStats());
     if (!ObjLinker->mergeSections())
       return false;
@@ -625,7 +622,7 @@ bool Linker::resolve() {
 
   {
     LinkerProgress->incrementAndDisplayProgress();
-    eld::RegisterTimer T("Add Output Section symbols", "Output Symbols",
+    eld::RegisterTimer T("Add Output Section symbols", "Layout",
                          ThisConfig->options().printTimingStats());
     // Add all the section symbols
     if (!ObjLinker->addSectionSymbols())
@@ -639,14 +636,14 @@ bool Linker::layout() {
   //  init relaxation stuff.
   {
     LinkerProgress->incrementAndDisplayProgress();
-    eld::RegisterTimer T("Initialize Stubs", "Perform Layout",
+    eld::RegisterTimer T("Initialize Stubs", "Layout",
                          ThisConfig->options().printTimingStats());
     ObjLinker->initStubs();
   }
 
   {
     LinkerProgress->incrementAndDisplayProgress();
-    eld::RegisterTimer T("Do PreLayout", "Perform Layout",
+    eld::RegisterTimer T("Do PreLayout", "Layout",
                          ThisConfig->options().printTimingStats());
     ObjLinker->prelayout();
   }
@@ -654,14 +651,14 @@ bool Linker::layout() {
   if (ThisModule->getPrinter()->isVerbose())
     ThisConfig->raise(Diag::merging_strings);
   {
-    eld::RegisterTimer F("Merge strings", "Link Summary",
+    eld::RegisterTimer F("Merge strings", "Layout",
                          ThisConfig->options().printTimingStats());
     ObjLinker->doMergeStrings();
   }
 
   {
     LinkerProgress->incrementAndDisplayProgress();
-    eld::RegisterTimer T("Establish Layout", "Perform Layout",
+    eld::RegisterTimer T("Perform Layout", "Layout",
                          ThisConfig->options().printTimingStats());
     if (!ObjLinker->layout())
       return false;
@@ -669,7 +666,7 @@ bool Linker::layout() {
 
   {
     LinkerProgress->incrementAndDisplayProgress();
-    eld::RegisterTimer T("Scan Relocations", "Perform Layout",
+    eld::RegisterTimer T("Scan Relocations", "Layout",
                          ThisConfig->options().printTimingStats());
     if (LinkerConfig::Object == ThisConfig->codeGenType()) {
       if (!ObjLinker->scanRelocations(true))
@@ -679,7 +676,7 @@ bool Linker::layout() {
 
   {
     LinkerProgress->incrementAndDisplayProgress();
-    eld::RegisterTimer T("Create Output Section Table", "Perform Layout",
+    eld::RegisterTimer T("Create Output Section Table", "Layout",
                          ThisConfig->options().printTimingStats());
     if (!ObjLinker->postlayout())
       return false;
@@ -687,15 +684,14 @@ bool Linker::layout() {
 
   {
     LinkerProgress->incrementAndDisplayProgress();
-    eld::RegisterTimer T("Finalize Target specific symbol Values",
-                         "Perform Layout",
+    eld::RegisterTimer T("Finalize Target specific symbol Values", "Layout",
                          ThisConfig->options().printTimingStats());
     Backend->finalizeSymbols();
   }
 
   {
     LinkerProgress->incrementAndDisplayProgress();
-    eld::RegisterTimer T("AfterLayout OutputSection Iterator", "Perform Layout",
+    eld::RegisterTimer T("AfterLayout OutputSection Iterator", "Layout",
                          ThisConfig->options().printTimingStats("plugin"));
     // Run the output section iterator plugin after all the layout is done.
     ThisModule->setLinkState(LinkState::AfterLayout);
@@ -711,21 +707,21 @@ bool Linker::layout() {
 
   {
     LinkerProgress->incrementAndDisplayProgress();
-    eld::RegisterTimer T("Apply Relocation", "Perform Layout",
+    eld::RegisterTimer T("Apply Relocation", "Layout",
                          ThisConfig->options().printTimingStats());
     ObjLinker->relocation(ThisConfig->options().emitRelocs());
   }
 
   {
     LinkerProgress->incrementAndDisplayProgress();
-    eld::RegisterTimer T("Finalize Input Symbol Values", "Perform Layout",
+    eld::RegisterTimer T("Finalize Input Symbol Values", "Layout",
                          ThisConfig->options().printTimingStats());
     ObjLinker->finalizeSymbolValues();
   }
 
   {
     LinkerProgress->incrementAndDisplayProgress();
-    eld::RegisterTimer T("Finalize Output File", "Perform Layout",
+    eld::RegisterTimer T("Finalize Output File", "Layout",
                          ThisConfig->options().printTimingStats());
     ObjLinker->finalizeBeforeWrite();
   }
@@ -739,7 +735,7 @@ bool Linker::layout() {
 }
 
 bool Linker::emit() {
-  eld::RegisterTimer T("Emit Output File", "Emit Output File",
+  eld::RegisterTimer T("Write Output", "Emit",
                        ThisConfig->options().printTimingStats());
   std::string Path = ThisConfig->options().outputFileName();
 
@@ -790,7 +786,7 @@ bool Linker::emit() {
   }
   {
     LinkerProgress->incrementAndDisplayProgress();
-    eld::RegisterTimer T("Write All Sections", "Emit Output File",
+    eld::RegisterTimer T("Write All Sections", "Emit",
                          ThisConfig->options().printTimingStats());
     ObjLinker->emitOutput(*OutputOrError.get());
   }
@@ -812,7 +808,7 @@ bool Linker::emit() {
 
   {
     LinkerProgress->incrementAndDisplayProgress();
-    eld::RegisterTimer T("Commit File", "Emit Output File",
+    eld::RegisterTimer T("Commit File", "Emit",
                          ThisConfig->options().printTimingStats());
     if (auto E = (*OutputOrError)->commit()) {
       ThisConfig->raise(Diag::unable_to_write_output_file)

--- a/lib/GarbageCollection/GarbageCollection.cpp
+++ b/lib/GarbageCollection/GarbageCollection.cpp
@@ -211,7 +211,7 @@ bool GarbageCollection::run(const std::string &Phase, bool CommonSectionsOnly) {
   // 1. traverse all the relocations to set up the reached sections of each
   // section
   {
-    eld::RegisterTimer T("Get Reachable Sections", "Garbage Collection",
+    eld::RegisterTimer T("Get Reachable Sections", "Layout",
                          ThisConfig.options().printTimingStats());
 
     setUpReachedSectionsAndSymbols();
@@ -221,7 +221,7 @@ bool GarbageCollection::run(const std::string &Phase, bool CommonSectionsOnly) {
   SectionSetTy Entry;
   SectionSetTy LiveSet;
   {
-    eld::RegisterTimer T("Compute Entry Sections", "Garbage Collection",
+    eld::RegisterTimer T("Compute Entry Sections", "Layout",
                          ThisConfig.options().printTimingStats());
     // 2. get all sections defined the entry point
     if (!getEntrySections(Entry))
@@ -229,7 +229,7 @@ bool GarbageCollection::run(const std::string &Phase, bool CommonSectionsOnly) {
   }
 
   {
-    eld::RegisterTimer T("Find Dead Code", "Garbage Collection",
+    eld::RegisterTimer T("Find Dead Code", "Layout",
                          ThisConfig.options().printTimingStats());
     // 3. find all the referenced sections those can be reached by entry
     if (ThisModule.getPrinter()->traceGCLive())
@@ -239,7 +239,7 @@ bool GarbageCollection::run(const std::string &Phase, bool CommonSectionsOnly) {
 
   // 4. stripSections - set the unreached sections to Ignore
   {
-    eld::RegisterTimer T("Apply Dead Code Elimination", "Garbage Collection",
+    eld::RegisterTimer T("Apply Dead Code Elimination", "Layout",
                          ThisConfig.options().printTimingStats());
     stripSections(LiveSet, CommonSectionsOnly);
   }

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -34,6 +34,7 @@
 #include "eld/Support/MsgHandling.h"
 #include "eld/Support/OutputTarWriter.h"
 #include "eld/Support/Path.h"
+#include "eld/Support/RegisterTimer.h"
 #include "eld/Support/StringUtils.h"
 #include "eld/Support/TargetRegistry.h"
 #include "eld/Support/TargetSelect.h"
@@ -157,7 +158,7 @@ bool GnuLdDriver::emitStats(eld::Module &M) const {
   llvm::raw_fd_ostream *OutStream = &llvm::outs();
   if (StatsFile)
     OutStream = StatsFile;
-  llvm::TimerGroup::printAll(*OutStream);
+  RegisterTimer::printTimingReport(*OutStream);
   llvm::TimerGroup::clearAll();
   M.getLinkerScript().printPluginTimers(*OutStream);
   delete StatsFile;

--- a/lib/Object/LibReader.cpp
+++ b/lib/Object/LibReader.cpp
@@ -100,7 +100,7 @@ bool LibReader::readLib(InputBuilder::InputIteratorT &CurNode,
   std::string ArchiveName = getStartLibArchiveName(IsThin, LibId);
   MemoryArea *MemArea = CachedArchiveArea;
   if (!MemArea) {
-    eld::RegisterTimer T("Build --start-lib archive", "Read all Input files",
+    eld::RegisterTimer T("Build --start-lib archive", "Read",
                          Config.options().printTimingStats());
     llvm::Expected<std::unique_ptr<llvm::MemoryBuffer>> ExpArchiveBuf =
         llvm::writeArchiveToBuffer(Members,

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -260,8 +260,7 @@ bool ObjectLinker::readInputs(const std::vector<Node *> &InputVector) {
        ++Begin) {
     // is a group node
     if ((*Begin)->kind() == Node::GroupStart) {
-      eld::RegisterTimer T("Read Start Group and End Group",
-                           "Read all Input files",
+      eld::RegisterTimer T("Read Start Group and End Group", "Read",
                            ThisConfig.options().printTimingStats());
       getGroupReader()->readGroup(Begin,
                                   ThisModule->getIRBuilder()->getInputBuilder(),
@@ -270,7 +269,7 @@ bool ObjectLinker::readInputs(const std::vector<Node *> &InputVector) {
     }
 
     if ((*Begin)->kind() == Node::LibStart) {
-      eld::RegisterTimer T("Read Start Lib and End Lib", "Read all Input files",
+      eld::RegisterTimer T("Read Start Lib and End Lib", "Read",
                            ThisConfig.options().printTimingStats());
       getLibReader()->readLib(Begin,
                               ThisModule->getIRBuilder()->getInputBuilder(),
@@ -574,7 +573,7 @@ void ObjectLinker::dataStrippingOpt() {
 
 void ObjectLinker::runGarbageCollection(const std::string &Phase,
                                         bool CommonSectionsOnly) {
-  eld::RegisterTimer T("Perform Garbage collection", "Garbage Collection",
+  eld::RegisterTimer T("Perform Garbage collection", "Layout",
                        ThisConfig.options().printTimingStats());
   GarbageCollection GC(ThisConfig, getTargetBackend(), *ThisModule);
   GC.run(Phase, CommonSectionsOnly);
@@ -916,7 +915,7 @@ void ObjectLinker::sortByInitPriority(RuleContainer *I, bool SortRule) {
 }
 
 bool ObjectLinker::sortSections(RuleContainer *I, bool SortRule) {
-  eld::RegisterTimer T("Sort Sections", "Merge Sections",
+  eld::RegisterTimer T("Sort Sections", "Layout",
                        ThisConfig.options().printTimingStats());
   if (!SortRule && (!(I->getSection()->hasSectionData())))
     return false;
@@ -1055,7 +1054,7 @@ bool ObjectLinker::initializeMerge() {
   if (AllInputSections.size())
     return true;
   {
-    eld::RegisterTimer T("Prepare Input Files For Merge", "Merge Sections",
+    eld::RegisterTimer T("Prepare Input Files For Merge", "Layout",
                          ThisConfig.options().printTimingStats());
     // Gather all input sections.
     eld::Module::obj_iterator Obj, ObjEnd = ThisModule->objEnd();
@@ -1076,7 +1075,7 @@ bool ObjectLinker::initializeMerge() {
 }
 
 bool ObjectLinker::updateInputSectionMappingsForPlugin() {
-  eld::RegisterTimer T("Update Input Rules For Plugin", "Merge Sections",
+  eld::RegisterTimer T("Update Input Rules For Plugin", "Layout",
                        ThisConfig.options().printTimingStats());
   // Initialize merging of sections.
   initializeMerge();
@@ -1111,7 +1110,7 @@ bool ObjectLinker::updateInputSectionMappingsForPlugin() {
 }
 
 bool ObjectLinker::finishAssignOutputSections() {
-  eld::RegisterTimer T("Update Input Rules From Plugin", "Perform Layout",
+  eld::RegisterTimer T("Update Input Rules From Plugin", "Layout",
                        ThisConfig.options().printTimingStats());
   ObjectBuilder Builder(ThisConfig, *ThisModule);
   // Override output sections again!!
@@ -1123,7 +1122,7 @@ bool ObjectLinker::finishAssignOutputSections() {
 }
 
 bool ObjectLinker::finishAssignOutputSections(const plugin::LinkerWrapper *LW) {
-  eld::RegisterTimer T("Update Input Rules From Plugin", "Perform Layout",
+  eld::RegisterTimer T("Update Input Rules From Plugin", "Layout",
                        ThisConfig.options().printTimingStats());
   ObjectBuilder Builder(ThisConfig, *ThisModule);
   // Update section mapping of pending section overrides associated with the
@@ -1195,7 +1194,7 @@ bool ObjectLinker::mergeSections() {
   ObjectBuilder Builder(ThisConfig, *ThisModule);
   // Output section iterator plugin.
   {
-    eld::RegisterTimer T("Init", "Merge Sections",
+    eld::RegisterTimer T("Init", "Layout",
                          ThisConfig.options().printTimingStats());
     // Initialize merging of input sections.
     if (!initializeMerge())
@@ -1210,7 +1209,7 @@ bool ObjectLinker::mergeSections() {
   setCopyRelocSectionsFallbackToBSS();
 
   {
-    eld::RegisterTimer T("Universal Plugin", "Merge Sections",
+    eld::RegisterTimer T("Universal Plugin", "Layout",
                          ThisConfig.options().printTimingStats());
     auto &PM = ThisModule->getPluginManager();
     ThisModule->setLinkState(LinkState::ActBeforeSectionMerging);
@@ -1221,8 +1220,7 @@ bool ObjectLinker::mergeSections() {
   // Output section iterator plugin.
   {
     eld::RegisterTimer T("Plugin: Output Section Iterator Before Layout",
-                         "Merge Sections",
-                         ThisConfig.options().printTimingStats());
+                         "Layout", ThisConfig.options().printTimingStats());
     // For backward compatibility
     ThisModule->setLinkState(LinkState::BeforeLayout);
     if (!runOutputSectionIteratorPlugin())
@@ -1232,15 +1230,14 @@ bool ObjectLinker::mergeSections() {
 
   // Merge all the input sections.
   {
-    eld::RegisterTimer T("Merge Input Sections", "Merge Sections",
+    eld::RegisterTimer T("Merge Input Sections", "Layout",
                          ThisConfig.options().printTimingStats());
     mergeInputSections(Builder, AllInputSections);
   }
 
   // Update plugins from the YAML config file specified.
   {
-    eld::RegisterTimer T("Update Output Sections With Plugins",
-                         "Merge Sections",
+    eld::RegisterTimer T("Update Output Sections With Plugins", "Layout",
                          ThisConfig.options().printTimingStats());
     if (!ThisModule->updateOutputSectionsWithPlugins()) {
       ThisModule->setFailure(true);
@@ -1259,8 +1256,7 @@ bool ObjectLinker::mergeSections() {
 
   {
     eld::RegisterTimer T("Plugin: Output Section Iterator Creating Sections",
-                         "Merge Sections",
-                         ThisConfig.options().printTimingStats());
+                         "Layout", ThisConfig.options().printTimingStats());
     if (!initializeOutputSectionsAndRunPlugin())
       return false;
   }
@@ -1269,7 +1265,7 @@ bool ObjectLinker::mergeSections() {
   reportPendingScriptSectionInsertions();
 
   {
-    eld::RegisterTimer T("Create Output Section", "Merge Sections",
+    eld::RegisterTimer T("Create Output Section", "Layout",
                          ThisConfig.options().printTimingStats());
     // Prepass: apply SUBALIGN to first fragments per input section per output
     // section serially to avoid races in parallel output creation.
@@ -1301,7 +1297,7 @@ bool ObjectLinker::mergeSections() {
       return false;
     }
     {
-      eld::RegisterTimer T("Assign Group Sections Offset", "Merge Sections",
+      eld::RegisterTimer T("Assign Group Sections Offset", "Layout",
                            ThisConfig.options().printTimingStats());
       assignOffsetToGroupSections();
     }
@@ -2528,13 +2524,13 @@ ObjectLinker::postProcessing(llvm::FileOutputBuffer &POutput) {
   getTargetBackend().applyPluginFragmentReplacements(POutput);
 
   {
-    eld::RegisterTimer T("Sync Relocations", "Emit Output File",
+    eld::RegisterTimer T("Sync Relocations", "Emit",
                          ThisConfig.options().printTimingStats());
     syncRelocations(POutput.getBufferStart());
   }
 
   {
-    eld::RegisterTimer T("Post Process Output File", "Emit Output File",
+    eld::RegisterTimer T("Post Process Output File", "Emit",
                          ThisConfig.options().printTimingStats());
     eld::Expected<void> ExpPostProcess =
         getTargetBackend().postProcessing(POutput);
@@ -2799,7 +2795,7 @@ bool ObjectLinker::runAssembler(std::vector<std::string> &Files,
 std::unique_ptr<llvm::lto::LTO> ObjectLinker::ltoInit(llvm::lto::Config Conf,
                                                       bool CompileToAssembly) {
   // Parse codegen options and pre-initialize the config
-  eld::RegisterTimer T("Initialize LTO", "LTO",
+  eld::RegisterTimer T("Initialize LTO", "Read",
                        ThisConfig.options().printTimingStats());
   if (MTraceLTO) {
     if (ThisConfig.options().codegenOpts()) {
@@ -2886,7 +2882,7 @@ std::unique_ptr<llvm::lto::LTO> ObjectLinker::ltoInit(llvm::lto::Config Conf,
 bool ObjectLinker::finalizeLtoSymbolResolution(
     llvm::lto::LTO &LTO, const std::vector<BitcodeFile *> &BitCodeInputs) {
 
-  eld::RegisterTimer T("Finalize Symbol Resolution", "LTO",
+  eld::RegisterTimer T("Finalize Symbol Resolution", "Read",
                        ThisConfig.options().printTimingStats());
   bool IsPreserveAllSet = ThisConfig.options().preserveAllLTO();
   bool IsPreserveGlobals = ThisConfig.options().exportDynamic();
@@ -3137,7 +3133,7 @@ void ObjectLinker::addLTOOutputToTar() {
 }
 
 bool ObjectLinker::doLto(llvm::lto::LTO &LTO, bool CompileToAssembly) {
-  eld::RegisterTimer T("Invoke LTO", "LTO",
+  eld::RegisterTimer T("Invoke LTO", "Read",
                        ThisConfig.options().printTimingStats());
   // Run LTO
   std::vector<std::string> Files;
@@ -3341,7 +3337,7 @@ bool ObjectLinker::createLTOObject(void) {
     return true;
   {
     eld::RegisterTimer T("Assign Output sections to Bitcode sections and ELF",
-                         "LTO", ThisConfig.options().printTimingStats());
+                         "Read", ThisConfig.options().printTimingStats());
     // Centralize assigning output sections.
     assignOutputSections(AllInputs);
   }
@@ -3638,7 +3634,7 @@ bool ObjectLinker::readAndProcessInput(Input *Input, bool IsPostLto) {
   }
 
   if (CurInput->isBinaryFile()) {
-    eld::RegisterTimer T("Read ELF Executable Files", "Read all Input files",
+    eld::RegisterTimer T("Read ELF Executable Files", "Read",
                          ThisConfig.options().printTimingStats());
     if (layoutInfo)
       layoutInfo->recordInputKind(InputFile::InputFileKind::BinaryFileKind);
@@ -3651,7 +3647,7 @@ bool ObjectLinker::readAndProcessInput(Input *Input, bool IsPostLto) {
     ThisModule->getObjectList().push_back(CurInput);
     addInputFileToTar(CurInput, eld::MappingFile::Kind::ObjectFile);
   } else if (CurInput->getKind() == InputFile::ELFExecutableFileKind) {
-    eld::RegisterTimer T("Read ELF Executable Files", "Read all Input files",
+    eld::RegisterTimer T("Read ELF Executable Files", "Read",
                          ThisConfig.options().printTimingStats());
     if (layoutInfo)
       layoutInfo->recordInputKind(CurInput->getKind());
@@ -3682,7 +3678,7 @@ bool ObjectLinker::readAndProcessInput(Input *Input, bool IsPostLto) {
     ThisModule->getObjectList().push_back(CurInput);
     addInputFileToTar(CurInput, eld::MappingFile::Kind::ObjectFile);
   } else if (CurInput->getKind() == InputFile::ELFObjFileKind) {
-    eld::RegisterTimer T("Read ELF Object Files", "Read all Input files",
+    eld::RegisterTimer T("Read ELF Object Files", "Read",
                          ThisConfig.options().printTimingStats());
     if (layoutInfo)
       layoutInfo->recordInputKind(CurInput->getKind());
@@ -3723,7 +3719,7 @@ bool ObjectLinker::readAndProcessInput(Input *Input, bool IsPostLto) {
     ThisModule->getObjectList().push_back(CurInput);
     addInputFileToTar(CurInput, eld::MappingFile::Kind::ObjectFile);
   } else if (CurInput->getKind() == InputFile::BitcodeFileKind) {
-    eld::RegisterTimer T("Read Bitcode Object Files", "Read all Input files",
+    eld::RegisterTimer T("Read Bitcode Object Files", "Read",
                          ThisConfig.options().printTimingStats());
     if (layoutInfo)
       layoutInfo->recordInputKind(CurInput->getKind());
@@ -3742,7 +3738,7 @@ bool ObjectLinker::readAndProcessInput(Input *Input, bool IsPostLto) {
     ThisModule->getObjectList().push_back(CurInput);
     addInputFileToTar(CurInput, MappingFile::Bitcode);
   } else if (CurInput->getKind() == InputFile::ELFSymDefFileKind) {
-    eld::RegisterTimer T("Read SymDef Object Files", "Read all Input files",
+    eld::RegisterTimer T("Read SymDef Object Files", "Read",
                          ThisConfig.options().printTimingStats());
     if (layoutInfo)
       layoutInfo->recordInputKind(CurInput->getKind());
@@ -3764,7 +3760,7 @@ bool ObjectLinker::readAndProcessInput(Input *Input, bool IsPostLto) {
     if (layoutInfo)
       layoutInfo->recordInputActions(LayoutInfo::Load, Input);
   } else if (CurInput->getKind() == InputFile::ELFDynObjFileKind) {
-    eld::RegisterTimer T("Read ELF Shared Object Files", "Read all Input files",
+    eld::RegisterTimer T("Read ELF Shared Object Files", "Read",
                          ThisConfig.options().printTimingStats());
     if (layoutInfo)
       layoutInfo->recordInputKind(CurInput->getKind());
@@ -3809,7 +3805,7 @@ bool ObjectLinker::readAndProcessInput(Input *Input, bool IsPostLto) {
 #endif
     ThisModule->getDynLibraryList().push_back(CurInput);
   } else if (CurInput->getKind() == InputFile::GNUArchiveFileKind) {
-    eld::RegisterTimer T("Read Archive Files", "Read all Input files",
+    eld::RegisterTimer T("Read Archive Files", "Read",
                          ThisConfig.options().printTimingStats());
     if (layoutInfo)
       layoutInfo->recordInputKind(CurInput->getKind());
@@ -3853,7 +3849,7 @@ bool ObjectLinker::readAndProcessInput(Input *Input, bool IsPostLto) {
   }
   // try to parse input as a linker script
   else if (CurInput->getKind() == InputFile::GNULinkerScriptKind) {
-    eld::RegisterTimer T("Read Linker Script", "Read all Input files",
+    eld::RegisterTimer T("Read Linker Script", "Read",
                          ThisConfig.options().printTimingStats());
     if (layoutInfo)
       layoutInfo->recordInputKind(CurInput->getKind());
@@ -3882,8 +3878,7 @@ bool ObjectLinker::overrideELFObjectWithBitCode(InputFile *CurInputFile) {
       !ThisConfig.options().hasFatLTOObjects())
     return false;
 
-  eld::RegisterTimer T("Read Mixed ELF/Bitcode Object Files",
-                       "Read all Input files",
+  eld::RegisterTimer T("Read Mixed ELF/Bitcode Object Files", "Read",
                        ThisConfig.options().printTimingStats());
 
   ELFObjectFile *EObj = llvm::dyn_cast<eld::ELFObjectFile>(CurInputFile);

--- a/lib/Plugin/PluginManager.cpp
+++ b/lib/Plugin/PluginManager.cpp
@@ -23,8 +23,9 @@ void PluginManager::storeUniversalPlugins() {
 }
 
 bool PluginManager::callInitHook() {
-  RegisterTimer T("Init", "Plugins", ShouldPrintTimingStats);
   for (auto *P : UniversalPlugins) {
+    RegisterTimer T(P->getPluginName() + "/Init", "Plugins",
+                    ShouldPrintTimingStats);
     P->callInitHook();
     if (!DE.diagnose())
       return false;
@@ -33,8 +34,9 @@ bool PluginManager::callInitHook() {
 }
 
 bool PluginManager::callDestroyHook() {
-  RegisterTimer T("Destroy", "Plugins", ShouldPrintTimingStats);
   for (auto *P : UniversalPlugins) {
+    RegisterTimer T(P->getPluginName() + "/Destroy", "Plugins",
+                    ShouldPrintTimingStats);
     P->callDestroyHook();
     if (!DE.diagnose())
       return false;
@@ -43,11 +45,11 @@ bool PluginManager::callDestroyHook() {
 }
 
 bool PluginManager::processPluginCommandLineOptions(GeneralOptions &Options) {
-  RegisterTimer T("PluginCommandLineOptions", "Plugins",
-                  ShouldPrintTimingStats);
   const auto &UnknownOpts = Options.getUnknownOptions();
   std::unordered_set<std::size_t> UsedOpts;
   for (Plugin *P : UniversalPlugins) {
+    RegisterTimer T(P->getPluginName() + "/CommandLineOptions", "Plugins",
+                    ShouldPrintTimingStats);
     for (std::size_t UnknownOptIdx = 0; UnknownOptIdx < UnknownOpts.size();
          ++UnknownOptIdx) {
       const std::string &Option = UnknownOpts[UnknownOptIdx];
@@ -77,8 +79,9 @@ bool PluginManager::processPluginCommandLineOptions(GeneralOptions &Options) {
 }
 
 bool PluginManager::callVisitSectionsHook(InputFile &IF) {
-  RegisterTimer T("VisitSections", "Plugins", ShouldPrintTimingStats);
   for (auto *P : UniversalPlugins) {
+    RegisterTimer T(P->getPluginName() + "/VisitSections", "Plugins",
+                    ShouldPrintTimingStats);
     P->callVisitSectionsHook(IF);
     if (!DE.diagnose())
       return false;
@@ -87,8 +90,9 @@ bool PluginManager::callVisitSectionsHook(InputFile &IF) {
 }
 
 bool PluginManager::callActBeforeRuleMatchingHook() {
-  RegisterTimer T("ActBeforeRuleMatching", "Plugins", ShouldPrintTimingStats);
   for (auto *P : UniversalPlugins) {
+    RegisterTimer T(P->getPluginName() + "/ActBeforeRuleMatching", "Plugins",
+                    ShouldPrintTimingStats);
     P->callActBeforeRuleMatchingHook();
     if (!DE.diagnose())
       return false;
@@ -98,9 +102,10 @@ bool PluginManager::callActBeforeRuleMatchingHook() {
 
 bool PluginManager::callVisitSymbolHook(LDSymbol *Sym, llvm::StringRef SymName,
                                         const SymbolInfo &SymInfo) {
-  RegisterTimer T("VisitSymbol", "Plugins", ShouldPrintTimingStats);
   for (auto *P : UniversalPlugins) {
     if (SymbolVisitors.count(P)) {
+      RegisterTimer T(P->getPluginName() + "/VisitSymbol", "Plugins",
+                      ShouldPrintTimingStats);
       P->callVisitSymbolHook(Sym, SymName, SymInfo);
       if (!DE.diagnose())
         return false;
@@ -116,8 +121,9 @@ void PluginManager::addSymbolVisitor(eld::Plugin *P) {
 }
 
 bool PluginManager::callActBeforeSectionMergingHook() {
-  RegisterTimer T("ActBeforeSectionMerging", "Plugins", ShouldPrintTimingStats);
   for (auto *P : UniversalPlugins) {
+    RegisterTimer T(P->getPluginName() + "/ActBeforeSectionMerging", "Plugins",
+                    ShouldPrintTimingStats);
     P->callActBeforeSectionMergingHook();
     if (!DE.diagnose())
       return false;
@@ -142,9 +148,9 @@ void PluginManager::setAuxiliarySymbolNameMap(
 }
 
 bool PluginManager::callActBeforePerformingLayoutHook() {
-  RegisterTimer T("ActBeforePerformingLayout", "Plugins",
-                  ShouldPrintTimingStats);
   for (auto *P : UniversalPlugins) {
+    RegisterTimer T(P->getPluginName() + "/ActBeforePerformingLayout",
+                    "Plugins", ShouldPrintTimingStats);
     P->callActBeforePerformingLayoutHook();
     if (!DE.diagnose())
       return false;
@@ -153,8 +159,9 @@ bool PluginManager::callActBeforePerformingLayoutHook() {
 }
 
 bool PluginManager::callActBeforeWritingOutputHook() {
-  RegisterTimer T("ActBeforeWritingOutput", "Plugins", ShouldPrintTimingStats);
   for (auto *P : UniversalPlugins) {
+    RegisterTimer T(P->getPluginName() + "/ActBeforeWritingOutput", "Plugins",
+                    ShouldPrintTimingStats);
     P->callActBeforeWritingOutputHook();
     if (!DE.diagnose())
       return false;

--- a/lib/Readers/ELFExecObjParser.cpp
+++ b/lib/Readers/ELFExecObjParser.cpp
@@ -82,7 +82,7 @@ eld::Expected<void> ELFExecObjParser::readSections(ELFReaderBase &ELFReader) {
   LinkerConfig &config = m_Module.getConfig();
   InputFile *inputFile = ELFReader.getInputFile();
   GNULDBackend &backend = m_Module.getBackend();
-  eld::RegisterTimer T("Read Sections", "Link Summary",
+  eld::RegisterTimer T("Read Sections", "Read",
                        config.options().printTimingStats());
 
   if (m_Module.getPrinter()->traceFiles())

--- a/lib/Readers/ELFRelocObjParser.cpp
+++ b/lib/Readers/ELFRelocObjParser.cpp
@@ -87,7 +87,7 @@ ELFRelocObjParser::readSectionHeaders(ELFReaderBase &ELFReader) {
 
 eld::Expected<bool> ELFRelocObjParser::readSections(ELFReaderBase &ELFReader) {
   LinkerConfig &config = m_Module.getConfig();
-  eld::RegisterTimer T("Read Sections", "Link Summary",
+  eld::RegisterTimer T("Read Sections", "Read",
                        config.options().printTimingStats());
   InputFile *inputFile = ELFReader.getInputFile();
   GNULDBackend &backend = m_Module.getBackend();

--- a/lib/Script/Plugin.cpp
+++ b/lib/Script/Plugin.cpp
@@ -210,7 +210,8 @@ bool Plugin::init(eld::OutputTarWriter *OutputTar) {
   if (!UserPluginHandle)
     return false;
   eld::RegisterTimer T(
-      "Init", ThisModule.saveString(UserPluginHandle->GetName()), Stats);
+      std::string(ThisModule.saveString(UserPluginHandle->GetName())) + "/Init",
+      "Plugins", Stats);
   if (ThisModule.getPrinter()->tracePlugins())
     ThisConfig.raise(Diag::note_initializing_plugin)
         << getPluginType() << DynamicLibrary::getLibraryName(Name)
@@ -234,7 +235,8 @@ bool Plugin::run(std::vector<Plugin *> &Plugins) {
   if (!UserPluginHandle)
     return false;
   eld::RegisterTimer T(
-      "Run", ThisModule.saveString(UserPluginHandle->GetName()), Stats);
+      std::string(ThisModule.saveString(UserPluginHandle->GetName())) + "/Run",
+      "Plugins", Stats);
   if (ThisModule.getPrinter()->tracePlugins())
     ThisConfig.raise(Diag::running_plugin)
         << getPluginType() << DynamicLibrary::getLibraryName(Name)
@@ -259,7 +261,9 @@ bool Plugin::cleanup() {
   if (!UserPluginHandle)
     return false;
   eld::RegisterTimer T(
-      "Cleanup", ThisModule.saveString(UserPluginHandle->GetName()), Stats);
+      std::string(ThisModule.saveString(UserPluginHandle->GetName())) +
+          "/Cleanup",
+      "Plugins", Stats);
   if (PluginCleanupFunction)
     (*PluginCleanupFunction)();
   clearResources();
@@ -289,7 +293,9 @@ bool Plugin::destroy() {
   if (!UserPluginHandle)
     return false;
   eld::RegisterTimer T(
-      "Destroy", ThisModule.saveString(UserPluginHandle->GetName()), Stats);
+      std::string(ThisModule.saveString(UserPluginHandle->GetName())) +
+          "/Destroy",
+      "Plugins", Stats);
   if (ThisModule.getPrinter()->tracePlugins())
     ThisConfig.raise(Diag::plugin_destroy) << getPluginType();
   plugin::Plugin *P = llvm::cast<plugin::Plugin>(UserPluginHandle);
@@ -309,7 +315,9 @@ bool Plugin::check() {
   if (!UserPluginHandle)
     return false;
   eld::RegisterTimer T(
-      "Check", ThisModule.saveString(UserPluginHandle->GetName()), Stats);
+      std::string(ThisModule.saveString(UserPluginHandle->GetName())) +
+          "/Check",
+      "Plugins", Stats);
   if (UserPluginHandle->getType() != ThisType) {
     ThisConfig.raise(Diag::plugin_mismatch)
         << DynamicLibrary::getLibraryName(Name) << getPluginType();
@@ -520,8 +528,9 @@ Plugin::loadLibrary(const std::string &LibraryName) {
 
 void Plugin::callInitHook() {
   plugin::LinkerPlugin *P = llvm::cast<plugin::LinkerPlugin>(UserPluginHandle);
-  RegisterTimer T("Init", ThisModule.saveString(UserPluginHandle->GetName()),
-                  Stats);
+  RegisterTimer T(
+      std::string(ThisModule.saveString(UserPluginHandle->GetName())) + "/Init",
+      "Plugins", Stats);
   if (ThisModule.getPrinter()->tracePlugins())
     ThisConfig.raise(Diag::trace_plugin_init) << getPluginName();
   P->Init(PluginOptions);
@@ -529,8 +538,10 @@ void Plugin::callInitHook() {
 
 void Plugin::callDestroyHook() {
   plugin::LinkerPlugin *P = llvm::cast<plugin::LinkerPlugin>(UserPluginHandle);
-  RegisterTimer T("Destroy", ThisModule.saveString(UserPluginHandle->GetName()),
-                  Stats);
+  RegisterTimer T(
+      std::string(ThisModule.saveString(UserPluginHandle->GetName())) +
+          "/Destroy",
+      "Plugins", Stats);
   if (ThisModule.getPrinter()->tracePlugins())
     ThisConfig.raise(Diag::trace_plugin_destroy) << getPluginName();
   P->Destroy();
@@ -553,8 +564,10 @@ void Plugin::registerCommandLineOption(
 void Plugin::callCommandLineOptionHandler(
     const std::string &Option, const std::optional<std::string> &Val,
     const CommandLineOptionSpec::OptionHandlerType &OptionHandler) {
-  RegisterTimer T("Command-line option handler",
-                  ThisModule.saveString(UserPluginHandle->GetName()), Stats);
+  RegisterTimer T(
+      std::string(ThisModule.saveString(UserPluginHandle->GetName())) +
+          "/Command-line option handler",
+      "Plugins", Stats);
   if (Val)
     ThisConfig.raise(Diag::verbose_calling_plugin_opt_handler_with_val)
         << getPluginName() << Option << Val.value();
@@ -566,8 +579,10 @@ void Plugin::callCommandLineOptionHandler(
 
 void Plugin::callVisitSectionsHook(InputFile &IF) {
   plugin::LinkerPlugin *P = llvm::cast<plugin::LinkerPlugin>(UserPluginHandle);
-  RegisterTimer T("VisitSections",
-                  ThisModule.saveString(UserPluginHandle->GetName()), Stats);
+  RegisterTimer T(
+      std::string(ThisModule.saveString(UserPluginHandle->GetName())) +
+          "/VisitSections",
+      "Plugins", Stats);
   if (ThisModule.getPrinter()->tracePlugins())
     ThisConfig.raise(Diag::trace_plugin_visit_sections)
         << getPluginName() << IF.getInput()->decoratedPath();
@@ -577,8 +592,10 @@ void Plugin::callVisitSectionsHook(InputFile &IF) {
 void Plugin::callVisitSymbolHook(LDSymbol *Sym, llvm::StringRef SymName,
                                  const SymbolInfo &SymInfo) {
   plugin::LinkerPlugin *P = llvm::cast<plugin::LinkerPlugin>(UserPluginHandle);
-  RegisterTimer T("VisitSymbol",
-                  ThisModule.saveString(UserPluginHandle->GetName()), Stats);
+  RegisterTimer T(
+      std::string(ThisModule.saveString(UserPluginHandle->GetName())) +
+          "/VisitSymbol",
+      "Plugins", Stats);
   if (ThisModule.getPrinter()->tracePlugins())
     ThisConfig.raise(Diag::trace_plugin_visit_symbol)
         << getPluginName() << SymName;
@@ -591,8 +608,10 @@ void Plugin::callVisitSymbolHook(LDSymbol *Sym, llvm::StringRef SymName,
 void Plugin::callActBeforeRuleMatchingHook() {
   llvm::StringRef HookName = "ActBeforeRuleMatching";
   plugin::LinkerPlugin *P = llvm::cast<plugin::LinkerPlugin>(UserPluginHandle);
-  RegisterTimer T(HookName, ThisModule.saveString(UserPluginHandle->GetName()),
-                  Stats);
+  RegisterTimer T(
+      std::string(ThisModule.saveString(UserPluginHandle->GetName())) + "/" +
+          HookName.str(),
+      "Plugins", Stats);
   if (ThisModule.getPrinter()->tracePlugins())
     ThisConfig.raise(Diag::trace_plugin_hook) << getPluginName() << HookName;
   P->ActBeforeRuleMatching();
@@ -601,8 +620,10 @@ void Plugin::callActBeforeRuleMatchingHook() {
 void Plugin::callActBeforeSectionMergingHook() {
   llvm::StringRef HookName = "ActBeforeSectionMerging";
   plugin::LinkerPlugin *P = llvm::cast<plugin::LinkerPlugin>(UserPluginHandle);
-  RegisterTimer T(HookName, ThisModule.saveString(UserPluginHandle->GetName()),
-                  Stats);
+  RegisterTimer T(
+      std::string(ThisModule.saveString(UserPluginHandle->GetName())) + "/" +
+          HookName.str(),
+      "Plugins", Stats);
   if (ThisModule.getPrinter()->tracePlugins())
     ThisConfig.raise(Diag::trace_plugin_hook) << getPluginName() << HookName;
   P->ActBeforeSectionMerging();
@@ -611,8 +632,10 @@ void Plugin::callActBeforeSectionMergingHook() {
 void Plugin::callActBeforePerformingLayoutHook() {
   llvm::StringRef HookName = "ActBeforePerformingLayout";
   plugin::LinkerPlugin *P = llvm::cast<plugin::LinkerPlugin>(UserPluginHandle);
-  RegisterTimer T(HookName, ThisModule.saveString(UserPluginHandle->GetName()),
-                  Stats);
+  RegisterTimer T(
+      std::string(ThisModule.saveString(UserPluginHandle->GetName())) + "/" +
+          HookName.str(),
+      "Plugins", Stats);
   if (ThisModule.getPrinter()->tracePlugins())
     ThisConfig.raise(Diag::trace_plugin_hook) << getPluginName() << HookName;
   P->ActBeforePerformingLayout();
@@ -621,8 +644,10 @@ void Plugin::callActBeforePerformingLayoutHook() {
 void Plugin::callActBeforeWritingOutputHook() {
   llvm::StringRef HookName = "ActBeforeWritingOutput";
   plugin::LinkerPlugin *P = llvm::cast<plugin::LinkerPlugin>(UserPluginHandle);
-  RegisterTimer T(HookName, ThisModule.saveString(UserPluginHandle->GetName()),
-                  Stats);
+  RegisterTimer T(
+      std::string(ThisModule.saveString(UserPluginHandle->GetName())) + "/" +
+          HookName.str(),
+      "Plugins", Stats);
   if (ThisModule.getPrinter()->tracePlugins())
     ThisConfig.raise(Diag::trace_plugin_hook) << getPluginName() << HookName;
   P->ActBeforeWritingOutput();

--- a/lib/Support/RegisterTimer.cpp
+++ b/lib/Support/RegisterTimer.cpp
@@ -6,10 +6,18 @@
 
 #include "eld/Support/RegisterTimer.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Format.h"
 #include <memory>
 #include <mutex>
+#include <vector>
 
 namespace {
+
+// Pipeline order for the hierarchical report.
+static const llvm::StringRef PipelineOrder[] = {
+    "Initialize", "Read", "Resolve", "Layout", "Emit", "Plugins",
+};
 
 class RegisterTimerRegistry {
 public:
@@ -27,7 +35,10 @@ public:
     GroupTimers &GroupEntry = Groups[GroupName];
     if (!GroupEntry.Group)
       GroupEntry.Group = std::make_unique<llvm::TimerGroup>(
-          GroupName, GroupDescription, /*PrintOnExit=*/true);
+          GroupName, GroupDescription, /*PrintOnExit=*/false);
+
+    if (GroupEntry.Timers.find(Name) == GroupEntry.Timers.end())
+      GroupEntry.Order.push_back(Name.str());
 
     llvm::Timer &T = GroupEntry.Timers[Name];
     if (!T.isInitialized())
@@ -36,10 +47,54 @@ public:
     return T;
   }
 
+  struct TimerData {
+    std::string Name;
+    double Wall = 0.0;
+    double User = 0.0;
+    double Sys = 0.0;
+  };
+
+  struct PhaseData {
+    std::string Name;
+    double Wall = 0.0;
+    double User = 0.0;
+    double Sys = 0.0;
+    std::vector<TimerData> Timers; // in first-seen (linker flow) order
+  };
+
+  // Snapshot all timer data under a single lock and return phases in pipeline
+  // order with timers in first-seen order. Callers must not hold the mutex.
+  std::vector<PhaseData> snapshot() {
+    std::lock_guard<std::mutex> Lock(Mu);
+    std::vector<PhaseData> Result;
+    for (llvm::StringRef Phase : PipelineOrder) {
+      auto It = Groups.find(Phase);
+      if (It == Groups.end())
+        continue;
+      PhaseData PD;
+      PD.Name = Phase;
+      for (const std::string &Name : It->second.Order) {
+        llvm::TimeRecord TR = It->second.Timers[Name].getTotalTime();
+        TimerData TD;
+        TD.Name = Name;
+        TD.Wall = TR.getWallTime();
+        TD.User = TR.getUserTime();
+        TD.Sys = TR.getSystemTime();
+        PD.Wall += TD.Wall;
+        PD.User += TD.User;
+        PD.Sys += TD.Sys;
+        PD.Timers.push_back(std::move(TD));
+      }
+      Result.push_back(std::move(PD));
+    }
+    return Result;
+  }
+
 private:
   struct GroupTimers {
     std::unique_ptr<llvm::TimerGroup> Group;
     llvm::StringMap<llvm::Timer> Timers;
+    std::vector<std::string> Order; // insertion order
   };
 
   std::mutex Mu;
@@ -50,18 +105,79 @@ private:
 
 namespace eld {
 
-RegisterTimer::RegisterTimer(llvm::StringRef Name, llvm::StringRef Group,
+RegisterTimer::RegisterTimer(llvm::StringRef Name, llvm::StringRef Phase,
                              bool Enable)
-    : RegisterTimer(Name, Name, Group, Group, Enable) {}
+    : RegisterTimer(Name, Name, Phase, Phase, Enable) {}
 
 RegisterTimer::RegisterTimer(llvm::StringRef Name, llvm::StringRef Description,
-                             llvm::StringRef Group,
-                             llvm::StringRef GroupDescription, bool Enable) {
+                             llvm::StringRef Phase,
+                             llvm::StringRef PhaseDescription, bool Enable) {
   if (!Enable)
     return;
 
   T = &RegisterTimerRegistry::instance().getOrCreateTimer(
-      Name, Description, Group, GroupDescription);
+      Name, Description, Phase, PhaseDescription);
   Region.emplace(*T);
 }
+
+void RegisterTimer::printTimingReport(llvm::raw_ostream &OS) {
+  auto Phases = RegisterTimerRegistry::instance().snapshot();
+
+  double TotalWall = 0.0;
+  double TotalUser = 0.0;
+  double TotalSys = 0.0;
+  for (auto &P : Phases) {
+    TotalWall += P.Wall;
+    TotalUser += P.User;
+    TotalSys += P.Sys;
+  }
+
+  // Compute name field width from the longest name actually present.
+  // Phase rows have no indent; sub-timer rows have 2-space indent, so their
+  // effective text budget is NW-2.  We size NW so all names fit untruncated.
+  int NW = (int)llvm::StringRef("Phase / Timer").size();
+  for (auto &P : Phases) {
+    NW = std::max(NW, (int)P.Name.size());
+    for (auto &T : P.Timers)
+      NW = std::max(NW, (int)T.Name.size() + 2); // +2 for sub-timer indent
+  }
+  NW += 2; // a little breathing room
+
+  // Separator line: "  " + NW dashes + "  " + 4*(8+2) number columns + "  " + 5
+  // pct
+  int SepLen = 2 + NW + 2 + 8 + 2 + 8 + 2 + 8 + 2 + 5;
+  std::string Sep = "  " + std::string(SepLen - 2, '-') + "\n";
+
+  // Banner: "===---------===", same width as SepLen.
+  std::string Banner = "===" + std::string(SepLen - 6, '-') + "===";
+  std::string Title = "ELD Link Timing Report";
+  int TitlePad = (SepLen - (int)Title.size()) / 2;
+  std::string TitleLine(TitlePad, ' ');
+  TitleLine += Title;
+
+  OS << "\n" << Banner << "\n";
+  OS << TitleLine << "\n";
+  OS << Banner << "\n";
+  OS << llvm::format("  %-*s  %8s  %8s  %8s  %5s\n", NW, "Phase / Timer",
+                     "Wall(s)", "User(s)", "Sys(s)", "%");
+  OS << Sep;
+
+  for (auto &P : Phases) {
+    double Pct = (TotalWall > 0.0) ? 100.0 * P.Wall / TotalWall : 0.0;
+    OS << llvm::format("  %-*s  %8.4f  %8.4f  %8.4f  %5.1f%%\n", NW,
+                       P.Name.c_str(), P.Wall, P.User, P.Sys, Pct);
+    for (auto &T : P.Timers) {
+      double TPct = (TotalWall > 0.0) ? 100.0 * T.Wall / TotalWall : 0.0;
+      std::string Indented = "  " + T.Name;
+      OS << llvm::format("  %-*s  %8.4f  %8.4f  %8.4f  %5.1f%%\n", NW,
+                         Indented.c_str(), T.Wall, T.User, T.Sys, TPct);
+    }
+  }
+
+  OS << Sep;
+  OS << llvm::format("  %-*s  %8.4f  %8.4f  %8.4f\n", NW, "Total", TotalWall,
+                     TotalUser, TotalSys);
+  OS << "\n";
+}
+
 } // namespace eld

--- a/lib/SymbolResolver/IRBuilder.cpp
+++ b/lib/SymbolResolver/IRBuilder.cpp
@@ -177,7 +177,7 @@ LDSymbol *IRBuilder::addSymbol(InputFile &Input, const std::string &SymbolName,
 
     LDSymbol *InputSym = nullptr;
     {
-      eld::RegisterTimer T("Add symbols from object files", "Symbol Resolution",
+      eld::RegisterTimer T("Add symbols from object files", "Resolve",
                            ThisConfig.options().printTimingStats());
 
       InputSym = addSymbolFromObject(Input, Name, Type, Desc, Binding, Size,
@@ -212,8 +212,7 @@ LDSymbol *IRBuilder::addSymbol(InputFile &Input, const std::string &SymbolName,
   }
   case InputFile::ELFDynObjFileKind: {
     {
-      eld::RegisterTimer T("Add symbols from dynamic object files",
-                           "Symbol Resolution",
+      eld::RegisterTimer T("Add symbols from dynamic object files", "Resolve",
                            ThisConfig.options().printTimingStats());
 
       LDSymbol *InputSym =
@@ -239,7 +238,7 @@ LDSymbol *IRBuilder::addSymbolFromObject(
   // Step 1. calculate a Resolver::Result
   // ResolvedResult is a triple <resolved_info, existent, override>
   Resolver::Result ResolvedResult = {nullptr, false, false};
-  eld::RegisterTimer T("Create && Resolve symbols", "Symbol Resolution",
+  eld::RegisterTimer T("Create && Resolve symbols", "Resolve",
                        ThisConfig.options().printTimingStats());
   NamePool &NP = ThisModule.getNamePool();
   ResolveInfo InputSymbolResolveInfo =
@@ -326,7 +325,7 @@ LDSymbol *IRBuilder::addSymbolFromDynObj(
       Visibility == ResolveInfo::Hidden)
     return nullptr;
 
-  eld::RegisterTimer T("Create && Resolve dynamic symbols", "Symbol Resolution",
+  eld::RegisterTimer T("Create && Resolve dynamic symbols", "Resolve",
                        ThisConfig.options().printTimingStats());
   NamePool &NP = ThisModule.getNamePool();
 
@@ -447,8 +446,7 @@ LDSymbol *IRBuilder::addSymbolFromDynObj(
 }
 
 void IRBuilder::addToCref(InputFile &Input, Resolver::Result PResult) {
-  eld::RegisterTimer T("Add Symbols to Cross Reference Table",
-                       "Symbol Resolution",
+  eld::RegisterTimer T("Add Symbols to Cross Reference Table", "Resolve",
                        ThisConfig.options().printTimingStats());
 
   GeneralOptions &Options = ThisConfig.options();

--- a/lib/Target/ARM/ARMLDBackend.cpp
+++ b/lib/Target/ARM/ARMLDBackend.cpp
@@ -548,7 +548,7 @@ bool ARMGNULDBackend::readSection(InputFile &pInput, ELFSection *S) {
 
 void ARMGNULDBackend::doPostLayout() {
   {
-    eld::RegisterTimer T("Sort EXIDX Fragments if Present", "Do Post Layout",
+    eld::RegisterTimer T("Sort EXIDX Fragments if Present", "Layout",
                          m_Module.getConfig().options().printTimingStats());
     ELFSection *exidx =
         m_Module.getScript().sectionMap().find(llvm::ELF::SHT_ARM_EXIDX);

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -206,7 +206,7 @@ void GNULDBackend::insertTimingFragmentStub() {
 }
 
 eld::Expected<void> GNULDBackend::initStdSections() {
-  eld::RegisterTimer T("Initialize ELF default sections", "Link Summary",
+  eld::RegisterTimer T("Initialize ELF default sections", "Initialize",
                        m_Module.getConfig().options().printTimingStats());
   m_pFileFormat = make<ELFFileFormat>();
 
@@ -327,8 +327,7 @@ eld::Expected<void> GNULDBackend::initStdSections() {
 /// initStandardSymbols - define and initialize standard symbols.
 /// This function is called after section merging but before read relocations.
 bool GNULDBackend::initStandardSymbols() {
-  eld::RegisterTimer T("Define and Initialize Standard Symbols",
-                       "Add Default Standard Symbols",
+  eld::RegisterTimer T("Define and Initialize Standard Symbols", "Resolve",
                        m_Module.getConfig().options().printTimingStats());
   if (LinkerConfig::Object == config().codeGenType() ||
       m_Module.getScript().linkerScriptHasSectionsCommand())
@@ -401,8 +400,7 @@ void GNULDBackend::DefineStandardSymFromSegment(
     llvm::StringRef A, llvm::StringRef B, uint32_t IncludePermissions,
     uint32_t ExcludePermissions, int SymBAlign, bool isBSS, bool isBackWards,
     uint32_t SegType) {
-  eld::RegisterTimer T("Define Standard Symbols from Segments",
-                       "Perform Layout",
+  eld::RegisterTimer T("Define Standard Symbols from Segments", "Layout",
                        m_Module.getConfig().options().printTimingStats());
   LDSymbol *SymA = nullptr;
   LDSymbol *SymB = nullptr;
@@ -443,7 +441,7 @@ void GNULDBackend::DefineStandardSymFromSegment(
 int64_t GNULDBackend::getPLTAddr(ResolveInfo *pInfo) const { return 0; }
 
 bool GNULDBackend::finalizeStandardSymbols() {
-  eld::RegisterTimer T("Finalize Standard Symbols", "Perform Layout",
+  eld::RegisterTimer T("Finalize Standard Symbols", "Layout",
                        m_Module.getConfig().options().printTimingStats());
   if (LinkerConfig::Object == config().codeGenType() ||
       m_Module.getScript().linkerScriptHasSectionsCommand())
@@ -755,7 +753,7 @@ ELFFileFormat *GNULDBackend::getOutputFormat() const { return m_pFileFormat; }
 
 /// sizeShstrtab - compute the size of .shstrtab
 void GNULDBackend::sizeShstrtab() {
-  eld::RegisterTimer T("Compute the size of .shstrtab", "Perform Layout",
+  eld::RegisterTimer T("Compute the size of .shstrtab", "Layout",
                        m_Module.getConfig().options().printTimingStats());
   size_t shstrtab = 0;
   // compute the size of .shstrtab section.
@@ -788,7 +786,7 @@ bool GNULDBackend::canSkipSymbolFromExport(ResolveInfo *R, bool isEntry) const {
 }
 
 bool GNULDBackend::applyVersionScriptScopes() {
-  eld::RegisterTimer T("Apply Version Script Scopes", "Output Symbols",
+  eld::RegisterTimer T("Apply Version Script Scopes", "Layout",
                        m_Module.getConfig().options().printTimingStats());
   if (!config().options().hasVersionScript())
     return true;
@@ -809,7 +807,7 @@ bool GNULDBackend::applyVersionScriptScopes() {
 }
 
 bool GNULDBackend::SetSymbolsToBeExported() {
-  eld::RegisterTimer T("Set Symbols to be Exported", "Output Symbols",
+  eld::RegisterTimer T("Set Symbols to be Exported", "Layout",
                        m_Module.getConfig().options().printTimingStats());
   // If we are not building a forced dynamic executable, dont build any dynamic
   // namepools.
@@ -896,7 +894,7 @@ void GNULDBackend::sizeDynNamePools() {
   // the end of the table.
   RIter PartitionBegin;
   {
-    eld::RegisterTimer T("Partition Symbols for Export", "Output Symbols",
+    eld::RegisterTimer T("Partition Symbols for Export", "Layout",
                          m_Module.getConfig().options().printTimingStats());
     PartitionBegin =
         std::stable_partition(RVect.begin(), RVect.end(),
@@ -909,7 +907,7 @@ void GNULDBackend::sizeDynNamePools() {
   }
 
   {
-    eld::RegisterTimer T("Create System V Fragments", "Output Symbols",
+    eld::RegisterTimer T("Create System V Fragments", "Layout",
                          m_Module.getConfig().options().printTimingStats());
     // Create a SysV Fragment.
     if (m_pSysVHash) {
@@ -925,7 +923,7 @@ void GNULDBackend::sizeDynNamePools() {
   }
 
   {
-    eld::RegisterTimer T("GNU Hash Fragments", "Output Symbols",
+    eld::RegisterTimer T("GNU Hash Fragments", "Layout",
                          m_Module.getConfig().options().printTimingStats());
     // Create a GNU Hash Fragment.
     if (m_pGNUHash) {
@@ -998,7 +996,7 @@ void GNULDBackend::sizeDynNamePools() {
 }
 
 void GNULDBackend::createEhFrameFillerAndHdrFragment() {
-  eld::RegisterTimer T("Create EhFrame Hdr Output Section", "Perform Layout",
+  eld::RegisterTimer T("Create EhFrame Hdr Output Section", "Layout",
                        m_Module.getConfig().options().printTimingStats());
 
   LayoutInfo *layoutInfo = m_Module.getLayoutInfo();
@@ -1042,7 +1040,7 @@ void GNULDBackend::createSFrameFragment() {
 }
 
 void GNULDBackend::sizeDynamic() {
-  eld::RegisterTimer T("Create Dynamic Output Section", "Perform Layout",
+  eld::RegisterTimer T("Create Dynamic Output Section", "Layout",
                        m_Module.getConfig().options().printTimingStats());
   if (config().isCodeStatic() && !config().options().forceDynamic()) {
     return;
@@ -1120,7 +1118,7 @@ void GNULDBackend::reserveDynamic() {
 }
 
 void GNULDBackend::initSymTab() {
-  eld::RegisterTimer T("Initialize Symbol Table", "Perform Layout",
+  eld::RegisterTimer T("Initialize Symbol Table", "Layout",
                        m_Module.getConfig().options().printTimingStats());
   getOutputFormat()->getShStrTab()->setSize(0x1);
 
@@ -1138,7 +1136,7 @@ void GNULDBackend::initSymTab() {
 }
 
 void GNULDBackend::sizeSymTab() {
-  eld::RegisterTimer T("Create Symbol Table", "Perform Layout",
+  eld::RegisterTimer T("Create Symbol Table", "Layout",
                        m_Module.getConfig().options().printTimingStats());
 
   GeneralOptions::StripSymbolMode S = config().options().getStripSymbolMode();
@@ -1282,13 +1280,13 @@ void GNULDBackend::emitSymbol64(llvm::ELF::Elf64_Sym &pSym, LDSymbol *pSymbol,
 eld::Expected<void>
 GNULDBackend::emitRegNamePools(llvm::FileOutputBuffer &pOutput) {
   {
-    eld::RegisterTimer T("Sort Symbols", "Emit Output File",
+    eld::RegisterTimer T("Sort Symbols", "Emit",
                          m_Module.getConfig().options().printTimingStats());
     m_Module.sortSymbols();
   }
   // Emit SymDef Information.
   {
-    eld::RegisterTimer T("Emit SymDef Information", "Emit Output File",
+    eld::RegisterTimer T("Emit SymDef Information", "Emit",
                          m_Module.getConfig().options().printTimingStats());
     if (config().options().symDef()) {
       std::unique_ptr<SymDefWriter> symDefWriter(new SymDefWriter(config()));
@@ -1934,7 +1932,7 @@ bool GNULDBackend::readRelocation(const llvm::ELF::Elf64_Rela &pRel,
 #include "CreateScriptProgramHeaders.hpp"
 
 void GNULDBackend::changeSymbolsFromAbsoluteToGlobal(OutputSectionEntry *out) {
-  eld::RegisterTimer T("Change Symbol to Global", "Setup Output Section Offset",
+  eld::RegisterTimer T("Change Symbol to Global", "Layout",
                        m_Module.getConfig().options().printTimingStats());
   for (OutputSectionEntry::iterator in = out->begin(), inEnd = out->end();
        in != inEnd; ++in) {
@@ -1981,7 +1979,7 @@ static void checkFragOffset(const Fragment *F, DiagnosticEngine *DiagEngine) {
 // getOffset(config().getDiagEngine()).
 void GNULDBackend::evaluateAssignments(OutputSectionEntry *out) {
 
-  eld::RegisterTimer T("Evaluate Expressions", "Establish Layout",
+  eld::RegisterTimer T("Evaluate Assignments", "Layout",
                        m_Module.getConfig().options().printTimingStats());
 
   ELFSection *OutSection = out->getSection();
@@ -2151,7 +2149,7 @@ void GNULDBackend::evaluateAssignments(OutputSectionEntry *out) {
 
 void GNULDBackend::evaluateAssignmentsAtEndOfOutputSection(
     OutputSectionEntry *out) {
-  eld::RegisterTimer T("Evaluate Expressions", "Establish Layout",
+  eld::RegisterTimer T("Evaluate End-of-Section Assignments", "Layout",
                        m_Module.getConfig().options().printTimingStats());
   if (m_Module.getPrinter()->traceAssignments())
     config().raise(Diag::output_section_eval)
@@ -2182,7 +2180,7 @@ void GNULDBackend::evaluateAssignmentsAtEndOfOutputSection(
 /// createSegmentsFromLinkerScript - Create program headers mentioned in Linker
 /// Script
 bool GNULDBackend::createSegmentsFromLinkerScript() {
-  eld::RegisterTimer T("Create Segments From PHDRS", "Perform Layout",
+  eld::RegisterTimer T("Create Segments From PHDRS", "Layout",
                        m_Module.getConfig().options().printTimingStats());
 
   LinkerScript &ldscript = m_Module.getScript();
@@ -2311,7 +2309,7 @@ bool GNULDBackend::createSegmentsFromLinkerScript() {
 }
 
 void GNULDBackend::assignOffsetsToSkippedSections() {
-  eld::RegisterTimer T("Assign Offsets to Skipped Sections", "Establish Layout",
+  eld::RegisterTimer T("Assign Offsets to Skipped Sections", "Layout",
                        m_Module.getConfig().options().printTimingStats());
   ELFSection *prev = nullptr;
   uint64_t offset = 0;
@@ -2334,7 +2332,7 @@ void GNULDBackend::assignOffsetsToSkippedSections() {
 std::pair<int64_t, ELFSection *>
 GNULDBackend::setupSegmentOffset(ELFSegment *Seg, ELFSection *P,
                                  int64_t BeginOffset) {
-  eld::RegisterTimer T("Setup Segment Offsets", "Establish Layout",
+  eld::RegisterTimer T("Setup Segment Offsets", "Layout",
                        m_Module.getConfig().options().printTimingStats());
   ELFSection *prev = P;
   // If offsets are already assigned, dont change the offsets.
@@ -2480,7 +2478,7 @@ bool GNULDBackend::setupSegment(ELFSegment *E) {
   uint64_t segAlign = E->align();
   bool canMergePrevious = true;
 
-  eld::RegisterTimer T("Setup Segment", "Perform Layout",
+  eld::RegisterTimer T("Setup Segment", "Layout",
                        m_Module.getConfig().options().printTimingStats());
   for (auto &O : *E) {
     bool isCurSectionNoLoad = (O->prolog().type() == OutputSectDesc::NOLOAD);
@@ -2562,7 +2560,7 @@ bool GNULDBackend::setupSegment(ELFSegment *E) {
 }
 
 void GNULDBackend::clearSegmentOffset(ELFSegment *S) {
-  eld::RegisterTimer T("Clear Segment Offsets", "Evaluate Expressions",
+  eld::RegisterTimer T("Clear Segment Offsets", "Layout",
                        m_Module.getConfig().options().printTimingStats());
   if (m_OffsetsAssigned)
     return;
@@ -2573,7 +2571,7 @@ void GNULDBackend::clearSegmentOffset(ELFSegment *S) {
 /// setupProgramHdrs - set up the attributes of segments as per PHDRS
 bool GNULDBackend::setupProgramHdrs() {
   {
-    eld::RegisterTimer X("Setup Program Headers", "Establish Layout",
+    eld::RegisterTimer X("Setup Program Headers", "Layout",
                          m_Module.getConfig().options().printTimingStats());
     int64_t segmentOffset = 0;
     // update segment info
@@ -2602,7 +2600,7 @@ bool GNULDBackend::setupProgramHdrs() {
 
   // Setup the TLS parameters.
   {
-    eld::RegisterTimer X("Setup TLS parameters", "Establish Layout",
+    eld::RegisterTimer X("Setup TLS parameters", "Layout",
                          m_Module.getConfig().options().printTimingStats());
     std::vector<ELFSegment *> tls_segs =
         elfSegmentTable().getSegments(llvm::ELF::PT_TLS);
@@ -2642,7 +2640,7 @@ bool GNULDBackend::setOutputSectionOffset() {
 
   uint64_t one_ehdr_size = 0;
 
-  eld::RegisterTimer T("Setup Output Section Offset", "Establish Layout",
+  eld::RegisterTimer T("Set Output Section Offsets", "Layout",
                        m_Module.getConfig().options().printTimingStats());
 
   if (config().targets().is32Bits())
@@ -2729,7 +2727,7 @@ void GNULDBackend::checkCrossReferencesHelper(InputFile *input) {
 }
 
 bool GNULDBackend::checkCrossReferences() {
-  eld::RegisterTimer T("Evaluate NOCROSSREFS", "Establish Layout",
+  eld::RegisterTimer T("Evaluate NOCROSSREFS", "Layout",
                        m_Module.getConfig().options().printTimingStats());
   if (config().options().numThreads() <= 1 ||
       !config().isCheckCrossRefsMultiThreaded()) {
@@ -2789,8 +2787,7 @@ bool GNULDBackend::placeOutputSections() {
   SectionMap &sectionMap = script.sectionMap();
   LayoutInfo *layoutInfo = m_Module.getLayoutInfo();
   {
-    eld::RegisterTimer T("Select Sections Needed in Output",
-                         "Place Output Sections",
+    eld::RegisterTimer T("Select Sections Needed in Output", "Layout",
                          m_Module.getConfig().options().printTimingStats());
     for (auto &elem : m_Module) {
       bool wanted = false;
@@ -2958,7 +2955,7 @@ bool GNULDBackend::placeOutputSections() {
   bool debugSectionSeen = false;
   OutputSectDesc::Type type = OutputSectDesc::LOAD;
   {
-    eld::RegisterTimer T("Set Section Permissions", "Place Output Sections",
+    eld::RegisterTimer T("Set Section Permissions", "Layout",
                          m_Module.getConfig().options().printTimingStats());
     for (auto &elem : sectionMap) {
       ELFSection *cur = (elem)->getSection();
@@ -3014,7 +3011,7 @@ bool GNULDBackend::placeOutputSections() {
 
   // sort output section orders if there is no default ldscript
   if (!linkerScriptHasSectionsCommand) {
-    eld::RegisterTimer T("Sort Output Section Order", "Place Output Sections",
+    eld::RegisterTimer T("Sort Output Section Order", "Layout",
                          m_Module.getConfig().options().printTimingStats());
     std::stable_sort(
         sectionMap.begin(), sectionMap.end(),
@@ -3025,7 +3022,7 @@ bool GNULDBackend::placeOutputSections() {
 
   // place orphan sections
   {
-    eld::RegisterTimer T("Place Orphan Sections", "Place Output Sections",
+    eld::RegisterTimer T("Place Orphan Sections", "Layout",
                          m_Module.getConfig().options().printTimingStats());
     for (auto &orphan : orphans) {
       if (layoutInfo)
@@ -3101,8 +3098,7 @@ bool GNULDBackend::placeOutputSections() {
   }
   // Set the right properties for sections.
   {
-    eld::RegisterTimer T("Override Output Section Properties",
-                         "Place Output Sections",
+    eld::RegisterTimer T("Override Output Section Properties", "Layout",
                          m_Module.getConfig().options().printTimingStats());
     for (SectionMap::iterator out = sectionMap.begin(),
                               outEnd = sectionMap.end();
@@ -3189,8 +3185,7 @@ bool GNULDBackend::layout() {
 
   // Evaluate all assignments.
   {
-    eld::RegisterTimer T("Evaluate Script Assignments and Asserts",
-                         "Establish Layout",
+    eld::RegisterTimer T("Evaluate Script Assignments and Asserts", "Layout",
                          m_Module.getConfig().options().printTimingStats());
     evaluateScriptAssignments();
   }
@@ -3203,7 +3198,7 @@ bool GNULDBackend::layout() {
 
   // FIXME: Adding more symbols this late can cause layout issues.
   {
-    eld::RegisterTimer T("Define Magic Symbols", "Establish Layout",
+    eld::RegisterTimer T("Define Magic Symbols", "Layout",
                          m_Module.getConfig().options().printTimingStats());
     if (!defineStandardAndSectionMagicSymbols())
       return false;
@@ -3219,7 +3214,7 @@ bool GNULDBackend::layout() {
 
   // Insert all sections that are needed in the section table
   {
-    eld::RegisterTimer T("Do Post Layout", "Establish Layout",
+    eld::RegisterTimer T("Post Layout", "Layout",
                          m_Module.getConfig().options().printTimingStats());
     doPostLayout();
   }
@@ -3361,7 +3356,7 @@ ELFSection *GNULDBackend::getOutputRelocationSection(ELFSection *S,
 void GNULDBackend::preLayout() {
   // prelayout target first
   {
-    eld::RegisterTimer T("Do Target Pre-Layout", "Pre-Layout",
+    eld::RegisterTimer T("Do Target Pre-Layout", "Layout",
                          m_Module.getConfig().options().printTimingStats());
     doPreLayout();
   }
@@ -3371,7 +3366,7 @@ void GNULDBackend::preLayout() {
   // If we are generating relocatables (-r), move input relocation sections
   // to corresponding output relocation sections.
   if (LinkerConfig::Object == config().codeGenType()) {
-    eld::RegisterTimer T("Copy Input Relocations to Output", "Perform Layout",
+    eld::RegisterTimer T("Copy Input Relocations to Output", "Layout",
                          m_Module.getConfig().options().printTimingStats());
     Module::obj_iterator input, inEnd = m_Module.objEnd();
     for (input = m_Module.objBegin(); input != inEnd; ++input) {
@@ -3433,7 +3428,7 @@ void GNULDBackend::preLayout() {
 
 /// postLayout - Backend can do any needed modification after layout
 bool GNULDBackend::postLayout() {
-  eld::RegisterTimer T("Do Post Layout", "Post-Layout",
+  eld::RegisterTimer T("Post Layout Processing", "Layout",
                        m_Module.getConfig().options().printTimingStats());
   size_t sectionIdx = 0;
   LayoutInfo *layoutInfo = m_Module.getLayoutInfo();
@@ -3556,7 +3551,7 @@ void GNULDBackend::finalizeBeforeWrite() {
 
   ELFSection *symtab = getOutputFormat()->getSymTab();
 
-  eld::RegisterTimer T("Set Offset of SymTab", "Perform Layout",
+  eld::RegisterTimer T("Set Offset of SymTab", "Layout",
                        m_Module.getConfig().options().printTimingStats());
 
   for (out = outBegin; out != outEnd; ++out) {
@@ -3578,7 +3573,7 @@ void GNULDBackend::finalizeBeforeWrite() {
 }
 
 bool GNULDBackend::printLayout() {
-  eld::RegisterTimer T("Emit Map File", "Diagnostics",
+  eld::RegisterTimer T("Emit Map file", "Emit",
                        m_Module.getConfig().options().printTimingStats());
   // Emit Map
   TextLayoutPrinter *printer = m_Module.getTextMapPrinter();
@@ -3638,7 +3633,7 @@ void GNULDBackend::printCref(bool pIsPostLTO) const {
   else
     stream = &(llvm::outs());
 
-  eld::RegisterTimer T("Emit CRef", "Diagnostics",
+  eld::RegisterTimer T("Emit CRef", "Emit",
                        m_Module.getConfig().options().printTimingStats());
 
   const GeneralOptions::CrefTableType &table = config().options().crefTable();
@@ -3734,7 +3729,7 @@ void GNULDBackend::fillValuesFromUser(llvm::FileOutputBuffer &pOutput) {
   if (!m_PaddingMap.size())
     return;
 
-  eld::RegisterTimer T("Apply Fill Patterns", "Post Processing",
+  eld::RegisterTimer T("Apply Fill Patterns", "Emit",
                        m_Module.getConfig().options().printTimingStats());
 
   for (auto &fsections : m_PaddingMap) {
@@ -3752,7 +3747,7 @@ GNULDBackend::postProcessing(llvm::FileOutputBuffer &pOutput) {
   fillValuesFromUser(pOutput);
 
   if (m_pEhFrameHdrFragment) {
-    eld::RegisterTimer T("EhFrameHdr Emit", "Post Processing",
+    eld::RegisterTimer T("EhFrameHdr Emit", "Emit",
                          m_Module.getConfig().options().printTimingStats());
     MemoryRegion region =
         getFileOutputRegion(pOutput, 0, pOutput.getBufferSize());
@@ -3762,7 +3757,7 @@ GNULDBackend::postProcessing(llvm::FileOutputBuffer &pOutput) {
   }
 
   if (m_pSFrameFragment) {
-    eld::RegisterTimer T("SFrame Emit", "Post Processing",
+    eld::RegisterTimer T("SFrame Emit", "Emit",
                          m_Module.getConfig().options().printTimingStats());
     MemoryRegion region =
         getFileOutputRegion(pOutput, 0, pOutput.getBufferSize());
@@ -3775,7 +3770,7 @@ GNULDBackend::postProcessing(llvm::FileOutputBuffer &pOutput) {
 void GNULDBackend::applyPluginFragmentReplacements(
     llvm::FileOutputBuffer &Output) {
   eld::RegisterTimer T(
-      "Replace Fragments from Plugin", "Post Processing",
+      "Replace Fragments from Plugin", "Emit",
       m_Module.getConfig().options().printTimingStats("Plugin"));
   for (auto &V : m_Module.getReplaceFrags()) {
     FragmentRef *F = V.first;
@@ -4170,7 +4165,7 @@ bool GNULDBackend::relax() {
       constexpr int maxIterations = 4;
       DivergenceResult diverged;
       for (int i = 0; i < maxIterations; ++i) {
-        eld::RegisterTimer T("Assign Address", "Establish Layout",
+        eld::RegisterTimer T("Assign Address", "Layout",
                              m_Module.getConfig().options().printTimingStats());
         bool hasError = createProgramHdrs();
         if (hasError)
@@ -4209,7 +4204,7 @@ bool GNULDBackend::relax() {
       return false;
     }
     {
-      eld::RegisterTimer T("Prepare Relaxation", "Establish Layout",
+      eld::RegisterTimer T("Prepare Relaxation", "Layout",
                            m_Module.getConfig().options().printTimingStats());
       preRelaxation();
     }
@@ -4220,7 +4215,7 @@ bool GNULDBackend::relax() {
       return false;
     }
     {
-      eld::RegisterTimer T("Create Trampolines", "Establish Layout",
+      eld::RegisterTimer T("Create Trampolines", "Layout",
                            m_Module.getConfig().options().printTimingStats());
       mayBeRelax(iteration, finished);
     }
@@ -4250,7 +4245,7 @@ bool GNULDBackend::relax() {
 
 MemoryRegion GNULDBackend::getFileOutputRegion(llvm::FileOutputBuffer &pBuffer,
                                                size_t pOffset, size_t pLength) {
-  eld::RegisterTimer T("Create File Output Region", "Post Processing",
+  eld::RegisterTimer T("Create File Output Region", "Emit",
                        m_Module.getConfig().options().printTimingStats());
   if (pOffset > pBuffer.getBufferSize() ||
       (pOffset + pLength > pBuffer.getBufferSize()))
@@ -4333,7 +4328,7 @@ LDSymbol &GNULDBackend::defineSymbolforCopyReloc(eld::IRBuilder &pBuilder,
   ResolveInfo *curSym = pSym;
   ResolveInfo *aliasSym = pSym->alias();
 
-  eld::RegisterTimer T("Define Symbol for COPY Reloc", "Perform Layout",
+  eld::RegisterTimer T("Define Symbol for COPY Reloc", "Layout",
                        m_Module.getConfig().options().printTimingStats());
   // If the alias symbol and the aliasee are from different input files,
   // they are not really aliases.
@@ -4476,7 +4471,7 @@ bool GNULDBackend::assignOffsets(uint64_t offset) {
   // Iterate through all sections to get to the debug sections
   // for assigning offsets to them.
   {
-    eld::RegisterTimer T("Get Debug Sections", "Establish Layout",
+    eld::RegisterTimer T("Get Debug Sections", "Layout",
                          m_Module.getConfig().options().printTimingStats());
     while (out != outEnd) {
       ELFSection *cur = (*out)->getSection();
@@ -4487,7 +4482,7 @@ bool GNULDBackend::assignOffsets(uint64_t offset) {
   }
 
   {
-    eld::RegisterTimer T("Run File Size Plugin", "Establish Layout",
+    eld::RegisterTimer T("Run File Size Plugin", "Layout",
                          m_Module.getConfig().options().printTimingStats());
 
     if (!RunPluginsAndProcessHelper(OList)) {
@@ -4579,7 +4574,7 @@ bool GNULDBackend::RunPluginsAndProcessHelper(
     SectionMap::OutputSectionEntryDescList &OList, bool MatchSections) {
   {
     eld::RegisterTimer T(
-        "VA/File Size Plugin and Process Helper", "Establish Layout",
+        "VA/File Size Plugin and Process Helper", "Layout",
         m_Module.getConfig().options().printTimingStats("Plugin"));
 
     if (!OList.size())
@@ -4799,7 +4794,7 @@ void GNULDBackend::doPostLayout() {
 
   // Update all relative relocations to point to the right fragment.
   {
-    eld::RegisterTimer T("Update Relative Relocations", "Do Post Layout",
+    eld::RegisterTimer T("Update Relative Relocations", "Layout",
                          m_Module.getConfig().options().printTimingStats());
     for (auto &r : m_RelativeRelocMap) {
       const Relocation *N = r.first;
@@ -4813,7 +4808,7 @@ void GNULDBackend::doPostLayout() {
   }
 
   {
-    eld::RegisterTimer T("Run VA Plugin", "Establish Layout",
+    eld::RegisterTimer T("Run VA Plugin", "Layout",
                          m_Module.getConfig().options().printTimingStats());
     SectionMap::OutputSectionEntryDescList OList =
         m_Module.getScript()
@@ -4834,7 +4829,7 @@ void GNULDBackend::doPostLayout() {
   }
 
   {
-    eld::RegisterTimer T("Create Script Program Headers", "Establish Layout",
+    eld::RegisterTimer T("Create Script Program Headers", "Layout",
                          m_Module.getConfig().options().printTimingStats());
     createScriptProgramHdrs();
   }
@@ -4950,7 +4945,7 @@ void GNULDBackend::makeVersionString() {
 }
 
 bool GNULDBackend::addPhdrsIfNeeded(void) {
-  eld::RegisterTimer T("Add Phdrs", "Perform Layout",
+  eld::RegisterTimer T("Add Phdrs", "Layout",
                        m_Module.getConfig().options().printTimingStats());
   bool hasFileHdrOrPhdr = false;
   std::optional<PhdrSpec> firstPTLOAD;
@@ -5229,7 +5224,7 @@ void GNULDBackend::setNewSectionsAddToLayout() {
 void GNULDBackend::createFileHeader() {
   if (m_ehdr)
     return;
-  eld::RegisterTimer T("Add File Header", "Perform Layout",
+  eld::RegisterTimer T("Add File Header", "Layout",
                        m_Module.getConfig().options().printTimingStats());
   LinkerScript &script = m_Module.getScript();
   m_ehdr = script.sectionMap().createELFSection(
@@ -5260,7 +5255,7 @@ void GNULDBackend::addFileHeaderToLayout() {
 void GNULDBackend::createProgramHeader() {
   if (m_phdr)
     return;
-  eld::RegisterTimer T("Add Program Header", "Perform Layout",
+  eld::RegisterTimer T("Add Program Header", "Layout",
                        m_Module.getConfig().options().printTimingStats());
   LinkerScript &script = m_Module.getScript();
   m_phdr = script.sectionMap().createELFSection(

--- a/lib/Writers/ELFObjectWriter.cpp
+++ b/lib/Writers/ELFObjectWriter.cpp
@@ -189,7 +189,7 @@ ELFObjectWriter::writeObject(llvm::FileOutputBuffer &CurOutput) {
 
   if (IsDynobj || IsExec) {
     // Write out name pool sections: .dynsym, .dynstr, .hash
-    eld::RegisterTimer T("Emit Dynamic Name Pool sections", "Emit Output File",
+    eld::RegisterTimer T("Emit Dynamic Name Pool sections", "Emit",
                          ThisModule.getConfig().options().printTimingStats());
     if (!ThisModule.getBackend().emitDynNamePools(CurOutput))
       return make_error_code(std::errc::function_not_supported);
@@ -237,7 +237,7 @@ ELFObjectWriter::writeObject(llvm::FileOutputBuffer &CurOutput) {
       }
     }
   } else {
-    eld::RegisterTimer T("Emit Regular ELF Sections", "Emit Output File",
+    eld::RegisterTimer T("Emit Regular ELF Sections", "Emit",
                          ThisModule.getConfig().options().printTimingStats());
     // Write out regular ELF sections
     Module::iterator Sect, SectEnd = ThisModule.end();


### PR DESCRIPTION
Replace the flat per-group LLVM timer output with a custom report that reflects the actual linker pipeline. Timers are now grouped under six top-level phases in execution order/categories:

  Initialize -> Read -> Resolve -> Layout -> Emit -> Plugins

Each phase shows total wall, user, and system time plus its percentage of the total link time. Sub-timers appear in linker flow order (first seen) under their phase so the report reads as a trace of the pipeline. The name column width is computed from the longest timer name present so no names are truncated.

Previously, --print-timing-stats emitted one flat table per TimerGroup using LLVM's default printer. There were ~25 group names with no relationship to linker phases, numbers in only one column (wall time), and no sense of which phase dominated the link.