### PR TITLE
[Workflow] Fix GitHub Actions Security Scan (zizmor) errors

### DIFF
--- a/.github/workflows/BuildStatusDataRecorder/action.yaml
+++ b/.github/workflows/BuildStatusDataRecorder/action.yaml
@@ -34,15 +34,23 @@ runs:
   using: "composite"
   steps:
     - name: Record ${{ inputs.stage }}build entry
-      if: ${{ inputs.enabled }} == "true"
+      if: ${{ inputs.enabled == 'true' }}
       shell: bash
+      env:
+        PROJECT: ${{ inputs.project }}
+        WORKFLOW_NAME: ${{ inputs.workflow-name }}
+        ARCH_NAME: ${{ inputs.arch-name }}
+        RECORD_MODE: ${{ inputs.record-mode }}
+        STATUS: ${{ inputs.status }}
+        RUN_ID: ${{ inputs.run-id }}
+        BRANCH_NAME: ${{ inputs.branch-name }}
       run: |
         # Set +e to not immediately exit "run" step on failure.
         set +e
 
-        cd ${{ inputs.project }}
+        cd "${PROJECT}"
         DASH_DIR="$(mktemp -d)"
-        cp .github/workflows/scripts/record_builds.py ${DASH_DIR}/
+        cp .github/workflows/scripts/record_builds.py "${DASH_DIR}/"
         git config user.name 'github-actions'
         git config user.email 'github-actions@github.com'
 
@@ -78,11 +86,11 @@ runs:
         check_lock
 
         # After data lock is released by other workflows, a lock is acquired for current workflow.
-        lock_file_msg="Add data lock for ${{ inputs.workflow-name }} ${{ inputs.arch-name }} build status data to be written"
+        lock_file_msg="Add data lock for ${WORKFLOW_NAME} ${ARCH_NAME} build status data to be written"
         echo "$(date) -> $lock_file_msg" >> dash.log
         touch data.lock
         git add .
-        git commit -m "Add data lock for ${{ inputs.workflow-name }} ${{ inputs.arch-name }} build status data to be written"
+        git commit -m "Add data lock for ${WORKFLOW_NAME} ${ARCH_NAME} build status data to be written"
 
         # Keep trying until a data lock is pushed successfully.
         until git push -f origin HEAD:refs/heads/dashboard; do
@@ -97,8 +105,8 @@ runs:
         # Record build status data for current workflow.
         echo "Proceeding with data recording..."
         git checkout --orphan dash
-        cp ${DASH_DIR}/record_builds.py .
-        python3 record_builds.py --workflow ${{ inputs.workflow-name }} --${{ inputs.record-mode }} --${{ inputs.status }} --run-id ${{ inputs.run-id }} --arch ${{ inputs.arch-name }} --branch ${{ inputs.branch-name }}
+        cp "${DASH_DIR}/record_builds.py" .
+        python3 record_builds.py --workflow "${WORKFLOW_NAME}" --"${RECORD_MODE}" --"${STATUS}" --run-id "${RUN_ID}" --arch "${ARCH_NAME}" --branch "${BRANCH_NAME}"
         EXITCODE=$?
         if [ "$EXITCODE" -ne 0 ]; then
            echo "Build Data Recording Failed!"
@@ -106,24 +114,24 @@ runs:
            rm -f record_builds.py
            rm -f data.lock
            git add .
-           git commit -m "Removing ${{ inputs.workflow-name }} ${{ inputs.arch-name }} data lock."
+           git commit -m "Removing ${WORKFLOW_NAME} ${ARCH_NAME} data lock."
            until git push -f origin HEAD:refs/heads/dashboard; do
             sleep 5
             git fetch --all
             git reset --hard origin/dashboard
             rm -f data.lock
             git add .
-            git commit -m "Removing ${{ inputs.workflow-name }} ${{ inputs.arch-name }} data lock."
+            git commit -m "Removing ${WORKFLOW_NAME} ${ARCH_NAME} data lock."
           done
