### PR TITLE
[X86] Fix missing mutex on R_X86_64_PLT32 in scanGlobalReloc

### DIFF
--- a/lib/Target/X86/x86_64Relocator.cpp
+++ b/lib/Target/X86/x86_64Relocator.cpp
@@ -375,6 +375,7 @@ void x86_64Relocator::scanGlobalReloc(InputFile &pInputFile, Relocation &pReloc,
     return;
   }
   case llvm::ELF::R_X86_64_PLT32: {
+    std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
     // return if we already create plt for this symbol
     if (rsym->reserved() & ReservePLT)
       return;


### PR DESCRIPTION
R_X86_64_PLT32 in scanGlobalReloc was the only case without a m_RelocMutex guard. Under --enable-threads=all, concurrent calls to createPLT() corrupt the SmallVector fragment/relocation lists and DenseMap, causing a crash.