### PR TITLE
[Relocator] Show referenced symbol in overflow diagnostics

### DIFF
--- a/include/eld/Diagnostics/DiagRelocations.inc
+++ b/include/eld/Diagnostics/DiagRelocations.inc
@@ -39,7 +39,7 @@ DIAG(reloc_trace, DiagnosticEngine::Note,
 DIAG(tls_non_tls_mix, DiagnosticEngine::Error,
      "Relocation %0 is TLS type but symbol %1 is non-TLS type")
 DIAG(result_overflow_moreinfo, DiagnosticEngine::Error,
-     "%0: relocation %1 out of range: %2 is not in [%3, %4]; references '%5'")
+     "%0: relocation %1 out of range: %2 is not in [%3, %4]; references %5")
 DIAG(result_badreloc_moreinfo, DiagnosticEngine::Error,
      "Relocation error when applying relocation `%0' for symbol `%1' referred "
      "from %2 symbol defined in %3")

--- a/lib/Readers/Relocation.cpp
+++ b/lib/Readers/Relocation.cpp
@@ -10,6 +10,7 @@
 #include "eld/Core/Module.h"
 #include "eld/Diagnostics/DiagnosticEngine.h"
 #include "eld/Input/ELFObjectFile.h"
+#include "eld/Input/Input.h"
 #include "eld/Readers/ELFSection.h"
 #include "eld/Support/MsgHandling.h"
 #include "eld/SymbolResolver/LDSymbol.h"
@@ -214,22 +215,41 @@ static std::string getLocation(FragmentRef *Ref, Relocator &R) {
   return "";
 }
 
