### PR TITLE
Add a --emit-all option to dashboard recorder

### DIFF
--- a/.github/workflows/scripts/record_builds.py
+++ b/.github/workflows/scripts/record_builds.py
@@ -11,6 +11,7 @@ E.g.
     Record: python record_builds.py --workflow musl --record --pass --run_id 1500
     Update: python record_builds.py --workflow musl --update --run_id 1650 --pass
     Emit: python record_builds.py --workflow musl --emit
+    Emit all: python record_builds.py --emit-all
 This tool needs no user invocation or intervention for generating data and displaying the dashboard.
 """
 
@@ -158,8 +159,8 @@ def writeJSData(workflow, data):
     print("\nBuild data written to " + workflow_file_name + "\n")
 
 
-def emitJSData(args):
-    workflow = args.workflow_build.lower()
+def emitJSDataForWorkflow(workflow):
+    workflow = workflow.lower()
     conn = get_connection()
     cursor = conn.cursor()
     all_data = []
@@ -187,7 +188,31 @@ def emitJSData(args):
     writeJSData(workflow, all_states_data)
 
 
+def emitJSData(args):
+    emitJSDataForWorkflow(args.workflow_build)
+
+
+def getAllWorkflows():
+    conn = get_connection()
+    cursor = conn.cursor()
+    try:
+        cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name;"
+        )
+        return [workflow[0] for workflow in cursor.fetchall()]
+    except Exception as e:
+        sys.exit("Error fetching workflow tables: " + str(e))
+
+
+def emitAllJSData():
+    for workflow in getAllWorkflows():
+        emitJSDataForWorkflow(workflow)
+
+
 def validateArgs(args):
+    if not args.emit_all_data and args.workflow_build is None:
+        sys.exit("Build workflow must be specified! E.g. --workflow <workflow>")
+
     # Record/update mode must have a run_id.
     if args.record_mode or args.update_mode:
         if args.run_id is None:
@@ -204,7 +229,7 @@ def handleArguments():
         "--workflow",
         "-w",
         dest="workflow_build",
-        required=True,
+        required=False,
         help="The workflow build name. E.g. picolibc, musl, nightly, etc. ",
     )
     parser.add_argument(
@@ -248,6 +273,12 @@ def handleArguments():
         action="store_true",
         help="Emit build data in JavaScript format.",
     )
+    record_mode_group.add_argument(
+        "--emit-all",
+        dest="emit_all_data",
+        action="store_true",
+        help="Emit build data in JavaScript format for all workflows.",
+    )
     # Create a build status flag group to make either flag required.
     status_group = parser.add_mutually_exclusive_group()
     status_group.add_argument(
@@ -278,6 +309,9 @@ def main():
     if args.emit_data:
         # For dashboard, emit data in JavaScript compatible variable declaration file.
         emitJSData(args)
+    elif args.emit_all_data:
+        # For dashboard, emit data for all workflows in JavaScript compatible variable declaration files.
+        emitAllJSData()
     else:
         # Insert or update build state data
         handleBuildData(args)

--- a/.github/workflows/update-build-dashboard-data.yml
+++ b/.github/workflows/update-build-dashboard-data.yml
@@ -35,14 +35,7 @@ jobs:
             git checkout documentation
             cp -r ${DASH_DIR}/dash .
             cd dash
-            python3 record_builds.py --workflow picolibc --emit
-            python3 record_builds.py --workflow musl --emit
-            python3 record_builds.py --workflow sanitizer --emit
-            python3 record_builds.py --workflow nightly --emit
-            python3 record_builds.py --workflow reverse_iterator --emit
-            python3 record_builds.py --workflow release --emit
-            python3 record_builds.py --workflow windows_nightly --emit
-            python3 record_builds.py --workflow busybox --emit
+            python3 record_builds.py --emit-all
             rm -f record_builds.py build-status.db
             rm -rf ${DASH_DIR}
             cd ..


### PR DESCRIPTION
This commit adds a --emit-all option in the dashboard data recorder to emit all the available workflow data.