### PR TITLE
[Command Line][Driver] Add -v option to match GNU ld/ld.lld

### DIFF
--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -315,6 +315,11 @@ defm sysroot : mDashDeprEq<"sysroot", "Set the system root">,
 def version : FF<"version">,
               HelpText<"Print the Linker version">,
               Group<grp_general>;
+// Unlike --version, -v prints the version banner but does not short-circuit
+// if input files are present.
+def v : Flag<["-"], "v">,
+       HelpText<"Print the Linker version and continue processing">,
+       Group<grp_general>;
 def repository_version : FF<"repository-version">,
                          HelpText<"Print the Linker Repository version">,
                          Group<grp_general>;

--- a/include/eld/Input/InputAction.h
+++ b/include/eld/Input/InputAction.h
@@ -16,6 +16,7 @@
 #include "eld/Input/Input.h"
 #include "eld/Support/Path.h"
 #include <string>
+#include <vector>
 
 namespace eld {
 
@@ -51,6 +52,7 @@ public:
     StartLib,
     WholeArchive,
     JustSymbols,
+    Version,
   };
 
 protected:
@@ -364,6 +366,24 @@ public:
 
 private:
   const std::string InputFormat;
+};
+
+/// VersionAction handles '-v', which prints the version banner and lets
+/// linking continue (unlike '--version', which always short-circuits and
+/// is handled directly in parseOptions, not as an InputAction).
+class VersionAction : public InputAction {
+public:
+  explicit VersionAction(const std::vector<std::string> &SupportedTargets,
+                         DiagnosticPrinter *Printer);
+
+  bool activate(InputBuilder &) override;
+
+  static bool classof(const InputAction *I) {
+    return I->getInputActionKind() == InputActionKind::Version;
+  }
+
+private:
+  std::vector<std::string> SupportedTargets;
 };
 
 } // namespace eld

--- a/lib/Input/InputAction.cpp
+++ b/lib/Input/InputAction.cpp
@@ -13,12 +13,14 @@
 
 #include "eld/Input/InputAction.h"
 #include "eld/Config/LinkerConfig.h"
+#include "eld/Config/Version.h"
 #include "eld/Input/Input.h"
 #include "eld/Input/InputBuilder.h"
 #include "eld/Input/InputTree.h"
 #include "eld/Input/SearchDirs.h"
 #include "eld/Support/FileSystem.h"
 #include "eld/Support/MsgHandling.h"
+#include "llvm/Support/raw_ostream.h"
 #include <fstream>
 
 using namespace eld;
@@ -268,5 +270,29 @@ bool InputFormatAction::activate(InputBuilder &Builder) {
         << InputFormat;
     return false;
   }
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+// VersionAction
+//===----------------------------------------------------------------------===//
+VersionAction::VersionAction(const std::vector<std::string> &SupportedTargets,
+                             DiagnosticPrinter *Printer)
+    : InputAction(InputAction::InputActionKind::Version, Printer),
+      SupportedTargets(SupportedTargets) {}
+
+bool VersionAction::activate(InputBuilder &) {
+  // The first line's first two words are deliberately "GNU"/"ld", ending in
+  // nothing but the bare version number. Build systems that identify the
+  // linker by parsing --version output (e.g. the Linux kernel's
+  // scripts/ld-version.sh) look for a first line whose first two words are
+  // exactly "GNU"/"ld" and take the last word on that line as the version;
+  // without this, such scripts reject eld as an "unknown linker".
+  llvm::outs() << "GNU ld compatible linker - eld " << eld::getELDVersion()
+               << "\n";
+  llvm::outs() << "Supported Targets: ";
+  for (const auto &Target : SupportedTargets)
+    llvm::outs() << Target << " ";
+  llvm::outs() << "\n";
   return true;
 }

