### PR TITLE
Add linux as a requirement for MergeStringAndGOTRelativeReloc test

### DIFF
--- a/test/x86_64/linux/MergeStringRelativeRelocAddend/MergeStringRelativeRelocAddend.test
+++ b/test/x86_64/linux/MergeStringRelativeRelocAddend/MergeStringRelativeRelocAddend.test
@@ -1,3 +1,4 @@
+REQUIRES: linux
 #--MergeStringAndGOTRelativeReloc.test-----------Executable--------#
 #BEGIN_COMMENT
 # Test: x86_64 merge-string R_X86_64_RELATIVE relocation addend, and the


### PR DESCRIPTION
Fix: qualcomm#1529