### PR TITLE
[Zephyr] Automatically run PR workflow on CI completion across all boards

### DIFF
--- a/.github/workflows/FetchEldToolset/action.yaml
+++ b/.github/workflows/FetchEldToolset/action.yaml
@@ -1,0 +1,38 @@
+name: FetchEldToolset
+description: >
+  Download an ELD toolset artifact from a workflow run, extract it to ./inst,
+  and prepend inst/bin to PATH.
+inputs:
+  run-id:
+    description: "Workflow run id to download the artifact from"
+    required: true
+  artifact-name:
+    description: "Artifact name to download (e.g. pr-eld-toolset)"
+    required: true
+  tarball:
+    description: "Tar filename inside the artifact to extract (e.g. install-pr-toolset.tar.xz)"
+    required: true
+  strip-components:
+    description: "tar --strip-components value applied during extraction"
+    required: false
+    default: "1"
+runs:
+  using: "composite"
+  steps:
+    - name: Download toolset
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
+      with:
+        name: ${{ inputs.artifact-name }}
+        run-id: ${{ inputs.run-id }}
+        github-token: ${{ github.token }}
+
+    - name: Extract toolset
+      shell: bash
+      env:
+        TARBALL: ${{ inputs.tarball }}
+        STRIP_COMPONENTS: ${{ inputs.strip-components }}
+      run: |
+        mkdir -p inst
+        tar -xf "$TARBALL" -C inst --strip-components="$STRIP_COMPONENTS"
+        ls inst
+        echo "PATH=$(pwd)/inst/bin:$PATH" >> "$GITHUB_ENV"

--- a/.github/workflows/zephyr-nightly.yml
+++ b/.github/workflows/zephyr-nightly.yml
@@ -11,8 +11,37 @@ permissions:
   contents: write
   actions: read
 jobs:
-  zephyr:
+  resolve:
     if: github.repository == 'qualcomm/eld' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    outputs:
+      run_id: ${{ steps.find.outputs.run_id }}
+    steps:
+      - name: Resolve nightly-test.yml run id
+        id: find
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9.0.0
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const resp = await github.rest.actions.listWorkflowRuns({
+              owner, repo,
+              workflow_id: 'nightly-test.yml',
+              status: 'success',
+              per_page: 1, // we only need the latest
+            });
+            const runs = resp.data.workflow_runs || [];
+            if (runs.length === 0) {
+              core.setFailed('No successful nightly-test.yml run found.');
+              return;
+            }
+            const run = runs[0];
+            core.info(`Latest successful nightly-test.yml run: id=${run.id}, run_number=${run.run_number}`);
+            core.setOutput('run_id', String(run.id));
+
+  zephyr:
+    needs: resolve
     strategy:
       fail-fast: false
       matrix:
@@ -30,4 +59,6 @@ jobs:
       arch: ${{ matrix.target.arch }}
       extra_args: ${{ matrix.target.extra_args }}
       test_scope: tests
-      eld_source: nightly
+      toolset_run_id: ${{ needs.resolve.outputs.run_id }}
+      toolset_artifact: install-nightly-toolchain.tar.xz
+      toolset_tarball: install-nightly-toolchain.tar.xz

--- a/.github/workflows/zephyr-pr.yml
+++ b/.github/workflows/zephyr-pr.yml
@@ -1,12 +1,17 @@
 name: Zephyr on ELD PR
 
-# Opt-in: run Zephyr against a PR's own ELD build. Requires the
-# PR to carry the `zephyr-check` label so ci.yml uploads the `pr-eld-toolset`
-# artifact. Given a PR number, finds the latest successful ci.yml run for its
-# head commit; ci_run_id overrides. Scope: aarch64 (qemu_cortex_a53),
-# tests/kernel. Add arches later by mirroring zephyr-nightly.yml's matrix.
+# Run Zephyr against a PR's own ELD build. Opt-in via the `zephyr-check` label:
+# ci.yml uploads the `pr-eld-toolset` artifact only when the PR carries it, and
+# that artifact's presence gates this workflow. Triggers:
+#   - workflow_run: auto-fires when CI completes; skips if there's no artifact.
+#   - workflow_dispatch: manual. Give a PR number or an explicit ci_run_id.
+#     NOTE: workflow_run only fires from the default-branch copy, so the auto
+#     path can't be exercised pre-merge.
 
 on:
+  workflow_run:
+    workflows: ["CI"]   # ci.yml's `name:`
+    types: [completed]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -16,6 +21,11 @@ on:
         description: "CI (ci.yml) run id to pull ld.eld from (overrides auto-discovery)"
         required: false
   # pull_request: {} # Uncomment only to test this WF file update.