-          rm -rf ${DASH_DIR}
+          rm -rf "${DASH_DIR}"
           git checkout -
         else
-          cp build-status.db ${DASH_DIR}/
+          cp build-status.db "${DASH_DIR}/"
           rm -f record_builds.py
-          echo "Removing ${{ inputs.workflow-name }} ${{ inputs.arch-name }} data lock."
+          echo "Removing ${WORKFLOW_NAME} ${ARCH_NAME} data lock."
           rm -f data.lock
           git add .
-          git commit -m "Add ${{ inputs.workflow-name }} ${{ inputs.arch-name }} build status data in DB"
+          git commit -m "Add ${WORKFLOW_NAME} ${ARCH_NAME} build status data in DB"
           # Keep trying until lock/conflicts are resolved and build data is pushed successfully.
           until git push -f origin HEAD:refs/heads/dashboard; do
             sleep 5
@@ -132,13 +140,13 @@ runs:
             git fetch --all
             git reset --hard origin/dashboard
             git checkout --orphan dash
-            cp -f ${DASH_DIR}/build-status.db .
+            cp -f "${DASH_DIR}/build-status.db" .
             rm -f data.lock
-            lock_file_msg="Add ${{ inputs.workflow-name }} ${{ inputs.arch-name }} build status data in DB"
+            lock_file_msg="Add ${WORKFLOW_NAME} ${ARCH_NAME} build status data in DB"
             echo "$(date) -> $lock_file_msg" >> dash.log
             git add .
             git commit -m "$lock_file_msg"
           done
-          rm -rf ${DASH_DIR}
+          rm -rf "${DASH_DIR}"
           git checkout "$current_branch"
         fi

--- a/.github/workflows/FetchEldToolset/action.yaml
+++ b/.github/workflows/FetchEldToolset/action.yaml
@@ -31,8 +31,8 @@ runs:
       env:
         TARBALL: ${{ inputs.tarball }}
         STRIP_COMPONENTS: ${{ inputs.strip-components }}
-      run: |
+      run: | # zizmor: ignore[github-env] literal $(pwd)-derived path, not attacker-controlled
         mkdir -p inst
         tar -xf "$TARBALL" -C inst --strip-components="$STRIP_COMPONENTS"
         ls inst
-        echo "PATH=$(pwd)/inst/bin:$PATH" >> "$GITHUB_ENV"
+        echo "$(pwd)/inst/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/FetchNightlyToolset/action.yaml
+++ b/.github/workflows/FetchNightlyToolset/action.yaml
@@ -40,8 +40,8 @@ runs:
 
     - name: Extract toolset
       shell: bash
-      run: |
+      run: | # zizmor: ignore[github-env] literal $(pwd)-derived path, not attacker-controlled
         mkdir -p inst
         tar -xvf install-nightly-toolchain.tar.xz -C inst --strip-components=1
         ls inst
-        echo "PATH=$(pwd)/inst/bin:$PATH" >> $GITHUB_ENV
+        echo "$(pwd)/inst/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/MuslBuilderBuildELD/action.yaml
+++ b/.github/workflows/MuslBuilderBuildELD/action.yaml
@@ -40,7 +40,7 @@ runs:
 
     - name: Build eld
       shell: bash
-      run: |
+      run: | # zizmor: ignore[github-env] literal $(pwd)-derived path, not attacker-controlled
         cd obj
         ninja ld.eld FileCheck
-        echo "PATH=$(pwd)/bin:$PATH" >> $GITHUB_ENV
+        echo "$(pwd)/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/busybox-eld.yml
+++ b/.github/workflows/busybox-eld.yml
@@ -6,8 +6,7 @@ on:
   schedule:
    - cron: "0 5 * * *"
 
-permissions:
-  contents: write
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -36,6 +35,8 @@ jobs:
             toolchain_asset: aarch64-unknown-linux-musl.tar.xz
             enabled: 1
     uses: ./.github/workflows/clang-cross-download.yml
