### PR TITLE
Add x86_64 to nightly picolibc workflow

### DIFF
--- a/.github/workflows/picolibc-builder.yml
+++ b/.github/workflows/picolibc-builder.yml
@@ -1,7 +1,9 @@
 name: nightly picolibc builder
 
 on:
-  # pull_request: {} # Uncomment only to test this WF file update.
+  pull_request:
+    paths:
+      - '.github/workflows/picolibc-builder.yml'
   schedule:
     # 10:00 PM Central
     - cron: '0 4 * * *'
@@ -58,6 +60,13 @@ jobs:
             picolibc-tls-ie: "-Dtls-model=initial-exec"
             extra-c-flags: "-march=armv7-a"
             extra-cxx-flags: "-march=armv7-a"
+          - name: x86_64
+            picolibc-name: x86_64
+            triple: x86_64-none-elf
+            llvm-target: X86
+            picolibc-default-config: "-Dc_link_args=-L$(clang -print-resource-dir)/lib/x86_64-none-elf"
+            picolibc-no-tls: "-Dc_link_args=-L$(clang -print-resource-dir)/lib/x86_64-none-elf -Dthread-local-storage=false"
+            picolibc-tls-ie: "-Dc_link_args=-L$(clang -print-resource-dir)/lib/x86_64-none-elf -Dtls-model=initial-exec"
 
     steps:
       - name: Set up Clang 20
@@ -69,7 +78,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt update
-          sudo apt install -y libc++-dev libc++abi-dev ccache libclang-rt-20-dev cmake ninja-build make bison flex python3 m4 git libglib2.0-dev
+          sudo apt install -y libc++-dev libc++abi-dev ccache libclang-rt-20-dev cmake ninja-build make bison flex python3 m4 git libglib2.0-dev lld
       - name: Checkout LLVM Project
         run: |
           git clone --branch main --single-branch --depth 1 https://github.com/llvm/llvm-project ${{ github.workspace }}/llvm-project
@@ -182,6 +191,34 @@ jobs:
           ln -s $(realpath meson.pyz) bin/meson
           echo "PATH=$PWD/bin:$PATH" >> $GITHUB_ENV
 
+      - name: Set up ELD i386 linker wrapper (x86_64 only)
+        if: matrix.arch.name == 'x86_64'
+        run: |
+          # ELD has no i386 backend. picolibc builds a 32-bit semihosting BIOS for QEMU
+          # using elf_i386 emulation. Route that to lld; all others go to eld.
+          export PATH=${{ github.workspace }}/install-${{ matrix.arch.name }}-toolchain/bin:$PATH
+          ELD_BIN=$(which ld.eld)
+          ELD_DIR=$(dirname "$ELD_BIN")
+          LLD_BIN=$(which ld.lld 2>/dev/null || which ld.lld-20 2>/dev/null || which ld.lld-19 2>/dev/null)
+          if [ -z "$LLD_BIN" ]; then
+            echo "ERROR: ld.lld not found"; exit 1
+          fi
+          mv "$ELD_BIN" "$ELD_DIR/ld.eld.real"
+          ELD_REAL="$ELD_DIR/ld.eld.real"
+          printf '%s\n' \
+            '#!/bin/sh' \
+            'for arg in "$@"; do' \
+            '    case "$arg" in' \
+            "        -melf_i386|elf_i386|-m32) exec \"$LLD_BIN\" \"\$@\" ;;" \
+            '    esac' \
+            'done' \
+            "exec \"$ELD_REAL\" \"\$@\"" \
+            > "$ELD_BIN"
+          chmod +x "$ELD_BIN"
+          # Verify
+          ld.eld --version 2>&1 | head -1
+          ld.eld -melf_i386 --version 2>&1 | head -1
+
       - name: Checkout Picolibc
         run: |
           git clone https://github.com/picolibc/picolibc.git ${{ github.workspace }}/picolibc
@@ -197,35 +234,47 @@ jobs:
 
       - name: Build Picolibc for ${{ matrix.arch.name }}, default-config
         run: |
