### PR TITLE
[Workflow] Add Hexagon sysroot builder

### DIFF
--- a/.github/workflows/hexagon-sysroot-builder.yml
+++ b/.github/workflows/hexagon-sysroot-builder.yml
@@ -1,0 +1,147 @@
+name: Nightly Hexagon sysroot builder
+
+on:
+  workflow_run:
+    workflows: ["Nightly check"]   # matches name: in nightly-test.yml
+    types: [completed]
+  workflow_dispatch:     # Allows manual triggering
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-hexagon-sysroot:
+    name: Build Hexagon sysroot
+    if: >
+      github.repository == 'qualcomm/eld' &&
+      (github.event_name != 'workflow_run' ||
+       github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-latest
+    env:
+      ELD_SOURCE_DIR: llvm-project/llvm/tools/eld
+    steps:
+      - name: Checkout eld
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: llvm-project/llvm/tools/eld
+
+      - name: Configure workflow environment variables
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/ConfigureBuildWorkflowENV
+
+      - name: Record pre-build entry
+        if: github.event_name == 'workflow_run'
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "pre-"
+          workflow-name: "hexagon-sysroot"
+          record-mode: "record"
+          status: "fail"
+          run-id: ${{github.run_id}}
+          arch-name: "hexagon"
+          branch-name: "${{env.BUILD_BRANCH}}"
+
+      - name: Install system dependencies
+        shell: bash
+        run: |
+          sudo apt update
+          sudo apt install -y clang ninja-build make bison flex python3 m4 git libglib2.0-dev cmake
+
+      - name: Fetch latest nightly toolset
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/FetchNightlyToolset
+
+      - name: Clone QEMU
+        shell: bash
+        run: |
+          git clone --depth 1 --branch hexagon-sysemu-23-apr-2026 \
+            https://github.com/qualcomm/qemu.git ${{ github.workspace }}/qemu-system-hexagon
+
+      - name: Build and install QEMU
+        shell: bash
+        run: |
+          cd ${{ github.workspace }}/qemu-system-hexagon
+          ./configure --cc=clang --cxx=clang++ \
+            --target-list=hexagon-softmmu \
+            --prefix=${{ github.workspace }}/install-qemu-system-hexagon \
+            --extra-cflags="-Wno-misleading-indentation -Wno-unused-but-set-variable"
+          cd build
+          ninja install
+          echo "${{ github.workspace }}/install-qemu-system-hexagon/bin" >> "$GITHUB_PATH"
+
+      - name: Install Meson
+        shell: bash
+        run: |
+          git clone https://github.com/mesonbuild/meson.git meson
+          cd meson
+          ./packaging/create_zipapp.py --outfile meson.pyz --interpreter '/usr/bin/env python3' .
+          mkdir -p bin
+          ln -s $(realpath meson.pyz) bin/meson
+          echo "PATH=$PWD/bin:$PATH" >> $GITHUB_ENV
+
+      - name: Clone LLVM Project
+        shell: bash
+        run: |
+          git clone --depth 1 --branch main \
+            https://github.com/llvm/llvm-project ${{ github.workspace }}/llvm-project-src
+
+      - name: Clone Picolibc
+        shell: bash
+        run: |
+          git clone --depth 1 --branch main \
+            https://github.com/picolibc/picolibc.git ${{ github.workspace }}/picolibc
+
+      - name: Clone Hexagon Hypervisor (H2)
+        shell: bash
+        run: |
+          git clone --depth 1 --branch upstream-toolchain \
+            https://github.com/quic-k/hexagon-hypervisor.git ${{ github.workspace }}/hexagon-hypervisor
+
+      - name: Configure Hexagon sysroot build
+        shell: bash
+        run: |
+          set -euo pipefail
+          SYSROOT_CMAKE_DIR="${{ github.workspace }}/llvm-project/llvm/tools/eld/.github/workflows/hexagon-sysroot"
+          cmake -C "${SYSROOT_CMAKE_DIR}/build-hexagon-sysroot.cmake" \
+            -DTOOLCHAIN="${{ github.workspace }}/inst" \
+            -DSOURCECODE="${{ github.workspace }}/llvm-project-src" \
+            -DPICOLIBC_SRC="${{ github.workspace }}/picolibc" \
+            -DH2_SRC="${{ github.workspace }}/hexagon-hypervisor" \
+            -S "${SYSROOT_CMAKE_DIR}" \
+            -B "${{ github.workspace }}/build-hexagon-sysroot"
+
+      - name: Build Hexagon sysroot
+        shell: bash
+        run: |
+          cmake --build ${{ github.workspace }}/build-hexagon-sysroot -j"$(nproc)"
+
+      - name: Pack Hexagon sysroot tarball
+        shell: bash
+        run: |
+          tar -C ${{ github.workspace }}/inst \
+            -Jcvf hexagon-sysroot.tar.xz target/picolibc bin/h2-picolibc.cfg
+
+      - name: Upload Hexagon sysroot tarball
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
+        with:
+          name: hexagon-sysroot
+          path: hexagon-sysroot.tar.xz
+          retention-days: 2
+
+      - name: Update build entry
+        if: github.event_name == 'workflow_run'
+        uses: ./llvm-project/llvm/tools/eld/.github/workflows/BuildStatusDataRecorder
+        with:
+          enabled: true
+          project: "llvm-project/llvm/tools/eld"
+          stage: "post-"
+          workflow-name: "hexagon-sysroot"
+          record-mode: "update"
+          status: "pass"
+          run-id: ${{github.run_id}}
+          arch-name: "hexagon"
+          branch-name: "${{env.BUILD_BRANCH}}"

--- a/.github/workflows/hexagon-sysroot/CMakeLists.txt
+++ b/.github/workflows/hexagon-sysroot/CMakeLists.txt
@@ -1,0 +1,126 @@
+# CMakeLists.txt — Hexagon sysroot orchestrator
+#
+# Do not invoke directly.  See build-hexagon-sysroot.cmake for the intended
+# usage.  This file validates the user-supplied inputs, derives shared paths,
+# and includes the four component modules.
+
+cmake_minimum_required(VERSION 3.20)
+
+# project(... NONE) — we don't build anything with the host toolchain here.
+# All actual compilation is done inside ExternalProject sub-builds that use
+# the installed Hexagon LLVM toolchain (${TOOLCHAIN}/bin/clang etc.).
+project(HexagonSysroot NONE)
+
+include(ExternalProject)
+
+# ---------------------------------------------------------------------------
+# Validate required inputs
+# ---------------------------------------------------------------------------
+foreach(var IN ITEMS TOOLCHAIN SOURCECODE PICOLIBC_SRC H2_SRC)
+    if(NOT ${var})
+        message(FATAL_ERROR
+            "${var} is not set.  Pass -D${var}=<path> on the cmake command line.")
+    endif()
+    if(NOT IS_DIRECTORY "${${var}}")
+        message(FATAL_ERROR "${var} = '${${var}}' is not a directory.")
+    endif()
+endforeach()
+
+# ---------------------------------------------------------------------------
+# Derived paths
+# ---------------------------------------------------------------------------
+set(CLANG   "${TOOLCHAIN}/bin/clang"    CACHE INTERNAL "")
+set(CLANGXX "${TOOLCHAIN}/bin/clang++"  CACHE INTERNAL "")
+
+if(NOT EXISTS "${CLANG}")
+    message(FATAL_ERROR "Hexagon clang not found at ${CLANG}")
+endif()
+if(NOT EXISTS "${CLANGXX}")
+    message(FATAL_ERROR "Hexagon clang++ not found at ${CLANGXX}")
+endif()
+
+# INSTALLPATH is the parent of TOOLCHAIN so that:
+#   ${INSTALLPATH}/Tools  ==  ${TOOLCHAIN}
+# and everything the scripts install under ${INSTALLPATH}/Tools/target/picolibc/
+# lands at ${TOOLCHAIN}/target/picolibc/ — exactly where clang's compiled-in
+# sysroot lookup (bin/../target/picolibc/<triple>/) resolves.
+cmake_path(GET TOOLCHAIN PARENT_PATH INSTALLPATH)
+set(INSTALLPATH "${INSTALLPATH}" CACHE INTERNAL "")
+
+# Final install root (matches FINAL_INSTALL in the bash scripts).
+set(FINAL_INSTALL "${TOOLCHAIN}" CACHE INTERNAL "")
+
+# Sysroot subtree under target/picolibc/ for each triple.
+set(SYSROOT_ROOT           "${FINAL_INSTALL}/target/picolibc" CACHE INTERNAL "")
+set(SYSROOT_NONE_ELF       "${SYSROOT_ROOT}/hexagon-unknown-none-elf" CACHE INTERNAL "")
+set(SYSROOT_H2_ELF         "${SYSROOT_ROOT}/hexagon-unknown-h2-elf" CACHE INTERNAL "")
+set(SYSROOT_QURT_ELF       "${SYSROOT_ROOT}/hexagon-unknown-qurt-elf" CACHE INTERNAL "")
+
+# ---------------------------------------------------------------------------
+# Resolve JOBS (empty = number of logical cores on the build host)
+# ---------------------------------------------------------------------------
+if(NOT JOBS)
+    cmake_host_system_information(RESULT JOBS QUERY NUMBER_OF_LOGICAL_CORES)
+endif()
+set(JOBS "${JOBS}" CACHE INTERNAL "")
+
+# ---------------------------------------------------------------------------
+# Convert space-separated core lists to cmake list form.  SOURCE_CORE is the
+# first entry in BUILD_CORES — non-built cores get per-file symlinks into it.
+# ---------------------------------------------------------------------------
+string(REPLACE " " ";" BUILD_CORES_LIST "${BUILD_CORES}")
+string(REPLACE " " ";" ALL_CORES_LIST   "${ALL_CORES}")
+list(GET BUILD_CORES_LIST 0 SOURCE_CORE)
+set(BUILD_CORES_LIST "${BUILD_CORES_LIST}" CACHE INTERNAL "")
+set(ALL_CORES_LIST   "${ALL_CORES_LIST}"   CACHE INTERNAL "")
+set(SOURCE_CORE      "${SOURCE_CORE}"      CACHE INTERNAL "")
+
+# Variants and their per-variant compiler flags (mirrors the bash scripts).
+set(VARIANTS "non-G0;G0;G0-pic" CACHE INTERNAL "")
+
+# ---------------------------------------------------------------------------
+# Locate build tools
+# ---------------------------------------------------------------------------
+find_program(NINJA_EXECUTABLE ninja REQUIRED)
+find_program(MESON_EXECUTABLE meson REQUIRED)
+find_program(MAKE_EXECUTABLE  make  REQUIRED)
+# qemu-system-hexagon is required by the H2 build (runs the asm_offsets
+# generator ELF in a Hexagon system emulator).  Located at configure time
+# so the full path can be baked into the H2 build environment; a user
+# adding it to PATH after cmake configure would not be visible otherwise
+# because cmake -E env captures $ENV{PATH} at configure time.
+find_program(QEMU_SYSTEM_HEXAGON qemu-system-hexagon REQUIRED)
+
+# ---------------------------------------------------------------------------
+# Diagnostic banner
+# ---------------------------------------------------------------------------
+message(STATUS "=== Hexagon Sysroot Build ===")
+message(STATUS "  TOOLCHAIN     = ${TOOLCHAIN}")
+message(STATUS "  SOURCECODE    = ${SOURCECODE}")
+message(STATUS "  PICOLIBC_SRC  = ${PICOLIBC_SRC}")
+message(STATUS "  H2_SRC        = ${H2_SRC}")
+message(STATUS "  INSTALLPATH   = ${INSTALLPATH}")
+message(STATUS "  SYSROOT_ROOT  = ${SYSROOT_ROOT}")
+message(STATUS "  BUILD_CORES   = ${BUILD_CORES}")
+message(STATUS "  ALL_CORES     = ${ALL_CORES}")
+message(STATUS "  SOURCE_CORE   = ${SOURCE_CORE}")
+message(STATUS "  VARIANTS      = ${VARIANTS}")
+message(STATUS "  JOBS          = ${JOBS}")
+message(STATUS "  ninja         = ${NINJA_EXECUTABLE}")
+message(STATUS "  meson         = ${MESON_EXECUTABLE}")
+message(STATUS "  make          = ${MAKE_EXECUTABLE}")
+message(STATUS "  qemu          = ${QEMU_SYSTEM_HEXAGON}")
+
+# ---------------------------------------------------------------------------
+# Include the four component modules.  Each defines its own ExternalProject
+# targets and the appropriate DEPENDS chain.
+# ---------------------------------------------------------------------------
+include(${CMAKE_CURRENT_LIST_DIR}/HexagonSysrootBuiltins.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/HexagonSysrootPicolibc.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/HexagonSysrootH2.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/HexagonSysrootRuntimes.cmake)
+
+# TODO(sysroot): once the cmake build is validated in production, replace the
+# four bash scripts under sysroot-scripts/ and update
+# .github/workflows/build-sysroot.yml to invoke `cmake -C ... -B build/` and
+# `cmake --build build/` in place of the four `bash sysroot-scripts/*.sh` steps.

--- a/.github/workflows/hexagon-sysroot/HexagonInstallSymlinks.cmake
+++ b/.github/workflows/hexagon-sysroot/HexagonInstallSymlinks.cmake
@@ -1,0 +1,366 @@
+# HexagonInstallSymlinks.cmake
+#
+# Multi-mode -P script.  Dispatches to a helper function based on the MODE
+# variable passed via -DMODE=<mode>.
+#
+# Modes:
+#   builtins-fanout      builtins: fan out SOURCE_CORE variant dirs to non-built
+#                        cores as per-file symlinks; symlink h2-elf into
+#                        none-elf; copy (deref) none-elf into qurt-elf.
+#   picolibc-copy-libs   picolibc: copy per-(core, variant) install lib dir
+#                        into ${SYSROOT_NONE_ELF}/lib/${core}${suffix}/.
+#   picolibc-fanout      picolibc: install headers, fan out to non-built cores,
+#                        symlink h2-elf into none-elf, copy (deref) qurt-elf.
+#   h2-fanout            h2: fan out h2-install-<base> -> h2-install-<version>,
+#                        install bin/lib/include into hexagon-unknown-h2-elf/,
+#                        write h2-picolibc.cfg into ${FINAL_INSTALL}/bin/.
+#   runtimes-copy        runtimes: copy per-(triple, core, variant) install
+#                        into ${dest}/lib/${core}${suffix}/ and merge headers
+#                        into ${dest}/include/.
+#   runtimes-fanout      runtimes: symlink non-built cores to SOURCE_CORE
+#                        under both none-elf and h2-elf.
+
+cmake_minimum_required(VERSION 3.20)
+
+# ---------------------------------------------------------------------------
+# Helper: create per-entry symlinks from src_dir/* to dest_dir/, with the
+# symlink target being ${rel_prefix}/<name>.  Overwrites existing entries.
+#
+# By default, subdirectories are skipped (flat, per-file fanout as used for
+# lib/<core>/ mirrors).  Pass `INCLUDE_DIRS TRUE` to also create directory
+# symlinks (needed for header trees that have sys/, bits/, machine/, etc.
+# subdirectories).
+# ---------------------------------------------------------------------------
+function(_symlink_dir_files src_dir dest_dir rel_prefix)
+    cmake_parse_arguments(PARSE_ARGV 3 SL "" "INCLUDE_DIRS" "")
+    if(NOT IS_DIRECTORY "${src_dir}")
+        return()
+    endif()
+    file(MAKE_DIRECTORY "${dest_dir}")
+    file(GLOB _files LIST_DIRECTORIES TRUE "${src_dir}/*")
+    foreach(_src IN LISTS _files)
+        # Skip real subdirectories unless caller opts in via INCLUDE_DIRS.
+        if(IS_DIRECTORY "${_src}" AND NOT IS_SYMLINK "${_src}")
+            if(NOT SL_INCLUDE_DIRS)
+                continue()
+            endif()
+        endif()
+        get_filename_component(_name "${_src}" NAME)
+        set(_dest "${dest_dir}/${_name}")
+        file(REMOVE_RECURSE "${_dest}")
+        file(CREATE_LINK "${rel_prefix}/${_name}" "${_dest}" SYMBOLIC)
+    endforeach()
+endfunction()
+
+# ---------------------------------------------------------------------------
+# MODE: builtins-fanout
+# ---------------------------------------------------------------------------
+function(_mode_builtins_fanout)
+    message(STATUS "[builtins-fanout] SOURCE_CORE=${SOURCE_CORE}")
+
+    set(_lib_base "${SYSROOT_NONE_ELF}/lib")
+
+    # 1) Non-built cores in ALL_CORES_LIST get per-file symlinks into SOURCE_CORE
+    foreach(_core IN LISTS ALL_CORES_LIST)
+        if(_core IN_LIST BUILD_CORES_LIST)
+            continue()
+        endif()
+        foreach(_suffix "" "-G0" "-G0-pic")
+            _symlink_dir_files(
+                "${_lib_base}/${SOURCE_CORE}${_suffix}"
+                "${_lib_base}/${_core}${_suffix}"
+                "../${SOURCE_CORE}${_suffix}"
+            )
+        endforeach()
+    endforeach()
+
+    # 2) h2-elf/lib/<core>[-suffix]/<file> -> ../../../hexagon-unknown-none-elf/lib/<core>[-suffix]/<file>
+    set(_h2_lib_base "${SYSROOT_H2_ELF}/lib")
+    file(GLOB _core_dirs LIST_DIRECTORIES TRUE "${_lib_base}/*")
+    foreach(_core_dir IN LISTS _core_dirs)
+        if(NOT IS_DIRECTORY "${_core_dir}")
+            continue()
+        endif()
+        get_filename_component(_core_name "${_core_dir}" NAME)
+        _symlink_dir_files(
+            "${_lib_base}/${_core_name}"
+            "${_h2_lib_base}/${_core_name}"
+            "../../../hexagon-unknown-none-elf/lib/${_core_name}"
+        )
+    endforeach()
+
+    # 3) qurt-elf = real copy of none-elf (dereferences symlinks)
+    file(MAKE_DIRECTORY "${SYSROOT_QURT_ELF}")
+    if(IS_DIRECTORY "${SYSROOT_QURT_ELF}/lib")
+        file(REMOVE_RECURSE "${SYSROOT_QURT_ELF}/lib")
+    endif()
+    file(COPY "${_lib_base}/"
+         DESTINATION "${SYSROOT_QURT_ELF}/lib"
+         FOLLOW_SYMLINK_CHAIN)
+
+    message(STATUS "[builtins-fanout] done")
+endfunction()
+
+# ---------------------------------------------------------------------------
+# MODE: picolibc-copy-libs
+#
+# Copies ${SRC_LIB_DIR}/. into ${DEST_LIB_DIR}/ (matches `cp -a src/. dest/`).
+# ---------------------------------------------------------------------------
+function(_mode_picolibc_copy_libs)
+    if(NOT IS_DIRECTORY "${SRC_LIB_DIR}")
+        message(WARNING "[picolibc-copy-libs] SRC_LIB_DIR '${SRC_LIB_DIR}' does not exist")
+        return()
+    endif()
+    file(MAKE_DIRECTORY "${DEST_LIB_DIR}")
+    file(GLOB _entries LIST_DIRECTORIES TRUE "${SRC_LIB_DIR}/*")
+    foreach(_entry IN LISTS _entries)
+        file(COPY "${_entry}" DESTINATION "${DEST_LIB_DIR}")
+    endforeach()
+    message(STATUS "[picolibc-copy-libs] ${SRC_LIB_DIR} -> ${DEST_LIB_DIR}")
+endfunction()
+
+# ---------------------------------------------------------------------------
+# MODE: picolibc-fanout
+# ---------------------------------------------------------------------------
+function(_mode_picolibc_fanout)
+    message(STATUS "[picolibc-fanout] SOURCE_CORE=${SOURCE_CORE}")
+
+    # 1) Install headers into ${SYSROOT_NONE_ELF}/include/
+    if(NOT IS_DIRECTORY "${PICOLIBC_HEADERS_SRC}")
+        # Fallback: any include dir under picolibc-install
+        file(GLOB _fallback "${PICOLIBC_HEADERS_SRC}/../*/include")
+        list(FILTER _fallback INCLUDE REGEX "/include$")
+        list(LENGTH _fallback _nf)
+        if(_nf GREATER 0)
+            list(GET _fallback 0 PICOLIBC_HEADERS_SRC)
+        else()
+            message(FATAL_ERROR "[picolibc-fanout] no picolibc headers found")
+        endif()
+    endif()
+    file(MAKE_DIRECTORY "${SYSROOT_NONE_ELF}/include")
+    file(GLOB _hdr_entries LIST_DIRECTORIES TRUE "${PICOLIBC_HEADERS_SRC}/*")
+    foreach(_h IN LISTS _hdr_entries)
+        file(COPY "${_h}" DESTINATION "${SYSROOT_NONE_ELF}/include")
+    endforeach()
+
+    set(_lib_base "${SYSROOT_NONE_ELF}/lib")
+
+    # 2) Non-built cores get per-file symlinks into SOURCE_CORE
+    foreach(_core IN LISTS ALL_CORES_LIST)
+        if(_core IN_LIST BUILD_CORES_LIST)
+            continue()
+        endif()
+        foreach(_suffix "" "-G0" "-G0-pic")
+            _symlink_dir_files(
+                "${_lib_base}/${SOURCE_CORE}${_suffix}"
+                "${_lib_base}/${_core}${_suffix}"
+                "../${SOURCE_CORE}${_suffix}"
+            )
+        endforeach()
+    endforeach()
+
+    # 3) h2-elf: rebuild from scratch as per-file symlinks into none-elf.
+    if(IS_DIRECTORY "${SYSROOT_H2_ELF}")
+        file(REMOVE_RECURSE "${SYSROOT_H2_ELF}")
+    endif()
+    file(MAKE_DIRECTORY "${SYSROOT_H2_ELF}/include" "${SYSROOT_H2_ELF}/lib")
+
+    # 3a) headers: h2-elf/include/<entry> -> ../../hexagon-unknown-none-elf/include/<entry>
+    #     INCLUDE_DIRS TRUE — the picolibc header tree has sys/, bits/,
+    #     machine/, arpa/, rpc/, ssp/ subdirectories that must be
+    #     symlinked (as directory symlinks) so `#include <sys/cdefs.h>`
+    #     resolves through the h2-elf sysroot.
+    _symlink_dir_files(
+        "${SYSROOT_NONE_ELF}/include"
+        "${SYSROOT_H2_ELF}/include"
+        "../../hexagon-unknown-none-elf/include"
+        INCLUDE_DIRS TRUE
+    )
+
+    # 3b) libs: h2-elf/lib/<core>[-suffix]/<file> -> ../../../hexagon-unknown-none-elf/lib/<core>[-suffix]/<file>
+    file(GLOB _core_dirs LIST_DIRECTORIES TRUE "${_lib_base}/*")
+    foreach(_core_dir IN LISTS _core_dirs)
+        if(NOT IS_DIRECTORY "${_core_dir}")
+            continue()
+        endif()
+        get_filename_component(_core_name "${_core_dir}" NAME)
+        _symlink_dir_files(
+            "${_lib_base}/${_core_name}"
+            "${SYSROOT_H2_ELF}/lib/${_core_name}"
+            "../../../hexagon-unknown-none-elf/lib/${_core_name}"
+        )
+    endforeach()
+
+    # 4) qurt-elf = full copy of none-elf (preserves symlinks as-is)
+    if(IS_DIRECTORY "${SYSROOT_QURT_ELF}")
+        file(REMOVE_RECURSE "${SYSROOT_QURT_ELF}")
+    endif()
+    file(COPY "${SYSROOT_NONE_ELF}/" DESTINATION "${SYSROOT_QURT_ELF}")
+
+    message(STATUS "[picolibc-fanout] done")
+endfunction()
+
+# ---------------------------------------------------------------------------
+# MODE: h2-fanout
+# ---------------------------------------------------------------------------
+function(_mode_h2_fanout)
+    message(STATUS "[h2-fanout] BUILD_DIR=${BUILD_DIR}")
+
+    # 1) Copy h2-install-<base> to h2-install-<version> for each version.
+    foreach(_pair
+            "68;${H2_VERSIONS_FROM_68}"
+            "73;${H2_VERSIONS_FROM_73}"
+            "81;${H2_VERSIONS_FROM_81}")
+        list(GET _pair 0 _base)
+        list(REMOVE_AT _pair 0)
+        set(_src "${BUILD_DIR}/h2-install-${_base}")
+        foreach(_v IN LISTS _pair)
+            set(_dst "${BUILD_DIR}/h2-install-${_v}")
+            if(IS_DIRECTORY "${_dst}")
+                file(REMOVE_RECURSE "${_dst}")
+            endif()
+            file(COPY "${_src}/" DESTINATION "${_dst}")
+        endforeach()
+    endforeach()
+
+    # 2) Install per-version bin -> h2-elf/bin/<v>/G0/, plus non-G0 symlinks.
+    foreach(_v IN LISTS H2_ALL_VERSIONS)
+        set(_bin_src "${BUILD_DIR}/h2-install-${_v}/bin")
+        set(_bin_g0  "${SYSROOT_H2_ELF}/bin/${_v}/G0")
+        set(_bin_top "${SYSROOT_H2_ELF}/bin/${_v}")
+        if(IS_DIRECTORY "${_bin_src}")
+            file(MAKE_DIRECTORY "${_bin_g0}")
+            file(GLOB _binfiles LIST_DIRECTORIES TRUE "${_bin_src}/*")
+            foreach(_bf IN LISTS _binfiles)
+                file(COPY "${_bf}" DESTINATION "${_bin_g0}")
+            endforeach()
+            # non-G0 symlinks: bin/<v>/<file> -> G0/<file>
+            file(GLOB _inst LIST_DIRECTORIES FALSE "${_bin_g0}/*")
+            foreach(_f IN LISTS _inst)
+                get_filename_component(_name "${_f}" NAME)
+                set(_lnk "${_bin_top}/${_name}")
+                file(REMOVE "${_lnk}")
+                file(CREATE_LINK "G0/${_name}" "${_lnk}" SYMBOLIC)
+            endforeach()
+        endif()
+    endforeach()
+
+    # 3) Install per-version lib -> h2-elf/lib/<v>-G0/, plus non-G0 symlinks.
+    foreach(_v IN LISTS H2_ALL_VERSIONS)
+        set(_lib_src "${BUILD_DIR}/h2-install-${_v}/lib")
+        set(_lib_g0  "${SYSROOT_H2_ELF}/lib/${_v}-G0")
+        set(_lib_top "${SYSROOT_H2_ELF}/lib/${_v}")
+        if(IS_DIRECTORY "${_lib_src}")
+            file(MAKE_DIRECTORY "${_lib_g0}")
+            file(GLOB _libfiles LIST_DIRECTORIES TRUE "${_lib_src}/*")
+            foreach(_lf IN LISTS _libfiles)
+                file(COPY "${_lf}" DESTINATION "${_lib_g0}")
+            endforeach()
+            # non-G0 symlinks: lib/<v>/<file> -> ../<v>-G0/<file>
+            file(MAKE_DIRECTORY "${_lib_top}")
+            file(GLOB _inst LIST_DIRECTORIES FALSE "${_lib_g0}/*")
+            foreach(_f IN LISTS _inst)
+                get_filename_component(_name "${_f}" NAME)
+                set(_lnk "${_lib_top}/${_name}")
+                file(REMOVE "${_lnk}")
+                file(CREATE_LINK "../${_v}-G0/${_name}" "${_lnk}" SYMBOLIC)
+            endforeach()
+        endif()
+    endforeach()
+
+    # 4) Headers from v81 (canonical) -> h2-elf/include/
+    set(_inc_src "${BUILD_DIR}/h2-install-v81/include")
+    set(_inc_dst "${SYSROOT_H2_ELF}/include")
+    if(IS_DIRECTORY "${_inc_src}")
+        file(MAKE_DIRECTORY "${_inc_dst}")
+        file(GLOB _hdrs LIST_DIRECTORIES TRUE "${_inc_src}/*")
+        foreach(_h IN LISTS _hdrs)
+            file(COPY "${_h}" DESTINATION "${_inc_dst}")
+        endforeach()
+    endif()
+
+    # 5) Write h2-picolibc.cfg into ${FINAL_INSTALL}/bin/
+    file(MAKE_DIRECTORY "${FINAL_INSTALL}/bin")
+    file(WRITE "${FINAL_INSTALL}/bin/h2-picolibc.cfg"
+"--target=hexagon-unknown-h2-elf \\
+--cstdlib=picolibc \\
+\$-Wl,--undefined=__retarget_lock_init \\
+\$-Wl,-l:liblocks.a \\
+\$-Wl,--section-start=.start=0x2000000 \\
+\$-Wl,-T,<CFGDIR>/../templates/staticExecutable/static-executable-h2-picolibc.lcs.template
+")
+
+    message(STATUS "[h2-fanout] done")
+endfunction()
+
+# ---------------------------------------------------------------------------
+# MODE: runtimes-copy
+#
+# Copies ${SRC_INSTALL_DIR}/lib/* into ${DEST_LIB_DIR}/ and
+# ${SRC_INSTALL_DIR}/include/* into ${DEST_INC_DIR}/.
+# ---------------------------------------------------------------------------
+function(_mode_runtimes_copy)
+    if(IS_DIRECTORY "${SRC_INSTALL_DIR}/lib")
+        file(MAKE_DIRECTORY "${DEST_LIB_DIR}")
+        file(GLOB _libs LIST_DIRECTORIES TRUE "${SRC_INSTALL_DIR}/lib/*")
+        foreach(_l IN LISTS _libs)
+            file(COPY "${_l}" DESTINATION "${DEST_LIB_DIR}")
+        endforeach()
+    endif()
+    if(IS_DIRECTORY "${SRC_INSTALL_DIR}/include")
+        file(MAKE_DIRECTORY "${DEST_INC_DIR}")
+        file(GLOB _incs LIST_DIRECTORIES TRUE "${SRC_INSTALL_DIR}/include/*")
+        foreach(_i IN LISTS _incs)
+            file(COPY "${_i}" DESTINATION "${DEST_INC_DIR}")
+        endforeach()
+    endif()
+    message(STATUS "[runtimes-copy] ${SRC_INSTALL_DIR} -> ${DEST_LIB_DIR}")
+endfunction()
+
+# ---------------------------------------------------------------------------
+# MODE: runtimes-fanout
+# ---------------------------------------------------------------------------
+function(_mode_runtimes_fanout)
+    foreach(_sysroot "${SYSROOT_NONE_ELF}" "${SYSROOT_H2_ELF}")
+        set(_lib_base "${_sysroot}/lib")
+        if(NOT IS_DIRECTORY "${_lib_base}")
+            continue()
+        endif()
+        foreach(_core IN LISTS ALL_CORES_LIST)
+            if(_core IN_LIST BUILD_CORES_LIST)
+                continue()
+            endif()
+            foreach(_suffix "" "-G0" "-G0-pic")
+                _symlink_dir_files(
+                    "${_lib_base}/${SOURCE_CORE}${_suffix}"
+                    "${_lib_base}/${_core}${_suffix}"
+                    "../${SOURCE_CORE}${_suffix}"
+                )
+            endforeach()
+        endforeach()
+    endforeach()
+    message(STATUS "[runtimes-fanout] done")
+endfunction()
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+if(NOT DEFINED MODE)
+    message(FATAL_ERROR "MODE variable is required (-DMODE=<mode>)")
+endif()
+
+if(MODE STREQUAL "builtins-fanout")
+    _mode_builtins_fanout()
+elseif(MODE STREQUAL "picolibc-copy-libs")
+    _mode_picolibc_copy_libs()
+elseif(MODE STREQUAL "picolibc-fanout")
+    _mode_picolibc_fanout()
+elseif(MODE STREQUAL "h2-fanout")
+    _mode_h2_fanout()
+elseif(MODE STREQUAL "runtimes-copy")
+    _mode_runtimes_copy()
+elseif(MODE STREQUAL "runtimes-fanout")
+    _mode_runtimes_fanout()
+else()
+    message(FATAL_ERROR "Unknown MODE: ${MODE}")
+endif()

--- a/.github/workflows/hexagon-sysroot/HexagonPicolibcCrossFile.cmake.in
+++ b/.github/workflows/hexagon-sysroot/HexagonPicolibcCrossFile.cmake.in
@@ -1,0 +1,33 @@
+[binaries]
+c = '@CLANG@'
+cpp = '@CLANGXX@'
+c_ld = 'eld'
+ar = 'llvm-ar'
+nm = 'llvm-nm'
+strip = 'llvm-strip'
+objcopy = 'llvm-objcopy'
+# only needed to run tests
+exe_wrapper = ['env', 'run-hexagon']
+
+[host_machine]
+system = 'linux'
+cpu_family = 'hexagon'
+cpu = 'hexagon'
+endian = 'little'
+
+[built-in options]
+c_args = @C_ARGS@
+c_link_args = @C_LINK_ARGS@
+cpp_args = @C_ARGS@
+cpp_link_args = @C_LINK_ARGS@
+
+[properties]
+librt = '-lclang_rt.builtins'
+skip_sanity_check = true
+needs_exe_wrapper = true
+link_spec = '--build-id=none'
+sdata_alignment = '64'
+default_ram_addr   = '0x00500000'
+default_ram_size   = '0x00800000'
+default_flash_addr = '0x00100000'
+default_flash_size = '0x00400000'

--- a/.github/workflows/hexagon-sysroot/HexagonSysrootBuiltins.cmake
+++ b/.github/workflows/hexagon-sysroot/HexagonSysrootBuiltins.cmake
@@ -1,0 +1,141 @@
+# HexagonSysrootBuiltins.cmake
+#
+# Builds compiler-rt builtins for hexagon-unknown-none-elf, per (core, variant).
+# Mirrors sysroot-scripts/build_hexagon_builtins.sh.
+#
+# Targets:
+#   builtins-<core>-<variant>          e.g. builtins-v68-G0
+#   builtins-symlinks                  fan-out to non-built cores + h2/qurt
+#   builtins                           umbrella (depends on all of the above)
+
+# ---------------------------------------------------------------------------
+# Per-variant flag table
+#
+#   variant    G0_FLAG   PIC_FLAG   PIC_ENABLED   SUFFIX   EXTRA_FLAGS
+#   non-G0     (empty)   (empty)    OFF           (empty)  -O3 -ffunction-sections -fdata-sections
+#   G0         -G0       (empty)    OFF           -G0      -O3 -ffunction-sections -fdata-sections
+#   G0-pic     -G0       -fPIC      ON            -G0-pic  -O3 -ffunction-sections -fdata-sections -fvisibility=hidden
+# ---------------------------------------------------------------------------
+function(_hexagon_builtins_variant_flags variant out_g0 out_pic out_pic_enabled out_suffix out_extra)
+    if(variant STREQUAL "non-G0")
+        set(${out_g0}          ""    PARENT_SCOPE)
+        set(${out_pic}         ""    PARENT_SCOPE)
+        set(${out_pic_enabled} "OFF" PARENT_SCOPE)
+        set(${out_suffix}      ""    PARENT_SCOPE)
+        set(${out_extra}       "-O3 -ffunction-sections -fdata-sections" PARENT_SCOPE)
+    elseif(variant STREQUAL "G0")
+        set(${out_g0}          "-G0" PARENT_SCOPE)
+        set(${out_pic}         ""    PARENT_SCOPE)
+        set(${out_pic_enabled} "OFF" PARENT_SCOPE)
+        set(${out_suffix}      "-G0" PARENT_SCOPE)
+        set(${out_extra}       "-O3 -ffunction-sections -fdata-sections" PARENT_SCOPE)
+    elseif(variant STREQUAL "G0-pic")
+        set(${out_g0}          "-G0"    PARENT_SCOPE)
+        set(${out_pic}         "-fPIC"  PARENT_SCOPE)
+        set(${out_pic_enabled} "ON"     PARENT_SCOPE)
+        set(${out_suffix}      "-G0-pic" PARENT_SCOPE)
+        set(${out_extra}
+            "-O3 -ffunction-sections -fdata-sections -fvisibility=hidden"
+            PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "Unknown variant: ${variant}")
+    endif()
+endfunction()
+
+# ---------------------------------------------------------------------------
+# Per-(core, variant) ExternalProject
+# ---------------------------------------------------------------------------
+set(_builtins_targets "")
+
+foreach(core IN LISTS BUILD_CORES_LIST)
+    foreach(variant IN LISTS VARIANTS)
+        _hexagon_builtins_variant_flags(${variant}
+            _g0 _pic _pic_enabled _suffix _extra)
+
+        set(_target        "builtins-${core}-${variant}")
+        set(_build_dir     "${CMAKE_BINARY_DIR}/builtins/${core}${_suffix}")
+        set(_install_dir   "${CMAKE_BINARY_DIR}/builtins-install/${core}${_suffix}")
+        set(_dest_lib_dir  "${SYSROOT_NONE_ELF}/lib/${core}${_suffix}")
+
+        # With LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON compiler-rt installs to:
+        #   <prefix>/lib/hexagon-unknown-none-elf/libclang_rt.builtins.a
+        set(_builtins_lib
+            "${_install_dir}/lib/hexagon-unknown-none-elf/libclang_rt.builtins.a")
+
+        # Bake --target=hexagon-unknown-none-elf into every flag string.  The
+        # nightly clang is multi-arch, so without an explicit --target the
+        # driver (especially the ASM driver, which CMAKE_C/CXX_COMPILER_TARGET
+        # does not reach) defaults to the host triple and fails on Hexagon
+        # assembler directives (.falign, memd(...)).
+        set(_c_flags   "--target=hexagon-unknown-none-elf ${_g0} -ffreestanding -m${core} ${_pic} ${_extra} --cstdlib=picolibc")
+        set(_cxx_flags "--target=hexagon-unknown-none-elf ${_g0} -ffreestanding -m${core} ${_pic} ${_extra} --cstdlib=picolibc")
+        set(_asm_flags "--target=hexagon-unknown-none-elf ${_g0} -mlong-calls -m${core} ${_pic} ${_extra} --cstdlib=picolibc")
+
+        ExternalProject_Add(${_target}
+            SOURCE_DIR       "${SOURCECODE}/compiler-rt"
+            BINARY_DIR       "${_build_dir}"
+            INSTALL_DIR      "${_install_dir}"
+            CMAKE_GENERATOR  "Ninja"
+            CMAKE_ARGS
+                -DCMAKE_C_COMPILER=${CLANG}
+                -DCMAKE_CXX_COMPILER=${CLANGXX}
+                -DCMAKE_ASM_FLAGS=${_asm_flags}
+                -DCMAKE_C_FLAGS=${_c_flags}
+                -DCMAKE_CXX_FLAGS=${_cxx_flags}
+                -DCMAKE_BUILD_TYPE=Release
+                -DCMAKE_INSTALL_PREFIX=${_install_dir}
+                -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR:BOOL=ON
+                -DLLVM_TARGET_TRIPLE=hexagon-unknown-none-elf
+                -DCOMPILER_RT_DEFAULT_TARGET_TRIPLE=hexagon-unknown-none-elf
+                -DCOMPILER_RT_BUILD_BUILTINS:BOOL=ON
+                -DCOMPILER_RT_BUILD_SANITIZERS:BOOL=OFF
+                -DCOMPILER_RT_BUILD_XRAY:BOOL=OFF
+                -DCOMPILER_RT_BUILD_LIBFUZZER:BOOL=OFF
+                -DCOMPILER_RT_BUILD_PROFILE:BOOL=OFF
+                -DCOMPILER_RT_BUILD_MEMPROF:BOOL=OFF
+                -DCOMPILER_RT_BUILD_ORC:BOOL=OFF
+                -DCOMPILER_RT_BUILD_GWP_ASAN:BOOL=OFF
+                -DCOMPILER_RT_BUILTINS_ENABLE_PIC:BOOL=${_pic_enabled}
+                -DCOMPILER_RT_SUPPORTED_ARCH=hexagon
+                -DCOMPILER_RT_BAREMETAL_BUILD:BOOL=ON
+                -DCMAKE_CROSSCOMPILING:BOOL=ON
+                -DCAN_TARGET_hexagon=1
+                -DCMAKE_C_COMPILER_FORCED:BOOL=ON
+                -DCMAKE_CXX_COMPILER_FORCED:BOOL=ON
+                -DCMAKE_C_COMPILER_TARGET=hexagon-unknown-none-elf
+                -DCMAKE_CXX_COMPILER_TARGET=hexagon-unknown-none-elf
+            BUILD_COMMAND
+                ${CMAKE_COMMAND} --build <BINARY_DIR> -j${JOBS} --target install-builtins
+            # install-builtins is invoked via BUILD_COMMAND above; suppress the
+            # default install step so ExternalProject doesn't run cmake --install.
+            INSTALL_COMMAND
+                ${CMAKE_COMMAND} -E make_directory ${_dest_lib_dir}
+            COMMAND
+                ${CMAKE_COMMAND} -E copy ${_builtins_lib} ${_dest_lib_dir}/libclang_rt.builtins.a
+            BUILD_BYPRODUCTS ${_builtins_lib}
+        )
+
+        list(APPEND _builtins_targets ${_target})
+    endforeach()
+endforeach()
+
+# ---------------------------------------------------------------------------
+# Fan-out symlinks: non-built cores → SOURCE_CORE, then h2-elf → none-elf,
+# then qurt-elf = deref copy of none-elf.
+# ---------------------------------------------------------------------------
+add_custom_target(builtins-symlinks
+    COMMAND ${CMAKE_COMMAND}
+        -DMODE=builtins-fanout
+        -DSYSROOT_NONE_ELF=${SYSROOT_NONE_ELF}
+        -DSYSROOT_H2_ELF=${SYSROOT_H2_ELF}
+        -DSYSROOT_QURT_ELF=${SYSROOT_QURT_ELF}
+        -DSOURCE_CORE=${SOURCE_CORE}
+        "-DBUILD_CORES_LIST=${BUILD_CORES_LIST}"
+        "-DALL_CORES_LIST=${ALL_CORES_LIST}"
+        -P ${CMAKE_CURRENT_LIST_DIR}/HexagonInstallSymlinks.cmake
+    DEPENDS ${_builtins_targets}
+    COMMENT "Fanning out compiler-rt builtins to non-built cores + h2/qurt"
+    VERBATIM
+)
+
+add_custom_target(builtins ALL DEPENDS builtins-symlinks)

--- a/.github/workflows/hexagon-sysroot/HexagonSysrootH2.cmake
+++ b/.github/workflows/hexagon-sysroot/HexagonSysrootH2.cmake
@@ -1,0 +1,115 @@
+# HexagonSysrootH2.cmake
+#
+# Builds H2 libraries for Hexagon base architectures 68, 73, 81 via `make`.
+# Mirrors sysroot-scripts/build_hexagon_h2.sh.
+#
+# Targets:
+#   h2-base-68 / h2-base-73 / h2-base-81   (one make invocation each)
+#   h2-fanout                              per-version fanout + install into sysroot
+#   h2                                     umbrella
+#
+# The H2 build's offsets step compiles a Hexagon ELF and runs it under
+# qemu-system-hexagon to generate asm_offsets.h.  We prepend both the
+# toolchain's bin/ (for clang, hexagon-*) and qemu-system-hexagon's directory
+# to PATH so make's $(shell $(CC) ...) invocations and the offsets runner
+# can find their tools regardless of the user's shell PATH at build time.
+
+# Hardcoded base-to-version fanout mapping (matches bash script).
+set(_h2_versions_from_68 v68 v69 v71t v71)
+set(_h2_versions_from_73 v73 v75 v77 v79)
+set(_h2_versions_from_81 v81 v83 v85 v87 v89 v91)
+set(_h2_all_versions ${_h2_versions_from_68} ${_h2_versions_from_73} ${_h2_versions_from_81})
+
+# Extract the directory containing qemu-system-hexagon so we can add it
+# to PATH for the H2 build.  QEMU_SYSTEM_HEXAGON is set in CMakeLists.txt.
+cmake_path(GET QEMU_SYSTEM_HEXAGON PARENT_PATH _qemu_bin_dir)
+
+set(_h2_base_targets "")
+set(_h2_previous_target "")
+
+foreach(base 68 73 81)
+    set(_target      "h2-base-${base}")
+    set(_install_dir "${CMAKE_BINARY_DIR}/h2-install-${base}")
+    set(_stamp_dir   "${CMAKE_BINARY_DIR}/h2-stamps")
+    set(_stamp       "${_stamp_dir}/h2-base-${base}.stamp")
+    # libh2kernel.a is produced by the H2 install step for every base; using
+    # it as the build byproduct lets cmake/ninja track completion.
+    set(_byproduct   "${_install_dir}/lib/libh2kernel.a")
+
+    # The H2 Makefile builds in-tree (BINARY_DIR = SOURCE_DIR = H2_SRC) and
+    # is NOT parallel-safe across base architectures.  Force each base to
+    # wait for the previous one by making its DEPENDS include the prior
+    # h2-base-* target.  The first base only depends on picolibc.
+    set(_deps picolibc)
+    if(_h2_previous_target)
+        list(APPEND _deps ${_h2_previous_target})
+    endif()
+
+    ExternalProject_Add(${_target}
+        SOURCE_DIR       "${H2_SRC}"
+        BINARY_DIR       "${H2_SRC}"           # H2 builds in-tree; not our choice
+        INSTALL_DIR      "${_install_dir}"
+        DOWNLOAD_COMMAND ""
+        UPDATE_COMMAND   ""
+        PATCH_COMMAND    ""
+        CONFIGURE_COMMAND ""
+        # Clean the shared H2 build tree AND the per-base install dir before
+        # each base build.
+        #
+        # H2's Makefile derives its build directory as INSTALLPATH/../build/,
+        # so every base build (which uses distinct INSTALLPATH values sharing
+        # the same parent, i.e. ${CMAKE_BINARY_DIR}) writes to the SAME
+        # ${CMAKE_BINARY_DIR}/build/ tree.  Without cleaning it between
+        # bases, leftover .o files from the previous base would get archived
+        # in this base's libraries, causing duplicate-symbol link errors.
+        #
+        # This matches the bash script's `rm -rf ${BUILDPATH}/build/` +
+        # `rm -rf ${H2_INSTALL_ROOT}-${base}/` cleanup step.
+        BUILD_COMMAND
+            ${CMAKE_COMMAND} -E rm -rf ${CMAKE_BINARY_DIR}/build ${_install_dir}
+        COMMAND
+            ${CMAKE_COMMAND} -E env
+                "PATH=${TOOLCHAIN}/bin:${_qemu_bin_dir}:$ENV{PATH}"
+            ${MAKE_EXECUTABLE} -j1 -C ${H2_SRC}
+                USE_PKW=0
+                ARCHV=${base}
+                TARGET=opt
+                INSTALLPATH=${_install_dir}
+                PICOLIBC=1
+                NULL_ANGEL_TRAP=1
+                JFLAG=-j1
+        INSTALL_COMMAND
+            ${CMAKE_COMMAND} -E make_directory ${_stamp_dir}
+        COMMAND
+            ${CMAKE_COMMAND} -E touch ${_stamp}
+        BUILD_ALWAYS      FALSE
+        BUILD_BYPRODUCTS  ${_byproduct} ${_stamp}
+        DEPENDS           ${_deps}
+    )
+
+    list(APPEND _h2_base_targets ${_target})
+    set(_h2_previous_target ${_target})
+endforeach()
+
+# ---------------------------------------------------------------------------
+# Fan-out: copy each base install to its version-specific dirs, then install
+# into the sysroot tree (bin/lib/include), then write h2-picolibc.cfg into
+# ${TOOLCHAIN}/bin/.  All handled by HexagonInstallSymlinks.cmake in one shot.
+# ---------------------------------------------------------------------------
+add_custom_target(h2-fanout
+    COMMAND ${CMAKE_COMMAND}
+        -DMODE=h2-fanout
+        -DBUILD_DIR=${CMAKE_BINARY_DIR}
+        -DSYSROOT_H2_ELF=${SYSROOT_H2_ELF}
+        -DFINAL_INSTALL=${FINAL_INSTALL}
+        "-DH2_VERSIONS_FROM_68=${_h2_versions_from_68}"
+        "-DH2_VERSIONS_FROM_73=${_h2_versions_from_73}"
+        "-DH2_VERSIONS_FROM_81=${_h2_versions_from_81}"
+        "-DH2_ALL_VERSIONS=${_h2_all_versions}"
+        -P ${CMAKE_CURRENT_LIST_DIR}/HexagonInstallSymlinks.cmake
+    DEPENDS ${_h2_base_targets}
+    COMMENT "Fanning out H2 to per-version install trees + installing into sysroot"
+    VERBATIM
+)
+
+add_custom_target(h2 ALL DEPENDS h2-fanout)

--- a/.github/workflows/hexagon-sysroot/HexagonSysrootPicolibc.cmake
+++ b/.github/workflows/hexagon-sysroot/HexagonSysrootPicolibc.cmake
@@ -1,0 +1,165 @@
+# HexagonSysrootPicolibc.cmake
+#
+# Builds picolibc for hexagon-unknown-none-elf, per (core, variant), using
+# meson.  Mirrors sysroot-scripts/build_hexagon_picolibc.sh.
+#
+# Targets:
+#   picolibc-<core>-<variant>          e.g. picolibc-v68-G0
+#   picolibc-symlinks                  fan-out to non-built cores + h2/qurt
+#   picolibc                           umbrella
+
+# ---------------------------------------------------------------------------
+# Per-variant meson c_args and meson options
+#
+#   variant     extra_cflags                        meson extra opts
+#   non-G0      -fno-pic -fno-PIE -static           (none)
+#   G0          -fno-pic -fno-PIE -static -G0       (none)
+#   G0-pic      -fPIC    -static -G0                -Dtls-model=local-dynamic
+# ---------------------------------------------------------------------------
+function(_hexagon_picolibc_variant_flags variant out_suffix out_extra_cflags out_meson_opts)
+    if(variant STREQUAL "non-G0")
+        set(${out_suffix}       ""    PARENT_SCOPE)
+        set(${out_extra_cflags} "-fno-pic;-fno-PIE;-static" PARENT_SCOPE)
+        set(${out_meson_opts}   "" PARENT_SCOPE)
+    elseif(variant STREQUAL "G0")
+        set(${out_suffix}       "-G0" PARENT_SCOPE)
+        set(${out_extra_cflags} "-fno-pic;-fno-PIE;-static;-G0" PARENT_SCOPE)
+        set(${out_meson_opts}   "" PARENT_SCOPE)
+    elseif(variant STREQUAL "G0-pic")
+        set(${out_suffix}       "-G0-pic" PARENT_SCOPE)
+        set(${out_extra_cflags} "-fPIC;-static;-G0" PARENT_SCOPE)
+        set(${out_meson_opts}   "-Dtls-model=local-dynamic" PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "Unknown variant: ${variant}")
+    endif()
+endfunction()
+
+# Common c_args added after per-variant extras (matches bash script).
+set(_picolibc_common_cflags
+    "--target=hexagon-unknown-none-elf"
+    "--cstdlib=picolibc"
+    "-nostdlib"
+    "-ffunction-sections"
+    "-fdata-sections"
+    "-fvisibility=hidden"
+)
+
+# Common c_link_args (identical for all variants).
+set(_picolibc_common_link_args
+    "--target=hexagon-unknown-none-elf"
+    "--cstdlib=picolibc"
+    "-nostdlib"
+)
+
+# ---------------------------------------------------------------------------
+# Helper: format a semicolon-separated cmake list as a meson array literal,
+# e.g. "-fPIC;-static" -> "[ '-fPIC', '-static' ]"
+# ---------------------------------------------------------------------------
+function(_meson_array_literal list_var out_var)
+    set(_items "")
+    foreach(_item IN LISTS ${list_var})
+        list(APPEND _items "'${_item}'")
+    endforeach()
+    list(JOIN _items ", " _joined)
+    set(${out_var} "[ ${_joined} ]" PARENT_SCOPE)
+endfunction()
+
+# ---------------------------------------------------------------------------
+# Per-(core, variant) ExternalProject
+# ---------------------------------------------------------------------------
+set(_picolibc_targets "")
+
+foreach(core IN LISTS BUILD_CORES_LIST)
+    foreach(variant IN LISTS VARIANTS)
+        _hexagon_picolibc_variant_flags(${variant}
+            _suffix _extra_cflags _meson_extra)
+
+        set(_target       "picolibc-${core}-${variant}")
+        set(_build_dir    "${CMAKE_BINARY_DIR}/picolibc/${core}${_suffix}")
+        set(_install_dir  "${CMAKE_BINARY_DIR}/picolibc-install/${core}${_suffix}")
+        set(_dest_lib_dir "${SYSROOT_NONE_ELF}/lib/${core}${_suffix}")
+        set(_cross_file   "${CMAKE_BINARY_DIR}/picolibc/cross-clang-hexagon-${core}${_suffix}.txt")
+
+        # Build the full c_args list: per-variant extras + -m<core> + common.
+        set(_c_args_list ${_extra_cflags} "-m${core}" ${_picolibc_common_cflags})
+        _meson_array_literal(_c_args_list      C_ARGS)
+        _meson_array_literal(_picolibc_common_link_args C_LINK_ARGS)
+
+        # Generate the meson cross-file via configure_file at cmake configure
+        # time.  @CLANG@ / @CLANGXX@ / @C_ARGS@ / @C_LINK_ARGS@ are substituted.
+        configure_file(
+            "${CMAKE_CURRENT_LIST_DIR}/HexagonPicolibcCrossFile.cmake.in"
+            "${_cross_file}"
+            @ONLY
+        )
+
+        # ExternalProject_Add for a meson build.  Every step (configure,
+        # build, install) is wrapped with `cmake -E env` to prepend the
+        # toolchain's bin/ to PATH so that bare tool names in meson's
+        # generated build.ninja (llvm-ar, llvm-strip, eld, etc.)
+        # resolve to the correct toolchain binaries.
+        ExternalProject_Add(${_target}
+            SOURCE_DIR       "${PICOLIBC_SRC}"
+            BINARY_DIR       "${_build_dir}"
+            INSTALL_DIR      "${_install_dir}"
+            CONFIGURE_COMMAND
+                ${CMAKE_COMMAND} -E env
+                    "PATH=${TOOLCHAIN}/bin:$ENV{PATH}"
+                ${MESON_EXECUTABLE} setup
+                    --buildtype=release
+                    --cross-file=${_cross_file}
+                    --prefix=${_install_dir}
+                    -Dtests=false
+                    -Dstdio-locking=true
+                    -Dstdio-exit-flush=true
+                    -Dmultilib=false
+                    -Dposix-console=true
+                    ${_meson_extra}
+                    <BINARY_DIR>
+                    <SOURCE_DIR>
+            BUILD_COMMAND
+                ${CMAKE_COMMAND} -E env
+                    "PATH=${TOOLCHAIN}/bin:$ENV{PATH}"
+                ${NINJA_EXECUTABLE} -C <BINARY_DIR> -j${JOBS}
+            INSTALL_COMMAND
+                ${CMAKE_COMMAND} -E env
+                    "PATH=${TOOLCHAIN}/bin:$ENV{PATH}"
+                ${NINJA_EXECUTABLE} -C <BINARY_DIR> install
+            COMMAND
+                ${CMAKE_COMMAND} -E make_directory ${_dest_lib_dir}
+            COMMAND
+                ${CMAKE_COMMAND}
+                    -DMODE=picolibc-copy-libs
+                    -DSRC_LIB_DIR=${_install_dir}/lib
+                    -DDEST_LIB_DIR=${_dest_lib_dir}
+                    -P ${CMAKE_CURRENT_LIST_DIR}/HexagonInstallSymlinks.cmake
+            BUILD_ALWAYS FALSE
+            DEPENDS builtins
+        )
+
+        list(APPEND _picolibc_targets ${_target})
+    endforeach()
+endforeach()
+
+# ---------------------------------------------------------------------------
+# Fan-out symlinks + headers install + h2-elf symlinks + qurt-elf copy.
+#
+# Headers come from the SOURCE_CORE-G0 install (identical across variants).
+# ---------------------------------------------------------------------------
+add_custom_target(picolibc-symlinks
+    COMMAND ${CMAKE_COMMAND}
+        -DMODE=picolibc-fanout
+        -DSYSROOT_NONE_ELF=${SYSROOT_NONE_ELF}
+        -DSYSROOT_H2_ELF=${SYSROOT_H2_ELF}
+        -DSYSROOT_QURT_ELF=${SYSROOT_QURT_ELF}
+        -DSOURCE_CORE=${SOURCE_CORE}
+        "-DBUILD_CORES_LIST=${BUILD_CORES_LIST}"
+        "-DALL_CORES_LIST=${ALL_CORES_LIST}"
+        -DPICOLIBC_HEADERS_SRC=${CMAKE_BINARY_DIR}/picolibc-install/${SOURCE_CORE}-G0/include
+        -P ${CMAKE_CURRENT_LIST_DIR}/HexagonInstallSymlinks.cmake
+    DEPENDS ${_picolibc_targets}
+    COMMENT "Fanning out picolibc to non-built cores + h2/qurt + installing headers"
+    VERBATIM
+)
+
+add_custom_target(picolibc ALL DEPENDS picolibc-symlinks)

--- a/.github/workflows/hexagon-sysroot/HexagonSysrootRuntimes.cmake
+++ b/.github/workflows/hexagon-sysroot/HexagonSysrootRuntimes.cmake
@@ -1,0 +1,201 @@
+# HexagonSysrootRuntimes.cmake
+#
+# Builds runtimes (libunwind, libcxxabi, libcxx) for two triples:
+#   hexagon-unknown-none-elf   (baremetal: threads OFF, no localization, no wide chars)
+#   hexagon-unknown-h2-elf     (H2: threads ON, localization ON, wide chars ON, H2 site defines)
+#
+# Per (triple, core, variant).  Mirrors sysroot-scripts/build_hexagon_runtimes.sh.
+#
+# Both triples depend on `h2` because the h2-elf runtimes need pthread.h
+# from H2, and we keep none-elf runtimes serialized after H2 too for
+# consistency with the bash-script build order.
+#
+# Targets:
+#   runtimes-<triple-short>-<core>-<variant>   e.g. runtimes-none-elf-v68-G0
+#   runtimes-symlinks                          fan-out to non-built cores
+#   runtimes                                   umbrella
+
+# ---------------------------------------------------------------------------
+# Per-variant flag table (identical shape to builtins)
+# ---------------------------------------------------------------------------
+function(_hexagon_runtimes_variant_flags variant out_suffix out_g0 out_pic out_extra)
+    if(variant STREQUAL "non-G0")
+        set(${out_suffix} ""    PARENT_SCOPE)
+        set(${out_g0}     ""    PARENT_SCOPE)
+        set(${out_pic}    ""    PARENT_SCOPE)
+        set(${out_extra}  "-O3 -ffunction-sections -fdata-sections" PARENT_SCOPE)
+    elseif(variant STREQUAL "G0")
+        set(${out_suffix} "-G0" PARENT_SCOPE)
+        set(${out_g0}     "-G0" PARENT_SCOPE)
+        set(${out_pic}    ""    PARENT_SCOPE)
+        set(${out_extra}  "-O3 -ffunction-sections -fdata-sections" PARENT_SCOPE)
+    elseif(variant STREQUAL "G0-pic")
+        set(${out_suffix} "-G0-pic" PARENT_SCOPE)
+        set(${out_g0}     "-G0"     PARENT_SCOPE)
+        set(${out_pic}    "-fPIC"   PARENT_SCOPE)
+        set(${out_extra}  "-O3 -ffunction-sections -fdata-sections -fvisibility=hidden" PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "Unknown variant: ${variant}")
+    endif()
+endfunction()
+
+# ---------------------------------------------------------------------------
+# Emit one ExternalProject_Add for a (triple, core, variant) combo
+# ---------------------------------------------------------------------------
+function(_hexagon_runtimes_add triple triple_short core variant
+                               enable_threads monotonic_clock wide_chars localization
+                               extra_cxx_flags extra_site_defines dest_base
+                               out_target_var)
+    _hexagon_runtimes_variant_flags(${variant} _suffix _g0 _pic _extra)
+
+    set(_target      "runtimes-${triple_short}-${core}-${variant}")
+    set(_build_dir   "${CMAKE_BINARY_DIR}/runtimes/${triple_short}-${core}${_suffix}")
+    set(_install_dir "${CMAKE_BINARY_DIR}/runtimes-install/${triple_short}-${core}${_suffix}")
+
+    # Bake --target=${triple} into every flag string.  The nightly clang is
+    # multi-arch; without an explicit --target the driver (especially the ASM
+    # driver, which CMAKE_C/CXX_COMPILER_TARGET does not reach) defaults to the
+    # host triple and fails on libunwind's Hexagon .S sources.
+    set(_c_flags   "--target=${triple} ${_g0} -m${core} ${_pic} ${_extra} --cstdlib=picolibc")
+    set(_cxx_flags "--target=${triple} ${_g0} -m${core} ${_pic} ${_extra} --cstdlib=picolibc ${extra_cxx_flags}")
+    set(_asm_flags "--target=${triple} ${_g0} -m${core} ${_pic} ${_extra} --cstdlib=picolibc")
+
+    ExternalProject_Add(${_target}
+        SOURCE_DIR       "${SOURCECODE}/runtimes"
+        BINARY_DIR       "${_build_dir}"
+        INSTALL_DIR      "${_install_dir}"
+        CMAKE_GENERATOR  "Ninja"
+        # Use | as the list separator so semicolon-separated cmake lists
+        # (LLVM_ENABLE_RUNTIMES) can be passed as -D<VAR>=... without cmake
+        # splitting them into multiple arguments.
+        LIST_SEPARATOR "|"
+        CMAKE_ARGS
+            -DCMAKE_C_COMPILER=${CLANG}
+            -DCMAKE_CXX_COMPILER=${CLANGXX}
+            -DCMAKE_C_COMPILER_TARGET=${triple}
+            -DCMAKE_CXX_COMPILER_TARGET=${triple}
+            -DCMAKE_ASM_COMPILER_TARGET=${triple}
+            -DCMAKE_C_FLAGS=${_c_flags}
+            -DCMAKE_CXX_FLAGS=${_cxx_flags}
+            -DCMAKE_ASM_FLAGS=${_asm_flags}
+            -DLIBCXX_EXTRA_SITE_DEFINES=${extra_site_defines}
+            -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_INSTALL_PREFIX=${_install_dir}
+            -DCMAKE_CROSSCOMPILING=ON
+            -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY
+            -DLLVM_ENABLE_RUNTIMES=libunwind|libcxxabi|libcxx
+            -DLIBUNWIND_ENABLE_SHARED=OFF
+            -DLIBUNWIND_ENABLE_THREADS=${enable_threads}
+            -DLIBUNWIND_USE_COMPILER_RT=ON
+            -DLIBUNWIND_IS_BAREMETAL=ON
+            -DLIBCXXABI_ENABLE_SHARED=OFF
+            -DLIBCXXABI_ENABLE_THREADS=${enable_threads}
+            -DLIBCXXABI_BAREMETAL=ON
+            -DLIBCXXABI_USE_COMPILER_RT=ON
+            -DLIBCXXABI_USE_LLVM_UNWINDER=ON
+            -DLIBCXX_CXX_ABI=libcxxabi
+            -DLIBCXX_ENABLE_SHARED=OFF
+            -DLIBCXX_ENABLE_THREADS=${enable_threads}
+            -DLIBCXX_HAS_PTHREAD_API=${enable_threads}
+            -DLIBCXX_ENABLE_TIME_ZONE_DATABASE=OFF
+            -DLIBCXX_ENABLE_EXCEPTIONS=ON
+            -DLIBCXX_ENABLE_FILESYSTEM=${enable_threads}
+            -DLIBCXX_ENABLE_MONOTONIC_CLOCK=${monotonic_clock}
+            -DLIBCXX_ENABLE_RANDOM_DEVICE=OFF
+            -DLIBCXX_ENABLE_RTTI=ON
+            -DLIBCXX_ENABLE_WIDE_CHARACTERS=${wide_chars}
+            -DLIBCXX_ENABLE_LOCALIZATION=${localization}
+            -DLIBCXX_USE_COMPILER_RT=ON
+            -DRUNTIMES_USE_LIBC=picolibc
+        BUILD_COMMAND
+            ${CMAKE_COMMAND} --build <BINARY_DIR> -j${JOBS}
+        INSTALL_COMMAND
+            ${CMAKE_COMMAND} --install <BINARY_DIR>
+        COMMAND
+            ${CMAKE_COMMAND}
+                -DMODE=runtimes-copy
+                -DSRC_INSTALL_DIR=${_install_dir}
+                -DDEST_LIB_DIR=${dest_base}/lib/${core}${_suffix}
+                -DDEST_INC_DIR=${dest_base}/include
+                -P ${CMAKE_CURRENT_LIST_DIR}/HexagonInstallSymlinks.cmake
+        BUILD_ALWAYS FALSE
+        # Runtimes need builtins + picolibc + H2 (H2 provides pthread.h in
+        # hexagon-unknown-h2-elf/include/ which the threaded libcxx build
+        # requires).  Depend on the umbrella targets so all (core, variant)
+        # combinations of the deps are complete first.
+        DEPENDS builtins picolibc h2
+    )
+
+    set(${out_target_var} ${_target} PARENT_SCOPE)
+endfunction()
+
+# ---------------------------------------------------------------------------
+# Configuration 1: hexagon-unknown-none-elf (baremetal)
+# ---------------------------------------------------------------------------
+set(_runtimes_targets "")
+
+foreach(core IN LISTS BUILD_CORES_LIST)
+    foreach(variant IN LISTS VARIANTS)
+        _hexagon_runtimes_add(
+            "hexagon-unknown-none-elf"  "none-elf"
+            ${core} ${variant}
+            "OFF"                       # enable_threads
+            "OFF"                       # monotonic_clock
+            "OFF"                       # wide_chars
+            "OFF"                       # localization
+            "-nostdlib++ -nostdinc++"   # extra_cxx_flags
+            ""                          # extra_site_defines
+            "${SYSROOT_NONE_ELF}"       # dest_base
+            _t
+        )
+        list(APPEND _runtimes_targets ${_t})
+    endforeach()
+endforeach()
+
+# ---------------------------------------------------------------------------
+# Configuration 2: hexagon-unknown-h2-elf (threads + localization + wide chars)
+#
+# H2_SITE_DEFINES describe the picolibc platform's capabilities and are baked
+# into the installed __config_site header so all downstream consumers see them.
+# ---------------------------------------------------------------------------
+# Convert the semicolon-separated cmake list of site defines into a
+# pipe-separated string (paired with LIST_SEPARATOR "|" on ExternalProject_Add)
+# so cmake doesn't split it into multiple -D arguments to the sub-build.
+set(_h2_site_defines "_GNU_SOURCE=|_PICOLIBC_CTYPE_SMALL=0|_POSIX_TIMERS=1|_POSIX_THREADS")
+
+foreach(core IN LISTS BUILD_CORES_LIST)
+    foreach(variant IN LISTS VARIANTS)
+        _hexagon_runtimes_add(
+            "hexagon-unknown-h2-elf"    "h2-elf"
+            ${core} ${variant}
+            "ON"                        # enable_threads
+            "ON"                        # monotonic_clock
+            "ON"                        # wide_chars
+            "ON"                        # localization
+            "-nostdlib++ -nostdinc++"   # extra_cxx_flags
+            "${_h2_site_defines}"       # extra_site_defines
+            "${SYSROOT_H2_ELF}"         # dest_base
+            _t
+        )
+        list(APPEND _runtimes_targets ${_t})
+    endforeach()
+endforeach()
+
+# ---------------------------------------------------------------------------
+# Fan-out symlinks for non-built cores under both triples
+# ---------------------------------------------------------------------------
+add_custom_target(runtimes-symlinks
+    COMMAND ${CMAKE_COMMAND}
+        -DMODE=runtimes-fanout
+        -DSYSROOT_NONE_ELF=${SYSROOT_NONE_ELF}
+        -DSYSROOT_H2_ELF=${SYSROOT_H2_ELF}
+        -DSOURCE_CORE=${SOURCE_CORE}
+        "-DBUILD_CORES_LIST=${BUILD_CORES_LIST}"
+        "-DALL_CORES_LIST=${ALL_CORES_LIST}"
+        -P ${CMAKE_CURRENT_LIST_DIR}/HexagonInstallSymlinks.cmake
+    DEPENDS ${_runtimes_targets}
+    COMMENT "Fanning out runtimes to non-built cores"
+    VERBATIM
+)
+
+add_custom_target(runtimes ALL DEPENDS runtimes-symlinks)

--- a/.github/workflows/hexagon-sysroot/build-hexagon-sysroot.cmake
+++ b/.github/workflows/hexagon-sysroot/build-hexagon-sysroot.cmake
@@ -1,0 +1,43 @@
+# build-hexagon-sysroot.cmake
+#
+# CMake initial cache file for building the Hexagon sysroot on top of an
+# existing Hexagon LLVM/Clang toolchain.
+#
+# Usage:
+#   cmake -C cmake/hexagon-sysroot/build-hexagon-sysroot.cmake \
+#         -DTOOLCHAIN=/path/to/Tools \
+#         -DSOURCECODE=/path/to/llvm-project \
+#         -DPICOLIBC_SRC=/path/to/picolibc \
+#         -DH2_SRC=/path/to/hexagon-hypervisor \
+#         -B build-dir/ \
+#         -S cmake/hexagon-sysroot/
+#
+#   cmake --build build-dir/ -jN
+#
+# The four sysroot components (compiler-rt builtins, picolibc, H2, runtimes)
+# are built as ExternalProjects with the following dependency chain:
+#
+#   builtins ──► picolibc ──► h2 ──► runtimes (none-elf + h2-elf)
+#
+# Each is built per (core, variant) triple.  Non-built cores get per-file
+# symlinks into the built cores.  Everything installs directly under
+# ${TOOLCHAIN}/target/picolibc/ so clang can find the sysroot for each
+# subsequent step (matching clang's DEFAULT_SYSROOT of bin/../target/).
+
+# ---------------------------------------------------------------------------
+# Required inputs — no defaults; CMakeLists.txt will FATAL_ERROR if empty.
+# Override with -D<VAR>=<path> on the cmake command line.
+# ---------------------------------------------------------------------------
+set(TOOLCHAIN    "" CACHE PATH "Installed Hexagon LLVM toolchain (contains bin/clang)")
+set(SOURCECODE   "" CACHE PATH "llvm-project source tree (compiler-rt + runtimes)")
+set(PICOLIBC_SRC "" CACHE PATH "picolibc source tree (contains meson.build)")
+set(H2_SRC       "" CACHE PATH "hexagon-hypervisor source tree (contains makefile)")
+
+# ---------------------------------------------------------------------------
+# Optional tuning
+# ---------------------------------------------------------------------------
+set(BUILD_CORES "v68"
+    CACHE STRING "Space-separated Hexagon arch versions to fully build")
+set(ALL_CORES "v68 v69 v71 v71t v73 v75 v77 v79 v81 v83 v85 v87 v89 v91"
+    CACHE STRING "Space-separated full set of Hexagon arch versions to install for")
+set(JOBS "" CACHE STRING "Parallel jobs for ninja/make (empty = number of logical cores)")


### PR DESCRIPTION
Add .github/workflows/hexagon-sysroot-builder.yml to build the Hexagon sysroot on top of the nightly ELD toolchain.