### PR TITLE
[Fragment] Fix missing alignment on dynamic section fragments

### DIFF
--- a/include/eld/Fragment/DynSymFragment.h
+++ b/include/eld/Fragment/DynSymFragment.h
@@ -17,7 +17,7 @@ namespace eld {
 class DynSymFragment : public Fragment {
 public:
   DynSymFragment(ELFSection *S, const std::vector<ResolveInfo *> &DynSyms,
-                 bool Is32Bits);
+                 bool Is32Bits, uint32_t Align = 1);
 
   static bool classof(const Fragment *F) {
     return F->getKind() == Fragment::Type::DynSym;

--- a/include/eld/Fragment/DynamicFragment.h
+++ b/include/eld/Fragment/DynamicFragment.h
@@ -18,7 +18,7 @@ class ELFSection;
 /// It delegates size() and emit() to ELFDynamic.
 class DynamicFragment : public Fragment {
 public:
-  DynamicFragment(ELFSection *S, ELFDynamic &Dynamic);
+  DynamicFragment(ELFSection *S, ELFDynamic &Dynamic, uint32_t Align = 1);
 
   static bool classof(const Fragment *F) {
     return F->getKind() == Fragment::Type::Dynamic;

--- a/include/eld/Fragment/GNUVerDefFragment.h
+++ b/include/eld/Fragment/GNUVerDefFragment.h
@@ -25,7 +25,7 @@ class DynStrFragment;
 /// definitions for the symbols that are defined by the module.
 class GNUVerDefFragment : public Fragment {
 public:
-  GNUVerDefFragment(ELFSection *S);
+  GNUVerDefFragment(ELFSection *S, uint32_t Align = 1);
 
   static bool classof(const Fragment *F) {
     return F->getKind() == Fragment::Type::GNUVerDef;

--- a/include/eld/Fragment/GNUVerNeedFragment.h
+++ b/include/eld/Fragment/GNUVerNeedFragment.h
@@ -29,7 +29,7 @@ class InputFile;
 // Region fragment expression
 class GNUVerNeedFragment : public Fragment {
 public:
-  GNUVerNeedFragment(ELFSection *S);
+  GNUVerNeedFragment(ELFSection *S, uint32_t Align = 1);
 
   static bool classof(const Fragment *F) {
     return F->getKind() == Fragment::Type::GNUVerNeed;

--- a/include/eld/Fragment/GNUVerSymFragment.h
+++ b/include/eld/Fragment/GNUVerSymFragment.h
@@ -27,7 +27,8 @@ class ELFSEction;
 /// the dynamic symbol table.
 class GNUVerSymFragment : public Fragment {
 public:
-  GNUVerSymFragment(ELFSection *S, const std::vector<ResolveInfo *> &DynSyms);
+  GNUVerSymFragment(ELFSection *S, const std::vector<ResolveInfo *> &DynSyms,
+                    uint32_t Align = 1);
 
   static bool classof(const Fragment *F) {
     return F->getKind() == Fragment::Type::GNUVerSym;

--- a/lib/Fragment/DynSymFragment.cpp
+++ b/lib/Fragment/DynSymFragment.cpp
@@ -16,8 +16,8 @@ using namespace eld;
 
 DynSymFragment::DynSymFragment(ELFSection *S,
                                const std::vector<ResolveInfo *> &DynSyms,
-                               bool Is32Bits)
-    : Fragment(Fragment::Type::DynSym, S), DynamicSymbols(DynSyms),
+                               bool Is32Bits, uint32_t Align)
+    : Fragment(Fragment::Type::DynSym, S, Align), DynamicSymbols(DynSyms),
       Is32Bits(Is32Bits) {}
 
 size_t DynSymFragment::size() const {

--- a/lib/Fragment/DynamicFragment.cpp
+++ b/lib/Fragment/DynamicFragment.cpp
@@ -10,8 +10,9 @@
 
 using namespace eld;
 
-DynamicFragment::DynamicFragment(ELFSection *S, ELFDynamic &Dynamic)
-    : Fragment(Fragment::Type::Dynamic, S), m_Dynamic(Dynamic) {}
+DynamicFragment::DynamicFragment(ELFSection *S, ELFDynamic &Dynamic,
+                                 uint32_t Align)
+    : Fragment(Fragment::Type::Dynamic, S, Align), m_Dynamic(Dynamic) {}
 
 size_t DynamicFragment::size() const { return m_Dynamic.numOfBytes(); }
 

--- a/lib/Fragment/GNUVerDefFragment.cpp
+++ b/lib/Fragment/GNUVerDefFragment.cpp
@@ -24,8 +24,8 @@
 
 using namespace eld;
 
-GNUVerDefFragment::GNUVerDefFragment(ELFSection *S)
-    : Fragment(Fragment::Type::GNUVerDef, S) {}
+GNUVerDefFragment::GNUVerDefFragment(ELFSection *S, uint32_t Align)
+    : Fragment(Fragment::Type::GNUVerDef, S, Align) {}
 
 template <class ELFT>
 eld::Expected<void>

--- a/lib/Fragment/GNUVerNeedFragment.cpp
+++ b/lib/Fragment/GNUVerNeedFragment.cpp
@@ -21,8 +21,8 @@
 
 using namespace eld;
 
-GNUVerNeedFragment::GNUVerNeedFragment(ELFSection *S)
-    : Fragment(Fragment::Type::GNUVerNeed, S) {}
+GNUVerNeedFragment::GNUVerNeedFragment(ELFSection *S, uint32_t Align)
+    : Fragment(Fragment::Type::GNUVerNeed, S, Align) {}
 
 template <class ELFT>
 eld::Expected<void> GNUVerNeedFragment::computeVersionNeeds(

--- a/lib/Fragment/GNUVerSymFragment.cpp
+++ b/lib/Fragment/GNUVerSymFragment.cpp
@@ -17,8 +17,9 @@
 using namespace eld;
 
 GNUVerSymFragment::GNUVerSymFragment(ELFSection *S,
-                                     const std::vector<ResolveInfo *> &DynSyms)
-    : Fragment(Fragment::Type::GNUVerSym, S), DynamicSymbols(DynSyms) {}
+                                     const std::vector<ResolveInfo *> &DynSyms,
+                                     uint32_t Align)
+    : Fragment(Fragment::Type::GNUVerSym, S, Align), DynamicSymbols(DynSyms) {}
 
 size_t GNUVerSymFragment::size() const { return DynamicSymbols.size() * 2; }
 

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -235,7 +235,8 @@ eld::Expected<void> GNULDBackend::initStdSections() {
         ".dynsym", llvm::ELF::SHT_DYNSYM, llvm::ELF::SHF_ALLOC,
         config().targets().bitclass() / 8);
     m_pDynSymFrag = make<DynSymFragment>(DynSymSection, DynamicSymbols,
-                                         config().targets().is32Bits());
+                                         config().targets().is32Bits(),
+                                         config().targets().bitclass() / 8);
     DynSymSection->addFragmentAndUpdateSize(m_pDynSymFrag);
     m_pDynSymSection = DynSymSection;
 
@@ -252,7 +253,8 @@ eld::Expected<void> GNULDBackend::initStdSections() {
         llvm::ELF::SHF_ALLOC | llvm::ELF::SHF_WRITE,
         config().targets().bitclass() / 8);
     m_pDynamic = make<ELFDynamic>(config(), *DynSection);
-    m_pDynamicFrag = make<DynamicFragment>(DynSection, *m_pDynamic);
+    m_pDynamicFrag = make<DynamicFragment>(DynSection, *m_pDynamic,
+                                           config().targets().bitclass() / 8);
     DynSection->addFragment(m_pDynamicFrag);
     m_pDynamicSection = DynSection;
   }
@@ -988,7 +990,7 @@ void GNULDBackend::sizeDynNamePools() {
     if (DP->traceSymbolVersioning())
       config().raise(Diag::trace_creating_symbol_versioning_fragment)
           << GNUVerSymSection->name();
-    Fragment *F = make<GNUVerSymFragment>(GNUVerSymSection, DynamicSymbols);
+    Fragment *F = make<GNUVerSymFragment>(GNUVerSymSection, DynamicSymbols, 2);
     GNUVerSymSection->addFragmentAndUpdateSize(F);
   }
 
@@ -998,7 +1000,8 @@ void GNULDBackend::sizeDynNamePools() {
     if (DP->traceSymbolVersioning())
       config().raise(Diag::trace_creating_symbol_versioning_fragment)
           << GNUVerDefSection->name();
-    GNUVerDefFragment *F = make<GNUVerDefFragment>(GNUVerDefSection);
+    GNUVerDefFragment *F =
+        make<GNUVerDefFragment>(GNUVerDefSection, sizeof(uint32_t));
     bool is32Bits = config().targets().is32Bits();
     if (is32Bits)
       F->computeVersionDefs<llvm::object::ELF32LE>(m_Module, m_pDynStrFrag,
@@ -1015,7 +1018,8 @@ void GNULDBackend::sizeDynNamePools() {
     if (DP->traceSymbolVersioning())
       config().raise(Diag::trace_creating_symbol_versioning_fragment)
           << GNUVerNeedSection->name();
-    GNUVerNeedFragment *F = make<GNUVerNeedFragment>(GNUVerNeedSection);
+    GNUVerNeedFragment *F =
+        make<GNUVerNeedFragment>(GNUVerNeedSection, sizeof(uint32_t));
     bool is32Bits = config().targets().is32Bits();
     if (is32Bits)
       F->computeVersionNeeds<llvm::object::ELF32LE>(


### PR DESCRIPTION
DynSymFragment, DynamicFragment, GNUVerSymFragment, GNUVerDefFragment, and GNUVerNeedFragment were created with default fragment alignment of 1. Their emit() implementations cast the MemoryRegion buffer pointer directly to a typed ELF entry pointer, which requires the buffer to be aligned to the entry type's natural alignment. When the section file offset is not aligned (e.g. in a linker-script test where .dynsym follows an odd-sized section), UBSan reports a misaligned reference.

The fix adds a uint32_t Align parameter to each fragment constructor, matching the pattern already used by RegionFragment.

Fragment            | Entry type          | Alignment requirement
--------------------|---------------------|----------------------
DynSymFragment      | Elf32/64_Sym        | bitclass()/8 (4/8)
DynamicFragment     | Elf32/64_Dyn        | bitclass()/8 (4/8)
GNUVerSymFragment   | Elf32_Versym        | 2
GNUVerDefFragment   | Elf32/64_Verdef     | 4
GNUVerNeedFragment  | Elf32/64_Verneed    | 4
DynStrFragment      | char (byte string)  | 1 (no fix needed)