### PR TITLE
[Layout] Fix LMA alignment when section-description ALIGN() is used w…

### DIFF
--- a/docs/userguide/documentation/linker_script.rst
+++ b/docs/userguide/documentation/linker_script.rst
@@ -1182,8 +1182,40 @@ In GNU linker scripts, the AT command is used to control the Load Memory Address
 
 .. important::
 
-   When an AT command is specified as part of the output section, the linker
-   will not automatically align the load memory address of the section.
+   When ``AT>REGION`` is specified on an output section, the linker does **not**
+   automatically align the LMA to match the natural alignment of the input
+   sections. The LMA region cursor is authoritative in that case.
+
+   However, if the output section description contains an explicit ``ALIGN(n)``
+   keyword *after* the colon (the section address expression form, e.g.
+   ``.sec : ALIGN(n) { }``), ELD applies that alignment to both the VMA and the
+   LMA, even when ``AT>REGION`` is present.
+
+   The ``ALIGN(n)`` keyword *before* the colon (the prolog/address-expression
+   form, e.g. ``.sec ALIGN(n) : { }``) sets only the VMA; the LMA stays at
+   the LMA region cursor and is not aligned.
+
+   Summary of LMA alignment behavior with ``AT>REGION``:
+
+   .. list-table::
+      :widths: 45 25 30
+      :header-rows: 1
+
+      * - Syntax
+        - VMA aligned?
+        - LMA aligned?
+      * - ``.sec : { }`` (no ALIGN)
+        - natural alignment
+        - no (cursor only)
+      * - ``.sec ALIGN(n) : { }`` (prolog form)
+        - yes, to n
+        - no (cursor only)
+      * - ``.sec : ALIGN(n) { }`` (section-description form)
+        - yes, to n
+        - yes, to n
+      * - ``.sec : ALIGN_WITH_INPUT { }``
+        - natural alignment
+        - tracks VMA delta
 
 ALIGN_WITH_INPUT attribute on an output section preserves the VMA-to-LMA offset
 from the previous output section when both sections use the same VMA region and
@@ -1198,6 +1230,10 @@ Behavior summary:
   the selected VMA region.
 - LMA placement is governed by the AT/AT> directives and the selected LMA
   region, and it is tracked independently from the VMA placement.
+- Explicit ``ALIGN(n)`` in the section description (after the colon) aligns
+  both VMA and LMA, even with ``AT>REGION``.
+- Prolog ``ALIGN(n)`` (before the colon) aligns only the VMA; LMA follows the
+  LMA region cursor.
 - ALIGN_WITH_INPUT preserves the prior VMA-to-LMA delta, but only while both
   regions remain the same.
 - When VMA and LMA resolve to the same region (for example, no ``AT>REGION``),
@@ -1208,6 +1244,8 @@ See also:
 - :file:`test/Common/standalone/linkerscript/AlignWithInput/NoPhdrs/AlignWithInput.test`
 - :file:`test/Common/standalone/linkerscript/AlignWithInput/TLS/TLS.test`
 - :file:`test/Common/standalone/linkerscript/AlignWithInput/NoLoadATRAM/NoLoadATRAM.test`
+- :file:`test/Common/standalone/linkerscript/MEMORY/ATRegionAlign/ATRegionAlign.test`
+- :file:`test/Common/standalone/linkerscript/MEMORY/ATRegionAlignPHDRS/ATRegionAlignPHDRS.test`
 
 GNU-compatibility
 --------------------