+          export PATH=${{ github.workspace }}/install-${{ matrix.arch.name }}-toolchain/bin:$PATH
           cd ${{ github.workspace }}/picolibc
           mkdir -p build-clang-${{ matrix.arch.name }}-picolibc-default-config
           cd build-clang-${{ matrix.arch.name }}-picolibc-default-config
-          export PATH=${{ github.workspace }}/install-${{ matrix.arch.name }}-toolchain/bin:$PATH
-          export CC_LD=eld
-          export CXX_LD=eld
-          ../scripts/do-clang-${{ matrix.arch.picolibc-name }}-configure -Dc_ld=ld.eld -Dcpp_ld=ld.eld ${{ matrix.arch.picolibc-default-config }} -Dc_args="${{ matrix.arch.extra-c-flags }}" -Dcpp_args="${{ matrix.arch.extra-cxx-flags }}"
+          if [ "${{ matrix.arch.name }}" = "x86_64" ]; then
+            ../scripts/do-eld-x86_64-configure ${{ matrix.arch.picolibc-default-config }}
+          else
+            export CC_LD=eld
+            export CXX_LD=eld
+            ../scripts/do-clang-${{ matrix.arch.picolibc-name }}-configure -Dc_ld=ld.eld -Dcpp_ld=ld.eld ${{ matrix.arch.picolibc-default-config }} -Dc_args="${{ matrix.arch.extra-c-flags }}" -Dcpp_args="${{ matrix.arch.extra-cxx-flags }}"
+          fi
           ninja
 
       - name: Build Picolibc for ${{ matrix.arch.name }}, no-tls
         run: |
+          export PATH=${{ github.workspace }}/install-${{ matrix.arch.name }}-toolchain/bin:$PATH
           cd ${{ github.workspace }}/picolibc
           mkdir -p build-clang-${{ matrix.arch.name }}-picolibc-no-tls
           cd build-clang-${{ matrix.arch.name }}-picolibc-no-tls
-          export PATH=${{ github.workspace }}/install-${{ matrix.arch.name }}-toolchain/bin:$PATH
-          export CC_LD=eld
-          export CXX_LD=eld
-          ../scripts/do-clang-${{ matrix.arch.picolibc-name }}-configure -Dc_ld=ld.eld -Dcpp_ld=ld.eld ${{ matrix.arch.picolibc-no-tls }} -Dc_args="${{ matrix.arch.extra-c-flags }}" -Dcpp_args="${{ matrix.arch.extra-cxx-flags }}"
+          if [ "${{ matrix.arch.name }}" = "x86_64" ]; then
+            ../scripts/do-eld-x86_64-configure ${{ matrix.arch.picolibc-no-tls }}
+          else
+            export CC_LD=eld
+            export CXX_LD=eld
+            ../scripts/do-clang-${{ matrix.arch.picolibc-name }}-configure -Dc_ld=ld.eld -Dcpp_ld=ld.eld ${{ matrix.arch.picolibc-no-tls }} -Dc_args="${{ matrix.arch.extra-c-flags }}" -Dcpp_args="${{ matrix.arch.extra-cxx-flags }}"
+          fi
           ninja
 
       - name: Build Picolibc for ${{ matrix.arch.name }}, tls-ie
         run: |
+          export PATH=${{ github.workspace }}/install-${{ matrix.arch.name }}-toolchain/bin:$PATH
           cd ${{ github.workspace }}/picolibc
           mkdir -p build-clang-${{ matrix.arch.name }}-picolibc-tls-ie
           cd build-clang-${{ matrix.arch.name }}-picolibc-tls-ie