--- a/lib/LinkerWrapper/ARMLinkDriver.cpp
+++ b/lib/LinkerWrapper/ARMLinkDriver.cpp
@@ -106,9 +106,12 @@ ARMLinkDriver::parseOptions(ArrayRef<const char *> Args,
                      /*ShowAllAliases=*/true);
     return LINK_SUCCESS;
   }
-  if (ArgList.hasArg(OPT_ARMLinkOptTable::version)) {
-    printVersionInfo();
-    return LINK_SUCCESS;
+  if (llvm::opt::Arg *Arg = ArgList.getLastArg(OPT_ARMLinkOptTable::v,
+                                               OPT_ARMLinkOptTable::version)) {
+    if (Arg->getOption().matches(OPT_ARMLinkOptTable::version)) {
+      printVersionInfo();
+      return LINK_SUCCESS;
+    }
   }
   // --about
   if (ArgList.hasArg(OPT_ARMLinkOptTable::about)) {

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -196,10 +196,7 @@ void GnuLdDriver::printVersionInfo() const {
   // linker by parsing --version output (e.g. the Linux kernel's
   // scripts/ld-version.sh) look for a first line whose first two words are
   // exactly "GNU"/"ld" and take the last word on that line as the version;
-  // without this, such scripts reject eld as an "unknown linker". This is
-  // an interim identification (agreed on until eld is proposed/added to the
-  // kernel community's own linker-detection logic) -- not a claim that eld
-  // is GNU ld.
+  // without this, such scripts reject eld as an "unknown linker".
   outs() << "GNU ld compatible linker - eld " << eld::getELDVersion() << "\n";
   outs() << "Supported Targets: ";
   for (const auto &x : m_SupportedTargets)
@@ -1346,6 +1343,7 @@ bool GnuLdDriver::createInputActions(llvm::opt::InputArgList &Args,
   size_t input_num = 0;
   int GroupMatchCount = 0;
   int LibMatchCount = 0;
+  bool HasVersionAction = false;
 
   for (llvm::opt::Arg *arg : Args) {
     switch (arg->getOption().getID()) {
@@ -1510,6 +1508,14 @@ bool GnuLdDriver::createInputActions(llvm::opt::InputArgList &Args,
       ++input_num;
     } break;
 
+    // -v prints the version banner and lets linking continue. Unlike
+    // --version, -v only short-circuits when there are no real inputs.
+    case T::v: {
+      actions.push_back(eld::make<eld::VersionAction>(m_SupportedTargets,
+                                                      Config.getPrinter()));
+      HasVersionAction = true;
+    } break;
+
     default:
       break;
     }
@@ -1527,7 +1533,7 @@ bool GnuLdDriver::createInputActions(llvm::opt::InputArgList &Args,
     return false;
   }
 
-  if (input_num == 0) {
+  if (input_num == 0 && !HasVersionAction) {
     Config.raise(Diag::err_no_inputs);
     Config.raise(Diag::linking_had_errors) << getOutputFileName();
     return false;
@@ -1958,6 +1964,12 @@ eld::Module *GnuLdDriver::ThisModule = nullptr;
 template <class T>
 bool GnuLdDriver::doLink(llvm::opt::InputArgList &Args,
                          std::vector<eld::InputAction *> &actions) {
+  // Bare -v (no real inputs): print the banner and exit immediately.
+  if (Args.hasArg(T::v) && !Args.hasArg(T::INPUT)) {
+    printVersionInfo();
+    return true;
+  }
+
   const eld::Target *ELDTarget = nullptr;
   if (!isDriverFlavorUnknown()) {
     // Get the target specific parser.
@@ -2139,9 +2151,12 @@ std::optional<int> GnuLdDriver::parseOptions(ArrayRef<const char *> Args,
                      /*ShowAllAliases=*/true);
     return LINK_SUCCESS;
   }
-  if (ArgList.hasArg(OPT_GnuLdOptTable::version)) {
-    printVersionInfo();
-    return LINK_SUCCESS;
+  if (llvm::opt::Arg *Arg = ArgList.getLastArg(OPT_GnuLdOptTable::v,
+                                               OPT_GnuLdOptTable::version)) {
+    if (Arg->getOption().matches(OPT_GnuLdOptTable::version)) {
+      printVersionInfo();
+      return LINK_SUCCESS;
+    }
   }
   // --about
   if (ArgList.hasArg(OPT_GnuLdOptTable::about)) {

--- a/lib/LinkerWrapper/HexagonLinkDriver.cpp
+++ b/lib/LinkerWrapper/HexagonLinkDriver.cpp
@@ -89,9 +89,12 @@ HexagonLinkDriver::parseOptions(ArrayRef<const char *> Args,
                      /*ShowAllAliases=*/true);
     return LINK_SUCCESS;
   }
-  if (ArgList.hasArg(OPT_HexagonLinkOptTable::version)) {
-    printVersionInfo();
-    return LINK_SUCCESS;
+  if (llvm::opt::Arg *Arg = ArgList.getLastArg(
+          OPT_HexagonLinkOptTable::v, OPT_HexagonLinkOptTable::version)) {
+    if (Arg->getOption().matches(OPT_HexagonLinkOptTable::version)) {
+      printVersionInfo();
+      return LINK_SUCCESS;
+    }
   }
   // --about
   if (ArgList.hasArg(OPT_HexagonLinkOptTable::about)) {

--- a/lib/LinkerWrapper/RISCVLinkDriver.cpp
+++ b/lib/LinkerWrapper/RISCVLinkDriver.cpp
@@ -99,9 +99,12 @@ RISCVLinkDriver::parseOptions(ArrayRef<const char *> Args,
                      /*ShowAllAliases=*/true);
     return LINK_SUCCESS;
   }
-  if (ArgList.hasArg(OPT_RISCVLinkOptTable::version)) {
-    printVersionInfo();
-    return LINK_SUCCESS;
+  if (llvm::opt::Arg *Arg = ArgList.getLastArg(
+          OPT_RISCVLinkOptTable::v, OPT_RISCVLinkOptTable::version)) {
+    if (Arg->getOption().matches(OPT_RISCVLinkOptTable::version)) {
+      printVersionInfo();
+      return LINK_SUCCESS;
+    }
   }
   // --about
   if (ArgList.hasArg(OPT_RISCVLinkOptTable::about)) {

--- a/lib/LinkerWrapper/TemplateLinkDriver.cpp
+++ b/lib/LinkerWrapper/TemplateLinkDriver.cpp
@@ -99,9 +99,12 @@ TemplateLinkDriver::parseOptions(ArrayRef<const char *> Args,
                      /*ShowAllAliases=*/true);
     return LINK_SUCCESS;
   }
-  if (ArgList.hasArg(OPT_TemplateLinkOptTable::version)) {
-    printVersionInfo();
-    return LINK_SUCCESS;
+  if (llvm::opt::Arg *Arg = ArgList.getLastArg(
+          OPT_TemplateLinkOptTable::v, OPT_TemplateLinkOptTable::version)) {
+    if (Arg->getOption().matches(OPT_TemplateLinkOptTable::version)) {
+      printVersionInfo();
+      return LINK_SUCCESS;
+    }
   }
   // --about
   if (ArgList.hasArg(OPT_TemplateLinkOptTable::about)) {

--- a/lib/LinkerWrapper/x86_64LinkDriver.cpp
+++ b/lib/LinkerWrapper/x86_64LinkDriver.cpp
@@ -79,9 +79,12 @@ x86_64LinkDriver::parseOptions(ArrayRef<const char *> Args,
                      /*ShowAllAliases=*/true);
     return LINK_SUCCESS;
   }
-  if (ArgList.hasArg(OPT_x86_64LinkOptTable::version)) {
-    printVersionInfo();
-    return LINK_SUCCESS;
+  if (llvm::opt::Arg *Arg = ArgList.getLastArg(
+          OPT_x86_64LinkOptTable::v, OPT_x86_64LinkOptTable::version)) {
+    if (Arg->getOption().matches(OPT_x86_64LinkOptTable::version)) {
+      printVersionInfo();
+      return LINK_SUCCESS;
+    }
   }
   // --about
   if (ArgList.hasArg(OPT_x86_64LinkOptTable::about)) {

--- a/test/Common/standalone/CommandLine/DashV/DashV.test
+++ b/test/Common/standalone/CommandLine/DashV/DashV.test
@@ -1,0 +1,39 @@
+#---DashV.test--------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# Checks GNU ld/ld.lld compatible semantics for -v and --version:
+# - Bare `-v` (no inputs) prints the version banner and exits successfully,
+#   instead of erroring with "no inputs". This matters for tools like the
+#   Linux kernel's scripts/mkcompile_h, which runs `$LD -v` to capture the
+#   linker version string.
+# - `-v` combined with real inputs prints the banner but does not
+#   short-circuit: the link still proceeds and produces output.
+# - `--version` always short-circuits and exits successfully, with or
+#   without inputs.
+# - `-v` and `--version` conflict with each other and the last one on the
+#   command line wins
+#END_COMMENT
+#START_TEST
+RUN: %link -v 2>&1 | %filecheck %s --check-prefixes=BANNER,NOERROR
+
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.1.o
+RUN: %link %linkopts -v %t.1.o -o %t.1.out 2>&1 | %filecheck %s --check-prefix=BANNER
+RUN: %readelf -h %t.1.out | %filecheck %s --check-prefix=ELFHEADER
+
+RUN: %link --version 2>&1 | %filecheck %s --check-prefix=BANNER
+RUN: %link %linkopts --version %t.1.o -o %t.2.out 2>&1 | %filecheck %s --check-prefix=BANNER
+
+# `--version` last wins: short-circuits, no output produced.
+RUN: %rm -f %t.3.out
+RUN: %link %linkopts -v --version %t.1.o -o %t.3.out 2>&1 | %filecheck %s --check-prefix=SINGLEBANNER
+RUN: %not ls %t.3.out
+
+# `-v` last wins: link proceeds, output produced, banner printed once.
+RUN: %link %linkopts --version -v %t.1.o -o %t.4.out 2>&1 | %filecheck %s --check-prefix=SINGLEBANNER
+RUN: %readelf -h %t.4.out | %filecheck %s --check-prefix=ELFHEADER
+
+#BANNER: GNU ld compatible linker - eld {{.*}}
+#NOERROR-NOT: no inputs
+#ELFHEADER: ELF Header
+#SINGLEBANNER-COUNT-1: GNU ld compatible linker - eld {{.*}}
+#SINGLEBANNER-NOT: GNU ld compatible linker - eld {{.*}}
+#END_TEST

--- a/test/Common/standalone/CommandLine/DashV/Inputs/1.c
+++ b/test/Common/standalone/CommandLine/DashV/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo() { return 0; }

--- a/test/Common/standalone/CommandLine/PrintHelp/PrintModHelp.test
+++ b/test/Common/standalone/CommandLine/PrintHelp/PrintModHelp.test
@@ -263,6 +263,7 @@ RUN: %link --help 2>&1 | %filecheck %s
 #CHECK:   --sysroot <sysroot-path>
 #CHECK:   -sysroot <sysroot-path>
 #CHECK:   --version
+#CHECK:   -v
 #CHECK:   --help-hidden
 #CHECK:   --help
 #CHECK:   --b=<input-format>


### PR DESCRIPTION
Add support for -v option. The behavior is the following:

  - Bare `-v` (no inputs) prints the version banner and exits successfully, instead of erroring with "no inputs". This matters for tools like the Linux kernel's scripts/mkcompile_h, which runs `$LD -v` to capture the linker version string.
  - `-v` combined with real inputs prints the banner but does not short-circuit: the link still proceeds and produces output.
  - `-v` and `--version` conflict with each other and the last one on the command line wins.

Fix: qualcomm#1610