### PR TITLE
[x86] Implement R_X86_64_TLSGD GD→LE TLS relaxation

### DIFF
--- a/include/eld/Diagnostics/DiagVerbose.inc
+++ b/include/eld/Diagnostics/DiagVerbose.inc
@@ -36,6 +36,8 @@ DIAG(relax_to_compress, DiagnosticEngine::Verbose,
      "%3 in section %4+0x%5 file %6")
 DIAG(trace_relax_gotpcrelx, DiagnosticEngine::Trace,
      "%0: relaxed GOTPCRELX (%1) for symbol '%2' to PC-relative access")
+DIAG(trace_relax_tlsgd_le, DiagnosticEngine::Trace,
+     "relaxed TLSGD for symbol '%0' to LE access in section %1+0x%2 file %3")
 DIAG(verbose_ehframe_remove_fde, DiagnosticEngine::Verbose, "EhFrame %0")
 DIAG(verbose_ehframe_read_fde, DiagnosticEngine::Verbose, "EhFrame %0")
 DIAG(verbose_ehframe_read_cie, DiagnosticEngine::Verbose, "EhFrame %0")

--- a/lib/Target/X86/x86_64LDBackend.cpp
+++ b/lib/Target/X86/x86_64LDBackend.cpp
@@ -151,7 +151,7 @@ bool x86_64LDBackend::isGOTPCRELXRelaxable(const Relocation *reloc) const {
 }
 
 bool x86_64LDBackend::shouldIgnoreRelocSync(Relocation *reloc) const {
-  return isGOTPCRELXRelaxCandidate(reloc);
+  return isGOTPCRELXRelaxCandidate(reloc) || isTLSGDRelaxCandidate(reloc);
 }
 
 eld::Expected<void>
