### PR TITLE
[all] Simplify scanRelocation section lookup to use pSection.getLink()

### DIFF
--- a/lib/Target/AArch64/AArch64Relocator.cpp
+++ b/lib/Target/AArch64/AArch64Relocator.cpp
@@ -654,9 +654,7 @@ void AArch64Relocator::scanRelocation(Relocation &pReloc,
     }
   }
 
-  ELFSection *section = pSection.getLink()
-                            ? pSection.getLink()
-                            : pReloc.targetRef()->frag()->getOwningSection();
+  ELFSection *section = pSection.getLink();
 
   if (!section->isAlloc()) {
     // Cannot have authenticated relocations in non-alloc sections (like .debug)

--- a/lib/Target/ARM/ARMRelocator.cpp
+++ b/lib/Target/ARM/ARMRelocator.cpp
@@ -899,9 +899,7 @@ void ARMRelocator::scanRelocation(Relocation &pReloc, eld::IRBuilder &pBuilder,
     }
   }
 
-  ELFSection *section = pSection.getLink()
-                            ? pSection.getLink()
-                            : pReloc.targetRef()->frag()->getOwningSection();
+  ELFSection *section = pSection.getLink();
 
   if (!section->isAlloc())
     return;

--- a/lib/Target/Hexagon/HexagonRelocator.cpp
+++ b/lib/Target/Hexagon/HexagonRelocator.cpp
@@ -318,9 +318,7 @@ void HexagonRelocator::scanRelocation(Relocation &pReloc,
       }
     }
   }
-  ELFSection *section = pSection.getLink()
-                            ? pSection.getLink()
-                            : pReloc.targetRef()->frag()->getOwningSection();
+  ELFSection *section = pSection.getLink();
 
   if (!section->isAlloc())
     return;

--- a/lib/Target/RISCV/RISCVRelocator.cpp
+++ b/lib/Target/RISCV/RISCVRelocator.cpp
@@ -448,9 +448,7 @@ void RISCVRelocator::scanRelocation(Relocation &pReloc, eld::IRBuilder &pLinker,
       }
     }
 
-    ELFSection *section = pSection.getLink()
-                              ? pSection.getLink()
-                              : pReloc.targetRef()->frag()->getOwningSection();
+    ELFSection *section = pSection.getLink();
 
     if (!section->isAlloc())
       return;

--- a/lib/Target/Template/TemplateRelocator.cpp
+++ b/lib/Target/Template/TemplateRelocator.cpp
@@ -97,9 +97,7 @@ void TemplateRelocator::scanRelocation(Relocation &pReloc,
     }
   }
 
-  ELFSection *section = pSection.getLink()
-                            ? pSection.getLink()
-                            : pReloc.targetRef()->frag()->getOwningSection();
+  ELFSection *section = pSection.getLink();
 
   if (!section->isAlloc())
     return;

--- a/lib/Target/X86/x86_64Relocator.cpp
+++ b/lib/Target/X86/x86_64Relocator.cpp
@@ -144,9 +144,7 @@ void x86_64Relocator::scanRelocation(Relocation &pReloc,
       }
     }
   }
-  ELFSection *section = pSection.getLink()
-                            ? pSection.getLink()
-                            : pReloc.targetRef()->frag()->getOwningSection();
+  ELFSection *section = pSection.getLink();
 
   if (!section->isAlloc())
     return;


### PR DESCRIPTION
The relocation section passed to scanRelocation always has a valid link section, so the fallback is unnecessary.