### PR TITLE
[Zephyr] Reduce CI disk usage and quarantine rv32 FPU test

### DIFF
--- a/.github/workflows/zephyr-run.yml
+++ b/.github/workflows/zephyr-run.yml
@@ -139,10 +139,17 @@ jobs:
           git apply eld-support.patch
 
       - name: West setup
+        shell: bash
         run: |
           cd zephyr
           west init -l .
-          west update
+          # SoC-gated vendor HALs no QEMU board we build uses. Never compiled,
+          # only waste disk. Keep cmsis + cmsis_6 (Cortex-M core headers).
+          exclude='hal_adi|hal_afbr|hal_ambiq|hal_atmel|hal_bouffalolab|hal_espressif|hal_ethos_u|hal_gigadevice|hal_infineon|hal_intel|hal_microchip|hal_nordic|hal_nuvoton|hal_nxp|hal_openisa|hal_quicklogic|hal_realtek|hal_renesas|hal_rpi_pico|hal_sifli|hal_silabs|hal_st|hal_stm32|hal_tdk|hal_telink|hal_ti|hal_wch|hal_wurthelektronik|hal_xtensa|libmetal'
+          # Deny-list: modules upstream adds later are still fetched.
+          mapfile -t projects < <(west list --format '{name}' | grep -vxE "manifest|$exclude")
+          # Shallow + narrow: full fetch has run the container disk out of space.
+          west update --narrow --fetch-opt=--depth=1 "${projects[@]}"
 
       - name: Install Zephyr SDK hosttools
         run: |
@@ -195,6 +202,8 @@ jobs:
           export LLVM_TOOLCHAIN_PATH=${CPULLVM_DIR}
           west twister -W -p "$BOARD" \
             -T "$TEST_SCOPE" \
+            --quarantine-list "$GITHUB_WORKSPACE/llvm-project/llvm/tools/eld/.github/zephyr-quarantine.yml" \
+            -M pass \
             --inline-logs \
             --timestamps \
             -j 3 \

--- a/.github/zephyr-quarantine.yml
+++ b/.github/zephyr-quarantine.yml
@@ -1,0 +1,9 @@
+# Twister quarantine list for Zephyr-on-ELD runs (PR and nightly), passed via
+# `west twister --quarantine-list`. Entries are skipped, not failed.
+
+- scenarios:
+  - kernel.fpu_sharing.generic.riscv32
+  comment: >-
+    Forces -mabi=ilp32d -march=rv32imafdc (hard double-float); cpullvm picolibc
+    has no matching multilib, so the build fails with 'string.h' not found.
+


### PR DESCRIPTION
We can sometimes hit "No space left on device" mid-setup since the runs sit right at the runner disk limit. Trim usage in zephyr-run.yml (shared by PR and nightly):
- west update: drop 30 vendor HALs no QEMU board we build uses (~4-5 GB saved).
- twister: pass -M pass to delete passing tests' build dirs as they run.

Also quarantine kernel.fpu_sharing.generic.riscv32, which forces hard-float rv32 that cpullvm picolibc has no multilib for.

The PR workflow should pass for all targets after this change.