--- a/lib/Target/CreateProgramHeaders.hpp
+++ b/lib/Target/CreateProgramHeaders.hpp
@@ -466,12 +466,11 @@ bool GNULDBackend::createProgramHdrs() {
       } else if (hasVMARegion || hasLMARegion) {
         ScriptMemoryRegion &R = (*out)->epilog().lmaRegion();
         pma = R.getPhysicalAddr(*out);
-        // If LMA region has been explicitly specified
-        // do not align LMA. A LMA region exists for the VMA
-        // region just for making it easy for us to handle assigning
-        // physical addresses
-        if (!(*out)->prolog().hasAlignWithInput() && !hasLMARegion)
-          alignAddress(pma, cur->getAddrAlign());
+        if (!(*out)->prolog().hasAlignWithInput()) {
+          bool explicitAlign = (*out)->prolog().hasAlign();
+          if (!hasLMARegion || explicitAlign)
+            alignAddress(pma, cur->getAddrAlign());
+        }
       } else if (!prev || !disconnect_lma_vma) {
         pma = vma;
         // Only align LMA if VMA is also aligned
@@ -579,8 +578,11 @@ bool GNULDBackend::createProgramHdrs() {
       } else if (hasVMARegion || hasLMARegion) {
         ScriptMemoryRegion &R = (*out)->epilog().lmaRegion();
         pma = R.getPhysicalAddr(*out);
-        if (!(*out)->prolog().hasAlignWithInput() && !hasLMARegion)
-          alignAddress(pma, cur->getAddrAlign());
+        if (!(*out)->prolog().hasAlignWithInput()) {
+          bool explicitAlign = (*out)->prolog().hasAlign();
+          if (!hasLMARegion || explicitAlign)
+            alignAddress(pma, cur->getAddrAlign());
+        }
       } else if (!prev || !disconnect_lma_vma) {
         pma = vma;
         if (cur->getAddrAlign() > 0 && vma % cur->getAddrAlign() == 0)

--- a/lib/Target/CreateScriptProgramHeaders.hpp
+++ b/lib/Target/CreateScriptProgramHeaders.hpp
@@ -272,9 +272,16 @@ bool GNULDBackend::createScriptProgramHdrs() {
     } else if (hasVMARegion || hasLMARegion) {
       ScriptMemoryRegion &R = (*out)->epilog().lmaRegion();
       pma = R.getPhysicalAddr(*out);
-      if (!(*out)->prolog().hasAlignWithInput() && !hasLMARegion)
-        if (cur->getAddrAlign() > 0 && vma % cur->getAddrAlign() == 0)
-          alignAddress(pma, cur->getAddrAlign());
+      if (!(*out)->prolog().hasAlignWithInput()) {
+        // Apply alignment to LMA when there is no explicit AT> region, or when
+        // the script explicitly requested alignment via ALIGN() in the section
+        // description. Natural input-section alignment is suppressed with AT>
+        // because the LMA region cursor is authoritative in that case.
+        bool explicitAlign = (*out)->prolog().hasAlign();
+        if (!hasLMARegion || explicitAlign)
+          if (cur->getAddrAlign() > 0 && vma % cur->getAddrAlign() == 0)
+            alignAddress(pma, cur->getAddrAlign());
+      }
     } else if (hasFixedLMA) {
       // If the current segment has a fixed LMA address, then
       curLoadSegment->fixedLMA()->evaluateAndRaiseError();

--- a/test/Common/standalone/linkerscript/MEMORY/ATRegionAlign/ATRegionAlign.test
+++ b/test/Common/standalone/linkerscript/MEMORY/ATRegionAlign/ATRegionAlign.test
@@ -1,0 +1,17 @@
+#---ATRegionAlign.test--------------------- Executable,LS------------------#
+#BEGIN_COMMENT
+# Test that ALIGN() in the section address expression (after colon) causes the
+# LMA to be aligned when an explicit AT> LMA region is used (no PHDRS), while
+# ALIGN() in the section prolog (before colon) does NOT affect the LMA.
+#
+# .bar ALIGN(0x1000) :  -- prolog ALIGN, VMA aligned to page, LMA stays at cursor
+# .baz : ALIGN(0x1000)  -- section-expr ALIGN, both VMA and LMA aligned to page
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o -ffunction-sections
+RUN: %link %linkopts %t1.o -T %p/Inputs/script.t -Map %t1.map -o %t1.out 2>&1
+RUN: %filecheck %s -check-prefix=MAP < %t1.map
+#END_TEST
+#MAP: .foo {{.*}} # Offset: {{.*}}, LMA: 0x1000, {{.*}}, Memory : [M1, M1_LMA]
+#MAP: .bar {{.*}} # Offset: {{.*}}, LMA: 0x1{{[0-9a-f][0-9a-f][0-9a-f]}}, {{.*}}, Memory : [M1, M1_LMA]
+#MAP: .baz {{.*}} # Offset: {{.*}}, LMA: 0x2000, {{.*}}, Memory : [M1, M1_LMA]

--- a/test/Common/standalone/linkerscript/MEMORY/ATRegionAlign/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/MEMORY/ATRegionAlign/Inputs/1.c
@@ -1,0 +1,3 @@
+int foo() { return 0; }
+int bar() { return 0; }
+int baz() { return 0; }

--- a/test/Common/standalone/linkerscript/MEMORY/ATRegionAlign/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/MEMORY/ATRegionAlign/Inputs/script.t
@@ -1,0 +1,11 @@
+MEMORY {
+  M1     : ORIGIN = 0x1000, LENGTH = 1M
+  M1_LMA : ORIGIN = 0x1000, LENGTH = 1M
+}
+
+SECTIONS {
+  .foo :               { *(.text.foo) } >M1 AT>M1_LMA
+  .bar ALIGN(0x1000) : { *(.text.bar) } >M1 AT>M1_LMA
+  .baz : ALIGN(0x1000) { *(.text.baz) } >M1 AT>M1_LMA
+  /DISCARD/ : { *(.ARM.exidx*) *(.*.attributes) *(.eh_frame*) }
+}

--- a/test/Common/standalone/linkerscript/MEMORY/ATRegionAlignPHDRS/ATRegionAlignPHDRS.test
+++ b/test/Common/standalone/linkerscript/MEMORY/ATRegionAlignPHDRS/ATRegionAlignPHDRS.test
@@ -1,0 +1,29 @@
+#---ATRegionAlignPHDRS.test--------------------- Executable,LS------------------#
+#BEGIN_COMMENT
+# Test that ALIGN() in the section address expression (after colon) causes the
+# LMA to be aligned when an explicit AT> LMA region is used, while ALIGN() in
+# the section prolog (before colon) does NOT affect the LMA -- only the VMA.
+#
+# .bar ALIGN(0x1000) :  -- prolog ALIGN, VMA aligned to page, LMA stays at cursor
+# .baz : ALIGN(0x1000)  -- section-expr ALIGN, both VMA and LMA aligned to page
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.o -ffunction-sections
+RUN: %link %linkopts %t1.o -T %p/Inputs/script.t -Map %t1.map -o %t1.out 2>&1
+RUN: %readelf -l -W %t1.out | %filecheck %s
+RUN: %filecheck %s -check-prefix=MAP < %t1.map
+#END_TEST
+# .foo: VMA == PhysAddr == 0x1000
+#CHECK: Type           Offset   VirtAddr   PhysAddr
+#CHECK: LOAD {{.*}} 0x{{0+}}1000 0x{{0+}}1000 {{.*}} R E
+# .bar: VMA 0x2000 (prolog ALIGN applied), PhysAddr stays at cursor (not page-aligned)
+#CHECK: LOAD {{.*}} 0x{{0+}}2000 0x{{0+}}1{{.*}} {{.*}} R E
+# .baz: VMA 0x3000, PhysAddr 0x2000 (section-expr ALIGN applied to LMA)
+#CHECK: LOAD {{.*}} 0x{{0+}}3000 0x{{0+}}2000 {{.*}} R E
+#CHECK: Segment Sections...
+#CHECK:  00     .foo
+#CHECK:  01     .bar
+#CHECK:  02     .baz
+#MAP: .foo {{.*}} # Offset: {{.*}}, LMA: 0x1000, {{.*}}, Memory : [M1, M1_LMA]
+#MAP: .bar {{.*}} # Offset: {{.*}}, LMA: 0x1{{[0-9a-f][0-9a-f][0-9a-f]}}, {{.*}}, Memory : [M1, M1_LMA]
+#MAP: .baz {{.*}} # Offset: {{.*}}, LMA: 0x2000, {{.*}}, Memory : [M1, M1_LMA]

--- a/test/Common/standalone/linkerscript/MEMORY/ATRegionAlignPHDRS/Inputs/1.c
+++ b/test/Common/standalone/linkerscript/MEMORY/ATRegionAlignPHDRS/Inputs/1.c
@@ -1,0 +1,3 @@
+int foo() { return 0; }
+int bar() { return 0; }
+int baz() { return 0; }

--- a/test/Common/standalone/linkerscript/MEMORY/ATRegionAlignPHDRS/Inputs/script.t
+++ b/test/Common/standalone/linkerscript/MEMORY/ATRegionAlignPHDRS/Inputs/script.t
@@ -1,0 +1,17 @@
+PHDRS {
+  A PT_LOAD;
+  B PT_LOAD;
+  C PT_LOAD;
+}
+
+MEMORY {
+  M1     : ORIGIN = 0x1000, LENGTH = 1M
+  M1_LMA : ORIGIN = 0x1000, LENGTH = 1M
+}
+
+SECTIONS {
+  .foo :                { *(.text.foo) } >M1 AT>M1_LMA :A
+  .bar ALIGN(0x1000) :  { *(.text.bar) } >M1 AT>M1_LMA :B
+  .baz : ALIGN(0x1000)  { *(.text.baz) } >M1 AT>M1_LMA :C
+  /DISCARD/ : { *(.ARM.exidx*) *(.*.attributes) *(.eh_frame*) }
+}


### PR DESCRIPTION
When a section uses ALIGN(n) in the section description (after the colon, e.g. `.sec : ALIGN(n) { }`) alongside AT>REGION, the LMA was not being aligned to match the VMA.

- Prolog ALIGN (before colon, e.g. `.sec ALIGN(n) : { }`): this sets the VMA only; the LMA stays at the LMA region cursor. No change in behavior.
- Section-description ALIGN (after colon, e.g. `.sec : ALIGN(n) { }`): this is an explicit alignment request that should apply to both VMA and LMA. With AT>, the LMA was previously left unaligned; now it is aligned to match the VMA.

Fixes #1614