### PR TITLE
Add nightly workflow to test x86_64 backend against llvm-test-suite

### DIFF
--- a/.github/workflows/nightly-llvm-test-suite.yml
+++ b/.github/workflows/nightly-llvm-test-suite.yml
@@ -1,0 +1,127 @@
+name: Nightly LLVM Test Suite (x86_64)
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/nightly-llvm-test-suite.yml'
+  schedule:
+    - cron: '0 11 * * *'  # 5:00 AM CST
+  workflow_dispatch:
+
+
+permissions:
+  contents: write
+  actions: read
+jobs:
+  test-llvm-test-suite-x86_64:
+    if: github.repository == 'qualcomm/eld' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    env:
+      ELD_SOURCE_DIR: ${{ github.workspace }}/llvm-project/llvm/tools/eld
+
+    steps:
+      - name: Checkout eld
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: llvm-project/llvm/tools/eld
+          persist-credentials: false
+
+      - name: Configure workflow environment variables
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/ConfigureBuildWorkflowENV
+
+      - name: Record pre-build entry
+        if: github.event_name == 'schedule'
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "pre-"
+          workflow-name: "llvm-test-suite"
+          record-mode: "record"
+          status: "fail"
+          run-id: ${{github.run_id}}
+          arch-name: "x86_64"
+          branch-name: "${{env.BUILD_BRANCH}}"
+
+      - name: Install dependencies
+        run: pip3 install lit
+
+      - name: Fetch nightly ELD
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/FetchNightlyToolset
+
+      - name: Clone LLVM test suite
+        run: |
+          git clone --depth 1 https://github.com/llvm/llvm-test-suite.git
+
+      - name: Configure test suite
+        run: |
+          ELD_BIN=$(which ld.eld)
+          LIB_DIR="$(dirname "$ELD_BIN")/../lib"
+          # TEST_SUITE_SUBDIRS is left unset, so llvm-test-suite/CMakeLists.txt
+          # runs its own auto-discovery.
+          # That resolves to:
+          #   Bitcode;External;MicroBenchmarks;MultiSource;SingleSource;tools/test
+          #
+          # What runs:
+          #   - Bitcode: runs. Needs -DELD_ENABLE_SYMBOL_VERSIONING=ON, which the
+          #     fetched nightly toolchain is built with.
+          #   - MicroBenchmarks, MultiSource, SingleSource, tools/test: run.
+          #
+          # What is discovered but contributes nothing on this runner:
+          #   - External: configures, but every benchmark under it is gated on
+          #     its own TEST_SUITE_<NAME>_ROOT pointing at licensed/proprietary
+          #     sources (e.g. TEST_SUITE_SPEC2000_ROOT) that are not supplied
+          #     here, so none of it builds.
+          #
+          # What auto-discovery drops before we ever see it:
+          #   - CTMark: removed by the suite itself; it is just symlinks into
+          #     MultiSource, so keeping it would double-build those tests.
+          #   - Fortran: removed because TEST_SUITE_FORTRAN defaults OFF unless
+          #     Fortran is already in TEST_SUITE_SUBDIRS, which it isn't since
+          #     we leave that variable unset.
+          #   - litsupport, tools: removed; these are the lit harness and its
+          #     support utilities, not tests (tools/test is added back above).
+          #
+          # Not part of the CMake-driven build:
+          #   ABI-Testsuite, ClangAnalyzer, LNTBased, litsupport-tests,
+          #   test-suite-externals, utils.
+
+          cmake -G Ninja \
+            -S llvm-test-suite \
+            -B build-llvm-test-suite \
+            -DCMAKE_C_COMPILER=$(which clang) \
+            -DCMAKE_CXX_COMPILER=$(which clang++) \
+            -DCMAKE_C_FLAGS="--ld-path=$ELD_BIN" \
+            -DCMAKE_CXX_FLAGS="--ld-path=$ELD_BIN -stdlib=libc++" \
+            -DCMAKE_EXE_LINKER_FLAGS="--ld-path=$ELD_BIN -stdlib=libc++ -Wl,-rpath,$LIB_DIR" \
+            -DTEST_SUITE_RUN_TYPE=nightly
+
+      - name: Build test suite
+        run: |
+          ninja -C build-llvm-test-suite -j$(nproc) -k 0
+
+      - name: Run tests
+        run: |
+          lit -j$(nproc) build-llvm-test-suite 2>&1 | tee test-output.txt
+
+      - name: Upload test output
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
+        with:
+          name: llvm-test-suite-results
+          path: test-output.txt
+          retention-days: 1
+
+      - name: Update build entry
+        if: github.event_name == 'schedule'
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "post-"
+          workflow-name: "llvm-test-suite"
+          record-mode: "update"
+          status: "pass"
+          run-id: ${{github.run_id}}
+          arch-name: "x86_64"
+          branch-name: "${{env.BUILD_BRANCH}}"


### PR DESCRIPTION
Add nightly workflow to test `x86_64` backend against `llvm-test-suite`

Runs `llvm-test-suite` nightly for `x86_64` backend, uses the toolchain built by `nightly-test.yml`.
`Bitcode`, `External`, `MicroBenchmarks`, `MultiSource`, `SingleSource` and `tools/test` directories are tested.
This is with the `TEST_SUITE_SUBDIRS` left unset, so the suite's own autodiscovery builds the
directories it can.
