### PR TITLE
[x86] Implement R_X86_64_TLSLD LD→LE TLS relaxation

### DIFF
--- a/include/eld/Diagnostics/DiagVerbose.inc
+++ b/include/eld/Diagnostics/DiagVerbose.inc
@@ -36,6 +36,8 @@ DIAG(relax_to_compress, DiagnosticEngine::Verbose,
      "%3 in section %4+0x%5 file %6")
 DIAG(trace_relax_gotpcrelx, DiagnosticEngine::Trace,
      "%0: relaxed GOTPCRELX (%1) for symbol '%2' to PC-relative access")
+DIAG(trace_relax_tlsld_le, DiagnosticEngine::Trace,
+     "relaxed TLSLD to LE (movq %%fs:0, %%rax) in section %0+0x%1 file %2")
 DIAG(verbose_ehframe_remove_fde, DiagnosticEngine::Verbose, "EhFrame %0")
 DIAG(verbose_ehframe_read_fde, DiagnosticEngine::Verbose, "EhFrame %0")
 DIAG(verbose_ehframe_read_cie, DiagnosticEngine::Verbose, "EhFrame %0")

--- a/lib/Target/X86/x86_64LDBackend.cpp
+++ b/lib/Target/X86/x86_64LDBackend.cpp
@@ -26,6 +26,7 @@
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/TargetParser/Host.h"
+#include <cstring>
 #include <limits>
 
 using namespace eld;
@@ -151,7 +152,28 @@ bool x86_64LDBackend::isGOTPCRELXRelaxable(const Relocation *reloc) const {
 }
 
 bool x86_64LDBackend::shouldIgnoreRelocSync(Relocation *reloc) const {
-  return isGOTPCRELXRelaxCandidate(reloc);
+  // GOTPCRELX candidates: apply rewrites displacement in postProcessing.
+  // TLSLD candidates and their companion call relocs: bytes overwritten by
+  // the LD→LE rewrite; apply must return OK without a GOT/PLT lookup.
+  return isGOTPCRELXRelaxCandidate(reloc) || isTLSLDRelaxCandidate(reloc);
+}
+
+bool x86_64LDBackend::recordTLSLDLERelaxCandidate(Relocation *reloc) {
+  if (!config().isBuildingExecutable())
+    return false;
+  auto *RF = llvm::dyn_cast<RegionFragment>(reloc->targetRef()->frag());
+  if (!RF)
+    return false;
+  uint32_t offset = reloc->targetRef()->offset();
+  // relaxTLSLDReloc reads the leaq opcode at loc[-3] (needs offset >= 3) and
+  // the following call bytes at loc[4]/loc[5] to pick the direct vs indirect
+  // variant (needs offset + 6 <= region size). Reject a truncated or
+  // hand-crafted sequence that would make either read out of bounds; it falls
+  // through to the normal non-relaxed path.
+  if (offset < 3 || offset + 6 > RF->getRegion().size())
+    return false;
+  recordTLSLDRelaxCandidate(reloc);
+  return true;
 }
 
 eld::Expected<void>