-          export PATH=${{ github.workspace }}/install-${{ matrix.arch.name }}-toolchain/bin:$PATH
-          export CC_LD=eld
-          export CXX_LD=eld
-          ../scripts/do-clang-${{ matrix.arch.picolibc-name }}-configure -Dc_ld=ld.eld -Dcpp_ld=ld.eld ${{ matrix.arch.picolibc-tls-ie }} -Dc_args="${{ matrix.arch.extra-c-flags }}" -Dcpp_args="${{ matrix.arch.extra-cxx-flags }}"
+          if [ "${{ matrix.arch.name }}" = "x86_64" ]; then
+            ../scripts/do-eld-x86_64-configure ${{ matrix.arch.picolibc-tls-ie }}
+          else
+            export CC_LD=eld
+            export CXX_LD=eld
+            ../scripts/do-clang-${{ matrix.arch.picolibc-name }}-configure -Dc_ld=ld.eld -Dcpp_ld=ld.eld ${{ matrix.arch.picolibc-tls-ie }} -Dc_args="${{ matrix.arch.extra-c-flags }}" -Dcpp_args="${{ matrix.arch.extra-cxx-flags }}"
+          fi
           ninja
 
       - name: Get QEMU
@@ -240,21 +289,24 @@ jobs:
             ninja install
             echo "PATH=$QEMU_INSTALL/bin/:$PATH" >> $GITHUB_ENV
           else
-            sudo apt install qemu-system-arm qemu-system-aarch64 qemu-system-riscv32 qemu-system-riscv64
+            sudo apt install qemu-system-arm qemu-system-aarch64 qemu-system-riscv32 qemu-system-riscv64 qemu-system-x86
           fi
 
       - name: Run Picolibc tests for ${{ matrix.arch.name }}, default-config
         run: |
+          export PATH=${{ github.workspace }}/install-${{ matrix.arch.name }}-toolchain/bin:$PATH
           cd ${{ github.workspace }}/picolibc/build-clang-${{ matrix.arch.name }}-picolibc-default-config
           ninja test
 
       - name: Run Picolibc tests for ${{ matrix.arch.name }}, no-tls
         run: |
+          export PATH=${{ github.workspace }}/install-${{ matrix.arch.name }}-toolchain/bin:$PATH
           cd ${{ github.workspace }}/picolibc/build-clang-${{ matrix.arch.name }}-picolibc-no-tls
           ninja test
 
       - name: Run Picolibc tests for ${{ matrix.arch.name }}, tls-ie
         run: |
+          export PATH=${{ github.workspace }}/install-${{ matrix.arch.name }}-toolchain/bin:$PATH
           cd ${{ github.workspace }}/picolibc/build-clang-${{ matrix.arch.name }}-picolibc-tls-ie
           ninja test
 
@@ -266,6 +318,7 @@ jobs:
           path: |
             picolibc/build-clang-${{ matrix.arch.name }}-picolibc-default-config/meson-logs/testlog.txt
             picolibc/build-clang-${{ matrix.arch.name }}-picolibc-no-tls/meson-logs/testlog.txt
+            picolibc/build-clang-${{ matrix.arch.name }}-picolibc-tls-ie/meson-logs/testlog.txt
           if-no-files-found: ignore
           retention-days: 2
 

--- a/.github/workflows/picolibc-builder.yml
+++ b/.github/workflows/picolibc-builder.yml
@@ -28,44 +28,56 @@ jobs:
       matrix:
         arch:
           - name: hexagon
-            picolibc-name: hexagon
+            configure-script: do-clang-hexagon-configure
             triple: hexagon-unknown-none-elf
             llvm-target: Hexagon
             picolibc-default-config: "-Dc_link_args=-L$(clang -print-resource-dir)/lib/hexagon-unknown-none-elf"
             picolibc-no-tls: "-Dc_link_args=-L$(clang -print-resource-dir)/lib/hexagon-unknown-none-elf -Dthread-local-storage=false "
             picolibc-tls-ie: "-Dc_link_args=-L$(clang -print-resource-dir)/lib/hexagon-unknown-none-elf -Dtls-model=initial-exec"
           - name: aarch64
-            picolibc-name: aarch64
+            configure-script: do-clang-aarch64-configure
             triple: aarch64-none-elf
             llvm-target: AArch64
+            qemu-package: qemu-system-aarch64
             picolibc-default-config: ""
             picolibc-no-tls: "-Dthread-local-storage=false"
             picolibc-tls-ie: "-Dtls-model=initial-exec"
           - name: riscv64
