### PR TITLE
[command-line] Add --[no-]warn-rwx-segments

### DIFF
--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -343,6 +343,11 @@ public:
 
   bool warnSharedTextrel() const { return BWarnSharedTextrel; }
 
+  // --no-warn-rwx-segments
+  void setWarnRWXSegments(bool V = true) { BWarnRWXSegments = V; }
+
+  bool warnRWXSegments() const { return BWarnRWXSegments; }
+
   void setDefineCommon(bool PEnable = true) { BDefineCommon = PEnable; }
 
   bool isDefineCommon() const { return BDefineCommon; }
@@ -1255,6 +1260,7 @@ private:
   bool BStripDebug = false;        // -S, --strip-debug
   bool BExportDynamic = false;     //-E, --export-dynamic
   bool BWarnSharedTextrel = false; // --warn-shared-textrel
+  bool BWarnRWXSegments = true;    // --no-warn-rwx-segments
   bool BWarnCommon = false;        // --warn-common
   bool BDefineCommon = false;      // -d, -dc, -dp
   bool BFatalWarnings = false;     // --fatal-warnings

--- a/include/eld/Diagnostics/DiagCommonKinds.inc
+++ b/include/eld/Diagnostics/DiagCommonKinds.inc
@@ -56,6 +56,8 @@ DIAG(symdef_incompatible_option, DiagnosticEngine::Fatal,
      "SymDef files are valid only when building executables")
 DIAG(warn_shared_textrel, DiagnosticEngine::Warning,
      "Add DT_TEXTREL in a shared object!")
