### PR TITLE
[ELD] Intialize backend in ArchiveParser using ELF member

### DIFF
--- a/lib/Readers/ArchiveParser.cpp
+++ b/lib/Readers/ArchiveParser.cpp
@@ -103,9 +103,6 @@ eld::Expected<uint32_t> ArchiveParser::parseFile(InputFile &inputFile) const {
     return numObjects;
   }
 
-  if (!m_Module.isBackendInitialized())
-    return 0;
-
   if (!hasAFI) {
     auto expInitAF = initArchiveFile(archiveFile);
     DG_ELDEXP_REPORT_AND_RETURN_FALSE_IF_ERROR(*config.getDiagEngine(),
@@ -285,6 +282,14 @@ eld::Expected<bool> ArchiveParser::computeSymInfoTableForELFMember(
   ASSERT(ELFObjFile.isRelocatableObject(),
          "Only relocatable object files are supported as archive members!");
   using Elf_Sym = typename ELFT::Sym;
+
+  if (!m_Module.isBackendInitialized()) {
+    auto *ELFObj = llvm::dyn_cast<llvm::object::ELFObjectFileBase>(&ELFObjFile);
+    uint16_t machine = ELFObj->getEMachine();
+    bool is64Bit = ELFObj->is64Bit();
+    if (!m_Module.getLinker()->initializeTarget(machine, is64Bit))
+      return false;
+  }
 
   for (const llvm::object::ELFSymbolRef &sym : ELFObjFile.symbols()) {
     llvm::Expected<const Elf_Sym *> expRawSym =

--- a/test/Common/standalone/Sniffing/Sniff.test
+++ b/test/Common/standalone/Sniffing/Sniff.test
@@ -17,7 +17,7 @@ RUN: %ar cr %t.lib1.a %t1.1.o
 # whole-archive sniffing (ELF)
 RUN: %eld --whole-archive %t.lib1.a -o %t2.out --verbose 2>&1 | %filecheck %s -check-prefix=INFERRED
 # only archive sniffing
-RUN: %not %eld %t.lib1.a -o %t2.out 2>&1 | %filecheck %s -check-prefix=CANNOTINFER
+RUN: %eld %t.lib1.a -o %t2.out --verbose 2>&1 | %filecheck %s -check-prefix=INFERRED
 # Create archive (LTO)
 RUN: %ar cr %t.lib1.lto.a %t1.1.lto.o
 # whole-archive sniffing (ELF)


### PR DESCRIPTION
The ArchiveParser now initialize the backend based on target
information in ELF members.

Fix: qualcomm#1526