### PR TITLE
[Zephyr] Fix PR workflow permission error

### DIFF
--- a/.github/workflows/zephyr-pr.yml
+++ b/.github/workflows/zephyr-pr.yml
@@ -146,7 +146,9 @@ jobs:
     needs: resolve
     if: needs.resolve.outputs.should_run == 'true'
     permissions:
-      contents: read # caps zephyr-run.yml's declared write, only used on the nightly path
+      # Must be >= zephyr-run.yml's declared contents: write; GitHub rejects
+      # the call otherwise. The write is only exercised on the nightly path.
+      contents: write
       actions: read
     strategy:
       fail-fast: false


### PR DESCRIPTION
The zephyr job granted `contents: read` but calls zephyr-run.yml which
declares `contents: write`.