-            picolibc-name: riscv
+            configure-script: do-clang-riscv-configure
             triple: riscv64-unknown-unknown-elf
             llvm-target: RISCV
+            qemu-package: qemu-system-riscv64
             picolibc-default-config: ""
             picolibc-no-tls: "-Dthread-local-storage=false"
             picolibc-tls-ie: "-Dtls-model=initial-exec"
           - name: riscv32
-            picolibc-name: rv32imafdc
+            configure-script: do-clang-rv32imafdc-configure
             triple: riscv32-unknown-unknown-elf
             llvm-target: RISCV
+            qemu-package: qemu-system-riscv32
             picolibc-default-config: ""
             picolibc-no-tls: "-Dthread-local-storage=false"
             picolibc-tls-ie: "-Dtls-model=initial-exec"
             extra-c-flags: "-march=rv32imafdc -mabi=ilp32d"
             extra-cxx-flags: "-march=rv32imafdc -mabi=ilp32d"
           - name: arm
-            picolibc-name: arm
+            configure-script: do-clang-arm-configure
             triple: arm-none-eabi
             llvm-target: ARM
+            qemu-package: qemu-system-arm
             picolibc-default-config: ""
             picolibc-no-tls: "-Dthread-local-storage=false"
             picolibc-tls-ie: "-Dtls-model=initial-exec"
             extra-c-flags: "-march=armv7-a"
             extra-cxx-flags: "-march=armv7-a"
+          - name: x86_64
+            configure-script: do-eld-x86_64-configure
+            triple: x86_64-none-elf
+            llvm-target: X86
+            qemu-package: qemu-system-x86
+            picolibc-default-config: "-Dc_link_args=-B$RUNNER_TEMP/eld-bin -Dcpp_link_args=-B$RUNNER_TEMP/eld-bin"
+            picolibc-no-tls: "-Dc_link_args=-B$RUNNER_TEMP/eld-bin -Dcpp_link_args=-B$RUNNER_TEMP/eld-bin -Dthread-local-storage=false"
+            picolibc-tls-ie: "-Dc_link_args=-B$RUNNER_TEMP/eld-bin -Dcpp_link_args=-B$RUNNER_TEMP/eld-bin -Dtls-model=initial-exec"
 
     steps:
       - name: Install system dependencies
@@ -105,6 +117,27 @@ jobs:
         # clang/clang++ and ld.eld) from the latest successful nightly-test.yml
         # run, prepending its bin dir to PATH.
         uses: ./llvm-project/llvm/tools/eld/.github/workflows/FetchNightlyToolset
+
+      - name: Use LLD for the x86 semihost BIOS (x86_64 only)
+        if: matrix.arch.name == 'x86_64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          WRAPPER_DIR="$RUNNER_TEMP/eld-bin"
+          mkdir -p "$WRAPPER_DIR"
+          ELD_BIN=$(command -v ld.eld)
+          LLD_BIN=$(command -v ld.lld)
+          printf '%s\n' \
+            '#!/bin/sh' \
+            'for arg in "$@"; do' \
+            '  case "$arg" in' \
+            '    */libos/semihost/machine/x86/bios.ld)' \
+            "      exec \"$LLD_BIN\" \"\$@\" ;;" \
+            '  esac' \
+            'done' \
+            "exec \"$ELD_BIN\" \"\$@\"" \
+            > "$WRAPPER_DIR/ld.eld"
+          chmod +x "$WRAPPER_DIR/ld.eld"
 
       - name: Build compiler-rt builtins
         run: |
@@ -179,7 +212,12 @@ jobs:
           cd build-clang-${{ matrix.arch.name }}-picolibc-default-config
           export CC_LD=eld
           export CXX_LD=eld
