### PR TITLE
Link MergeStringRelativeRelocAddend.test directly via %link

### DIFF
--- a/test/x86_64/linux/MergeStringRelativeRelocAddend/MergeStringRelativeRelocAddend.test
+++ b/test/x86_64/linux/MergeStringRelativeRelocAddend/MergeStringRelativeRelocAddend.test
@@ -1,4 +1,3 @@
-REQUIRES: linux
 #--MergeStringAndGOTRelativeReloc.test-----------Executable--------#
 #BEGIN_COMMENT
 # Test: x86_64 merge-string R_X86_64_RELATIVE relocation addend, and the
@@ -32,7 +31,7 @@ REQUIRES: linux
 #START_TEST
 RUN: %clang %clangopts -c %p/Inputs/pad.c -o %t.pad.o -fPIC
 RUN: %clang %clangopts -c %p/Inputs/main.c -o %t.main.o -fPIC
-RUN: %clang %clangopts -fuse-ld=%link -pie %t.pad.o %t.main.o -o %t.out
+RUN: %link %linkopts -pie %t.pad.o %t.main.o -o %t.out
 RUN: %readelf -sr -W %t.out | %filecheck %s
 #END_TEST
 


### PR DESCRIPTION
The test drove its -pie executable link through the clang driver, which auto-injects PIE CRT startup objects (`Scrt1.o`)
from a Linux sysroot. That dependency broke the Windows nightly CI (cannot read file `Scrt1.o`), link directly via `%link` instead.