+
+# A newer CI completion for the same branch supersedes the previous run.
+concurrency:
+  group: zephyr-pr-${{ github.event.workflow_run.head_branch || github.event.inputs.pr_number || github.run_id }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -28,6 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run_id: ${{ steps.find.outputs.run_id }}
+      should_run: ${{ steps.find.outputs.should_run }}
     steps:
       - name: Resolve ci.yml run id
         id: find
@@ -42,13 +53,39 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+
+            // Auto path: chained off a completed CI run. A missing
+            // pr-eld-toolset artifact means the PR isn't labeled, so skip.
+            if (context.eventName === 'workflow_run') {
+              const wr = context.payload.workflow_run;
+              core.info(`workflow_run: id=${wr.id} event=${wr.event} conclusion=${wr.conclusion} branch=${wr.head_branch}`);
+              if (wr.conclusion !== 'success' || wr.event !== 'pull_request') {
+                core.info('Not a successful pull_request CI run; skipping.');
+                core.setOutput('should_run', 'false');
+                return;
+              }
+              const { data: { artifacts } } = await github.rest.actions.listWorkflowRunArtifacts({
+                owner, repo, run_id: wr.id, per_page: 100,
+              });
+              if (!artifacts.some(a => a.name === 'pr-eld-toolset' && !a.expired)) {
+                core.info('No pr-eld-toolset artifact (PR not labeled zephyr-check); skipping.');
+                core.setOutput('should_run', 'false');
+                return;
+              }
+              core.info(`Using CI run ${wr.id}`);
+              core.setOutput('run_id', String(wr.id));
+              core.setOutput('should_run', 'true');
+              return;
+            }
+
+            // Manual path: workflow_dispatch.
             const ciRunId = (process.env.CI_RUN_ID || '').trim();
             const prNumber = (process.env.PR_NUMBER || process.env.EVENT_PR_NUMBER || '').trim();
 
-            // Explicit run id wins.
             if (ciRunId) {
               core.info(`Using explicit ci_run_id: ${ciRunId}`);
               core.setOutput('run_id', ciRunId);
+              core.setOutput('should_run', 'true');
               return;
             }
 
@@ -57,8 +94,7 @@ jobs:
               return;
             }
 
-            // Resolve the PR's head commit, then find the newest successful
-            // ci.yml run for that exact SHA.
+            // Find the newest successful ci.yml run for the PR's head SHA.
             const pr = await github.rest.pulls.get({
               owner, repo, pull_number: Number(prNumber),
             });
@@ -90,8 +126,8 @@ jobs:
             const run = success[0];
             core.info(`Latest successful ci.yml run: id=${run.id}, run_number=${run.run_number}`);
 
-            // Fail fast with a helpful message if the run predates the label
-            // (otherwise zephyr-run.yml's download-artifact fails cryptically).
+            // Fail with a clear message if the run predates the label, rather
+            // than letting the later download-artifact fail cryptically.
             const { data: { artifacts } } = await github.rest.actions.listWorkflowRunArtifacts({
               owner, repo, run_id: run.id, per_page: 100,
             });
@@ -104,17 +140,31 @@ jobs:
             }
 
             core.setOutput('run_id', String(run.id));
+            core.setOutput('should_run', 'true');
 
   zephyr:
     needs: resolve
+    if: needs.resolve.outputs.should_run == 'true'
     permissions:
-      contents: write # zephyr-run.yml requires write (unused outside the nightly schedule path)
+      contents: read # caps zephyr-run.yml's declared write, only used on the nightly path
       actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - { board: qemu_riscv32,     arch: riscv32,  extra_args: CONFIG_PICOLIBC_USE_TOOLCHAIN=y }
+          - { board: qemu_riscv32_xip, arch: riscv32,  extra_args: CONFIG_PICOLIBC_USE_TOOLCHAIN=y }
+          - { board: qemu_riscv64,     arch: riscv64,  extra_args: CONFIG_PICOLIBC_USE_TOOLCHAIN=y }
+          # cpullvm ARM picolibc is missing a _nopic version, so its objects
+          # have GOT relocations that fail when .got is discarded.
+          - { board: qemu_cortex_m3,   arch: arm,      extra_args: CONFIG_PICOLIBC_USE_MODULE=y }
+          - { board: qemu_cortex_a53,  arch: aarch64,  extra_args: CONFIG_PICOLIBC_USE_TOOLCHAIN=y }
     uses: ./.github/workflows/zephyr-run.yml
     with:
