### PR TITLE
[test] Fix fragile test in VersionScriptPatternMatching

### DIFF
--- a/test/Common/standalone/VersionScriptPatternMatching/VersionScriptPatternMatching.test
+++ b/test/Common/standalone/VersionScriptPatternMatching/VersionScriptPatternMatching.test
@@ -39,10 +39,10 @@ RUN: %readelf --dyn-syms %t3.so | %filecheck --check-prefix=STAR_LOW %s
 STAR_LOW-NOT: foo
 STAR_LOW-NOT: foo1
 STAR_LOW-NOT: foo2
-STAR_LOW-DAG: {{[[:space:]]+}}bar{{$}}
-STAR_LOW-DAG: {{[[:space:]]+}}bar1{{$}}
-STAR_LOW-DAG: {{[[:space:]]+}}baz{{$}}
-STAR_LOW-DAG: {{[[:space:]]+}}qux{{$}}
+STAR_LOW-DAG: bar{{$}}
+STAR_LOW-DAG: bar1{{$}}
+STAR_LOW-DAG: baz
+STAR_LOW-DAG: qux
 
 #---------------------------------------------------------------------------
 # TEST 4: Exact match takes precedence over wildcard

--- a/test/Common/standalone/VersionScriptPatternMatching/VersionScriptPatternMatching.test
+++ b/test/Common/standalone/VersionScriptPatternMatching/VersionScriptPatternMatching.test
@@ -39,10 +39,10 @@ RUN: %readelf --dyn-syms %t3.so | %filecheck --check-prefix=STAR_LOW %s
 STAR_LOW-NOT: foo
 STAR_LOW-NOT: foo1
 STAR_LOW-NOT: foo2
-STAR_LOW-DAG: bar
-STAR_LOW-DAG: bar1
-STAR_LOW-DAG: baz
-STAR_LOW-DAG: qux
+STAR_LOW-DAG: {{[[:space:]]+}}bar{{$}}
+STAR_LOW-DAG: {{[[:space:]]+}}bar1{{$}}
+STAR_LOW-DAG: {{[[:space:]]+}}baz{{$}}
+STAR_LOW-DAG: {{[[:space:]]+}}qux{{$}}
 
 #---------------------------------------------------------------------------
 # TEST 4: Exact match takes precedence over wildcard


### PR DESCRIPTION
 The VersionScriptPatternMatching `STAR_LOW` check used bare DAG patterns for symbols such as `bar` and `bar1`. This made the test fragile because `bar` could match as a substring of `bar1`, causing the later `bar1` DAG check to fail depending on `FileCheck` match selection.