+// Returns the text following "references " in the overflow diagnostic.
+static std::string getReferenceClause(const Relocation &Reloc,
+                                      const std::string &SymName) {
+  ResolveInfo *Info = Reloc.symInfo();
+  if (!Info || Info == ResolveInfo::null() || Info->isSection() ||
+      Info->isUndef())
+    return "'" + SymName + "'";
+  InputFile *Origin = Info->resolvedOrigin();
+  if (!Origin || !Origin->getInput() ||
+      !(Origin->isObjectFile() || Origin->isBitcode() ||
+        Origin->isDynamicLibrary()))
+    return "'" + SymName + "'";
+  return Origin->getInput()->decoratedPath() + "('" + SymName + "')";
+}
+
+template <typename ValueT>
+static void raiseOverflow(const Relocation &Reloc, Relocator &R, ValueT Value,
+                          ValueT Min, ValueT Max) {
+  std::string Location = getLocation(Reloc.targetRef(), R);
+  std::string SymName =
+      Relocation::getSymbolName(Reloc.symInfo(), R.doDeMangle());
+  R.config().getDiagEngine()->raise(Diag::result_overflow_moreinfo)
+      << Location << R.getName(Reloc.type()) << Value << Min << Max
+      << getReferenceClause(Reloc, SymName);
+  ASSERT(!Location.empty(), "expected a section location.");
+}
+
 void Relocation::issueSignedOverflow(Relocator &R, int64_t Value, int64_t Min,
                                      int64_t Max) const {
-  std::string Location = getLocation(targetRef(), R);
-  R.config().getDiagEngine()->raise(Diag::result_overflow_moreinfo)
-      << Location << R.getName(type()) << Value << Min << Max
-      << getSymbolName(symInfo(), R.doDeMangle());
-  ASSERT(!Location.empty(), "expected a section location.");
+  raiseOverflow(*this, R, Value, Min, Max);
 }
 
 void Relocation::issueUnsignedOverflow(Relocator &R, uint64_t Value,
                                        uint64_t Min, uint64_t Max) const {
-  std::string Location = getLocation(targetRef(), R);
-  R.config().getDiagEngine()->raise(Diag::result_overflow_moreinfo)
-      << Location << R.getName(type()) << Value << Min << Max
-      << getSymbolName(symInfo(), R.doDeMangle());
-  ASSERT(!Location.empty(), "expected a section location.");
+  raiseOverflow(*this, R, Value, Min, Max);
 }
 
 bool Relocation::issueUnencodableImmediate(Relocator &R, int64_t Imm) const {

--- a/test/AArch64/standalone/RelocAbs/RelocAbs.test
+++ b/test/AArch64/standalone/RelocAbs/RelocAbs.test
@@ -6,5 +6,5 @@
 #START_TEST
 RUN: %clang %clangopts -target aarch64 -c %p/Inputs/a.c -o %t1.1.o
 RUN: %not %link %linkopts -march aarch64 %t1.1.o -o %t2.out -z max-page-size=0x10000 2>&1 | %filecheck %s
-#CHECK: Error: {{.*}}1.o:(.text): relocation R_AARCH64_ABS16 out of range: 65536 is not in [-32768, 65535]; references 'a'
+#CHECK: Error: {{.*}}1.o:(.text): relocation R_AARCH64_ABS16 out of range: 65536 is not in [-32768, 65535]; references {{.*}}('a')
 #END_TEST

--- a/test/ARM/standalone/Relocs/R_ARM_LDR_PC_G2/R_ARM_LDR_PC_G2.test
+++ b/test/ARM/standalone/Relocs/R_ARM_LDR_PC_G2/R_ARM_LDR_PC_G2.test
@@ -14,5 +14,5 @@ RUN: %not %link %linkopts -march arm -T %p/Inputs/overflow.t %t3.1.o -o %t4.out 
 #VALID:      00800028 <_start>:
 #VALID-NEXT:   800028: e5900fd8 ldr r0, [r0, #0xfd8]
 
-#OVERFLOW: Error: {{.*}}3.1.o:(.text.1+0x28): relocation R_ARM_LDR_PC_G2 out of range: 16344 is not in [0, 4095]; references 'dat2'
+#OVERFLOW: Error: {{.*}}3.1.o:(.text.1+0x28): relocation R_ARM_LDR_PC_G2 out of range: 16344 is not in [0, 4095]; references {{.*}}'dat2'
 #END_TEST

--- a/test/Common/standalone/OverflowDefinedIn/OverflowDefinedIn.test
+++ b/test/Common/standalone/OverflowDefinedIn/OverflowDefinedIn.test
@@ -1,0 +1,81 @@
+## Does not overflows on these targets so no link would run at all.
+UNSUPPORTED: riscv32, x86
+
+## NOTE: The overflow diagnostic currently names the input file only for
+## symbols defined in an object, bitcode, or shared file. Linker-script
+## assignments still fall back to the bare symbol name; we plan to update
+## the diagnostic to name the script and line in a follow-up.
+
+## Verify an overflow diagnostic names where the referenced symbol is defined.
+
+RUN: split-file %s %t
+
+## Address of a far symbol: AArch64, RISC-V 64.
+
+RUN: %if aarch64 || riscv64 %{ %clang %clangopts -c %t/addr.c -o %t/addr.o %}
+RUN: %if aarch64 || riscv64 %{ %clang %clangopts -c %t/fardata.c -o %t/far.o %}
+
+RUN: %if aarch64 || riscv64 %{ %not %link %linkopts %t/addr.o -T %t/assign.t -o /dev/null 2>&1 \
+RUN:   | %filecheck %s --check-prefix=ASSIGN %}
+
+RUN: %if aarch64 || riscv64 %{ %not %link %linkopts %t/addr.o %t/far.o -T %t/section.t -o /dev/null 2>&1 \
+RUN:   | %filecheck %s --check-prefix=OBJECT %}
+
+## Far call: ARM, Hexagon.
+
+RUN: %if arm || hexagon %{ %clang %clangopts -fno-asynchronous-unwind-tables -c %t/call.c -o %t/call.o %}
+RUN: %if arm || hexagon %{ %clang %clangopts -fno-asynchronous-unwind-tables -c %t/far.c -o %t/far.o %}
+
+RUN: %if arm || hexagon %{ %not %link %linkopts --no-trampolines %t/call.o -T %t/callassign.t -o /dev/null 2>&1 \
+RUN:   | %filecheck %s --check-prefix=ASSIGN %}
+
+RUN: %if arm || hexagon %{ %not %link %linkopts --no-trampolines %t/call.o %t/far.o -T %t/callsection.t -o /dev/null 2>&1 \
+RUN:   | %filecheck %s --check-prefix=OBJECT %}
+
+## TODO: name the script and line (e.g. "assign.t:1('faraway')") once the diagnostic is extended.
+ASSIGN:      out of range
+ASSIGN-SAME: references 'faraway'
+
+OBJECT:      out of range
+OBJECT-SAME: references {{.*}}far.o('faraway')
+
+#--- addr.c
+extern int faraway;
+int *get(void) { return &faraway; }
+
+#--- fardata.c
+int faraway = 11;
+
+#--- call.c
+void faraway(void);
+void _start(void) { faraway(); }
+
+#--- far.c
+void faraway(void) {}
+
+#--- assign.t
+faraway = 0x100000000;
+SECTIONS {
+  .text 0x0 : { *(*text*) }
+}
+
+#--- section.t
+SECTIONS {
+  .text 0x0 : { *(*text*) }
+  .far 0x100000000 : { *(*data*) }
+}
+
+#--- callassign.t
+faraway = 0x70000000;
+SECTIONS {
+  . = 0x1000;
+  .text : { *(.text*) }
+}
+
+#--- callsection.t
+SECTIONS {
+  . = 0x1000;
+  .text : { *call.o(.text*) }
+  . = 0x70000000;
+  .far : { *far.o(.text*) }
+}

--- a/test/Hexagon/linux/notrampolines/no-trampoline.test
+++ b/test/Hexagon/linux/notrampolines/no-trampoline.test
@@ -1,4 +1,4 @@
 RUN: %clang %clangopts -c %p/Inputs/trampoline.s -o %t.o
 RUN: %not %link %linkopts --no-trampolines %t.o -o %t.out 2>&1 | %filecheck %s
 
-CHECK:  Error: {{.*}}o:(.text.othermain+0x4): relocation R_HEX_B22_PCREL out of range: {{.*}} is not in [-8388608, 8388607]; references 'myfn'
+CHECK:  Error: {{.*}}o:(.text.othermain+0x4): relocation R_HEX_B22_PCREL out of range: {{.*}} is not in [-8388608, 8388607]; references {{.*}}('myfn')

--- a/test/Hexagon/standalone/RelocationOverflow/RelocationOverflow.test
+++ b/test/Hexagon/standalone/RelocationOverflow/RelocationOverflow.test
@@ -8,7 +8,7 @@ RUN: %clang %clangopts -c %p/Inputs/foo.c -o %t1.foo.o
 RUN: %clang %clangopts -c %p/Inputs/trampoline.s -o %t1.trampoline.o
 RUN: %not %link %linkopts %t1.foo.o %t1.trampoline.o -o %t2.out --no-trampolines 2>&1 | %filecheck %s
 
-#CHECK: Error: {{.*}}.o:(.text.callfoo+0x1000000): relocation R_HEX_B22_PCREL out of range: {{.*}} is not in [-8388608, 8388607]; references 'foo'
-#CHECK: Error: {{.*}}.o:(.text.callfoo+0x1000004): relocation R_HEX_B22_PCREL out of range: {{.*}} is not in [-8388608, 8388607]; references 'bar'
+#CHECK: Error: {{.*}}.o:(.text.callfoo+0x1000000): relocation R_HEX_B22_PCREL out of range: {{.*}} is not in [-8388608, 8388607]; references {{.*}}('foo')
+#CHECK: Error: {{.*}}.o:(.text.callfoo+0x1000004): relocation R_HEX_B22_PCREL out of range: {{.*}} is not in [-8388608, 8388607]; references {{.*}}('bar')
 
 #END_TEST

--- a/test/Hexagon/standalone/notrampolines/no-trampoline.test
+++ b/test/Hexagon/standalone/notrampolines/no-trampoline.test
@@ -1,4 +1,4 @@
 RUN: %clang %clangopts -c %p/Inputs/trampoline.s -o %t.o
 RUN: %not %link %linkopts --no-trampolines %t.o -o %t.out 2>&1 | %filecheck %s
 
-CHECK:  Error: {{.*}}o:(.text.othermain+0x4): relocation R_HEX_B22_PCREL out of range: {{.*}} is not in [-8388608, 8388607]; references 'myfn'
+CHECK:  Error: {{.*}}o:(.text.othermain+0x4): relocation R_HEX_B22_PCREL out of range: {{.*}} is not in [-8388608, 8388607]; references {{.*}}('myfn')

--- a/test/RISCV/standalone/JAL/JALOverflow.s
+++ b/test/RISCV/standalone/JAL/JALOverflow.s
@@ -25,6 +25,8 @@
 # MAX: jal 0x8ffffe <_start+0xffffe>
 # MIN: jal 0x700000 <foo>
 
+## TODO: The overflow diagnostic currently prints the bare symbol name for
+## --defsym symbols; a follow-up will extend it to say "'--defsym foo'".
 # FAILPOS: Error: {{.*}}.o:(.text): relocation R_RISCV_JAL out of range: 1048576 is not in [-1048576, 1048575]; references 'foo'
 # FAILNEG: Error: {{.*}}.o:(.text): relocation R_RISCV_JAL out of range: -1048578 is not in [-1048576, 1048575]; references 'foo'
 

--- a/test/RISCV/standalone/JAL/JALOverflowDefinedIn.s
+++ b/test/RISCV/standalone/JAL/JALOverflowDefinedIn.s
@@ -1,0 +1,125 @@
+# UNSUPPORTED: riscv64
+
+# RUN: split-file %s %t
+
+# RUN: %llvm-mc -filetype=obj -triple=riscv32-unknown-elf -mattr=-relax %t/a.s -o %t/a.o
+# RUN: %llvm-mc -filetype=obj -triple=riscv32-unknown-elf -mattr=-relax %t/baz.s -o %t/baz.o
+# RUN: %llvm-mc -filetype=obj -triple=riscv32-unknown-elf -mattr=-relax %t/encap.s -o %t/encap.o
+# RUN: %llvm-mc -filetype=obj -triple=riscv32-unknown-elf -mattr=-relax %t/weak.s -o %t/weak.o
+# RUN: %llvm-mc -filetype=obj -triple=riscv32-unknown-elf -mattr=-relax %t/shared.s -o %t/shared.o
+# RUN: %llvm-mc -filetype=obj -triple=riscv32-unknown-elf -mattr=-relax %t/refshared.s -o %t/refshared.o
+
+# RUN: %link -shared %t/shared.o -o %t/libbaz.so
+
+# RUN: %not %link %t/a.o -T %t/assign.t -o /dev/null 2>&1 | %filecheck %s --check-prefix=ASSIGN
+# RUN: %not %link %t/a.o -T %t/provide.t -o /dev/null 2>&1 | %filecheck %s --check-prefix=PROVIDE
+# RUN: %not %link %t/baz.o %t/a.o -T %t/section.t -o /dev/null 2>&1 | %filecheck %s --check-prefix=OBJECT
+# RUN: %not %link %t/a.o --defsym baz=0x81090494 -T %t/defsym.t -o /dev/null 2>&1 | %filecheck %s --check-prefix=DEFSYM
+# RUN: %not %link %t/encap.o -T %t/encap.t -o /dev/null 2>&1 | %filecheck %s --check-prefix=INTERNAL
+# RUN: %not %link %t/weak.o -T %t/defsym.t -o /dev/null 2>&1 | %filecheck %s --check-prefix=UNDEF
+# RUN: %not %link %t/refshared.o %t/libbaz.so -T %t/defsym.t -o /dev/null 2>&1 | %filecheck %s --check-prefix=SHARED
+
+# RUN: %not %link %t/baz.o %t/a.o -T %t/sectionprovide.t -o /dev/null 2>&1 | %filecheck %s --check-prefix=OBJECT
+
+# ASSIGN: Error: {{.*}}a.o:(.text): relocation R_RISCV_JAL out of range: {{.*}}; references 'baz'
+
+# PROVIDE: Error: {{.*}}a.o:(.text): relocation R_RISCV_JAL out of range: {{.*}}; references 'baz'
+
+# OBJECT: Error: {{.*}}a.o:(.text): relocation R_RISCV_JAL out of range: {{.*}}; references {{.*}}baz.o('baz')
+
+# DEFSYM: Error: {{.*}}a.o:(.text): relocation R_RISCV_JAL out of range: {{.*}}; references 'baz'
+
+# INTERNAL: Error: {{.*}}encap.o:(.text): relocation R_RISCV_JAL out of range: {{.*}}; references '__start_foo'
+
+# UNDEF:     Error: {{.*}}weak.o:(.text): relocation R_RISCV_JAL out of range: {{.*}}; references 'wk'
+# UNDEF-NOT: defined in
+
+# SHARED: Error: {{.*}}refshared.o:(.text): relocation R_RISCV_JAL out of range: {{.*}}; references {{.*}}libbaz.so('baz')
+
+#--- a.s
+  .option exact
+  .text
+  .globl _start
+_start:
+  jal ra, baz
+
+#--- baz.s
+  .section .baz,"ax",%progbits
+  .globl baz
+baz:
+  nop
+
+#--- assign.t
+baz = 0x81090494;
+SECTIONS {
+  . = 0x812000a0;
+  .text : { *(.text) }
+}
+
+#--- provide.t
+SECTIONS {
+  . = 0x812000a0;
+  .text : { *(.text) }
+}
+PROVIDE(baz = 0x81090494);
+
+#--- section.t
+SECTIONS {
+  . = 0x81090494;
+  .baz : { *(.baz) }
+  . = 0x812000a0;
+  .text : { *(.text) }
+}
+
+#--- sectionprovide.t
+SECTIONS {
+  . = 0x81090494;
+  .baz : { *(.baz) }
+  . = 0x812000a0;
+  .text : { *(.text) }
+}
+PROVIDE(baz = 0x81090494);
+
+#--- weak.s
+  .option exact
+  .text
+  .globl _start
+_start:
+  jal ra, wk
+  .weak wk
+
+#--- shared.s
+  .text
+  .globl baz
+baz:
+  nop
+
+#--- refshared.s
+  .option exact
+  .text
+  .globl _start
+_start:
+  jal ra, baz
+
+#--- defsym.t
+SECTIONS {
+  . = 0x812000a0;
+  .text : { *(.text) }
+}
+
+#--- encap.s
+  .option exact
+  .text
+  .globl _start
+_start:
+  jal ra, __start_foo
+  .section foo,"a",%progbits
+  .long 0
+
+#--- encap.t
+SECTIONS {
+  . = 0x812000a0;
+  .text : { *(.text) }
+  . = 0x91090494;
+  foo : { *(foo) }
+}

--- a/test/RISCV/standalone/Relaxation/RelaxGPSegments/RelaxGPSegments.test
+++ b/test/RISCV/standalone/Relaxation/RelaxGPSegments/RelaxGPSegments.test
@@ -10,6 +10,6 @@
 #RELAXBYTESERR: Verbose: RISCV_PC_GP : Deleting 4 bytes for symbol 'a' in section .text+0xc file {{.*}}tmp.o
 #RELAXBYTESERR: Verbose: RISCV_PC_GP : Deleting 4 bytes for symbol 'a' in section .text+0x10 file {{.*}}tmp.o
 #RELAXBYTESERR: Verbose: RISCV_LUI_GP : Deleting 4 bytes for symbol 'b' in section .text+0x14 file {{.*}}tmp.o
-#RELAXBYTESERR: Error: {{.*}}.o:(.text+0x8):  relocation R_RISCV_GPREL_I out of range: 4352 is not in [-2048, 2047]; references 'a'
-#RELAXBYTESERR: Error: {{.*}}.o:(.text+0xc):  relocation R_RISCV_GPREL_I out of range: 4352 is not in [-2048, 2047]; references 'a'
-#RELAXBYTESERR: Error: {{.*}}.o:(.text+0x10): relocation R_RISCV_GPREL_I out of range: 4352 is not in [-2048, 2047]; references 'a'
+#RELAXBYTESERR: Error: {{.*}}.o:(.text+0x8):  relocation R_RISCV_GPREL_I out of range: 4352 is not in [-2048, 2047]; references {{.*}}('a')
+#RELAXBYTESERR: Error: {{.*}}.o:(.text+0xc):  relocation R_RISCV_GPREL_I out of range: 4352 is not in [-2048, 2047]; references {{.*}}('a')
+#RELAXBYTESERR: Error: {{.*}}.o:(.text+0x10): relocation R_RISCV_GPREL_I out of range: 4352 is not in [-2048, 2047]; references {{.*}}('a')

--- a/test/RISCV/standalone/RelocationOverflow/HI20Overflows/HI20Overflows.test
+++ b/test/RISCV/standalone/RelocationOverflow/HI20Overflows/HI20Overflows.test
@@ -10,5 +10,5 @@ RUN: %llvm-mc -filetype=obj %p/Inputs/1.s -o %t1.1.o
 RUN: %not %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script_1.t 2>&1 | %filecheck %s -check-prefix=OVERFLOW1
 RUN: %not %link %linkopts -o %t1.1.out %t1.1.o -T %p/Inputs/script_2.t 2>&1 | %filecheck %s -check-prefix=OVERFLOW2
 
-OVERFLOW1: Error: {{.*}}1.o:(.text.main): relocation R_RISCV_HI20 out of range: 4026531840 is not in [-2147483648, 2147483647]; references 'global_var'
-OVERFLOW2: Error: {{.*}}1.o:(.text.main): relocation R_RISCV_HI20 out of range: 4294967296 is not in [-2147483648, 2147483647]; references 'global_var'
+OVERFLOW1: Error: {{.*}}1.o:(.text.main): relocation R_RISCV_HI20 out of range: 4026531840 is not in [-2147483648, 2147483647]; references {{.*}}('global_var')
+OVERFLOW2: Error: {{.*}}1.o:(.text.main): relocation R_RISCV_HI20 out of range: 4294967296 is not in [-2147483648, 2147483647]; references {{.*}}('global_var')

--- a/test/lld/ELF/aarch64-abs16.s
+++ b/test/lld/ELF/aarch64-abs16.s
@@ -21,7 +21,7 @@ _start:
 // LE-NEXT: 220158 ffff0080
 
 // RUN: not %link %linkopts %t.o %t255.o -o /dev/null 2>&1 | FileCheck %s --check-prefix=OVERFLOW1
-// OVERFLOW1: Error: {{.*}}.o:(.data+0x2): relocation R_AARCH64_ABS16 out of range: -32769 is not in [-32768, 65535]; references 'foo'
+// OVERFLOW1: Error: {{.*}}.o:(.data+0x2): relocation R_AARCH64_ABS16 out of range: -32769 is not in [-32768, 65535]; references {{.*}}('foo')
 
 // RUN: not %link %linkopts %t.o %t257.o -o /dev/null 2>&1 | FileCheck %s --check-prefix=OVERFLOW2
-// OVERFLOW2: Error: {{.*}}.o:(.data): relocation R_AARCH64_ABS16 out of range: 65536 is not in [-32768, 65535]; references 'foo'
+// OVERFLOW2: Error: {{.*}}.o:(.data): relocation R_AARCH64_ABS16 out of range: 65536 is not in [-32768, 65535]; references {{.*}}('foo')

--- a/test/lld/ELF/aarch64-abs32.s
+++ b/test/lld/ELF/aarch64-abs32.s
@@ -21,7 +21,7 @@ _start:
 // LE-NEXT: 220158 ffffffff 00000080
 
 // RUN: not %link %linkopts %t.o %t255.o -o /dev/null 2>&1 | FileCheck %s --check-prefix=OVERFLOW1
-// OVERFLOW1: Error: {{.*}}.o:(.data+0x4): relocation R_AARCH64_ABS32 out of range: -2147483649 is not in [-2147483648, 4294967295]; references 'foo'
+// OVERFLOW1: Error: {{.*}}.o:(.data+0x4): relocation R_AARCH64_ABS32 out of range: -2147483649 is not in [-2147483648, 4294967295]; references {{.*}}('foo')
 
 // RUN: not %link %linkopts %t.o %t257.o -o /dev/null 2>&1 | FileCheck %s --check-prefix=OVERFLOW2
-// OVERFLOW2: Error: {{.*}}:(.data): relocation R_AARCH64_ABS32 out of range: 4294967296 is not in [-2147483648, 4294967295]; references 'foo'
+// OVERFLOW2: Error: {{.*}}:(.data): relocation R_AARCH64_ABS32 out of range: 4294967296 is not in [-2147483648, 4294967295]; references {{.*}}('foo')


### PR DESCRIPTION
Extend the relocation overflow error diagnostic to show the path and
name for the referenced symbol:

  references \<input-file>('sym')     

Fixes https://github.com/qualcomm/eld/issues/755