-      board: qemu_cortex_a53
-      arch: aarch64
-      extra_args: CONFIG_PICOLIBC_USE_TOOLCHAIN=y
+      board: ${{ matrix.target.board }}
+      arch: ${{ matrix.target.arch }}
+      extra_args: ${{ matrix.target.extra_args }}
       test_scope: tests/kernel
-      eld_source: artifact
-      artifact_run_id: ${{ needs.resolve.outputs.run_id }}
+      toolset_run_id: ${{ needs.resolve.outputs.run_id }}
+      toolset_artifact: pr-eld-toolset
+      toolset_tarball: install-pr-toolset.tar.xz

--- a/.github/workflows/zephyr-run.yml
+++ b/.github/workflows/zephyr-run.yml
@@ -1,8 +1,8 @@
 name: Zephyr build and test (reusable)
 
-# Reusable Zephyr build + twister body. Called by zephyr-nightly.yml (5-board
-# matrix, nightly ELD) and zephyr-pr.yml (aarch64, ELD from a PR's CI artifact).
-# Only `eld_source` differs between callers; the splice step onward is identical.
+# Reusable Zephyr build + twister body, called by zephyr-nightly.yml and
+# zephyr-pr.yml. Callers resolve a run id and pass the toolset artifact/tarball
+# names; the fetch step normalizes either source to ./inst.
 
 on:
   workflow_call:
@@ -25,16 +25,18 @@ on:
         required: false
         type: string
         default: "tests"
-      eld_source:
-        description: "Where ld.eld comes from: 'nightly' (FetchNightlyToolset) or 'artifact' (PR CI upload)"
-        required: false
+      toolset_run_id:
+        description: "Workflow run id to download the ELD toolset artifact from"
+        required: true
         type: string
-        default: "nightly"
-      artifact_run_id:
-        description: "ci.yml run id to download the pr-eld-toolset artifact from (eld_source=artifact)"
-        required: false
+      toolset_artifact:
+        description: "Artifact name to download (e.g. pr-eld-toolset or install-nightly-toolchain.tar.xz)"
+        required: true
         type: string
-        default: ""
+      toolset_tarball:
+        description: "Tar filename inside the artifact to extract (e.g. install-pr-toolset.tar.xz)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -91,27 +93,12 @@ jobs:
           arch-name: ${{ inputs.arch }}
           branch-name: "main"
 
-      # Both branches normalize the payload to ./inst so the splice is identical.
-      - name: Fetch nightly ELD
-        if: inputs.eld_source == 'nightly'
-        uses: ./llvm-project/llvm/tools/eld/.github/workflows/FetchNightlyToolset
-
-      - name: Download PR ELD artifact
-        if: inputs.eld_source == 'artifact'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
+      - name: Fetch ELD toolset
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/FetchEldToolset
         with:
-          name: pr-eld-toolset
-          run-id: ${{ inputs.artifact_run_id }}
-          github-token: ${{ github.token }}
-
-      - name: Extract PR ELD artifact
-        if: inputs.eld_source == 'artifact'
-        shell: bash
-        run: |
-          mkdir -p inst
-          tar -xf install-pr-toolset.tar.xz -C inst --strip-components=1
-          ls inst
-          echo "PATH=$(pwd)/inst/bin:$PATH" >> $GITHUB_ENV
+          run-id: ${{ inputs.toolset_run_id }}
+          artifact-name: ${{ inputs.toolset_artifact }}
+          tarball: ${{ inputs.toolset_tarball }}
 
       - name: Install cpullvm toolchain and splice ELD
         run: |
@@ -226,16 +213,6 @@ jobs:
           path: |
             zephyr/twister-out/twister.log
             zephyr/twister-out/twister.json
-
-      - name: Upload build artifacts
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
-        with:
-          name: zephyr-build-artifacts-${{ inputs.board }}
-          retention-days: 2
-          path: |
-            zephyr/build/zephyr/zephyr.elf
-            zephyr/build/zephyr/zephyr.map
 
       - name: ccache stats (after build)
         if: always()


### PR DESCRIPTION
Follow-up to #1348. Trigger zephyr-pr.yml automatically when CI completes, gated on the pr-eld-toolset artifact (zephyr-check label). Expand PR coverage from qemu_cortex_a53 to the full nightly board matrix and narrow the job to contents: read.

Factor the toolset download into a `FetchEldToolset` composite action so nightly and PR share one fetch path. Nightly now resolves the latest nightly-test.yml run instead of using eld_source.