### PR TITLE
[Command Line][Driver] Change version info to be compatible with linux kernel

### DIFF
--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -191,8 +191,16 @@ void GnuLdDriver::printAboutInfo() const {
 }
 
 void GnuLdDriver::printVersionInfo() const {
-  outs() << "eld " << eld::getELDVersion() << " (GNU Compatible linker)"
-         << "\n";
+  // The first line's first two words are deliberately "GNU"/"ld", ending in
+  // nothing but the bare version number. Build systems that identify the
+  // linker by parsing --version output (e.g. the Linux kernel's
+  // scripts/ld-version.sh) look for a first line whose first two words are
+  // exactly "GNU"/"ld" and take the last word on that line as the version;
+  // without this, such scripts reject eld as an "unknown linker". This is
+  // an interim identification (agreed on until eld is proposed/added to the
+  // kernel community's own linker-detection logic) -- not a claim that eld
+  // is GNU ld.
+  outs() << "GNU ld compatible linker - eld " << eld::getELDVersion() << "\n";
   outs() << "Supported Targets: ";
   for (const auto &x : m_SupportedTargets)
     outs() << x << " ";

--- a/test/Common/standalone/printVersion/printVersion.test
+++ b/test/Common/standalone/printVersion/printVersion.test
@@ -6,5 +6,5 @@
 RUN: %link --version 2>&1 | %filecheck %s
 RUN: %link --about 2>&1 | %filecheck %s -check-prefix=ABOUT
 
-#CHECK: eld {{.*}} (GNU Compatible linker)
+#CHECK: GNU ld compatible linker - eld {{.*}}
 #ABOUT: Linker Plugin Interface Version {{[[:xdigit:]]+}}.{{[[:xdigit:]]+}}


### PR DESCRIPTION
The Linux kernel only recognizes LLD and GNU LD as valid linkers. For now, the version information of ELD will be changed to be compatible with GNU. Eventually, this will be reverted after ELD is recognized as a valid linker for the Linux kernel.

Fix: qualcomm#1621