@@ -160,7 +160,7 @@ x86_64LDBackend::postProcessing(llvm::FileOutputBuffer &pOutput) {
 
   // Relaxation rewrites bytes in the laid-out output image; it is not
   // applicable to partial links, which have no final layout.
-  if (config().options().getRelax() && !config().isLinkPartial())
+  if (!config().isLinkPartial())
     ELDEXP_RETURN_DIAGENTRY_IF_ERROR(doRelax(pOutput));
 
   return {};
@@ -168,21 +168,24 @@ x86_64LDBackend::postProcessing(llvm::FileOutputBuffer &pOutput) {
 
 eld::Expected<void> x86_64LDBackend::doRelax(llvm::FileOutputBuffer &pOutput) {
   uint8_t *buf = pOutput.getBufferStart();
-  // The scan phase already identified every relaxation candidate (skipping
-  // debug relocations and internal files, which never carry a relaxable
-  // relocation). Iterate that cached set instead of re-walking all
-  // relocations, and dispatch on the relocation type. Future relaxable types
-  // (e.g. R_X86_64_REX_GOTPCRELX, TLS relaxations) add a case here.
-  for (Relocation *reloc : m_GOTPCRELXRelaxCandidates) {
-    switch (reloc->type()) {
-    case llvm::ELF::R_X86_64_GOTPCRELX:
-      ELDEXP_RETURN_DIAGENTRY_IF_ERROR(relaxGOTPCRELXReloc(reloc, buf));
-      break;
-    default:
-      // Only relaxable types are recorded as candidates; skip anything else.
-      break;
+  // The scan phase already identified every relaxation candidate
+  // GOTPCRELX relaxation is optional (--relax); GD→LE is
+  // mandatory (otherwise we get an undefined reference for __tls_get_addr in
+  // static links).
+  if (config().options().getRelax()) {
+    for (Relocation *reloc : m_GOTPCRELXRelaxCandidates) {
+      switch (reloc->type()) {
+      case llvm::ELF::R_X86_64_GOTPCRELX:
+        ELDEXP_RETURN_DIAGENTRY_IF_ERROR(relaxGOTPCRELXReloc(reloc, buf));
+        break;
+      default:
+        // Only relaxable types are recorded as candidates; skip anything else.
+        break;
+      }
     }
   }
+  for (Relocation *reloc : m_TLSGDLERelaxCandidates)
+    ELDEXP_RETURN_DIAGENTRY_IF_ERROR(relaxTLSGDToLEReloc(reloc, buf));
   return {};
 }
 
@@ -280,6 +283,62 @@ eld::Expected<void> x86_64LDBackend::relaxGOTPCRELXReloc(Relocation *reloc,
     location = traceSect->getLocation(offset, config().options());
     config().raise(Diag::trace_relax_gotpcrelx)
         << location << kind << rsym->name();
+  }
+
+  return {};
+}
+
+eld::Expected<void> x86_64LDBackend::relaxTLSGDToLEReloc(Relocation *reloc,
+                                                         uint8_t *buf) {
+  auto *RF = llvm::cast<RegionFragment>(reloc->targetRef()->frag());
+
+  uint32_t offset = reloc->targetRef()->offset();
+  assert(offset >= 4 && "TLSGD relax candidate offset must be >= 4");
+
+  FragmentRef::Offset off = reloc->targetRef()->getOutputOffset(m_Module);
+  if (off == (FragmentRef::Offset)-1)
+    return {};
+  size_t out_off = reloc->targetRef()->getOutputELFSection()->offset() + off;
+
+  uint64_t TLSTemplateSize = getTLSTemplateSize();
+  if (TLSTemplateSize == 0) {
+    config().raise(Diag::no_pt_tls_segment);
+    return {};
+  }
+  // Use finalizeTLSSymbol to get the TLS-segment-relative offset (S).
+  // Relocation::symValue() ASSERTs on TLS-type symbols; the correct path
+  // for TLS is through finalizeTLSSymbol(), mirroring what
+  // Relocator::getSymValue does for thread-local symbols.
+  uint64_t S = finalizeTLSSymbol(reloc->symInfo()->outSymbol());
+  int64_t A = static_cast<int64_t>(reloc->addend());
+  int64_t tpoff =
+      static_cast<int64_t>(S) + A - static_cast<int64_t>(TLSTemplateSize);
+
+  // Rewrite 16 bytes starting at out_off-4:
+  //   9 bytes: movq %fs:0x0, %rax
+  //   7 bytes: leaq tpoff(%rax), %rax
+  static const uint8_t kMoveFS[] = {0x64, 0x48, 0x8b, 0x04, 0x25,
+                                    0x00, 0x00, 0x00, 0x00};
+  std::memcpy(buf + out_off - 4, kMoveFS, sizeof(kMoveFS));
+  buf[out_off + 5] = 0x48; // REX.W
+  buf[out_off + 6] = 0x8d; // LEA opcode
+  buf[out_off + 7] = 0x80; // ModR/M: disp32(%rax) -> %rax
+  // imm32 at out_off+8: the R_X86_64_TLSGD addend is -4 (PC-relative bias);
+  // adding +4 cancels it, giving the raw tpoff = S_rel - templateSize.
+  llvm::support::endian::write32le(buf + out_off + 8,
+                                   static_cast<uint32_t>(tpoff + 4));
+
+  if (m_Module.getPrinter()->traceRelax()) {
+    ELFSection *traceSect = RF->getOwningSection();
+    assert(traceSect &&
+           "RegionFragment in relax candidate must have an owning section");
+    std::string fileName;
+    if (InputFile *F = traceSect->getInputFile())
+      if (auto *I = F->getInput())
+        fileName = I->decoratedPath();
+    config().raise(Diag::trace_relax_tlsgd_le)
+        << reloc->symInfo()->name() << traceSect->name()
+        << llvm::utohexstr(offset) << fileName;
   }
 
   return {};

--- a/lib/Target/X86/x86_64LDBackend.h
+++ b/lib/Target/X86/x86_64LDBackend.h
@@ -13,6 +13,7 @@
 #include "eld/SymbolResolver/IRBuilder.h"
 #include "eld/Target/GNULDBackend.h"
 #include "x86_64PLT.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include <unordered_set>
 
@@ -124,6 +125,38 @@ public:
     return m_GOTPCRELXRelaxCandidates.count(reloc) != 0;
   }
 
+  /// Records a TLSGD relocation for GD→LE relaxation during scan.
+  /// Called under the relocator mutex; no GOT pair will be created.
+  void recordTLSGDLERelaxCandidate(Relocation *reloc) {
+    m_TLSGDLERelaxCandidates.insert(reloc);
+    m_TLSGDLEFragOffsets.insert(
+        {reloc->targetRef()->frag(),
+         static_cast<uint32_t>(reloc->targetRef()->offset())});
+  }
+
+  /// Returns true if this R_X86_64_TLSGD was marked for GD→LE relaxation.
+  bool isTLSGDLERelaxCandidate(Relocation *reloc) const {
+    return m_TLSGDLERelaxCandidates.count(reloc) != 0;
+  }
+
+  /// Returns true if this relocation is the companion call in a GD→LE relaxed
+  /// sequence. The companion sits exactly 8 bytes after the TLSGD displacement
+  /// field and is R_X86_64_PLT32 (standard) or R_X86_64_GOTPCRELX (-fno-plt).
+  bool isTLSGDCompanion(const Relocation *reloc) const {
+    uint32_t offset = reloc->targetRef()->offset();
+    if (offset < 8)
+      return false;
+    return m_TLSGDLEFragOffsets.count(
+               {reloc->targetRef()->frag(), offset - 8}) != 0;
+  }
+
+  /// Returns true if this relocation is part of a GD→LE relaxed sequence and
+  /// will be rewritten by postProcessing. Used to skip apply and dynamic-reloc
+  /// sync for both the TLSGD reloc itself and its companion call reloc.
+  bool isTLSGDRelaxCandidate(Relocation *reloc) const {
+    return isTLSGDLERelaxCandidate(reloc) || isTLSGDCompanion(reloc);
+  }
+
   DynRelocType getDynRelocType(const Relocation *X) const override {
     if (X->type() == llvm::ELF::R_X86_64_GLOB_DAT)
       return DynRelocType::GLOB_DAT;
@@ -182,6 +215,9 @@ private:
   /// Iterates the cached relaxation candidates and rewrites each one.
   eld::Expected<void> doRelax(llvm::FileOutputBuffer &pOutput);
 
+  /// Rewrites the 16-byte GD sequence to the LE form (movq %fs:0 + leaq).
+  eld::Expected<void> relaxTLSGDToLEReloc(Relocation *reloc, uint8_t *buf);
+
 private:
   Relocator *m_pRelocator;
 
@@ -198,6 +234,16 @@ private:
   /// postProcessing. unordered_set for O(1) membership checks in
   /// shouldIgnoreRelocSync and the apply-path guard.
   std::unordered_set<Relocation *> m_GOTPCRELXRelaxCandidates;
+
+  /// TLSGD relocations selected for GD→LE relaxation during the scan phase.
+  /// Non-preemptible symbols in executables (static or dynamic); no GOT pair
+  /// is created for these. Consumed single-threaded in doRelax.
+  std::unordered_set<Relocation *> m_TLSGDLERelaxCandidates;
+
+  /// Fragment + intra-fragment offset of each TLSGD candidate, stored as a
+  /// (Fragment*, uint32_t) pair. Used for O(1) companion detection.
+  /// LLVM provides DenseMapInfo for pointer+integer pairs.
+  llvm::DenseSet<std::pair<const Fragment *, uint32_t>> m_TLSGDLEFragOffsets;
 };
 } // namespace eld
 

--- a/lib/Target/X86/x86_64Relocator.cpp
+++ b/lib/Target/X86/x86_64Relocator.cpp
@@ -136,11 +136,17 @@ void x86_64Relocator::scanRelocation(Relocation &pReloc,
   // symbol
   if (rsym->isUndef() || rsym->isBitCode()) {
     std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
-    if (!m_Target.canProvideSymbol(rsym)) {
-      if (m_Target.canIssueUndef(rsym)) {
-        if (rsym->visibility() != ResolveInfo::Default)
-          issueInvisibleRef(pReloc, pInputFile);
-        issueUndefRef(pReloc, pInputFile, &pSection);
+    // Suppress undefined-ref for the companion call in a GD→LE relaxed
+    // sequence (R_X86_64_PLT32 with PLT, or R_X86_64_GOTPCRELX with -fno-plt):
+    // __tls_get_addr is unavailable in a static link, but the bytes at this
+    // offset are fully overwritten by postProcessing.
+    if (!m_Target.isTLSGDCompanion(&pReloc)) {
+      if (!m_Target.canProvideSymbol(rsym)) {
+        if (m_Target.canIssueUndef(rsym)) {
+          if (rsym->visibility() != ResolveInfo::Default)
+            issueInvisibleRef(pReloc, pInputFile);
+          issueUndefRef(pReloc, pInputFile, &pSection);
+        }
       }
     }
   }
@@ -402,6 +408,12 @@ void x86_64Relocator::scanGlobalReloc(InputFile &pInputFile, Relocation &pReloc,
     if (rsym->reserved() & ReservePLT)
       return;
 
+    // Suppress the companion call in a GD→LE relaxed sequence: the
+    // R_X86_64_PLT32 at TLSGD_offset+8 references __tls_get_addr, which does
+    // not exist in a static link. The bytes are overwritten by postProcessing;
+    if (m_Target.isTLSGDCompanion(&pReloc))
+      return;
+
     // create IRELATIVE for IFUNC symbol
     if (rsym->type() == ResolveInfo::IndirectFunc && config().isCodeStatic()) {
       m_Target.createPLT(Obj, rsym, true);
@@ -435,6 +447,11 @@ void x86_64Relocator::scanGlobalReloc(InputFile &pInputFile, Relocation &pReloc,
       m_Target.recordGOTPCRELXRelaxCandidate(&pReloc);
       return;
     }
+    // The GOTPCRELX at TLSGD_offset+8 is the companion call in a -fno-plt
+    // GD sequence being relaxed to LE. Suppress GOT creation; the bytes are
+    // overwritten by postProcessing.
+    if (m_Target.isTLSGDCompanion(&pReloc))
+      return;
     if (rsym->reserved() & ReserveGOT)
       return;
     CreateGOT(Obj, pReloc, !config().isCodeStatic(), m_Target);
@@ -479,7 +496,32 @@ void x86_64Relocator::scanGlobalReloc(InputFile &pInputFile, Relocation &pReloc,
     if (rsym->reserved() & ReserveGOT)
       return;
 
-    // Create GD GOT pair (x86_64GDGOT creates both entries)
+    // GD→LE: non-preemptible symbol in an executable (static, dynamic, or PIE)
+    // that is not a partial link. LE requires the variable's offset from the
+    // thread pointer to be a link-time constant. That holds only for the
+    // executable's own TLS block, which is always placed at a fixed distance
+    // below TP. A DSO's block is positioned by the loader at startup, so its
+    // tpoff is not known at link time — even for a hidden (non-preemptible)
+    // symbol; DSOs are therefore excluded. Partial links are excluded because
+    // they have no final layout; the re-link will decide. Preemptible symbols
+    // in a non-shared executable would go GD→IE.
+    if (!m_Target.isSymbolPreemptible(*rsym) &&
+        m_Target.config().isBuildingExecutable() && !config().isLinkPartial()) {
+      // Guard against a corrupt or hand-crafted object: require a
+      // RegionFragment with offset >= 4. The 16-byte GD sequence requires 4
+      // bytes of prefix before the TLSGD displacement field (same rationale as
+      // GOTPCRELX guarding !RF and offset < 2 in isGOTPCRELXRelaxable). Fall
+      // through to GOT creation for the corrupt case, consistent with GOTPCRELX
+      // behavior.
+      auto *RF = llvm::dyn_cast<RegionFragment>(pReloc.targetRef()->frag());
+      if (RF && pReloc.targetRef()->offset() >= 4) {
+        m_Target.recordTLSGDLERelaxCandidate(&pReloc);
+        // Do not create a GOT pair; postProcessing rewrites the sequence.
+        return;
+      }
+    }
+
+    // Non-relaxable: keep the full GD sequence with dynamic relocations.
     x86_64GOT *G = m_Target.createGOT(GOT::TLS_GD, Obj, rsym);
 
     // Always emit DTPMOD64 for first entry (module ID unknown for DSO)
@@ -698,6 +740,13 @@ Relocator::Result eld::relocPLT32(Relocation &pReloc, x86_64Relocator &pParent,
                                   RelocationDescription &pRelocDesc) {
   DiagnosticEngine *DiagEngine = pParent.config().getDiagEngine();
   ResolveInfo *symInfo = pReloc.symInfo();
+
+  // The companion PLT32 in a relaxed GD sequence has its bytes overwritten
+  // by postProcessing. Skip apply to avoid an undefined-symbol lookup for
+  // __tls_get_addr.
+  if (pParent.getTarget().isTLSGDCompanion(&pReloc))
+    return Relocator::OK;
+
   Relocator::Address S;
   if (symInfo->reserved() & Relocator::ReservePLT) {
     // Symbol has PLT entry - redirect through PLT
@@ -736,6 +785,11 @@ Relocator::Result eld::relocGOTRelative(Relocation &pReloc,
   // For relaxable GOTPCRELX relocations, postProcessing handles the opcode
   // patch and displacement. Skip apply here to avoid a null GOT entry lookup.
   if (pParent.getTarget().isGOTPCRELXRelaxCandidate(&pReloc))
+    return Relocator::OK;
+
+  // GD→LE candidates and their companion relocs (PLT32 or GOTPCRELX) have no
+  // GOT pair; postProcessing rewrites the entire sequence.
+  if (pParent.getTarget().isTLSGDRelaxCandidate(&pReloc))
     return Relocator::OK;
 
   Relocator::DWord A = pReloc.addend();

--- a/test/x86_64/linux/TLSGDRelaxation/Inputs/tls_gd_gotpcrelx_companion.s
+++ b/test/x86_64/linux/TLSGDRelaxation/Inputs/tls_gd_gotpcrelx_companion.s
@@ -1,0 +1,13 @@
+	.globl tls_extern_def
+	.section .tbss,"awT",@nobits
+tls_extern_def:
+	.zero 4
+
+	.text
+	.globl get_tls_noplt
+get_tls_noplt:
+	.byte 0x66
+	leaq tls_extern_def@tlsgd(%rip), %rdi
+	.byte 0x66, 0x48
+	call *__tls_get_addr@GOTPCREL(%rip)
+	retq

--- a/test/x86_64/linux/TLSGDRelaxation/Inputs/tls_gd_hidden.s
+++ b/test/x86_64/linux/TLSGDRelaxation/Inputs/tls_gd_hidden.s
@@ -1,0 +1,14 @@
+	.globl tls_hidden
+	.hidden tls_hidden
+	.section .tbss,"awT",@nobits
+tls_hidden:
+	.zero 4
+
+	.text
+	.globl get_tls
+get_tls:
+	.byte 0x66
+	leaq tls_hidden@tlsgd(%rip), %rdi
+	.byte 0x66, 0x66, 0x48
+	call __tls_get_addr@PLT
+	retq

--- a/test/x86_64/linux/TLSGDRelaxation/Inputs/tls_gd_preemptible.s
+++ b/test/x86_64/linux/TLSGDRelaxation/Inputs/tls_gd_preemptible.s
@@ -1,0 +1,13 @@
+	.globl tls_default
+	.section .tbss,"awT",@nobits
+tls_default:
+	.zero 4
+
+	.text
+	.globl get_tls_preempt
+get_tls_preempt:
+	.byte 0x66
+	leaq tls_default@tlsgd(%rip), %rdi
+	.byte 0x66, 0x66, 0x48
+	call __tls_get_addr@PLT
+	retq

--- a/test/x86_64/linux/TLSGDRelaxation/TLSGDRelax_DynExeHidden.test
+++ b/test/x86_64/linux/TLSGDRelaxation/TLSGDRelax_DynExeHidden.test
@@ -1,0 +1,15 @@
+#--TLSGDRelax_DynExeHidden.test----------Dynamic Executable--------#
+# GD→LE relaxation for a non-preemptible hidden symbol in a dynamic executable.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/tls_gd_hidden.s -o %t.o
+RUN: %link %linkopts -e get_tls -o %t.eld %t.o
+RUN: %objdump -d %t.eld | %filecheck %s
+RUN: %readelf -r %t.eld | %filecheck %s --check-prefix=NORELOC
+#END_TEST
+
+CHECK: <get_tls>:
+CHECK-NEXT: {{[0-9a-f]+}}: 64 48 8b 04 25 {{.*}} movq
+CHECK-NEXT: {{[0-9a-f]+}}: 48 8d 80 {{.*}} leaq
+
+NORELOC-NOT: R_X86_64_DTPMOD64
+NORELOC-NOT: R_X86_64_DTPOFF64

--- a/test/x86_64/linux/TLSGDRelaxation/TLSGDRelax_NoPLT.test
+++ b/test/x86_64/linux/TLSGDRelaxation/TLSGDRelax_NoPLT.test
@@ -1,0 +1,15 @@
+#--TLSGDRelax_NoPLT.test----------Static Executable--------#
+# GD→LE relaxation when the companion is R_X86_64_GOTPCRELX (-fno-plt).
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/tls_gd_gotpcrelx_companion.s -o %t.o
+RUN: %link %linkopts -static -e get_tls_noplt -o %t.eld %t.o
+RUN: %objdump -d %t.eld | %filecheck %s
+RUN: %readelf -r %t.eld | %filecheck %s --check-prefix=NORELOC
+#END_TEST
+
+CHECK: <get_tls_noplt>:
+CHECK-NEXT: {{[0-9a-f]+}}: 64 48 8b 04 25 {{.*}} movq
+CHECK-NEXT: {{[0-9a-f]+}}: 48 8d 80 {{.*}} leaq
+
+NORELOC-NOT: R_X86_64_DTPMOD64
+NORELOC-NOT: R_X86_64_DTPOFF64

--- a/test/x86_64/linux/TLSGDRelaxation/TLSGDRelax_PIE_Hidden.test
+++ b/test/x86_64/linux/TLSGDRelaxation/TLSGDRelax_PIE_Hidden.test
@@ -1,0 +1,15 @@
+#--TLSGDRelax_PIE_Hidden.test----------PIE--------#
+# GD→LE relaxation for a non-preemptible hidden symbol in PIE.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/tls_gd_hidden.s -o %t.o
+RUN: %link %linkopts -pie -e get_tls -o %t.pie %t.o
+RUN: %objdump -d %t.pie | %filecheck %s
+RUN: %readelf -r %t.pie | %filecheck %s --check-prefix=NORELOC
+#END_TEST
+
+CHECK: <get_tls>:
+CHECK-NEXT: {{[0-9a-f]+}}: 64 48 8b 04 25 {{.*}} movq
+CHECK-NEXT: {{[0-9a-f]+}}: 48 8d 80 {{.*}} leaq
+
+NORELOC-NOT: R_X86_64_DTPMOD64
+NORELOC-NOT: R_X86_64_DTPOFF64

--- a/test/x86_64/linux/TLSGDRelaxation/TLSGDRelax_PartialRelink.test
+++ b/test/x86_64/linux/TLSGDRelaxation/TLSGDRelax_PartialRelink.test
@@ -1,0 +1,20 @@
+#--TLSGDRelax_PartialRelink.test----------Static Executable--------#
+# Partial link (-r) preserves TLSGD; final static link relaxes to LE.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/tls_gd_hidden.s -o %t.o
+RUN: %link %linkopts -r -o %t.partial.o %t.o
+RUN: %readelf -r %t.partial.o | %filecheck %s --check-prefix=PARTIAL
+RUN: %link %linkopts -static -e get_tls -o %t.eld %t.partial.o
+RUN: %objdump -d %t.eld | %filecheck %s --check-prefix=FINAL
+RUN: %readelf -r %t.eld | %filecheck %s --check-prefix=NORELOC
+#END_TEST
+
+PARTIAL: R_X86_64_TLSGD
+PARTIAL: R_X86_64_PLT32
+
+FINAL: <get_tls>:
+FINAL-NEXT: {{[0-9a-f]+}}: 64 48 8b 04 25 {{.*}} movq
+FINAL-NEXT: {{[0-9a-f]+}}: 48 8d 80 {{.*}} leaq
+
+NORELOC-NOT: R_X86_64_DTPMOD64
+NORELOC-NOT: R_X86_64_DTPOFF64

--- a/test/x86_64/linux/TLSGDRelaxation/TLSGDRelax_SharedHidden_NoRelax.test
+++ b/test/x86_64/linux/TLSGDRelaxation/TLSGDRelax_SharedHidden_NoRelax.test
@@ -1,0 +1,14 @@
+#--TLSGDRelax_SharedHidden_NoRelax.test----------Shared Library--------#
+# Non-preemptible hidden symbol in a DSO must not be relaxed; the tpoff
+# is not a link-time constant for DSO blocks.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/tls_gd_hidden.s -o %t.o
+RUN: %link %linkopts -shared -o %t.so %t.o
+RUN: %readelf -r %t.so | %filecheck %s
+RUN: %objdump -d %t.so | %filecheck %s --check-prefix=NORELAX
+#END_TEST
+
+CHECK: R_X86_64_DTPMOD64
+
+NORELAX: <get_tls>:
+NORELAX-NOT: 64 48 8b 04 25

--- a/test/x86_64/linux/TLSGDRelaxation/TLSGDRelax_SharedPreemptible_NoRelax.test
+++ b/test/x86_64/linux/TLSGDRelaxation/TLSGDRelax_SharedPreemptible_NoRelax.test
@@ -1,0 +1,10 @@
+#--TLSGDRelax_SharedPreemptible_NoRelax.test----------Shared Library--------#
+# Preemptible (default-visibility) symbol in a DSO must not be relaxed.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/tls_gd_preemptible.s -o %t.o
+RUN: %link %linkopts -shared -o %t.so %t.o
+RUN: %readelf -r %t.so | %filecheck %s
+#END_TEST
+
+CHECK: R_X86_64_DTPMOD64
+CHECK: R_X86_64_DTPOFF64

--- a/test/x86_64/linux/TLSGDRelaxation/TLSGDRelax_StaticHidden.test
+++ b/test/x86_64/linux/TLSGDRelaxation/TLSGDRelax_StaticHidden.test
@@ -1,0 +1,15 @@
+#--TLSGDRelax_StaticHidden.test----------Static Executable--------#
+# GD→LE relaxation for a non-preemptible hidden symbol in a static executable.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/tls_gd_hidden.s -o %t.o
+RUN: %link %linkopts -static -e get_tls -o %t.eld %t.o
+RUN: %objdump -d %t.eld | %filecheck %s
+RUN: %readelf -r %t.eld | %filecheck %s --check-prefix=NORELOC
+#END_TEST
+
+CHECK: <get_tls>:
+CHECK-NEXT: {{[0-9a-f]+}}: 64 48 8b 04 25 {{.*}} movq
+CHECK-NEXT: {{[0-9a-f]+}}: 48 8d 80 fc ff ff ff {{.*}}leaq
+
+NORELOC-NOT: R_X86_64_DTPMOD64
+NORELOC-NOT: R_X86_64_DTPOFF64

--- a/test/x86_64/linux/TLSGDRelaxation/TLSGDRelax_Trace.test
+++ b/test/x86_64/linux/TLSGDRelaxation/TLSGDRelax_Trace.test
@@ -1,0 +1,10 @@
+#--TLSGDRelax_Trace.test----------Static Executable--------#
+# --trace=relax emits a message for each relaxed TLSGD reference.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/tls_gd_hidden.s -o %t.o
+RUN: %link %linkopts -static -e get_tls --trace=relax -o %t.eld %t.o 2>&1 \
+RUN:   | %filecheck %s
+#END_TEST
+
+# The hidden (non-preemptible) TLSGD reference is relaxed to LE and traced.
+CHECK: Trace: relaxed TLSGD for symbol 'tls_hidden' to LE access in section {{.*}}+0x{{[0-9a-f]+}} file {{.*}}


### PR DESCRIPTION

  Implements GD→LE TLS relaxation for R_X86_64_TLSGD relocations.

  For non-preemptible symbols in executables, the 16-byte GD sequence is
  rewritten in-place to the LE form when:

  - The symbol is non-preemptible and the output is an executable (static,
    dynamic, or PIE)
  - The link is not partial (-r)

  GD→LE is mandatory and fires regardless of --relax, matching lld and
  bfd. Without this relaxation, executables fail with "undefined reference
  to __tls_get_addr".

  The companion call relocation at TLSGD_offset+8 may be either
  R_X86_64_PLT32 (standard) or R_X86_64_GOTPCRELX (-fno-plt). Both are
  handled.

  Note: This PR contains two commits. The first ([x86] Support
  R_X86_64_GOTPCRELX relaxation) is a dependency 
  Tests:

  - TLSGDRelax_StaticHidden
  - TLSGDRelax_DynExeHidden
  - TLSGDRelax_PIE_Hidden
  - TLSGDRelax_SharedPreemptible_NoRelax
  - TLSGDRelax_SharedHidden_NoRelax
  - TLSGDRelax_PartialRelink
  - TLSGDRelax_Trace
  - TLSGDRelax_NoPLT
  
Fixes #1490 