### PR TITLE
Report error when version script node has local block before the global

### DIFF
--- a/docs/userguide/documentation/linker_script.rst
+++ b/docs/userguide/documentation/linker_script.rst
@@ -1522,6 +1522,9 @@ A version script is a sequence of *version nodes*. Each node has an optional
 name and contains ``global:`` and/or ``local:`` blocks. Each block lists symbol
 patterns terminated by ``;``.
 
+It is an error for a ``local:`` block to appear before a ``global:`` block in
+the same version node.
+
 .. code-block::
 
   /* Anonymous (unnamed) version node. */

--- a/lib/ScriptParser/ScriptParser.cpp
+++ b/lib/ScriptParser/ScriptParser.cpp
@@ -1568,6 +1568,10 @@ void ScriptParser::readVersionSymbols(VersionScriptNode &VSN) {
         continue;
       }
       if (Tok == "global:" || (Tok == "global" && consume(":"))) {
+        if (VSN.getLocalBlock()) {
+          setError("global scope must appear before local scope", Tok);
+          return;
+        }
         VSN.switchToGlobal();
         continue;
       }

--- a/test/Common/standalone/VersionScriptDiagnostics/GlobalAfterLocal/GlobalAfterLocal.test
+++ b/test/Common/standalone/VersionScriptDiagnostics/GlobalAfterLocal/GlobalAfterLocal.test
@@ -1,0 +1,15 @@
+#---GlobalAfterLocal.test------------ SharedLib,VersionScript ----------------#
+#BEGIN_COMMENT
+# This test verifies that version-script diagnostics point at a global block
+# that appears after a local block.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.o -c %p/Inputs/1.c -fPIC
+RUN: %not %link %linkopts -o %t1.so %t1.o -shared \
+RUN:   --version-script %p/Inputs/vs.t 2>&1 \
+RUN:   | %filecheck %s --strict-whitespace --match-full-lines
+#END_TEST
+
+CHECK:Error: {{.*}}vs.t:4:3: global scope must appear before local scope{{.*}}
+CHECK-NEXT:>>>   global:
+CHECK-NEXT:>>>   ^

--- a/test/Common/standalone/VersionScriptDiagnostics/GlobalAfterLocal/Inputs/1.c
+++ b/test/Common/standalone/VersionScriptDiagnostics/GlobalAfterLocal/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 0; }

--- a/test/Common/standalone/VersionScriptDiagnostics/GlobalAfterLocal/Inputs/vs.t
+++ b/test/Common/standalone/VersionScriptDiagnostics/GlobalAfterLocal/Inputs/vs.t
@@ -1,0 +1,6 @@
+V1 {
+  local:
+    *;
+  global:
+    foo;
+};


### PR DESCRIPTION
This commit updates ScriptParser to report error when a version script node contains local block before the global block.

Resolves #1582