### PR TITLE
[Zephyr] Let zephyr-run.yml inherit caller permissions

### DIFF
--- a/.github/workflows/zephyr-run.yml
+++ b/.github/workflows/zephyr-run.yml
@@ -38,13 +38,9 @@ on:
         required: true
         type: string
 
-permissions: {}
 jobs:
   zephyr-build-and-test:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      actions: read
     container:
       image: ghcr.io/zephyrproject-rtos/ci-base:main
       options: --user 0


### PR DESCRIPTION
1594 dropped the PR zephyr caller job to `contents: read`, but
zephyr-run.yml still statically requested contents: write on its job.
The PR call failed with "requesting 'contents: write', but is only
allowed 'contents: read'".

Drop the static permissions block from zephyr-run.yml so it inherits each caller's grant: nightly grants contents: write for the dashboard-recording steps, and the PR path grants only read, where those steps are skipped.