-          ../scripts/do-clang-${{ matrix.arch.picolibc-name }}-configure -Dc_ld=ld.eld -Dcpp_ld=ld.eld ${{ matrix.arch.picolibc-default-config }} -Dc_args="${{ matrix.arch.extra-c-flags }}" -Dcpp_args="-nostdinc++ ${{ matrix.arch.extra-cxx-flags }}"
+          ../scripts/${{ matrix.arch.configure-script }} \
+            -Dc_ld=ld.eld \
+            -Dcpp_ld=ld.eld \
+            ${{ matrix.arch.picolibc-default-config }} \
+            -Dc_args="${{ matrix.arch.extra-c-flags }}" \
+            -Dcpp_args="-nostdinc++ ${{ matrix.arch.extra-cxx-flags }}"
           ninja
 
       - name: Build Picolibc for ${{ matrix.arch.name }}, no-tls
@@ -189,7 +227,12 @@ jobs:
           cd build-clang-${{ matrix.arch.name }}-picolibc-no-tls
           export CC_LD=eld
           export CXX_LD=eld
-          ../scripts/do-clang-${{ matrix.arch.picolibc-name }}-configure -Dc_ld=ld.eld -Dcpp_ld=ld.eld ${{ matrix.arch.picolibc-no-tls }} -Dc_args="${{ matrix.arch.extra-c-flags }}" -Dcpp_args="-nostdinc++ ${{ matrix.arch.extra-cxx-flags }}"
+          ../scripts/${{ matrix.arch.configure-script }} \
+            -Dc_ld=ld.eld \
+            -Dcpp_ld=ld.eld \
+            ${{ matrix.arch.picolibc-no-tls }} \
+            -Dc_args="${{ matrix.arch.extra-c-flags }}" \
+            -Dcpp_args="-nostdinc++ ${{ matrix.arch.extra-cxx-flags }}"
           ninja
 
       - name: Build Picolibc for ${{ matrix.arch.name }}, tls-ie
@@ -199,7 +242,12 @@ jobs:
           cd build-clang-${{ matrix.arch.name }}-picolibc-tls-ie
           export CC_LD=eld
           export CXX_LD=eld
-          ../scripts/do-clang-${{ matrix.arch.picolibc-name }}-configure -Dc_ld=ld.eld -Dcpp_ld=ld.eld ${{ matrix.arch.picolibc-tls-ie }} -Dc_args="${{ matrix.arch.extra-c-flags }}" -Dcpp_args="-nostdinc++ ${{ matrix.arch.extra-cxx-flags }}"
+          ../scripts/${{ matrix.arch.configure-script }} \
+            -Dc_ld=ld.eld \
+            -Dcpp_ld=ld.eld \
+            ${{ matrix.arch.picolibc-tls-ie }} \
+            -Dc_args="${{ matrix.arch.extra-c-flags }}" \
+            -Dcpp_args="-nostdinc++ ${{ matrix.arch.extra-cxx-flags }}"
           ninja
 
       - name: Get QEMU
@@ -217,7 +265,7 @@ jobs:
             ninja install
             echo "PATH=$QEMU_INSTALL/bin/:$PATH" >> $GITHUB_ENV
           else
-            sudo apt install qemu-system-arm qemu-system-aarch64 qemu-system-riscv32 qemu-system-riscv64
+            sudo apt install -y ${{ matrix.arch.qemu-package }}
           fi
 
       - name: Run Picolibc tests for ${{ matrix.arch.name }}, default-config

--- a/lib/Target/X86/x86_64Relocator.cpp
+++ b/lib/Target/X86/x86_64Relocator.cpp
@@ -14,6 +14,8 @@
 #include "llvm/ADT/Twine.h"
 #include "llvm/BinaryFormat/ELF.h"
 
+#include <algorithm>
+#include <limits>
 using namespace eld;
 
 //===--------------------------------------------------------------------===//
