### PR TITLE
Warn when --version-script has no effect

### DIFF
--- a/include/eld/Diagnostics/DiagLDScript.inc
+++ b/include/eld/Diagnostics/DiagLDScript.inc
@@ -65,12 +65,8 @@ DIAG(reading_dynamic_list, DiagnosticEngine::Verbose, "Dynamic List[%0] : %1")
 DIAG(reading_extern_list, DiagnosticEngine::Verbose, "Extern List[%0] : %1")
 DIAG(error_parsing_version_script, DiagnosticEngine::Error,
      "Error parsing version script %0")
-DIAG(warn_version_script_no_dynsym, DiagnosticEngine::Warning,
-     "%0: warning: version script has no effect: static executable does not "
-     "emit a dynamic symbol table")
-DIAG(warn_version_script_no_effect_relocatable, DiagnosticEngine::Warning,
-     "%0: warning: version script has no effect: relocatable output (-r) does "
-     "not emit a dynamic symbol table")
+DIAG(warn_version_script_no_effect, DiagnosticEngine::Warning,
+     "%0: version script has no effect")
 DIAG(fatal_divide_by_zero, DiagnosticEngine::Fatal,
      "%0: division by zero in expression %1")
 DIAG(fatal_modulo_by_zero, DiagnosticEngine::Fatal,

--- a/include/eld/Diagnostics/DiagLDScript.inc
+++ b/include/eld/Diagnostics/DiagLDScript.inc
@@ -65,6 +65,12 @@ DIAG(reading_dynamic_list, DiagnosticEngine::Verbose, "Dynamic List[%0] : %1")
 DIAG(reading_extern_list, DiagnosticEngine::Verbose, "Extern List[%0] : %1")
 DIAG(error_parsing_version_script, DiagnosticEngine::Error,
      "Error parsing version script %0")
+DIAG(warn_version_script_no_dynsym, DiagnosticEngine::Warning,
+     "%0: warning: version script has no effect: static executable does not "
+     "emit a dynamic symbol table")
+DIAG(warn_version_script_no_effect_relocatable, DiagnosticEngine::Warning,
+     "%0: warning: version script has no effect: relocatable output (-r) does "
+     "not emit a dynamic symbol table")
 DIAG(fatal_divide_by_zero, DiagnosticEngine::Fatal,
      "%0: division by zero in expression %1")
 DIAG(fatal_modulo_by_zero, DiagnosticEngine::Fatal,

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -352,37 +352,48 @@ bool ObjectLinker::normalize() {
 // FIXME: We should maybe parse version script after reading LTO-generated
 // object files.
 bool ObjectLinker::parseVersionScript() {
-  if (ThisConfig.options().hasVersionScript()) {
-    LayoutInfo *layoutInfo = ThisModule->getLayoutInfo();
-    for (const auto &List : ThisConfig.options().getVersionScripts()) {
-      Input *VersionScriptInput =
-          eld::make<Input>(List, ThisConfig.getDiagEngine(), Input::Script);
-      if (!VersionScriptInput->resolvePath(ThisConfig))
-        return false;
-      // Create an Input file and set the input file to be of kind DynamicList
-      InputFile *VersionScriptInputFile =
-          InputFile::create(VersionScriptInput, InputFile::GNULinkerScriptKind,
-                            ThisConfig.getDiagEngine());
-      addInputFileToTar(VersionScriptInputFile,
-                        eld::MappingFile::VersionScript);
-      VersionScriptInput->setInputFile(VersionScriptInputFile);
-      // Record the dynamic list script in the Map file.
-      if (layoutInfo)
-        layoutInfo->recordVersionScript(List);
-      // Read the dynamic List file
-      ScriptFile VersionScriptReader(
-          ScriptFile::VersionScript, *ThisModule,
-          *(llvm::dyn_cast<eld::LinkerScriptFile>(VersionScriptInputFile)),
-          ThisModule->getIRBuilder()->getInputBuilder());
-      bool SuccessFullInParse =
-          getScriptReader()->readScript(ThisConfig, VersionScriptReader);
-      if (!SuccessFullInParse)
-        return false;
-      ThisModule->addVersionScript(VersionScriptReader.getVersionScript());
-      if (!registerVersionScriptNodes(VersionScriptReader.getVersionScript(),
-                                      VersionScriptInput->decoratedPath()))
-        return false;
+  if (!ThisConfig.options().hasVersionScript())
+    return true;
+  LayoutInfo *layoutInfo = ThisModule->getLayoutInfo();
+  for (const auto &List : ThisConfig.options().getVersionScripts()) {
+    Input *VersionScriptInput =
+        eld::make<Input>(List, ThisConfig.getDiagEngine(), Input::Script);
+    if (!VersionScriptInput->resolvePath(ThisConfig))
+      return false;
+    // Create an Input file and set the input file to be of kind DynamicList
+    InputFile *VersionScriptInputFile =
+        InputFile::create(VersionScriptInput, InputFile::GNULinkerScriptKind,
+                          ThisConfig.getDiagEngine());
+    addInputFileToTar(VersionScriptInputFile, eld::MappingFile::VersionScript);
+    VersionScriptInput->setInputFile(VersionScriptInputFile);
+    // Record the dynamic list script in the Map file.
+    if (layoutInfo)
+      layoutInfo->recordVersionScript(List);
+    // Warn if the version script will have no effect because no dynamic
+    // symbol table will be emitted.
+    if (ThisConfig.isLinkPartial()) {
+      // Relocatable output (-r) never emits .dynsym.
+      ThisConfig.raise(Diag::warn_version_script_no_effect_relocatable)
+          << VersionScriptInput->decoratedPath();
+    } else if (ThisConfig.isCodeStatic() && !ThisConfig.options().isPIE() &&
+               !ThisConfig.options().forceDynamic()) {
+      // Static executable without PIE or --force-dynamic doesn't emit .dynsym.
+      ThisConfig.raise(Diag::warn_version_script_no_dynsym)
+          << VersionScriptInput->decoratedPath();
     }
+    // Read the dynamic List file
+    ScriptFile VersionScriptReader(
+        ScriptFile::VersionScript, *ThisModule,
+        *(llvm::dyn_cast<eld::LinkerScriptFile>(VersionScriptInputFile)),
+        ThisModule->getIRBuilder()->getInputBuilder());
+    bool SuccessFullInParse =
+        getScriptReader()->readScript(ThisConfig, VersionScriptReader);
+    if (!SuccessFullInParse)
+      return false;
+    ThisModule->addVersionScript(VersionScriptReader.getVersionScript());
+    if (!registerVersionScriptNodes(VersionScriptReader.getVersionScript(),
+                                    VersionScriptInput->decoratedPath()))
+      return false;
   }
 
   // VersionScript objects parsed from a VERSION{} block embedded directly

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -369,17 +369,18 @@ bool ObjectLinker::parseVersionScript() {
     // Record the dynamic list script in the Map file.
     if (layoutInfo)
       layoutInfo->recordVersionScript(List);
-    // Warn if the version script will have no effect because no dynamic
-    // symbol table will be emitted.
-    if (ThisConfig.isLinkPartial()) {
-      // Relocatable output (-r) never emits .dynsym.
-      ThisConfig.raise(Diag::warn_version_script_no_effect_relocatable)
+    // Warn if the version script will have no effect
+    if (ThisConfig.showLinkerScriptWarnings()) {
+      bool IsPIE = ThisConfig.options().isPIE();
+      bool IsShared = ThisConfig.options().hasShared();
+      bool ForceDynamic = ThisConfig.options().forceDynamic();
+      bool ExportDynamic = ThisConfig.options().exportDynamic();
+      bool NoEffect = IsPIE ? !ExportDynamic
+                            : (!IsShared && !ForceDynamic);
+      if (NoEffect) {
+        ThisConfig.raise(Diag::warn_version_script_no_effect)
           << VersionScriptInput->decoratedPath();
-    } else if (ThisConfig.isCodeStatic() && !ThisConfig.options().isPIE() &&
-               !ThisConfig.options().forceDynamic()) {
-      // Static executable without PIE or --force-dynamic doesn't emit .dynsym.
-      ThisConfig.raise(Diag::warn_version_script_no_dynsym)
-          << VersionScriptInput->decoratedPath();
+      }
     }
     // Read the dynamic List file
     ScriptFile VersionScriptReader(

--- a/test/Common/standalone/VersionScript/VersionScriptNoEffect.test
+++ b/test/Common/standalone/VersionScript/VersionScriptNoEffect.test
@@ -1,34 +1,18 @@
+#---VersionScriptNoEffect.test--- Standalone ---#
+#BEGIN_COMMENT
 # Test that version scripts emit warnings when they have no effect
-# (i.e., when no dynamic symbol table will be created)
-
-# RUN 1: Static executable should warn
+#END_COMMENT
+#START_TEST
 RUN: %clang %clangopts -c -O2 %p/Inputs/1.c -o %t1.o
-RUN: %link %linkopts -static --entry=main --version-script=%p/Inputs/vs1 -o %t_static.out %t1.o 2>&1 | %filecheck --check-prefix=WARN-STATIC %s
-
-WARN-STATIC: warning: version script has no effect: static executable does not emit a dynamic symbol table
-
-# RUN 2: Relocatable output should warn
-RUN: %link %linkopts -r --version-script=%p/Inputs/vs1 -o %t_reloc.o %t1.o 2>&1 | %filecheck --check-prefix=WARN-RELOC %s
-
-WARN-RELOC: warning: version script has no effect: relocatable output (-r) does not emit a dynamic symbol table
-
-# RUN 3: PIE executable should NOT warn (has .dynsym)
 RUN: %clang %clangopts -c -fpic -O2 %p/Inputs/1.c -o %t1_pic.o
-RUN: %link %linkopts -pie --entry=main --version-script=%p/Inputs/vs1 -o %t_pie.out %t1_pic.o 2>&1 | %filecheck --allow-empty --check-prefix=NO-WARN-PIE %s
-
-NO-WARN-PIE-NOT: warning: version script has no effect
-
-# RUN 4: Shared library should NOT warn (has .dynsym)
-RUN: %link %linkopts -shared --version-script=%p/Inputs/vs1 -o %t_shared.so %t1_pic.o 2>&1 | %filecheck --allow-empty --check-prefix=NO-WARN-SHARED %s
-
-NO-WARN-SHARED-NOT: warning: version script has no effect
-
-# RUN 5: Static with --force-dynamic should NOT warn (forces .dynsym)
-RUN: %link %linkopts -static --force-dynamic --entry=main --version-script=%p/Inputs/vs1 -o %t_force.out %t1.o 2>&1 | %filecheck --allow-empty --check-prefix=NO-WARN-FORCE %s
-
-NO-WARN-FORCE-NOT: warning: version script has no effect
-
-# RUN 6: Verify the warnings include the version script path
-RUN: %link %linkopts -static --entry=main --version-script=%p/Inputs/vs1 -o %t_path.out %t1.o 2>&1 | %filecheck --check-prefix=CHECK-PATH %s
-
-CHECK-PATH: {{.*}}/Inputs/vs1: warning: version script has no effect
+RUN: %link %linkopts -Wlinker-script -static --entry=main --version-script=%p/Inputs/vs1 -o %t_static.out %t1.o 2>&1 | FileCheck %s --check-prefix=CHECK-WARN
+RUN: %link -Wlinker-script -r --version-script=%p/Inputs/vs1 -o %t_reloc.o %t1.o 2>&1 | FileCheck %s --check-prefix=CHECK-WARN
+RUN: %link -Wlinker-script -pie --entry=main --version-script=%p/Inputs/vs1 -o %t_pie.out %t1_pic.o 2>&1 | FileCheck %s --check-prefix=CHECK-WARN
+RUN: %link -Wlinker-script -static -pie --entry=main --version-script=%p/Inputs/vs1 -o %t_static_pie.out %t1_pic.o 2>&1 | FileCheck %s --check-prefix=CHECK-WARN
+RUN: %link -Wlinker-script -shared -pie --version-script=%p/Inputs/vs1 -o %t_shared_pie.so %t1_pic.o 2>&1 | FileCheck %s --check-prefix=CHECK-WARN
+RUN: %link -Wlinker-script -shared --version-script=%p/Inputs/vs1 -o %t_shared.so %t1_pic.o 2>&1 | FileCheck %s --check-prefix=CHECK-NO-WARN --allow-empty
+RUN: %link -Wlinker-script -static --force-dynamic --entry=main --version-script=%p/Inputs/vs1 -o %t_force.out %t1.o 2>&1 | FileCheck %s --check-prefix=CHECK-NO-WARN --allow-empty
+RUN: %link -Wlinker-script -pie --export-dynamic --entry=main --version-script=%p/Inputs/vs1 -o %t_pie_ed.out %t1_pic.o 2>&1 | FileCheck %s --check-prefix=CHECK-NO-WARN --allow-empty
+#END_TEST
+#CHECK-WARN: {{.*}}vs1: version script has no effect
+#CHECK-NO-WARN-NOT: warning

--- a/test/Common/standalone/VersionScript/VersionScriptNoEffect.test
+++ b/test/Common/standalone/VersionScript/VersionScriptNoEffect.test
@@ -1,0 +1,34 @@
+# Test that version scripts emit warnings when they have no effect
+# (i.e., when no dynamic symbol table will be created)
+
+# RUN 1: Static executable should warn
+RUN: %clang %clangopts -c -O2 %p/Inputs/1.c -o %t1.o
+RUN: %link %linkopts -static --entry=main --version-script=%p/Inputs/vs1 -o %t_static.out %t1.o 2>&1 | %filecheck --check-prefix=WARN-STATIC %s
+
+WARN-STATIC: warning: version script has no effect: static executable does not emit a dynamic symbol table
+
+# RUN 2: Relocatable output should warn
+RUN: %link %linkopts -r --version-script=%p/Inputs/vs1 -o %t_reloc.o %t1.o 2>&1 | %filecheck --check-prefix=WARN-RELOC %s
+
+WARN-RELOC: warning: version script has no effect: relocatable output (-r) does not emit a dynamic symbol table
+
+# RUN 3: PIE executable should NOT warn (has .dynsym)
+RUN: %clang %clangopts -c -fpic -O2 %p/Inputs/1.c -o %t1_pic.o
+RUN: %link %linkopts -pie --entry=main --version-script=%p/Inputs/vs1 -o %t_pie.out %t1_pic.o 2>&1 | %filecheck --allow-empty --check-prefix=NO-WARN-PIE %s
+
+NO-WARN-PIE-NOT: warning: version script has no effect
+
+# RUN 4: Shared library should NOT warn (has .dynsym)
+RUN: %link %linkopts -shared --version-script=%p/Inputs/vs1 -o %t_shared.so %t1_pic.o 2>&1 | %filecheck --allow-empty --check-prefix=NO-WARN-SHARED %s
+
+NO-WARN-SHARED-NOT: warning: version script has no effect
+
+# RUN 5: Static with --force-dynamic should NOT warn (forces .dynsym)
+RUN: %link %linkopts -static --force-dynamic --entry=main --version-script=%p/Inputs/vs1 -o %t_force.out %t1.o 2>&1 | %filecheck --allow-empty --check-prefix=NO-WARN-FORCE %s
+
+NO-WARN-FORCE-NOT: warning: version script has no effect
+
+# RUN 6: Verify the warnings include the version script path
+RUN: %link %linkopts -static --entry=main --version-script=%p/Inputs/vs1 -o %t_path.out %t1.o 2>&1 | %filecheck --check-prefix=CHECK-PATH %s
+
+CHECK-PATH: {{.*}}/Inputs/vs1: warning: version script has no effect


### PR DESCRIPTION
Version scripts control symbol visibility in the dynamic symbol table (`.dynsym`). When output types don't create `.dynsym`, version scripts are silently ignored, So, analyzed when `.dynsym` is created: `isShared() || isPIE() || (isStatic() && forceDynamic())`

Negated these conditions to warn when version scripts have no effect:
- Static executable: `isCodeStatic() && !isPIE() && !forceDynamic()`
- Relocatable output: `isLinkPartial()`  (in this case also no `.dynsym` is created)

Implemented in `ObjectLinker::parseVersionScript()` after version script is recorded but before parsing.

 Changes:
- `DiagLDScript.inc`: Added 2 warning diagnostics
- `ObjectLinker.cpp`: Added warning checks 
- `VersionScriptNoEffect.test`: 6 test cases

Resolves #1444