+    permissions:
+      contents: write
     with:
       runner: ubuntu-latest
       workspace: /home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}
@@ -48,6 +49,8 @@ jobs:
     if: github.repository == 'qualcomm/eld'
     needs: fetch-clang-cross-toolchain
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,7 @@ on:
       - 'etc/**/*.sh'
       - '**/configure_external_llvm.sh'
 
-permissions:
-  contents: write
+permissions: {}
 jobs:
   build:
     # Skip label-triggered runs unless the label is `zephyr-check`.
@@ -72,8 +71,8 @@ jobs:
         id: file-check
         working-directory: pr-${{ env.PR_NUMBER }}/llvm-project/llvm/tools/eld
         run: |
-          git fetch origin ${{ env.BASE_BRANCH_NAME }}
-          MERGE_BASE=$(git merge-base origin/${{ env.BASE_BRANCH_NAME }} HEAD)
+          git fetch origin "${BASE_BRANCH_NAME}"
+          MERGE_BASE=$(git merge-base "origin/${BASE_BRANCH_NAME}" HEAD)
           CHANGED_FILES=$(git diff --name-only "$MERGE_BASE" HEAD)
           echo "Changed files: $CHANGED_FILES"
           for file in $CHANGED_FILES; do
@@ -207,4 +206,4 @@ jobs:
       - name: Clean up
         if: always()
         run: |
-          rm -rf "pr-${{ env.PR_NUMBER }}"
+          rm -rf "pr-${PR_NUMBER}"

--- a/.github/workflows/clang-cross-schedule.yml
+++ b/.github/workflows/clang-cross-schedule.yml
@@ -6,8 +6,7 @@ on:
   workflow_dispatch:
   # pull_request: {} # Uncomment only to test this WF file update.
 
-permissions:
-  contents: write
+permissions: {}
 jobs:
   gate:
     runs-on: self-hosted
@@ -26,6 +25,8 @@ jobs:
     needs: gate
     if: github.repository == 'qualcomm/eld' && needs.gate.outputs.run_fetch == 'true'
     uses: ./.github/workflows/clang-cross-download.yml
+    permissions:
+      contents: write
     with:
       runner: self-hosted
       workspace: "/local/mnt/workspace"

--- a/.github/workflows/clang-format-pr.yml
+++ b/.github/workflows/clang-format-pr.yml
@@ -36,9 +36,11 @@ jobs:
           clang-format --version
 
       - name: Check formatting of changed files
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
           set +e
           source ./etc/bash/eld_clang_format_helpers.sh
-          eld_clang_format_check "${{ github.base_ref }}"
+          eld_clang_format_check "${BASE_REF}"
           check_rc=$?
           exit "$check_rc"

--- a/.github/workflows/cpp-linter-pr.yml
+++ b/.github/workflows/cpp-linter-pr.yml
@@ -37,10 +37,11 @@ jobs:
       - name: Collect changed C/C++ files
         id: changed-files
         shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
           set -uo pipefail
           # Build a deterministic file list used by all later steps.
-          BASE_REF="${{ github.base_ref }}"
           git fetch origin "${BASE_REF}" --depth=1
           git diff --name-only --diff-filter=ACMRT "origin/${BASE_REF}...HEAD" \
             | grep -E '\.(c|cc|cpp|cxx|h|hh|hpp|hxx|inc|def)$' > .cpp-linter-files.txt || true
@@ -97,12 +98,14 @@ jobs:
       - name: Configure and build ELD with external LLVM
         if: steps.changed-files.outputs.has_files == 'true'
         shell: bash
+        env:
+          EXT_LLVM_DIR: ${{ steps.llvm-layout.outputs.ext_llvm_dir }}
         run: |
           set -uo pipefail
           # Produce compile_commands.json for clang-tidy-driven checks.
           mkdir -p "${CPP_LINTER_BUILD_DIR}" "${CPP_LINTER_CCACHE_DIR}"
           ./configure_external_llvm.sh \