+DIAG(warn_rwx_segment, DiagnosticEngine::Warning,
+     "'%0' has loadable segment(s) with RWX permissions")
 DIAG(err_invalid_emulation, DiagnosticEngine::Error,
      "Invalid target emulation: `%0'.")
 DIAG(err_cannot_find_scriptfile, DiagnosticEngine::Fatal,

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -657,6 +657,14 @@ def no_warn_shared_textrel : FF<"no-warn-shared-textrel">,
                              HelpText<"Don't Warn if the linker adds a "
                                       "DT_TEXTREL">,
                              Group<grp_dynlib>;
+def warn_rwx_segments : FF<"warn-rwx-segments">,
+                        HelpText<"Warn if the linker creates a segment with "
+                                 "RWX permissions (default)">,
+                        Group<grp_general>;
+def no_warn_rwx_segments : FF<"no-warn-rwx-segments">,
+                           HelpText<"Silence warnings for segments with RWX "
+                                    "permissions">,
+                           Group<grp_general>;
 defm Bsymbolic : mDashComp<"Bsymbolic", "Bind references to global symbols to "
                            "the definition within the shared library">,
                  Group<grp_dynlib>;

--- a/include/eld/Target/GNULDBackend.h
+++ b/include/eld/Target/GNULDBackend.h
@@ -512,6 +512,8 @@ public:
   /// Script
   bool createScriptProgramHdrs();
 
+  void warnRWXSegments();
+
   bool assignOffsets(uint64_t Offset);
 
   void evaluateAssignments(OutputSectionEntry *output);

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -595,6 +595,10 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
   Config.options().setWarnSharedTextrel(Args.hasFlag(
       T::warn_shared_textrel, T::no_warn_shared_textrel, /*default=*/false));
 
+  // --[no-]warn-rwx-segments
+  Config.options().setWarnRWXSegments(Args.hasFlag(
+      T::warn_rwx_segments, T::no_warn_rwx_segments, /*default=*/true));
+
   // --warn-common
   if (Args.hasArg(T::warn_common))
     Config.options().setWarnCommon();

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -4231,6 +4231,10 @@ bool GNULDBackend::relax() {
   // Print memory regions
   printMemoryRegionsUsage();
 
+  // Warn about RWX segments after the final layout is known.
+  if (LinkerConfig::Object != config().codeGenType())
+    warnRWXSegments();
+
   // Verify memory regions
   verifyMemoryRegions();
 
@@ -5557,3 +5561,18 @@ void GNULDBackend::assignOutputVersionIDs() {
   }
 }
 #endif
+
+void GNULDBackend::warnRWXSegments() {
+  if (!config().options().warnRWXSegments())
+    return;
+  for (auto *Seg : elfSegmentTable()) {
+    if (!Seg->isLoadSegment())
+      continue;
+    uint32_t f = Seg->flag();
+    if ((f & llvm::ELF::PF_W) && (f & llvm::ELF::PF_X)) {
+      config().raise(Diag::warn_rwx_segment)
+          << config().options().outputFileName();
+      return;
+    }
+  }
+}

--- a/test/Common/standalone/WarnRWXSegments/Inputs/1.c
+++ b/test/Common/standalone/WarnRWXSegments/Inputs/1.c
@@ -1,0 +1,1 @@
+int foo(void) { return 42; }

--- a/test/Common/standalone/WarnRWXSegments/Inputs/rwx.t
+++ b/test/Common/standalone/WarnRWXSegments/Inputs/rwx.t
@@ -1,0 +1,7 @@
+PHDRS {
+  text PT_LOAD FLAGS(7);
+}
+SECTIONS {
+  .text : { *(.text*) } :text
+  .data : { *(.data*) } :text
+}

--- a/test/Common/standalone/WarnRWXSegments/Inputs/rwx2.t
+++ b/test/Common/standalone/WarnRWXSegments/Inputs/rwx2.t
@@ -1,0 +1,8 @@
+PHDRS {
+  seg0 PT_LOAD FLAGS(7);
+  seg1 PT_LOAD FLAGS(7);
+}
+SECTIONS {
+  .foo 0x1000 : { *(.text.foo) } :seg0
+  .bar 0x2000 : { *(.text.bar) } :seg1
+}

--- a/test/Common/standalone/WarnRWXSegments/WarnRWXSegments.test
+++ b/test/Common/standalone/WarnRWXSegments/WarnRWXSegments.test
@@ -1,0 +1,35 @@
+#---WarnRWXSegments.test--------------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# Test --[no-]warn-rwx-segments option.
+# By default the linker warns when a PT_LOAD segment has RWX permissions.
+# --no-warn-rwx-segments suppresses the warning.
+# --warn-rwx-segments restores it.
+# Non-PT_LOAD segments with RWX (e.g. PT_GNU_STACK via -z execstack) must
+# not trigger the warning.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.o
+
+# Default: warning is emitted for a PT_LOAD with RWX permissions.
+RUN: %link %linkopts %t.o -T %p/Inputs/rwx.t -o %t.out 2>&1 | %filecheck %s --check-prefix=WARN
+
+# --no-warn-rwx-segments: warning is suppressed.
+RUN: %link %linkopts %t.o -T %p/Inputs/rwx.t --no-warn-rwx-segments -o %t.out 2>&1 | %filecheck %s --allow-empty --check-prefix=NOWARN
+
+# --warn-rwx-segments: warning is emitted (explicit enable).
+RUN: %link %linkopts %t.o -T %p/Inputs/rwx.t --warn-rwx-segments -o %t.out 2>&1 | %filecheck %s --check-prefix=WARN
+
+# -z execstack makes PT_GNU_STACK RWX but must NOT trigger the warning.
+RUN: %link %linkopts %t.o -z execstack -o %t.execstack.out 2>&1 | %filecheck %s --allow-empty --check-prefix=NOWARN
+
+# Two RWX PT_LOAD segments: warning must appear exactly once.
+RUN: %link %linkopts %t.o -T %p/Inputs/rwx2.t -o %t.out2 2>&1 | %filecheck %s --check-prefix=WARN-ONCE
+
+# No RWX segments: no warning.
+RUN: %link %linkopts %t.o -o %t.norwx.out 2>&1 | %filecheck %s --allow-empty --check-prefix=NOWARN
+
+#WARN:          Warning: '{{.*}}' has loadable segment(s) with RWX permissions
+#NOWARN-NOT:    RWX
+#WARN-ONCE:     Warning: '{{.*}}' has loadable segment(s) with RWX permissions
+#WARN-ONCE-NOT: Warning: '{{.*}}' has loadable segment(s) with RWX permissions
+#END_TEST


### PR DESCRIPTION
Warn by default when a PT_LOAD (or any) segment has both write and execute permissions (RWX). The warning can be silenced with --no-warn-rwx-segments and re-enabled with --warn-rwx-segments.

Fixes #1627