### PR TITLE
Initial relocation testing framework skeleton

### DIFF
--- a/utils/relocation-testing-framework/README.md
+++ b/utils/relocation-testing-framework/README.md
@@ -1,0 +1,14 @@
+TODO: add appropiate credit to the existing reloc-test utility and author
+
+Recommended usage:
+
+    ./framework.py --arch=<arch> --ld=<linker> --mode=<mode> --output-dir=<output-directory> >report.txt
+
+where
+* `<arch>` - architecture.
+* `<linker>` - linker invocation path, may include command line options. Example: `aarch64-linux-gnu-ld`.
+* `<output-directory>` - directory where work files are created.
+* `<mode>` - analyzis mode. options are static, run or both.
+
+The default path must include some tools:
+* `ld.lld`, used as a default linker

--- a/utils/relocation-testing-framework/arch/arm/arch.py
+++ b/utils/relocation-testing-framework/arch/arm/arch.py
@@ -1,0 +1,15 @@
+#"===------------------------------------------------------------------------===
+# Part of the eld Project, under the BSD License
+# See https://github.com/qualcomm/eld/LICENSE.txt for license information.
+# SPDX-License-Identifier: BSD-3-Clause
+#"===------------------------------------------------------------------------===
+
+ARCH = {
+  "mach": "EM_ARM",
+  "endianness": "little",
+  "bits": 32,
+  "instr_bytes": 4,
+  "relocs": [
+
+  ],
+}

--- a/utils/relocation-testing-framework/framework.py
+++ b/utils/relocation-testing-framework/framework.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+#"===------------------------------------------------------------------------===
+# Part of the eld Project, under the BSD License
+# See https://github.com/qualcomm/eld/LICENSE.txt for license information.
+# SPDX-License-Identifier: BSD-3-Clause
+#"===------------------------------------------------------------------------===
+
+"""Framework manager for ELD relocation testing.
+
+Owns CLI parsing, the arch registry, and dispatch to the two testing modes:
+static_analysis.py (link-success/failure + static ELF layout) and
+run_analysis.py (qemu-based runtime checks).
+"""
+
+import argparse
+import sys
+
+import run_analysis
+import static_analysis
+
+import arch.arm.arch
+
+ARCH = {
+    "arm": arch.arm.arch.ARCH,
+}
+
+MODES = ["static", "run", "both"]
+
+def create_argparser():
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument("--arch",
+                           dest="arch",
+                           help=f"Arch, one of [{','.join(ARCH.keys())}]")
+    argparser.add_argument("--ld",
+                           dest="link_cmd",
+                           help="Linker under test command line")
+    argparser.add_argument("--output-dir",
+                           dest="output_dir",
+                           help="Output directory")
+    argparser.add_argument("--mode",
+                           dest="mode",
+                           choices=MODES,
+                           default="both",
+                           help="Which testing mode(s) to run (default: both)")
+    return argparser
+
+def main():
+    args = create_argparser().parse_args()
+    output_dir = args.output_dir if args.output_dir else "."
+    link_cmd = args.link_cmd.split(
+    ) if args.link_cmd else static_analysis.DEFAULT_LINK  # TODO: spaces and quotes are probably not handled well.
+
+    if not args.arch in ARCH:
+        print(f"Don't know anything about architecture {args.arch}",
+              file=sys.stderr)
+        sys.exit(1)
+
+    arch_name = args.arch
+    arch_info = ARCH[arch_name]
+
+    if args.mode in ("static", "both"):
+        static_analysis.run(arch_name, arch_info, link_cmd, output_dir)
+    if args.mode in ("run", "both"):
+        run_analysis.run(arch_name, arch_info, link_cmd, output_dir)
+
+if __name__ == "__main__":
+    main()

--- a/utils/relocation-testing-framework/run_analysis.py
+++ b/utils/relocation-testing-framework/run_analysis.py
@@ -1,0 +1,15 @@
+#"===------------------------------------------------------------------------===
+# Part of the eld Project, under the BSD License
+# See https://github.com/qualcomm/eld/LICENSE.txt for license information.
+# SPDX-License-Identifier: BSD-3-Clause
+#"===------------------------------------------------------------------------===
+
+"""Runtime (qemu-based) relocation testing.
+
+
+"""
+
+import sys
+
+def run(arch_name, arch_info, link_cmd, output_dir):
+    print(f"run-pass mode not yet implemented for arch '{arch_name}'", file=sys.stderr)

--- a/utils/relocation-testing-framework/static_analysis.py
+++ b/utils/relocation-testing-framework/static_analysis.py
@@ -1,0 +1,15 @@
+#"===------------------------------------------------------------------------===
+# Part of the eld Project, under the BSD License
+# See https://github.com/qualcomm/eld/LICENSE.txt for license information.
+# SPDX-License-Identifier: BSD-3-Clause
+#"===------------------------------------------------------------------------===
+
+"""Static relocation testing.
+
+
+"""
+
+import sys
+
+def run(arch_name, arch_info, link_cmd, output_dir):
+    print(f"static-pass mode not yet implemented for arch '{arch_name}'", file=sys.stderr)


### PR DESCRIPTION
Initial structure/skeleton of the framework. It runs in two phases. One is the static analysis and the other is the run time analysis.

Fix: qualcomm#1589