-            "${{ steps.llvm-layout.outputs.ext_llvm_dir }}" \
+            "${EXT_LLVM_DIR}" \
             "${CPP_LINTER_BUILD_DIR}" \
             --target ld.eld \
             --ccache-dir "${CPP_LINTER_CCACHE_DIR}"
@@ -132,25 +135,32 @@ jobs:
         if: steps.changed-files.outputs.has_files == 'true'
         continue-on-error: true
         shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
           set -uo pipefail
           # Helper script collects richer clang-tidy diagnostics into a log artifact.
           source ./etc/bash/eld_cpp_linter_helpers.sh
           eld_cpp_linter_check \
-            --base-branch "${{ github.base_ref }}" \
+            --base-branch "${BASE_REF}" \
             --build-directory "${CPP_LINTER_BUILD_DIR}" \
             > cpp-linter-helper.log 2>&1 || true
 
       - name: Write cpp-linter report
         if: always()
         shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          CHECKS_FAILED: ${{ steps.cpp-lint.outputs.checks-failed }}
+          TIDY_CHECKS_FAILED: ${{ steps.cpp-lint.outputs.tidy-checks-failed }}
+          FORMAT_CHECKS_FAILED: ${{ steps.cpp-lint.outputs.format-checks-failed }}
         run: |
           # Single downloadable report for reviewers and authors.
           {
             echo "Cpp Linter PR Report"
             echo "===================="
             echo "Date (UTC): $(date -u '+%Y-%m-%d %H:%M:%S')"
-            echo "Base branch: ${{ github.base_ref }}"
+            echo "Base branch: ${BASE_REF}"
             echo "clang-tidy version:"
             clang-tidy --version || true
             echo
@@ -165,16 +175,16 @@ jobs:
             fi
             echo
             echo "cpp-linter action outputs:"
-            echo "  checks-failed: ${{ steps.cpp-lint.outputs.checks-failed }}"
-            echo "  tidy-checks-failed: ${{ steps.cpp-lint.outputs.tidy-checks-failed }}"
-            echo "  format-checks-failed: ${{ steps.cpp-lint.outputs.format-checks-failed }}"
+            echo "  checks-failed: ${CHECKS_FAILED}"
+            echo "  tidy-checks-failed: ${TIDY_CHECKS_FAILED}"
+            echo "  format-checks-failed: ${FORMAT_CHECKS_FAILED}"
             echo
             echo "What to fix:"
             echo "  1. Download the 'cpp-linter-report' artifact from this workflow run."
             echo "  2. For local reproduction/fixes, use:"
             echo "       source etc/bash/eld_cpp_linter_helpers.sh"
-            echo "       eld_cpp_linter_check --base-branch '${{ github.base_ref }}' --build-directory '<build-dir>'"
-            echo "       eld_cpp_linter_fix   --base-branch '${{ github.base_ref }}' --build-directory '<build-dir>'"
+            echo "       eld_cpp_linter_check --base-branch '${BASE_REF}' --build-directory '<build-dir>'"
+            echo "       eld_cpp_linter_fix   --base-branch '${BASE_REF}' --build-directory '<build-dir>'"
             echo
             echo "Helper linter detailed log:"
             if [[ -f cpp-linter-helper.log ]]; then
@@ -202,9 +212,11 @@ jobs:
 
       - name: Report non-blocking lint warnings
         if: ${{ steps.cpp-lint.outputs.checks-failed != '' && steps.cpp-lint.outputs.checks-failed != '0' }}
+        env:
+          CHECKS_FAILED: ${{ steps.cpp-lint.outputs.checks-failed }}
         run: |
           # Keep job green for now, but visibly flag that follow-up is required.
-          echo "::warning::cpp-linter reported ${{ steps.cpp-lint.outputs.checks-failed }} warning(s). See workflow artifacts: cpp-linter-report."
+          echo "::warning::cpp-linter reported ${CHECKS_FAILED} warning(s). See workflow artifacts: cpp-linter-report."
 
       - name: Post PR comment with report link
         if: ${{ steps.cpp-lint.outputs.checks-failed != '' && steps.cpp-lint.outputs.checks-failed != '0' }}

--- a/.github/workflows/nightly-musl-builder.yml
+++ b/.github/workflows/nightly-musl-builder.yml
@@ -6,8 +6,7 @@ on:
   # pull_request: {} # Uncomment only to test this WF file update.
 
 
-permissions:
-  contents: write
+permissions: {}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -16,6 +15,8 @@ jobs:
   test-musl-x86_64:
     if: github.repository == 'qualcomm/eld'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       ELD_SOURCE_DIR: llvm-project/llvm/tools/eld
     steps:
@@ -127,6 +128,8 @@ jobs:
       matrix:
         arch: [arm, aarch64, riscv32, riscv64]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       ELD_SOURCE_DIR: ${{ github.workspace }}/llvm-project/llvm/tools/eld
     steps:
@@ -162,15 +165,17 @@ jobs:
             libclang-rt-20-dev cmake ninja-build make qemu-user
 
       - name: Setup toolchain
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
           arm_toolchain_name_suffix=""
-          if [[ ${{ matrix.arch }} == "arm" ]]; then
+          if [[ "${ARCH}" == "arm" ]]; then
             arm_toolchain_name_suffix="eabi"
           fi
           echo "arm_toolchain_name_suffix=${arm_toolchain_name_suffix}" >> $GITHUB_ENV
-          wget https://github.com/cross-tools/clang-cross/releases/download/20251023/${{ matrix.arch }}-unknown-linux-musl${arm_toolchain_name_suffix}.tar.xz
+          wget "https://github.com/cross-tools/clang-cross/releases/download/20251023/${ARCH}-unknown-linux-musl${arm_toolchain_name_suffix}.tar.xz"
           mkdir toolchain
-          tar -xvf ${{ matrix.arch }}-unknown-linux-musl${arm_toolchain_name_suffix}.tar.xz -C toolchain --strip-components=1
+          tar -xvf "${ARCH}-unknown-linux-musl${arm_toolchain_name_suffix}.tar.xz" -C toolchain --strip-components=1
           echo "PATH=$PWD/toolchain/bin:$PATH" >> $GITHUB_ENV
           echo "TOOLCHAIN_ROOT=$(pwd)/toolchain" >> $GITHUB_ENV
 
@@ -183,6 +188,8 @@ jobs:
 
       - name: Setup musl libc-test environment
         shell: bash
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
           cd libc-test
           which grep
@@ -192,18 +199,20 @@ jobs:
             CFLAGS += -Wno-error -Wno-strict-prototypes -Wno-switch-bool -Wno-c23-extensions
             LDFLAGS += --ld-path=$(which ld.eld) -Wl,--image-base=0x1000
           EOF
-          cat >qemu-${{ matrix.arch }}-wrapper.sh <<EOF
+          cat >"qemu-${ARCH}-wrapper.sh" <<EOF
           #!/usr/bin/bash
-          qemu-${{ matrix.arch }} -L ${TOOLCHAIN_ROOT}/${{ matrix.arch }}-unknown-linux-musl${arm_toolchain_name_suffix}/sysroot "\$@"
+          qemu-${ARCH} -L ${TOOLCHAIN_ROOT}/${ARCH}-unknown-linux-musl${arm_toolchain_name_suffix}/sysroot "\$@"
           EOF
-          chmod +x ./qemu-${{ matrix.arch }}-wrapper.sh
+          chmod +x "./qemu-${ARCH}-wrapper.sh"
           cat config.mak
-          cat qemu-${{ matrix.arch }}-wrapper.sh
+          cat "qemu-${ARCH}-wrapper.sh"
 
       - name: Run musl libc-test suite
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
           cd libc-test
-          CC=${{ matrix.arch }}-unknown-linux-musl${arm_toolchain_name_suffix}-clang make RUN_WRAP="$(pwd)/qemu-${{ matrix.arch }}-wrapper.sh"
+          CC="${ARCH}-unknown-linux-musl${arm_toolchain_name_suffix}-clang" make RUN_WRAP="$(pwd)/qemu-${ARCH}-wrapper.sh"
 
       - name: Upload libc-test
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
@@ -213,10 +222,12 @@ jobs:
           path: libc-test
 
       - name: Validate test results with FileCheck
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
           cd libc-test
-          FileCheck --check-prefixes=CHECK ${ELD_SOURCE_DIR}/test/musl/${{ matrix.arch }}/test-failures.txt < src/REPORT
-          FileCheck --check-prefixes=COUNT ${ELD_SOURCE_DIR}/test/musl/${{ matrix.arch }}/test-failures.txt < src/REPORT
+          FileCheck --check-prefixes=CHECK "${ELD_SOURCE_DIR}/test/musl/${ARCH}/test-failures.txt" < src/REPORT
+          FileCheck --check-prefixes=COUNT "${ELD_SOURCE_DIR}/test/musl/${ARCH}/test-failures.txt" < src/REPORT
           echo "Test results validated"
 
       - name: Update build entry

--- a/.github/workflows/zephyr-nightly.yml
+++ b/.github/workflows/zephyr-nightly.yml
@@ -7,13 +7,13 @@ on:
   workflow_dispatch:
 
 
-permissions:
-  contents: write
-  actions: read
+permissions: {}
 jobs:
   resolve:
     if: github.repository == 'qualcomm/eld' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
     outputs:
       run_id: ${{ steps.find.outputs.run_id }}
     steps:
@@ -42,6 +42,9 @@ jobs:
 
   zephyr:
     needs: resolve
+    permissions:
+      contents: write
+      actions: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/zephyr-run.yml
+++ b/.github/workflows/zephyr-run.yml
@@ -38,12 +38,13 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
-  actions: read
+permissions: {}
 jobs:
   zephyr-build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
     container:
       image: ghcr.io/zephyrproject-rtos/ci-base:main
       options: --user 0


### PR DESCRIPTION
  - template-injection: move ${{ ... }} expansions into env vars and
    reference as quoted shell variables instead of interpolating
    directly into run: blocks (ci.yml, clang-format-pr.yml,
    cpp-linter-pr.yml, nightly-musl-builder.yml,
    BuildStatusDataRecorder/action.yaml)
  - overly-broad-permissions: drop workflow-level `contents: write` to
    `permissions: {}` and scope `contents: write` (and `actions: read`
    where needed) down to the individual jobs that require it
    (busybox-eld.yml, ci.yml, clang-cross-schedule.yml,
    nightly-musl-builder.yml, zephyr-nightly.yml, zephyr-run.yml)
  - reusable-workflow-permissions: grant `permissions: contents: write`
    on the calling job when it invokes a reusable workflow that
    requires it, since callers no longer inherit elevated permissions
    from the workflow level (busybox-eld.yml, clang-cross-schedule.yml)
  - dangerous-github-env: write PATH via GITHUB_PATH instead of
    GITHUB_ENV, and annotate one remaining GITHUB_ENV write as a false
    positive (literal $(pwd)-derived value, not attacker-controlled)
    (FetchEldToolset/action.yaml, FetchNightlyToolset/action.yaml,
    MuslBuilderBuildELD/action.yaml)
  - unsound-condition: fix `if: ${{ inputs.enabled }} == "true"` (always
    true, comparing a rendered string to a literal outside the
    expression) to `if: ${{ inputs.enabled == 'true' }}`
    (BuildStatusDataRecorder/action.yaml)
  - dangerous-triggers: suppress workflow_run trigger warning with an
    explanation comment; the alternative (pull_request_target) can't
    exercise this path pre-merge (zephyr-pr.yml)