### PR TITLE
[zephyr] include Nordic HAL modules

### DIFF
--- a/.github/workflows/zephyr-run.yml
+++ b/.github/workflows/zephyr-run.yml
@@ -142,7 +142,7 @@ jobs:
           west init -l .
           # SoC-gated vendor HALs no QEMU board we build uses. Never compiled,
           # only waste disk. Keep cmsis + cmsis_6 (Cortex-M core headers).
-          exclude='hal_adi|hal_afbr|hal_ambiq|hal_atmel|hal_bouffalolab|hal_espressif|hal_ethos_u|hal_gigadevice|hal_infineon|hal_intel|hal_microchip|hal_nordic|hal_nuvoton|hal_nxp|hal_openisa|hal_quicklogic|hal_realtek|hal_renesas|hal_rpi_pico|hal_sifli|hal_silabs|hal_st|hal_stm32|hal_tdk|hal_telink|hal_ti|hal_wch|hal_wurthelektronik|hal_xtensa|libmetal'
+          exclude='hal_adi|hal_afbr|hal_ambiq|hal_atmel|hal_bouffalolab|hal_espressif|hal_ethos_u|hal_gigadevice|hal_infineon|hal_intel|hal_microchip|hal_nordic|hal_nuvoton|hal_nxp|hal_openisa|hal_quicklogic|hal_realtek|hal_renesas|hal_rpi_pico|hal_sifli|hal_silabs|hal_st|hal_stm32|hal_tdk|hal_telink|hal_ti|hal_wch|hal_wurthelektronik|hal_xtensa|libmetal|nrf_hw_models'
           # Deny-list: modules upstream adds later are still fetched.
           mapfile -t projects < <(west list --format '{name}' | grep -vxE "manifest|$exclude")
           # Shallow + narrow: full fetch has run the container disk out of space.


### PR DESCRIPTION
4c6aed33 removed too much. It is a dependency for tests.