### PR TITLE
Refactor: Replace custom getOrigin() method with existing getOldInput…

### DIFF
--- a/include/eld/Readers/CommonELFSection.h
+++ b/include/eld/Readers/CommonELFSection.h
@@ -28,7 +28,9 @@ public:
     return S->getSectionKind() == Section::Kind::CommonELF;
   }
 
-  InputFile *getOrigin() const { return Origin; }
+  bool hasOldInputFile() const override { return Origin != nullptr; }
+
+  InputFile *getOldInputFile() const override { return Origin; }
 
   static constexpr uint32_t DefaultType = llvm::ELF::SHT_NOBITS;
   static constexpr uint32_t DefaultFlags =

--- a/lib/GarbageCollection/GarbageCollection.cpp
+++ b/lib/GarbageCollection/GarbageCollection.cpp
@@ -733,13 +733,13 @@ void GarbageCollection::stripSections(SectionSetTy &S,
       if (!mayProcessGC(*Section))
         continue;
       if (MReferencedSections.find(Section) == MReferencedSections.end()) {
-        bool IsCommonSection = false;
+        bool IsCommonSection = llvm::isa<CommonELFSection>(Section);
         Input *I = ObjFile->getInput();
-        if (CommonELFSection *CommonSection =
-                dyn_cast<CommonELFSection>(Section)) {
-          I = CommonSection->getOrigin()->getInput();
-          IsCommonSection = true;
+
+        if (IsCommonSection && Section->hasOldInputFile()) {
+          I = Section->getOldInputFile()->getInput();
         }
+
         // Print the GC collected input section if Tracing is enabled.
         if (ThisConfig.options().printGCSections() ||
             ThisModule.getPrinter()->traceGC()) {

--- a/lib/LinkerWrapper/PluginADT.cpp
+++ b/lib/LinkerWrapper/PluginADT.cpp
@@ -710,9 +710,6 @@ plugin::InputFile plugin::Section::getRuleMatchingInput() const {
     return plugin::InputFile(nullptr);
   if (m_Section->hasOldInputFile())
     return plugin::InputFile(m_Section->originalInput());
-  if (CommonELFSection *commonSect =
-          llvm::dyn_cast<CommonELFSection>(m_Section))
-    return plugin::InputFile(commonSect->getOrigin());
   return plugin::InputFile(m_Section->originalInput());
 }
 

--- a/lib/Object/ObjectBuilder.cpp
+++ b/lib/Object/ObjectBuilder.cpp
@@ -287,13 +287,8 @@ void ObjectBuilder::assignInputFromOutput(eld::InputFile *Obj) {
         !LinkerScriptHasSectionsCommand)
       continue;
     InputFile *Input = Obj;
-    bool IsCommonSection = false;
-    if (CommonELFSection *CommonSection =
-            llvm::dyn_cast<CommonELFSection>(Sect)) {
-      Input = CommonSection->getOrigin();
-      IsCommonSection = true;
-    }
-    if (Sect->getOldInputFile())
+    bool IsCommonSection = llvm::isa<CommonELFSection>(Sect);
+    if (Sect->hasOldInputFile())
       Input = Sect->getOldInputFile();
     std::string const &PInputFile =
         Input->getInput()->getResolvedPath().native();
@@ -424,13 +419,8 @@ void ObjectBuilder::assignInputFromOutputLegacy(eld::InputFile *Obj) {
             !LinkerScriptHasSectionsCommand)
           continue;
         InputFile *Input = Obj;
-        bool IsCommonSection = false;
-        if (CommonELFSection *CommonSection =
-                llvm::dyn_cast<CommonELFSection>(Section)) {
-          Input = CommonSection->getOrigin();
-          IsCommonSection = true;
-        }
-        if (Section->getOldInputFile())
+        bool IsCommonSection = llvm::isa<CommonELFSection>(Section);
+        if (Section->hasOldInputFile())
           Input = Section->getOldInputFile();
         std::string const &PInputFile =
             Input->getInput()->getResolvedPath().native();
@@ -798,14 +788,13 @@ void ObjectBuilder::reAssignOutputSections(const plugin::LinkerWrapper *LW) {
       return;
     std::string OutputSectionOverride = Override->getOutputSectionName();
     InputFile *Input = ELFSect->getInputFile();
-    if (CommonELFSection *CommonSection =
-            llvm::dyn_cast<CommonELFSection>(ELFSect))
-      Input = CommonSection->getOrigin();
+
+    if (ELFSect->hasOldInputFile())
+      Input = ELFSect->getOldInputFile();
+
     SectionMap::iterator OutputSectIter =
         SectionMap.findIter(OutputSectionOverride);
     if (OutputSectIter != SectionMap.end()) {
-      if (ELFSect->getOldInputFile())
-        Input = ELFSect->getOldInputFile();
       std::string const &Name = Input->getInput()->getName();
       bool IsArchive =
           Input->isArchive() ||
@@ -854,8 +843,8 @@ bool ObjectBuilder::assignOutputSectionsToCommonSymbols() {
       llvm::dyn_cast<ObjectFile>(ThisModule.getCommonInternalInput());
   llvm::SmallSet<InputFile *, 16> CommonOriginInputs;
   for (const auto &S : CommonSymbolsInput->getSections()) {
-    if (CommonELFSection *CommonSection = llvm::dyn_cast<CommonELFSection>(S)) {
-      InputFile *I = CommonSection->getOrigin();
+    if (llvm::isa<CommonELFSection>(S) && S->hasOldInputFile()) {
+      InputFile *I = S->getOldInputFile();
       if (I)
         CommonOriginInputs.insert(I);
     }

--- a/lib/Object/SectionMap.cpp
+++ b/lib/Object/SectionMap.cpp
@@ -588,12 +588,7 @@ bool SectionMap::doesRuleMatchWithSection(const RuleContainer &R,
                                           bool DoNotUseRmName) const {
   InputFile *IF = S.getInputFile();
   ASSERT(IF != nullptr, "Section must always have a non-empty InputFile!");
-  bool IsCommonSection = false;
-  if (const CommonELFSection *CommonSection =
-          llvm::dyn_cast<const CommonELFSection>(&S)) {
-    IF = CommonSection->getOrigin();
-    IsCommonSection = true;
-  }
+  bool IsCommonSection = llvm::isa<CommonELFSection>(&S);
   if (S.getOldInputFile())
     IF = S.getOldInputFile();
   const std::string &InputFileName = IF->getInput()->getResolvedPath().native();

--- a/lib/Object/SectionMap.cpp
+++ b/lib/Object/SectionMap.cpp
@@ -590,12 +590,7 @@ bool SectionMap::doesRuleMatchWithSection(const RuleContainer &R,
                                           bool DoNotUseRmName) const {
   InputFile *IF = S.getInputFile();
   ASSERT(IF != nullptr, "Section must always have a non-empty InputFile!");
-  bool IsCommonSection = false;
-  if (const CommonELFSection *CommonSection =
-          llvm::dyn_cast<const CommonELFSection>(&S)) {
-    IF = CommonSection->getOrigin();
-    IsCommonSection = true;
-  }
+  bool IsCommonSection = llvm::isa<CommonELFSection>(&S);
   if (S.getOldInputFile())
     IF = S.getOldInputFile();
   const std::string &InputFileName = IF->getInput()->getResolvedPath().native();


### PR DESCRIPTION
CommonELFSection had a custom getOrigin() method while other sections
used the virtual getOldInputFile(). This forced type-specific code:

    if (auto *CS = dyn_cast<CommonELFSection>(sect))
      input = CS->getOrigin();
    if (sect->getOldInputFile())
      input = sect->getOldInputFile();

Now CommonELFSection overrides getOldInputFile(), enabling uniform code:

    if (sect->hasOldInputFile())
      input = sect->getOldInputFile();

Changes:
- Add hasOldInputFile/getOldInputFile overrides to CommonELFSection
- Remove redundant getOrigin method
- Simplify ObjectBuilder, SectionMap, GarbageCollection call sites
- Replace dyn_cast + type-specific calls with polymorphic interface

Resolves #1300