@@ -570,19 +572,35 @@ Relocator::Result VerifyRelocAsNeededHelper(
 void x86_64Relocator::computeTLSOffsets() {
   std::vector<ELFSegment *> tlsSegments =
       getTarget().elfSegmentTable().getSegments(llvm::ELF::PT_TLS);
-
-  if (tlsSegments.empty()) {
+  if (tlsSegments.empty())
     return;
+
+  // The x86-64 TPOFF value is relative to the thread pointer.  With TLS
+  // Variant 2, the thread pointer is placed after the complete TLS image,
+  // rounded up to the required alignment.  A linker script may produce more
+  // than one PT_TLS segment, so use the complete span rather than one
+  // segment's memsz.  Empty PT_TLS segments do not contribute to the image.
+  bool hasNonEmptySegment = false;
+  uint64_t lo = std::numeric_limits<uint64_t>::max();
+  uint64_t hi = 0;
+  uint64_t alignment = 1;
+  for (ELFSegment *Segment : tlsSegments) {
+    if (Segment->memsz() == 0)
+      continue;
+
+    const uint64_t segmentEnd = Segment->vaddr() + Segment->memsz();
+    lo = std::min(lo, Segment->vaddr());
+    hi = std::max(hi, segmentEnd);
+    alignment = std::max(alignment, Segment->align());
+    hasNonEmptySegment = true;
   }
 
-  ASSERT(tlsSegments.size() == 1,
-         "Multiple TLS segments not supported in x86_64 backend");
+  if (!hasNonEmptySegment)
+    return;
 
-  ELFSegment *tlsSegment = tlsSegments[0];
-  uint64_t templateSize = tlsSegment->memsz();
-  uint64_t alignment = tlsSegment->align();
-  templateSize = llvm::alignTo(templateSize, alignment);
-  GNULDBackend::setTLSTemplateSize(templateSize);
+  const uint64_t alignedEnd = llvm::alignTo(hi, alignment);
+  const uint64_t threadPointerOffset = alignedEnd - lo;
+  GNULDBackend::setTLSTemplateSize(threadPointerOffset);
 }
 
 template <typename T>

--- a/test/x86_64/linux/TLSLocalExecMultipleSegments/Inputs/1.c
+++ b/test/x86_64/linux/TLSLocalExecMultipleSegments/Inputs/1.c
@@ -1,0 +1,5 @@
+__thread int u;
+__attribute__((aligned(256))) __thread int v;
+__thread int a = 12;
+__attribute__((aligned(128))) __thread int b = 13;
+int foo(void) { return a; }

--- a/test/x86_64/linux/TLSLocalExecMultipleSegments/Inputs/script.t
+++ b/test/x86_64/linux/TLSLocalExecMultipleSegments/Inputs/script.t
@@ -1,0 +1,12 @@
+PHDRS {
+  CODE PT_LOAD;
+  DATA PT_LOAD;
+  T1 PT_TLS;
+  T2 PT_TLS;
+}
+
+SECTIONS {
+  .text (0x1000) : { *(.text*) } :CODE
+  .tdata (0x4000) : { *(.tdata*) } :DATA :T1
+  .tbss : ALIGN(0x400) { *(.tbss*) } :DATA :T2
+}

--- a/test/x86_64/linux/TLSLocalExecMultipleSegments/TLSLocalExecMultipleSegments.test
+++ b/test/x86_64/linux/TLSLocalExecMultipleSegments/TLSLocalExecMultipleSegments.test
@@ -1,0 +1,15 @@
+#---TLSLocalExecMultipleSegments.test--------------------------- Executable,LS ---------------#
+#BEGIN_COMMENT
+# This checks x86-64 local-exec TLS relocation computation when the image has
+# multiple PT_TLS segments and the TLS segments have alignment padding.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.o
+RUN: %link %linkopts -o %t.out %t.o -T %p/Inputs/script.t
+RUN: %readelf -l %t.out | %filecheck %s --check-prefix=READELF
+RUN: %objdump -d %t.out | %filecheck %s --check-prefix=OBJDUMP
+#END_TEST
+
+READELF: TLS {{.*}} RW 0x400
+READELF: TLS {{.*}} RW 0x400
+OBJDUMP: leaq -0x800


### PR DESCRIPTION
Add `x86_64-none-elf` to the `Picolibc` matrix and exercise its default, no-TLS, and initial-exec TLS configurations. 
The `x86 semihost BIOS` link is a 32-bit `i386` link and must use LLD because ELD does not currently support the `i386` backend. All other x86_64 Picolibc links continue to use ELD.

Depends on #1840 