### PR TITLE
Honor --export-dynamic for PIE executables

### DIFF
--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -812,7 +812,10 @@ bool GNULDBackend::canSkipSymbolFromExport(ResolveInfo *R, bool isEntry) const {
     return false;
   // For PIE, only symbols that really need to be exported are the only ones
   // that can be exported. Dynamic List will control this as well.
-  if (config().options().isPIE() && !isEntry)
+  // --export-dynamic is an explicit request to export all globals, so it
+  // overrides this default restriction.
+  if (config().options().isPIE() && !isEntry &&
+      !config().options().exportDynamic())
     return true;
   if (R->isAbsolute())
     return true;

--- a/test/Common/RunTests/ExportDynamicPIE/ExportDynamicPIE_RUN.test
+++ b/test/Common/RunTests/ExportDynamicPIE/ExportDynamicPIE_RUN.test
@@ -1,0 +1,22 @@
+REQUIRES: run_test
+#--ExportDynamicPIE_RUN.test---------------------Executable--------#
+#BEGIN_COMMENT
+# Run test: --export-dynamic (-E) must export globals to .dynsym for PIE
+# executables, so that a plugin dlopen()'d at runtime can resolve symbols
+# defined in the host executable.
+#
+# main.c defines exported_var/exported_func and links -pie -Wl,--export-dynamic.
+# plugin.c references exported_func without defining it; at runtime, main
+# dlopen()'s plugin.so and calls into it, which calls back into main via
+# exported_func. This only works if the linker actually exported
+# exported_func into main's .dynsym.
+#END_COMMENT
+#START_TEST
+RUN: %run_cc -fPIC -c %p/Inputs/plugin.c -o %t.plugin.o
+RUN: %run_cc -shared %t.plugin.o -o %t.plugin.so
+RUN: %run_cc -fPIC -c %p/Inputs/main.c -o %t.main.o
+RUN: %run_cc -pie %t.main.o -o %t.out -Wl,--export-dynamic -ldl
+RUN: %run %t.out %t.plugin.so | %filecheck %s
+#END_TEST
+
+CHECK: plugin returned: 42

--- a/test/Common/RunTests/ExportDynamicPIE/Inputs/main.c
+++ b/test/Common/RunTests/ExportDynamicPIE/Inputs/main.c
@@ -1,0 +1,23 @@
+#include <dlfcn.h>
+#include <stdio.h>
+
+int exported_var = 42;
+int exported_func(void) { return exported_var; }
+
+int main(int argc, char **argv) {
+  void *handle = dlopen(argv[1], RTLD_NOW);
+  if (!handle) {
+    fprintf(stderr, "dlopen error: %s\n", dlerror());
+    return 1;
+  }
+
+  int (*run_plugin)(void) = dlsym(handle, "run_plugin");
+  if (!run_plugin) {
+    fprintf(stderr, "dlsym error: %s\n", dlerror());
+    return 1;
+  }
+
+  int result = run_plugin();
+  printf("plugin returned: %d\n", result);
+  return 0;
+}

--- a/test/Common/RunTests/ExportDynamicPIE/Inputs/plugin.c
+++ b/test/Common/RunTests/ExportDynamicPIE/Inputs/plugin.c
@@ -1,0 +1,2 @@
+extern int exported_func(void);
+int run_plugin(void) { return exported_func(); }

--- a/test/Common/standalone/ExportDynamicPIE/ExportDynamicPIE.test
+++ b/test/Common/standalone/ExportDynamicPIE/ExportDynamicPIE.test
@@ -1,0 +1,17 @@
+#---ExportDynamicPIE.test--------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# --export-dynamic (-E) must export all global symbols to .dynsym for PIE
+# executables too, not just non-PIE ones. GNULDBackend::canSkipSymbolFromExport
+# used to unconditionally skip exporting non-entry globals for PIE output,
+# ignoring an explicit --export-dynamic request.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -fPIC -c %p/Inputs/1.c -o %t1.o
+RUN: %link %linkopts -pie -E %t1.o -o %t1.out
+RUN: %readelf --dyn-syms %t1.out | %filecheck %s --check-prefix=EXPORTED
+RUN: %link %linkopts -pie %t1.o -o %t2.out
+RUN: %readelf --dyn-syms %t2.out | %filecheck %s --check-prefix=NOTEXPORTED
+#END_TEST
+
+EXPORTED: foo
+NOTEXPORTED-NOT: foo

--- a/test/Common/standalone/ExportDynamicPIE/Inputs/1.c
+++ b/test/Common/standalone/ExportDynamicPIE/Inputs/1.c
@@ -1,0 +1,2 @@
+int foo(void) { return 42; }
+int main(void) { return foo(); }


### PR DESCRIPTION
For PIE output, `canSkipSymbolFromExport()` skipped exporting every global symbol except the entry symbol, even when `--export-dynamic` was passed. As a result, a plugin `dlopen()`'d at runtime could not resolve symbols defined in the host executable.

Let `--export-dynamic` override that restriction.

This PR fixes failing tests in llvm-unit-tests for x86_64 backend

Resolves #1620 