### PR TITLE
[all] Accept weak hidden/protected undef symbols when building shared…

### DIFF
--- a/lib/Target/AArch64/AArch64Relocator.cpp
+++ b/lib/Target/AArch64/AArch64Relocator.cpp
@@ -90,6 +90,11 @@ AArch64GOT &CreateGOT(ELFObjectFile *Obj, Relocation &pReloc, bool pHasRel,
     return *G;
   }
 
+  // A non-default-visibility weak undefined symbol resolves to 0; no dynamic
+  // relocation needed.
+  if ((rsym->isHidden() || rsym->isProtected()) && rsym->isWeakUndef())
+    return *G;
+
   // If the symbol is not preemptible and we are not building an executable,
   // then try to use a relative reloc. We use a relative reloc if the symbol is
   // hidden otherwise.

--- a/lib/Target/ARM/ARMRelocator.cpp
+++ b/lib/Target/ARM/ARMRelocator.cpp
@@ -98,6 +98,11 @@ static ARMGOT *CreateGOT(ELFObjectFile *Obj, Relocation &pReloc, bool pHasRel,
     return G;
   }
 
+  // A non-default-visibility weak undefined symbol resolves to 0; no dynamic
+  // relocation needed.
+  if ((rsym->isHidden() || rsym->isProtected()) && rsym->isWeakUndef())
+    return G;
+
   // If the symbol is not preemptible and we are not building an executable,
   // then try to use a relative reloc. We use a relative reloc if the symbol is
   // hidden otherwise.

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -3846,8 +3846,9 @@ bool GNULDBackend::canIssueUndef(const ResolveInfo *pSym) {
       isSectionMagicSymbol(pSym->name()) || isStandardSymbol(pSym->name());
 
   // Visibility trumps --unresolved-symbols behavior. Dont check Unresolved
-  // symbol policy here.
-  if (!MagicSym && pSym->isUndef() &&
+  // symbol policy here. Weak undefined symbols with hidden/protected visibility
+  // are valid in shared objects — they resolve to 0 at runtime.
+  if (!MagicSym && pSym->isUndef() && !pSym->isWeak() &&
       pSym->visibility() != ResolveInfo::Default &&
       LinkerConfig::DynObj == config().codeGenType())
     return true;

--- a/lib/Target/Hexagon/HexagonRelocator.cpp
+++ b/lib/Target/Hexagon/HexagonRelocator.cpp
@@ -67,6 +67,11 @@ void HexagonRelocator::CreateGOTAbsolute(ELFObjectFile *Obj,
     return;
   }
 
+  // A non-default-visibility weak undefined symbol resolves to 0; no dynamic
+  // relocation needed.
+  if ((rsym->isHidden() || rsym->isProtected()) && rsym->isWeakUndef())
+    return;
+
   // If the symbol is not preemptible and we are not building an executable,
   // then try to use a relative reloc. We use a relative reloc if the symbol is
   // hidden otherwise.

--- a/lib/Target/RISCV/RISCVRelocator.cpp
+++ b/lib/Target/RISCV/RISCVRelocator.cpp
@@ -290,6 +290,12 @@ RISCVGOT &CreateGOT(ELFObjectFile *Obj, Relocation &pReloc, bool pHasRel,
   uint8_t Reloc = llvm::ELF::R_RISCV_32;
   if (!B.config().targets().is32Bits())
     Reloc = llvm::ELF::R_RISCV_64;
+
+  // A non-default-visibility weak undefined symbol resolves to 0; no dynamic
+  // relocation needed.
+  if ((rsym->isHidden() || rsym->isProtected()) && rsym->isWeakUndef())
+    return *G;
+
   // If the symbol is not preemptible and we are not building an executable,
   // then try to use a relative reloc. We use a relative reloc if the symbol is
   // hidden otherwise.

--- a/lib/Target/X86/x86_64Relocator.cpp
+++ b/lib/Target/X86/x86_64Relocator.cpp
@@ -212,6 +212,11 @@ x86_64GOT &CreateGOT(ELFObjectFile *Obj, Relocation &pReloc, bool pHasRel,
     G->setValueType(GOT::SymbolValue);
     return *G;
   }
+  // A non-default-visibility weak undefined symbol resolves to 0; no dynamic
+  // relocation needed.
+  if ((rsym->isHidden() || rsym->isProtected()) && rsym->isWeakUndef())
+    return *G;
+
   bool useRelative = !B.isSymbolPreemptible(*rsym);
   helper_DynRel_init(Obj, &pReloc, rsym, G, 0x0,
                      useRelative ? llvm::ELF::R_X86_64_RELATIVE

--- a/test/Common/standalone/UndefinedSymbolPolicy/UndefinedSymbolIgnoreAllVisibilitySharedLibrary/UndefinedSymbolIgnoreAllVisibilitySharedLibrary.test
+++ b/test/Common/standalone/UndefinedSymbolPolicy/UndefinedSymbolIgnoreAllVisibilitySharedLibrary/UndefinedSymbolIgnoreAllVisibilitySharedLibrary.test
@@ -1,13 +1,20 @@
 #---UndefinedSymbolIgnoreAllVisibilitySharedLibrary.test--------------------------- SharedLibrary -----------------#
 #BEGIN_COMMENT
-#This checks that undefined symbols are reported by the linker, when the
-#user uses the policy --unresolved-symbols=ignore-all because symbol visibility
-#is set to be protected or hidden. This is when building a shared object
+#This checks that weak undefined symbols with non-default visibility are accepted
+#when building a shared object, even with --unresolved-symbols=ignore-all.
+#A weak hidden/protected undef resolves to 0 at runtime; no dynamic relocation
+#should be emitted for the GOT entry.
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/foo.c -o %t1.1.o -fPIC
-RUN: %not %link %linkopts -shared %t1.1.o -o %t2.out --unresolved-symbols=ignore-all
+RUN: %link %linkopts -shared %t1.1.o -o %t1.out --unresolved-symbols=ignore-all
+RUN: %readelf -r -W %t1.out | %filecheck %s --check-prefix=PROT
 RUN: %clang %clangopts -c %p/Inputs/foohid.c -o %t1.2.o -fPIC
-RUN: %not %link %linkopts -shared %t1.2.o -o %t2.out --unresolved-symbols=ignore-all
+RUN: %link %linkopts -shared %t1.2.o -o %t2.out --unresolved-symbols=ignore-all
+RUN: %readelf -r -W %t2.out | %filecheck %s --check-prefix=HID
 
 #END_TEST
+
+# No dynamic relocation should be emitted for the weak protected/hidden undef.
+PROT-NOT: foo
+HID-NOT: foo

--- a/test/Common/standalone/WeakUndefNonDefaultVisibility/Inputs/3.c
+++ b/test/Common/standalone/WeakUndefNonDefaultVisibility/Inputs/3.c
@@ -1,0 +1,7 @@
+__attribute__((weak)) __attribute__((visibility("hidden"))) extern int foo;
+#ifdef PROTECTED
+__attribute__((weak)) __attribute__((visibility("protected"))) extern int bar;
+int baz() { return foo + bar; }
+#else
+int baz() { return foo; }
+#endif

--- a/test/Common/standalone/WeakUndefNonDefaultVisibility/WeakUndefNonDefaultVisibility.test
+++ b/test/Common/standalone/WeakUndefNonDefaultVisibility/WeakUndefNonDefaultVisibility.test
@@ -1,7 +1,9 @@
 #---WeakUndefNonDefaultVisibility.test----------- SharedLibrary----------------#
 #BEGIN_COMMENT
-# Weak undefined symbolos with non default visibility are not preemptible
-# They are converted to local default visibility and resolved to 0
+# Weak undefined symbols with non default visibility are not preemptible.
+# They are converted to local default visibility and resolved to 0.
+# When building a shared object the linker must also accept them (no error)
+# and must not emit a dynamic relocation for the GOT entry.
 #END_COMMENT
 RUN: %clang %clangopts -c %p/Inputs/1.c -fpic -o %t1.protected.o
 RUN: %clang %clangopts -c %p/Inputs/1.c -fpic -DHIDDEN -o %t1.hidden.o
@@ -18,3 +20,15 @@ RUN: %readelf --dyn-symbols %t2.out | %filecheck %s --check-prefix="DYNSYM-HIDDE
 #DYNSYM-PROT-NOT: foo
 #HIDDEN: NOTYPE  WEAK  HIDDEN  UND foo
 #DYNSYM-HIDDEN-NOT: foo
+
+# Shared object case: weak hidden/protected undef data symbol accessed via GOT.
+# Must link without error and must not emit a dynamic relocation for foo/bar.
+RUN: %clang %clangopts -c %p/Inputs/3.c -fPIC -o %t3.hidden.o
+RUN: %clang %clangopts -c %p/Inputs/3.c -fPIC -DPROTECTED -o %t3.protected.o
+RUN: %link %linkopts -shared %t3.hidden.o -o %t3.hidden.so
+RUN: %link %linkopts -shared %t3.protected.o -o %t3.protected.so
+RUN: %readelf -r -W %t3.hidden.so | %filecheck %s --check-prefix="SHLIB-HIDDEN"
+RUN: %readelf -r -W %t3.protected.so | %filecheck %s --check-prefix="SHLIB-PROT"
+
+#SHLIB-HIDDEN-NOT: foo
+#SHLIB-PROT-NOT: bar


### PR DESCRIPTION
A weak undefined symbol with hidden or protected visibility is valid in any output type: the dynamic linker cannot preempt it so it always resolves to zero at runtime. The linker should accept it silently and leave the GOT entry at zero with no dynamic relocation.

Fixes #1555