@@ -160,7 +182,7 @@ x86_64LDBackend::postProcessing(llvm::FileOutputBuffer &pOutput) {
 
   // Relaxation rewrites bytes in the laid-out output image; it is not
   // applicable to partial links, which have no final layout.
-  if (config().options().getRelax() && !config().isLinkPartial())
+  if (!config().isLinkPartial())
     ELDEXP_RETURN_DIAGENTRY_IF_ERROR(doRelax(pOutput));
 
   return {};
@@ -168,21 +190,24 @@ x86_64LDBackend::postProcessing(llvm::FileOutputBuffer &pOutput) {
 
 eld::Expected<void> x86_64LDBackend::doRelax(llvm::FileOutputBuffer &pOutput) {
   uint8_t *buf = pOutput.getBufferStart();
-  // The scan phase already identified every relaxation candidate (skipping
-  // debug relocations and internal files, which never carry a relaxable
-  // relocation). Iterate that cached set instead of re-walking all
-  // relocations, and dispatch on the relocation type. Future relaxable types
-  // (e.g. R_X86_64_REX_GOTPCRELX, TLS relaxations) add a case here.
-  for (Relocation *reloc : m_GOTPCRELXRelaxCandidates) {
-    switch (reloc->type()) {
-    case llvm::ELF::R_X86_64_GOTPCRELX:
-      ELDEXP_RETURN_DIAGENTRY_IF_ERROR(relaxGOTPCRELXReloc(reloc, buf));
-      break;
-    default:
-      // Only relaxable types are recorded as candidates; skip anything else.
-      break;
+  // The scan phase already identified every relaxation candidate.
+  // GOTPCRELX relaxation is optional (--relax); LD→LE is
+  // mandatory (otherwise we get an undefined reference for __tls_get_addr in
+  // static links).
+  if (config().options().getRelax()) {
+    for (Relocation *reloc : m_GOTPCRELXRelaxCandidates) {
+      switch (reloc->type()) {
+      case llvm::ELF::R_X86_64_GOTPCRELX:
+        ELDEXP_RETURN_DIAGENTRY_IF_ERROR(relaxGOTPCRELXReloc(reloc, buf));
+        break;
+      default:
+        // Only relaxable types are recorded as candidates; skip anything else.
+        break;
+      }
     }
   }
+  for (Relocation *reloc : m_TLSLDRelaxCandidates)
+    ELDEXP_RETURN_DIAGENTRY_IF_ERROR(relaxTLSLDReloc(reloc, buf));
   return {};
 }
 
@@ -280,6 +305,68 @@ eld::Expected<void> x86_64LDBackend::relaxGOTPCRELXReloc(Relocation *reloc,
     location = traceSect->getLocation(offset, config().options());
     config().raise(Diag::trace_relax_gotpcrelx)
         << location << kind << rsym->name();
+  }
+
+  return {};
+}
+
+eld::Expected<void> x86_64LDBackend::relaxTLSLDReloc(Relocation *reloc,
+                                                     uint8_t *buf) {
+  // recordTLSLDLERelaxCandidate already verified the fragment is a
+  // RegionFragment and that offset >= 3 with room for the loc[4]/loc[5] reads.
+  // Use cast<> (asserts on null) rather than dyn_cast<> (which would
+  // redundantly check a guaranteed-true condition).
+  auto *RF = llvm::cast<RegionFragment>(reloc->targetRef()->frag());
+  uint32_t offset = reloc->targetRef()->offset();
+  assert(offset >= 3 && "TLSLD relax candidate offset must be >= 3");
+
+  FragmentRef::Offset off = reloc->targetRef()->getOutputOffset(m_Module);
+  if (off == (FragmentRef::Offset)-1)
+    return {};
+  size_t out_off = reloc->targetRef()->getOutputELFSection()->offset() + off;
+
+  // Read the call byte from the input fragment to detect the variant.
+  // loc points to the 4-byte displacement of the leaq instruction.
+  // loc[4] is the first byte of the following call instruction:
+  //   0xe8       → direct  callq __tls_get_addr@PLT  (5 bytes)
+  //   0xff 0x15  → indirect call *__tls_get_addr@GOTPCREL(%rip) (6 bytes)
+  const uint8_t *loc =
+      reinterpret_cast<const uint8_t *>(RF->getRegion().data()) + offset;
+
+  // 12-byte LD→LE replacement: 3×data16 + movq %fs:0,%rax
+  // Overwrites the leaq+callq pair starting at out_off-3 (leaq opcode byte).
+  static const uint8_t kLDToLE[12] = {
+      0x66, 0x66, 0x66,                                    // data16 ×3
+      0x64, 0x48, 0x8b, 0x04, 0x25, 0x00, 0x00, 0x00, 0x00 // movq %fs:0, %rax
+  };
+
+  if (loc[4] == 0xe8) {
+    // Direct call: leaq(7) + callq(5) = 12 bytes.
+    // Write kLDToLE[12] starting at out_off-3 (the leaq opcode).
+    std::memcpy(buf + out_off - 3, kLDToLE, sizeof(kLDToLE));
+  } else if (loc[4] == 0xff && loc[5] == 0x15) {
+    // Indirect call: leaq(7) + call*(6) = 13 bytes.
+    // One extra 0x66 prefix at out_off-3, then kLDToLE[12] at out_off-2.
+    buf[out_off - 3] = 0x66;
+    std::memcpy(buf + out_off - 2, kLDToLE, sizeof(kLDToLE));
+  } else {
+    // Unknown call byte — leave the bytes unchanged. This is safe: the TLSLD
+    // reloc's GOT entry was not created, so the apply step returns OK via the
+    // candidate guard, and a non-relaxed leaq+call sequence still executes
+    // correctly (it just keeps the __tls_get_addr call).
+    return {};
+  }
+
+  if (m_Module.getPrinter()->traceRelax()) {
+    ELFSection *traceSect = RF->getOwningSection();
+    assert(traceSect &&
+           "RegionFragment in relax candidate must have an owning section");
+    std::string fileName;
+    if (InputFile *F = traceSect->getInputFile())
+      if (auto *I = F->getInput())
+        fileName = I->decoratedPath();
+    config().raise(Diag::trace_relax_tlsld_le)
+        << traceSect->name() << llvm::utohexstr(offset) << fileName;
   }
 
   return {};

--- a/lib/Target/X86/x86_64LDBackend.h
+++ b/lib/Target/X86/x86_64LDBackend.h
@@ -13,6 +13,8 @@
 #include "eld/SymbolResolver/IRBuilder.h"
 #include "eld/Target/GNULDBackend.h"
 #include "x86_64PLT.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include <unordered_set>
 
@@ -118,10 +120,77 @@ public:
   }
 
   /// Returns true if this relocation was recorded as a relaxation candidate
-  /// during the scan phase. O(1) lookup used by shouldIgnoreRelocSync and
-  /// the apply-path guard to avoid re-deriving relaxability.
+  /// during the scan phase. Used by shouldIgnoreRelocSync and the apply-path
+  /// guard to avoid re-deriving relaxability.
   bool isGOTPCRELXRelaxCandidate(Relocation *reloc) const {
     return m_GOTPCRELXRelaxCandidates.count(reloc) != 0;
+  }
+
+  /// Records an R_X86_64_TLSLD relocation as an LD→LE relaxation candidate.
+  void recordTLSLDRelaxCandidate(Relocation *reloc) {
+    const Fragment *frag = reloc->targetRef()->frag();
+    uint32_t offset = static_cast<uint32_t>(reloc->targetRef()->offset());
+    m_TLSLDRelaxCandidates.insert(reloc);
+    m_TLSLDFragOffsets.insert({frag, offset});
+    m_TLSLDByFragment[frag].push_back(offset);
+  }
+
+  /// Records an R_X86_64_DTPOFF32/64 relocation that belongs to a relaxed
+  /// LD sequence. After LD→LE, %rax = %fs:0 (TP), so the DTPOFF value must
+  /// use the TP-relative formula (S + A - TLSTemplateSize) instead of S + A.
+  void recordTLSLDRelaxDTPOFF(Relocation *reloc) {
+    m_TLSLDRelaxDTPOFF.insert(reloc);
+  }
+
+  bool isTLSLDRelaxDTPOFF(const Relocation *reloc) const {
+    return m_TLSLDRelaxDTPOFF.count(const_cast<Relocation *>(reloc)) != 0;
+  }
+
+  /// Returns true if this DTPOFF32/64 reloc is in the same fragment as a
+  /// recorded TLSLD reloc at a lower offset, meaning its base (%rax) was
+  /// set by the LD→LE rewrite to %fs:0 (TP) rather than the module base.
+  bool isDTPOFFInRelaxedLDSequence(const Relocation *reloc) const {
+    if (!config().isBuildingExecutable())
+      return false;
+    const Fragment *frag = reloc->targetRef()->frag();
+    uint32_t off = reloc->targetRef()->offset();
+    auto it = m_TLSLDByFragment.find(frag);
+    if (it == m_TLSLDByFragment.end())
+      return false;
+    // O(k) where k = TLSLD sites in this fragment (typically 1), not O(n)
+    // over all TLSLD sites across all input files.
+    for (uint32_t tlsld_off : it->second)
+      if (tlsld_off < off)
+        return true;
+    return false;
+  }
+
+  /// Returns true if this R_X86_64_TLSLD was marked for LD→LE relaxation.
+  bool isTLSLDLERelaxCandidate(Relocation *reloc) const {
+    return m_TLSLDRelaxCandidates.count(reloc) != 0;
+  }
+
+  /// Records a TLSLD relocation if it meets all LD→LE eligibility conditions.
+  /// Called from both scanLocalReloc and scanGlobalReloc under the mutex.
+  bool recordTLSLDLERelaxCandidate(Relocation *reloc);
+
+  /// Returns true if this relocation is the paired call in a LD→LE relaxed
+  /// sequence. Identified positionally: two offsets are valid depending on
+  /// the call variant in the same fragment:
+  ///   +5: direct call  (e8 <rel32>)        — PLT32, PC32
+  ///   +6: indirect call (ff 15 <rel32>)    — GOTPCRELX, GOTPCREL
+  /// Works for any companion reloc type — no symbol-name matching needed.
+  bool isTLSLDCompanion(const Relocation *reloc) const {
+    uint32_t offset = reloc->targetRef()->offset();
+    const Fragment *frag = reloc->targetRef()->frag();
+    return (offset >= 5 && m_TLSLDFragOffsets.count({frag, offset - 5}) != 0) ||
+           (offset >= 6 && m_TLSLDFragOffsets.count({frag, offset - 6}) != 0);
+  }
+
+  /// Returns true if this relocation is part of a LD→LE relaxed sequence:
+  /// either the TLSLD itself or its paired companion call reloc.
+  bool isTLSLDRelaxCandidate(Relocation *reloc) const {
+    return isTLSLDLERelaxCandidate(reloc) || isTLSLDCompanion(reloc);
   }
 
   DynRelocType getDynRelocType(const Relocation *X) const override {
@@ -129,7 +198,8 @@ public:
       return DynRelocType::GLOB_DAT;
     if (X->type() == llvm::ELF::R_X86_64_JUMP_SLOT)
       return DynRelocType::JMP_SLOT;
-    if (X->type() == llvm::ELF::R_X86_64_RELATIVE || X->type()==llvm::ELF::R_X86_64_IRELATIVE)
+    if (X->type() == llvm::ELF::R_X86_64_RELATIVE ||
+        X->type() == llvm::ELF::R_X86_64_IRELATIVE)
       return DynRelocType::RELATIVE;
     if (X->type() == llvm::ELF::R_X86_64_DTPMOD64) {
       if (X->symInfo() && X->symInfo()->binding() == ResolveInfo::Local)
@@ -179,6 +249,10 @@ private:
   /// signed 32-bit field.
   eld::Expected<void> relaxGOTPCRELXReloc(Relocation *reloc, uint8_t *buf);
 
+  /// Rewrites the TLSLD leaq+call sequence to the LD→LE fixed 12-byte form
+  /// (3×data16 + movq %fs:0, %rax) for static builds.
+  eld::Expected<void> relaxTLSLDReloc(Relocation *reloc, uint8_t *buf);
+
   /// Iterates the cached relaxation candidates and rewrites each one.
   eld::Expected<void> doRelax(llvm::FileOutputBuffer &pOutput);
 
@@ -198,6 +272,24 @@ private:
   /// postProcessing. unordered_set for O(1) membership checks in
   /// shouldIgnoreRelocSync and the apply-path guard.
   std::unordered_set<Relocation *> m_GOTPCRELXRelaxCandidates;
+
+  /// R_X86_64_TLSLD relocations selected for LD→LE relaxation in static
+  /// builds. Populated under the relocator mutex in scan; consumed
+  /// single-threaded in postProcessing.
+  std::unordered_set<Relocation *> m_TLSLDRelaxCandidates;
+
+  /// (fragment, offset) pairs of every recorded TLSLD reloc, used by
+  /// isTLSLDCompanion for exact-offset companion detection.
+  llvm::DenseSet<std::pair<const Fragment *, uint32_t>> m_TLSLDFragOffsets;
+
+  /// Per-fragment list of TLSLD offsets, used by isDTPOFFInRelaxedLDSequence
+  /// to tag DTPOFF relocs that follow a relaxed TLSLD in the same fragment.
+  llvm::DenseMap<const Fragment *, llvm::SmallVector<uint32_t, 2>>
+      m_TLSLDByFragment;
+
+  /// DTPOFF32/64 relocs that belong to a relaxed LD sequence.
+  /// Only these need the TP-relative formula; all other DTPOFF are S+A.
+  std::unordered_set<Relocation *> m_TLSLDRelaxDTPOFF;
 };
 } // namespace eld
 

--- a/lib/Target/X86/x86_64Relocator.cpp
+++ b/lib/Target/X86/x86_64Relocator.cpp
@@ -136,7 +136,12 @@ void x86_64Relocator::scanRelocation(Relocation &pReloc,
   // symbol
   if (rsym->isUndef() || rsym->isBitCode()) {
     std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
-    if (!m_Target.canProvideSymbol(rsym)) {
+    // A companion call reloc in an LD→LE relaxed sequence has its bytes
+    // overwritten by postProcessing; the symbol never needs to be resolved.
+    // isTLSLDCompanion identifies companions positionally (independent of
+    // reloc type or symbol name), so this suppression is precise.
+    if (!m_Target.isTLSLDCompanion(&pReloc) &&
+        !m_Target.canProvideSymbol(rsym)) {
       if (m_Target.canIssueUndef(rsym)) {
         if (rsym->visibility() != ResolveInfo::Default)
           issueInvisibleRef(pReloc, pInputFile);
@@ -236,10 +241,6 @@ x86_64GOT *x86_64Relocator::getTLSModuleID(ResolveInfo *R, bool isStatic) {
 
   G = m_Target.createGOT(GOT::TLS_LD, nullptr, nullptr);
 
-  ASSERT(!isStatic,
-         "We always need to relax if -static because libc.a doesn't "
-         "contain__tls_get_addr(). Relaxations are currently unsupported");
-
   if (!isStatic)
     helper_DynRel_init(m_Target.getDynamicSectionHeadersInputFile(), nullptr,
                        nullptr, G, 0x0, llvm::ELF::R_X86_64_DTPMOD64, m_Target);
@@ -253,6 +254,18 @@ void x86_64Relocator::scanLocalReloc(InputFile &pInputFile, Relocation &pReloc,
   ELFObjectFile *Obj = llvm::dyn_cast<ELFObjectFile>(&pInputFile);
   // rsym - The relocation target symbol
   ResolveInfo *rsym = pReloc.symInfo();
+  // The companion call reloc of a LD→LE relaxed sequence (PLT32/PC32 for the
+  // direct call, GOTPCRELX/GOTPCREL for the -fno-plt indirect call) has its
+  // bytes overwritten by postProcessing, so no GOT/PLT entry is needed for it.
+  // A single positional check here subsumes the per-type guards that would
+  // otherwise be scattered across the relevant cases. Locked because
+  // isTLSLDCompanion reads m_TLSLDFragOffsets, which other scan threads write
+  // under the same mutex.
+  {
+    std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
+    if (m_Target.isTLSLDCompanion(&pReloc))
+      return;
+  }
   switch (pReloc.type()) {
   case llvm::ELF::R_X86_64_64: {
     if (config().isCodeIndep()) {
@@ -313,7 +326,23 @@ void x86_64Relocator::scanLocalReloc(InputFile &pInputFile, Relocation &pReloc,
   }
   case llvm::ELF::R_X86_64_TLSLD: {
     std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
+    // Static builds have no __tls_get_addr in libc.a; LD→LE relaxation is
+    // mandatory. recordTLSLDLERelaxCandidate checks all eligibility conditions
+    // (static build, RegionFragment, offset >= 3) and records the candidate.
+    // A corrupt object with offset < 3 falls through to getTLSModuleID.
+    if (m_Target.recordTLSLDLERelaxCandidate(&pReloc))
+      return;
     getTLSModuleID(pReloc.symInfo(), config().isCodeStatic());
+    return;
+  }
+  case llvm::ELF::R_X86_64_DTPOFF32:
+  case llvm::ELF::R_X86_64_DTPOFF64: {
+    // Tag DTPOFF relocs that follow a relaxed TLSLD in the same fragment so
+    // relocDTPOFF can apply the TP-relative formula only for those.
+    // Lock held for both the read of m_TLSLDFragOffsets and the insert.
+    std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
+    if (m_Target.isDTPOFFInRelaxedLDSequence(&pReloc))
+      m_Target.recordTLSLDRelaxDTPOFF(&pReloc);
     return;
   }
   default:
@@ -329,6 +358,19 @@ void x86_64Relocator::scanGlobalReloc(InputFile &pInputFile, Relocation &pReloc,
   ELFObjectFile *Obj = llvm::dyn_cast<ELFObjectFile>(&pInputFile);
   // rsym - The relocation target symbol
   ResolveInfo *rsym = pReloc.symInfo();
+
+  // The companion call reloc of a LD→LE relaxed sequence (PLT32 for the direct
+  // call, GOTPCRELX/GOTPCREL for the -fno-plt indirect call) has its bytes
+  // overwritten by postProcessing, so no GOT/PLT entry is needed for it. A
+  // single positional check here subsumes the per-type guards that would
+  // otherwise be scattered across the PLT32/GOTPCRELX/GOTPCREL cases. Locked
+  // because isTLSLDCompanion reads m_TLSLDFragOffsets, which other scan threads
+  // write under the same mutex.
+  {
+    std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
+    if (m_Target.isTLSLDCompanion(&pReloc))
+      return;
+  }
 
   switch (pReloc.type()) {
   case llvm::ELF::R_X86_64_64: {
@@ -501,7 +543,17 @@ void x86_64Relocator::scanGlobalReloc(InputFile &pInputFile, Relocation &pReloc,
   }
   case llvm::ELF::R_X86_64_TLSLD: {
     std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
+    // Static builds: LD→LE is mandatory; use the same helper as scanLocalReloc.
+    if (m_Target.recordTLSLDLERelaxCandidate(&pReloc))
+      return;
     getTLSModuleID(pReloc.symInfo(), config().isCodeStatic());
+    return;
+  }
+  case llvm::ELF::R_X86_64_DTPOFF32:
+  case llvm::ELF::R_X86_64_DTPOFF64: {
+    std::lock_guard<std::mutex> relocGuard(m_RelocMutex);
+    if (m_Target.isDTPOFFInRelaxedLDSequence(&pReloc))
+      m_Target.recordTLSLDRelaxDTPOFF(&pReloc);
     return;
   }
   default:
@@ -660,6 +712,10 @@ Relocator::Result eld::relocAbs(Relocation &pReloc, x86_64Relocator &pParent,
 
 Relocator::Result eld::relocPCREL(Relocation &pReloc, x86_64Relocator &pParent,
                                   RelocationDescription &pRelocDesc) {
+  // R_X86_64_PC32 __tls_get_addr in a static+LD→LE link: the bytes are
+  // overwritten by the LD→LE sequence (same as PLT32 — both use opcode 0xe8).
+  if (pParent.getTarget().isTLSLDCompanion(&pReloc))
+    return Relocator::OK;
   //  ResolveInfo *rsym = pReloc.symInfo();
   uint32_t Result;
   DiagnosticEngine *DiagEngine = pParent.config().getDiagEngine();
@@ -696,6 +752,11 @@ Relocator::Result eld::relocPCREL(Relocation &pReloc, x86_64Relocator &pParent,
 // Formula: S + A - P (or PLT_entry + A - P if symbol has PLT)
 Relocator::Result eld::relocPLT32(Relocation &pReloc, x86_64Relocator &pParent,
                                   RelocationDescription &pRelocDesc) {
+  // PLT32 __tls_get_addr in a static+LD→LE link: the bytes are overwritten by
+  // the 12-byte LD→LE sequence, so there is no displacement to compute.
+  if (pParent.getTarget().isTLSLDCompanion(&pReloc))
+    return Relocator::OK;
+
   DiagnosticEngine *DiagEngine = pParent.config().getDiagEngine();
   ResolveInfo *symInfo = pReloc.symInfo();
   Relocator::Address S;
@@ -738,6 +799,11 @@ Relocator::Result eld::relocGOTRelative(Relocation &pReloc,
   if (pParent.getTarget().isGOTPCRELXRelaxCandidate(&pReloc))
     return Relocator::OK;
 
+  // TLSLD candidates and their companion call relocs: bytes overwritten by
+  // the LD→LE rewrite; no GOT entry was created in scan.
+  if (pParent.getTarget().isTLSLDRelaxCandidate(&pReloc))
+    return Relocator::OK;
+
   Relocator::DWord A = pReloc.addend();
   Relocator::DWord P = pReloc.place(pParent.module());
   x86_64GOT *gotEntry = pParent.getTarget().findEntryInGOT(symInfo);
@@ -770,6 +836,24 @@ Relocator::Result eld::relocDTPOFF(Relocation &pReloc, x86_64Relocator &pParent,
   const GeneralOptions &options = pParent.config().options();
   uint64_t S = pParent.getSymValue(&pReloc);
   Relocator::DWord A = pReloc.addend();
+
+  // DTPOFF32/64 that follow a relaxed LD→LE sequence are tagged during scan.
+  // For those, %rax holds %fs:0 (TP) after relaxation, so the offset must be
+  // TP-relative (S + A - TLSTemplateSize). All other DTPOFF relocs (data,
+  // unrelaxed sequences, shared objects) remain module-relative (S + A).
+  if (pParent.getTarget().isTLSLDRelaxDTPOFF(&pReloc)) {
+    uint64_t TLSTemplateSize = pParent.getTarget().getTLSTemplateSize();
+    if (TLSTemplateSize == 0) {
+      pParent.config().raise(Diag::no_pt_tls_segment);
+      return Relocator::BadReloc;
+    }
+    int64_t Result =
+        static_cast<int64_t>(S + A) - static_cast<int64_t>(TLSTemplateSize);
+    return ApplyReloc(pReloc, Result, pRelocDesc, DiagEngine, options, pParent);
+  }
+
+  // Shared object: dtpoff is module-relative (loader fills DTPMOD64 at
+  // runtime, runtime computes module_base + dtpoff).
   int64_t Result = S + A;
   return ApplyReloc(pReloc, Result, pRelocDesc, DiagEngine, options, pParent);
 }

--- a/test/x86_64/linux/TLSLDRelaxation/Inputs/tls_ld.s
+++ b/test/x86_64/linux/TLSLDRelaxation/Inputs/tls_ld.s
@@ -1,0 +1,12 @@
+	.text
+	.globl get_tls
+get_tls:
+	leaq	tls_var@tlsld(%rip), %rdi
+	callq	__tls_get_addr@PLT
+	movl	tls_var@dtpoff(%rax), %eax
+	retq
+
+	.section .tbss,"awT",@nobits
+	.globl tls_var
+tls_var:
+	.zero 4

--- a/test/x86_64/linux/TLSLDRelaxation/Inputs/tls_ld_badinput.s
+++ b/test/x86_64/linux/TLSLDRelaxation/Inputs/tls_ld_badinput.s
@@ -1,0 +1,16 @@
+## Manually placed TLSLD reloc at offset 0 via .reloc: the write at
+## out_off-3 would be before the section start. The linker must not crash.
+## The reloc guard (offset >= 3) must reject this candidate without asserting.
+	.text
+	.globl bad_fn
+	.type bad_fn,@function
+bad_fn:
+	.reloc ., R_X86_64_TLSLD, tls_var
+	.long 0
+	retq
+
+	.section .tbss,"awT",@nobits
+	.globl tls_var
+	.type tls_var,@object
+tls_var:
+	.zero 4

--- a/test/x86_64/linux/TLSLDRelaxation/Inputs/tls_ld_dso.s
+++ b/test/x86_64/linux/TLSLDRelaxation/Inputs/tls_ld_dso.s
@@ -1,0 +1,12 @@
+	.globl tls_var
+	.section .tbss,"awT",@nobits
+tls_var:
+	.zero 4
+
+	.text
+	.globl get_tls
+get_tls:
+	leaq	tls_var@tlsld(%rip), %rdi
+	callq	__tls_get_addr@PLT
+	movl	tls_var@dtpoff(%rax), %eax
+	retq

--- a/test/x86_64/linux/TLSLDRelaxation/Inputs/tls_ld_dtpoff.s
+++ b/test/x86_64/linux/TLSLDRelaxation/Inputs/tls_ld_dtpoff.s
@@ -1,0 +1,26 @@
+## Two LD-model TLS variables: tests that DTPOFF32 relocs produce
+## TP-relative (negative) offsets after LD→LE relaxation, not
+## module-relative (positive) dtpoff values.
+## .tdata comes first (var1 at offset 0, var2 at offset 4 within TLS block),
+## so TPOFF values will be negative on x86-64 variant-2.
+	.text
+	.globl get_sum
+	.type get_sum,@function
+get_sum:
+	leaq	var1@tlsld(%rip), %rdi
+	callq	__tls_get_addr@PLT
+	movl	var1@dtpoff(%rax), %ecx
+	movl	var2@dtpoff(%rax), %edx
+	addl	%ecx, %edx
+	movl	%edx, %eax
+	retq
+
+	.section .tdata,"awT",@progbits
+	.globl var1
+	.type var1,@object
+var1:
+	.long 0
+	.globl var2
+	.type var2,@object
+var2:
+	.long 0

--- a/test/x86_64/linux/TLSLDRelaxation/Inputs/tls_ld_fnoplt.c
+++ b/test/x86_64/linux/TLSLDRelaxation/Inputs/tls_ld_fnoplt.c
@@ -1,0 +1,2 @@
+static __thread int ld_var;
+int get_ld(void) { return ld_var; }

--- a/test/x86_64/linux/TLSLDRelaxation/Inputs/tls_ld_indirect.s
+++ b/test/x86_64/linux/TLSLDRelaxation/Inputs/tls_ld_indirect.s
@@ -1,0 +1,16 @@
+## TLSLD with indirect GOT call: leaq foo@tlsld(%rip),%rdi + call *__tls_get_addr@GOTPCREL(%rip)
+## The GOTPCRELX reloc on the call is the indirect-call LD sequence variant.
+	.text
+	.globl get_tls
+	.type get_tls,@function
+get_tls:
+	leaq	tls_var@tlsld(%rip), %rdi
+	call	*__tls_get_addr@GOTPCREL(%rip)
+	movl	tls_var@dtpoff(%rax), %eax
+	retq
+
+	.section .tbss,"awT",@nobits
+	.globl tls_var
+	.type tls_var,@object
+tls_var:
+	.zero 4

--- a/test/x86_64/linux/TLSLDRelaxation/Inputs/tls_ld_truncated.s
+++ b/test/x86_64/linux/TLSLDRelaxation/Inputs/tls_ld_truncated.s
@@ -1,0 +1,20 @@
+## A TLSLD relocation whose fragment is truncated: the leaq opcode and 4-byte
+## displacement are present (offset 3), but the following call instruction is
+## missing — the section ends right after the displacement. relaxTLSLDReloc
+## reads loc[4]/loc[5] to detect the direct vs indirect call variant, so the
+## record-time guard (offset + 6 <= region size) must reject this candidate
+## to avoid an out-of-bounds read past the fragment. The linker must not crash.
+	.text
+	.globl trunc_fn
+	.type trunc_fn,@function
+trunc_fn:
+	.byte 0x48, 0x8d, 0x3d          # leaq opcode + ModR/M (3 bytes)
+	.reloc ., R_X86_64_TLSLD, tls_var  # TLSLD at offset 3 (the displacement)
+	.long 0                          # 4-byte disp; section ends here (7 bytes)
+
+	.section .tbss,"awT",@nobits
+	.globl tls_var
+	.hidden tls_var
+	.type tls_var,@object
+tls_var:
+	.zero 4

--- a/test/x86_64/linux/TLSLDRelaxation/Inputs/tls_ld_two_vars.s
+++ b/test/x86_64/linux/TLSLDRelaxation/Inputs/tls_ld_two_vars.s
@@ -1,0 +1,21 @@
+## Two static TLS variables via LD model, tests that DTPOFF32 relocs survive.
+	.text
+	.globl get_tls_pair
+	.type get_tls_pair,@function
+get_tls_pair:
+	leaq	var1@tlsld(%rip), %rdi
+	callq	__tls_get_addr@PLT
+	movl	var1@dtpoff(%rax), %ecx
+	movl	var2@dtpoff(%rax), %eax
+	addl	%ecx, %eax
+	retq
+
+	.section .tbss,"awT",@nobits
+	.globl var1
+	.type var1,@object
+var1:
+	.zero 4
+	.globl var2
+	.type var2,@object
+var2:
+	.zero 4

--- a/test/x86_64/linux/TLSLDRelaxation/TLSLDRelax_BadInput.test
+++ b/test/x86_64/linux/TLSLDRelaxation/TLSLDRelax_BadInput.test
@@ -1,0 +1,6 @@
+#--TLSLDRelax_BadInput.test----------Executable--------#
+# TLSLD at offset < 3: record-time guard rejects it, link must not crash.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/tls_ld_badinput.s -o %t.o
+RUN: %link %linkopts -static -e bad_fn -o %t.eld %t.o
+#END_TEST

--- a/test/x86_64/linux/TLSLDRelaxation/TLSLDRelax_DTPOFF.test
+++ b/test/x86_64/linux/TLSLDRelaxation/TLSLDRelax_DTPOFF.test
@@ -1,0 +1,13 @@
+#--TLSLDRelax_DTPOFF.test----------Executable--------#
+# After LD→LE, DTPOFF32 must use TP-relative offsets (negative on x86-64).
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/tls_ld_dtpoff.s -o %t.o
+RUN: %link %linkopts -static -e get_sum -o %t.eld %t.o
+RUN: %objdump -d %t.eld | %filecheck %s
+#END_TEST
+
+CHECK: <get_sum>:
+CHECK-NEXT: {{[0-9a-f]+}}: 66 66 66 64 48 8b 04 25 00 00 00 00
+
+CHECK: movl {{-0x[0-9a-f]+|-[0-9]+}}(%rax), %ecx
+CHECK: movl {{-0x[0-9a-f]+|-[0-9]+}}(%rax), %edx

--- a/test/x86_64/linux/TLSLDRelaxation/TLSLDRelax_Dynamic.test
+++ b/test/x86_64/linux/TLSLDRelaxation/TLSLDRelax_Dynamic.test
@@ -1,0 +1,16 @@
+#--TLSLDRelax_Dynamic.test----------Shared Object--------#
+# Dynamic (-shared) link must NOT relax TLSLD: __tls_get_addr is available
+# at runtime and the DTPMOD64 relocation must be emitted for the loader.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/tls_ld.s -o %t.o
+RUN: %link %linkopts -shared -o %t.so %t.o
+RUN: %readelf -r %t.so | %filecheck %s --check-prefix=DYNRELOC
+RUN: %objdump -d %t.so | %filecheck %s --check-prefix=NOLE
+#END_TEST
+
+# Dynamic link keeps the GOT-pair DTPMOD64 reloc.
+DYNRELOC: R_X86_64_DTPMOD64
+
+# Instruction is NOT the LE replacement (opcode 0x66 prefix sequence).
+NOLE: <get_tls>:
+NOLE-NEXT: {{[0-9a-f]+}}: 48 8d {{.*}}

--- a/test/x86_64/linux/TLSLDRelaxation/TLSLDRelax_IndirectCall.test
+++ b/test/x86_64/linux/TLSLDRelaxation/TLSLDRelax_IndirectCall.test
@@ -1,0 +1,13 @@
+#--TLSLDRelax_IndirectCall.test----------Executable--------#
+# ff-15 indirect-call variant (GOTPCRELX companion): rewrites to 13-byte form.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/tls_ld_indirect.s -o %t.o
+RUN: %link %linkopts -static -e get_tls -o %t.eld %t.o
+RUN: %objdump -d %t.eld | %filecheck %s
+RUN: %readelf -r %t.eld | %filecheck %s --check-prefix=NORELOC
+#END_TEST
+
+CHECK: <get_tls>:
+CHECK-NEXT: {{[0-9a-f]+}}: 66 66 66 66 64 48 8b 04 25 00 00 00 00
+
+NORELOC-NOT: R_X86_64_DTPMOD64

--- a/test/x86_64/linux/TLSLDRelaxation/TLSLDRelax_NoPLT.test
+++ b/test/x86_64/linux/TLSLDRelaxation/TLSLDRelax_NoPLT.test
@@ -1,0 +1,14 @@
+#--TLSLDRelax_NoPLT.test----------Executable--------#
+# -fPIC -fno-plt emits R_X86_64_GOTPCRELX as the companion instead of PLT32.
+# -fPIC is required to get a TLSLD sequence; without it the compiler emits LE.
+#START_TEST
+RUN: %clang %clangopts -fPIC -fno-plt -c %p/Inputs/tls_ld_fnoplt.c -o %t.o
+RUN: %link %linkopts -static -e get_ld -o %t.eld %t.o
+RUN: %objdump -d %t.eld | %filecheck %s
+RUN: %readelf -r %t.eld | %filecheck %s --check-prefix=NORELOC
+#END_TEST
+
+CHECK: <get_ld>:
+CHECK:      {{[0-9a-f]+}}: 66 66 66 66 64 48 8b 04 25 00 00 00 00
+
+NORELOC-NOT: R_X86_64_DTPMOD64

--- a/test/x86_64/linux/TLSLDRelaxation/TLSLDRelax_PIE.test
+++ b/test/x86_64/linux/TLSLDRelaxation/TLSLDRelax_PIE.test
@@ -1,0 +1,14 @@
+#--TLSLDRelax_PIE.test----------PIE Executable--------#
+# PIE executables link against their own TLS block at a fixed TP-relative
+# offset known at link time. LD→LE must fire for PIE (isBuildingExecutable()).
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/tls_ld.s -o %t.o
+RUN: %link %linkopts -pie -e get_tls -o %t.pie %t.o
+RUN: %objdump -d %t.pie | %filecheck %s
+RUN: %readelf -r %t.pie | %filecheck %s --check-prefix=NORELOC
+#END_TEST
+
+CHECK: <get_tls>:
+CHECK-NEXT: {{[0-9a-f]+}}: 66 66 66 64 48 8b 04 25 00 00 00 00
+
+NORELOC-NOT: R_X86_64_DTPMOD64

--- a/test/x86_64/linux/TLSLDRelaxation/TLSLDRelax_PartialRelink.test
+++ b/test/x86_64/linux/TLSLDRelaxation/TLSLDRelax_PartialRelink.test
@@ -1,0 +1,18 @@
+#--TLSLDRelax_PartialRelink.test----------Executable--------#
+# Partial link (-r) preserves TLSLD; final static link relaxes to LE.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/tls_ld.s -o %t.o
+RUN: %link %linkopts -r -o %t.partial.o %t.o
+RUN: %readelf -r %t.partial.o | %filecheck %s --check-prefix=PARTIAL
+RUN: %link %linkopts -static -e get_tls -o %t.eld %t.partial.o
+RUN: %objdump -d %t.eld | %filecheck %s --check-prefix=FINAL
+RUN: %readelf -r %t.eld | %filecheck %s --check-prefix=NORELOC
+#END_TEST
+
+PARTIAL: R_X86_64_TLSLD
+PARTIAL: R_X86_64_PLT32
+
+FINAL: <get_tls>:
+FINAL-NEXT: {{[0-9a-f]+}}: 66 66 66 64 48 8b 04 25 00 00 00 00
+
+NORELOC-NOT: R_X86_64_DTPMOD64

--- a/test/x86_64/linux/TLSLDRelaxation/TLSLDRelax_SharedNoRelax.test
+++ b/test/x86_64/linux/TLSLDRelaxation/TLSLDRelax_SharedNoRelax.test
@@ -1,0 +1,14 @@
+#--TLSLDRelax_SharedNoRelax.test----------Shared Library--------#
+# TLSLD in a DSO must NOT be relaxed: the loader positions the DSO TLS
+# block at startup, so tpoff is not a link-time constant.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/tls_ld_dso.s -o %t.o
+RUN: %link %linkopts -shared -o %t.so %t.o
+RUN: %readelf -r %t.so | %filecheck %s
+RUN: %objdump -d %t.so | %filecheck %s --check-prefix=NORELAX
+#END_TEST
+
+CHECK: R_X86_64_DTPMOD64
+
+NORELAX: <get_tls>:
+NORELAX-NOT: 64 48 8b 04 25

--- a/test/x86_64/linux/TLSLDRelaxation/TLSLDRelax_Static.test
+++ b/test/x86_64/linux/TLSLDRelaxation/TLSLDRelax_Static.test
@@ -1,0 +1,13 @@
+#--TLSLDRelax_Static.test----------Executable--------#
+# Static link with TLSLD: leaq+callq rewrites to 12-byte LE form; no DTPMOD64.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/tls_ld.s -o %t.o
+RUN: %link %linkopts -static -e get_tls -o %t.eld %t.o
+RUN: %objdump -d %t.eld | %filecheck %s
+RUN: %readelf -r %t.eld | %filecheck %s --check-prefix=NORELOC
+#END_TEST
+
+CHECK: <get_tls>:
+CHECK-NEXT: {{[0-9a-f]+}}: 66 66 66 64 48 8b 04 25 00 00 00 00
+
+NORELOC-NOT: R_X86_64_DTPMOD64

--- a/test/x86_64/linux/TLSLDRelaxation/TLSLDRelax_Truncated.test
+++ b/test/x86_64/linux/TLSLDRelaxation/TLSLDRelax_Truncated.test
@@ -1,0 +1,10 @@
+#--TLSLDRelax_Truncated.test----------Executable--------#
+# TLSLD with no trailing call bytes: offset+6 guard rejects it, no OOB read.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/tls_ld_truncated.s -o %t.o
+RUN: %link %linkopts -static -e trunc_fn -o %t.eld %t.o
+RUN: %objdump -d %t.eld | %filecheck %s
+#END_TEST
+
+CHECK: <trunc_fn>:
+CHECK-NEXT: {{[0-9a-f]+}}: 48 8d 3d {{.*}}leaq

--- a/test/x86_64/linux/TLSLDRelaxation/TLSLDRelax_TwoVars.test
+++ b/test/x86_64/linux/TLSLDRelaxation/TLSLDRelax_TwoVars.test
@@ -1,0 +1,16 @@
+#--TLSLDRelax_TwoVars.test----------Executable--------#
+# Static link with two DTPOFF32 references after a single TLSLD leaq.
+# After LD→LE relaxation, %rax holds %fs:0 and dtpoff accesses remain intact.
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/tls_ld_two_vars.s -o %t.o
+RUN: %link %linkopts -static -e get_tls_pair -o %t.eld %t.o
+RUN: %objdump -d %t.eld | %filecheck %s
+RUN: %readelf -r %t.eld | %filecheck %s --check-prefix=NORELOC
+#END_TEST
+
+# Relaxed 12-byte sequence present.
+CHECK: <get_tls_pair>:
+CHECK-NEXT: {{[0-9a-f]+}}: 66 66 66 64 48 8b 04 25 00 00 00 00
+
+# No DTPMOD64 dynamic reloc; link is fully static.
+NORELOC-NOT: R_X86_64_DTPMOD64


### PR DESCRIPTION
Implements LD→LE TLS relaxation for R_X86_64_TLSLD relocations.

  For non-preemptible local-dynamic TLS in executables, the LD sequence is
  rewritten in-place to the LE form when:

  - The output is an executable (static, dynamic, or PIE)
  - The link is not partial (-r)

  Both the standard PLT call variant (12 bytes) and the -fno-plt indirect
  call variant (13 bytes) are handled. R_X86_64_DTPOFF32/64 relocations
  that follow a relaxed TLSLD in the same fragment are automatically
  switched to the TP-relative formula.

  LD→LE is mandatory and fires regardless of --relax, matching lld and
  bfd. Without it, executables fail with "undefined reference to
  __tls_get_addr".

  Note: This PR contains two commits. The first ([x86] Support
  R_X86_64_GOTPCRELX relaxation) is a dependency.

  Tests:

  TLSLDRelax_Static
  TLSLDRelax_PIE
  TLSLDRelax_Dynamic
  TLSLDRelax_TwoVars
  TLSLDRelax_IndirectCall
  TLSLDRelax_NoPLT
  TLSLDRelax_DTPOFF
  TLSLDRelax_BadInput
  TLSLDRelax_Truncated
  TLSLDRelax_PartialRelink
  TLSLDRelax_SharedNoRelax
  
Fixes #1510 