### PR TITLE
[LinkerScript] Support VERSION{} block embedded in a -T linker script

### DIFF
--- a/include/eld/Core/Module.h
+++ b/include/eld/Core/Module.h
@@ -607,6 +607,19 @@ public:
     return VersionScripts;
   }
 
+  // Tracks VersionScript objects parsed from a VERSION{} block embedded
+  // directly inside a -T linker script, as opposed to a standalone
+  // --version-script= file. These still need their nodes registered via
+  // ObjectLinker::parseVersionScript(), just not re-parsed from scratch.
+  void addLinkerScriptVersionScript(const VersionScript *VerScr) {
+    LinkerScriptVersionScripts.push_back(VerScr);
+  }
+
+  const llvm::SmallVectorImpl<const VersionScript *> &
+  getLinkerScriptVersionScripts() const {
+    return LinkerScriptVersionScripts;
+  }
+
   bool isLinkStateBeforeLayout() const {
     return getState() == LinkState::BeforeLayout;
   }
@@ -719,6 +732,7 @@ private:
       DynamicListFileToScriptSymbolsMap;
   llvm::StringSet<> OutputSectDescNameSet;
   llvm::SmallVector<const VersionScript *> VersionScripts;
+  llvm::SmallVector<const VersionScript *> LinkerScriptVersionScripts;
   llvm::DenseMap<Fragment *, uint64_t> FragmentPaddingValues;
   PluginManager PM;
   NamePool SymbolNamePool;

--- a/include/eld/Object/ObjectLinker.h
+++ b/include/eld/Object/ObjectLinker.h
@@ -406,6 +406,11 @@ private:
   /// - Pass 3: * wildcard (reverse order, last wins, lowest priority)
   void assignVersionNodesToSymbols();
 
+  /// Validates and registers every node of a single parsed VersionScript
+  /// DecoratedPath is used only for diagnostics.
+  bool registerVersionScriptNodes(const VersionScript *VS,
+                                  llvm::StringRef DecoratedPath);
+
   std::unique_ptr<llvm::lto::LTO> ltoInit(llvm::lto::Config Conf,
                                           bool CompileToAssembly);
 

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -247,6 +247,12 @@ bool ObjectLinker::readLinkerScript(InputFile *Input) {
       return false;
   }
 
+  // A -T script may embed its own VERSION{} block. Record it now so
+  // parseVersionScript() can register its nodes later, once the target
+  // backend is guaranteed to be initialized, which is not yet the case here.
+  if (S->getVersionScript())
+    ThisModule->addLinkerScriptVersionScript(S->getVersionScript());
+
   Input->setUsed(true);
 
   return true;
@@ -350,63 +356,79 @@ bool ObjectLinker::normalize() {
 // FIXME: We should maybe parse version script after reading LTO-generated
 // object files.
 bool ObjectLinker::parseVersionScript() {
-  if (!ThisConfig.options().hasVersionScript())
-    return true;
-  LayoutInfo *layoutInfo = ThisModule->getLayoutInfo();
-  for (const auto &List : ThisConfig.options().getVersionScripts()) {
-    Input *VersionScriptInput =
-        eld::make<Input>(List, ThisConfig.getDiagEngine(), Input::Script);
-    if (!VersionScriptInput->resolvePath(ThisConfig))
-      return false;
-    // Create an Input file and set the input file to be of kind DynamicList
-    InputFile *VersionScriptInputFile =
-        InputFile::create(VersionScriptInput, InputFile::GNULinkerScriptKind,
-                          ThisConfig.getDiagEngine());
-    addInputFileToTar(VersionScriptInputFile, eld::MappingFile::VersionScript);
-    VersionScriptInput->setInputFile(VersionScriptInputFile);
-    // Record the dynamic list script in the Map file.
-    if (layoutInfo)
-      layoutInfo->recordVersionScript(List);
-    // Read the dynamic List file
-    ScriptFile VersionScriptReader(
-        ScriptFile::VersionScript, *ThisModule,
-        *(llvm::dyn_cast<eld::LinkerScriptFile>(VersionScriptInputFile)),
-        ThisModule->getIRBuilder()->getInputBuilder());
-    bool SuccessFullInParse =
-        getScriptReader()->readScript(ThisConfig, VersionScriptReader);
-    if (!SuccessFullInParse)
-      return false;
-    ThisModule->addVersionScript(VersionScriptReader.getVersionScript());
-    for (auto &VersionScriptNode :
-         VersionScriptReader.getVersionScript()->getNodes()) {
-      if (!VersionScriptNode->isAnonymous()) {
-#ifdef ELD_ENABLE_SYMBOL_VERSIONING
-        getTargetBackend().setShouldEmitVersioningSections(true);
-#else
-        ThisConfig.raise(Diag::unsupported_version_node)
-            << VersionScriptInput->decoratedPath();
-        continue;
-#endif
-      }
-      if (VersionScriptNode->hasDependency()) {
-        ThisConfig.raise(Diag::unsupported_dependent_node)
-            << VersionScriptNode->getName()
-            << VersionScriptInput->decoratedPath();
-#ifndef ELD_ENABLE_SYMBOL_VERSIONING
-        continue;
-#endif
-      }
-      // FIXME: Why did we reach here at all if the version script parsing
-      // failed? Shouldn't we have exited before reaching here?
-      if (VersionScriptNode->hasError()) {
-        ThisConfig.raise(Diag::error_parsing_version_script)
-            << VersionScriptInput->decoratedPath();
+  if (ThisConfig.options().hasVersionScript()) {
+    LayoutInfo *layoutInfo = ThisModule->getLayoutInfo();
+    for (const auto &List : ThisConfig.options().getVersionScripts()) {
+      Input *VersionScriptInput =
+          eld::make<Input>(List, ThisConfig.getDiagEngine(), Input::Script);
+      if (!VersionScriptInput->resolvePath(ThisConfig))
         return false;
-      }
-      ThisModule->addVersionScriptNode(VersionScriptNode);
+      // Create an Input file and set the input file to be of kind DynamicList
+      InputFile *VersionScriptInputFile =
+          InputFile::create(VersionScriptInput, InputFile::GNULinkerScriptKind,
+                            ThisConfig.getDiagEngine());
+      addInputFileToTar(VersionScriptInputFile,
+                        eld::MappingFile::VersionScript);
+      VersionScriptInput->setInputFile(VersionScriptInputFile);
+      // Record the dynamic list script in the Map file.
+      if (layoutInfo)
+        layoutInfo->recordVersionScript(List);
+      // Read the dynamic List file
+      ScriptFile VersionScriptReader(
+          ScriptFile::VersionScript, *ThisModule,
+          *(llvm::dyn_cast<eld::LinkerScriptFile>(VersionScriptInputFile)),
+          ThisModule->getIRBuilder()->getInputBuilder());
+      bool SuccessFullInParse =
+          getScriptReader()->readScript(ThisConfig, VersionScriptReader);
+      if (!SuccessFullInParse)
+        return false;
+      ThisModule->addVersionScript(VersionScriptReader.getVersionScript());
+      if (!registerVersionScriptNodes(VersionScriptReader.getVersionScript(),
+                                      VersionScriptInput->decoratedPath()))
+        return false;
     }
   }
+
+  // VersionScript objects parsed from a VERSION{} block embedded directly
+  // inside a -T linker script (recorded by readLinkerScript(), which runs
+  // before the target backend is guaranteed to exist). Process them here,
+  // where registerVersionScriptNodes() can safely touch the backend.
+  for (const VersionScript *VS : ThisModule->getLinkerScriptVersionScripts()) {
+    if (!registerVersionScriptNodes(
+            VS, VS->getInputFile()->getInput()->decoratedPath()))
+      return false;
+  }
+
   assignVersionNodesToSymbols();
+  return true;
+}
+
+bool ObjectLinker::registerVersionScriptNodes(const VersionScript *VS,
+                                              llvm::StringRef DecoratedPath) {
+  for (auto &VersionScriptNode : VS->getNodes()) {
+    if (!VersionScriptNode->isAnonymous()) {
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+      getTargetBackend().setShouldEmitVersioningSections(true);
+#else
+      ThisConfig.raise(Diag::unsupported_version_node) << DecoratedPath;
+      continue;
+#endif
+    }
+    if (VersionScriptNode->hasDependency()) {
+      ThisConfig.raise(Diag::unsupported_dependent_node)
+          << VersionScriptNode->getName() << DecoratedPath;
+#ifndef ELD_ENABLE_SYMBOL_VERSIONING
+      continue;
+#endif
+    }
+    // FIXME: Why did we reach here at all if the version script parsing
+    // failed? Shouldn't we have exited before reaching here?
+    if (VersionScriptNode->hasError()) {
+      ThisConfig.raise(Diag::error_parsing_version_script) << DecoratedPath;
+      return false;
+    }
+    ThisModule->addVersionScriptNode(VersionScriptNode);
+  }
   return true;
 }
 

--- a/test/Common/standalone/VersionInLinkerScript/Inputs/1.c
+++ b/test/Common/standalone/VersionInLinkerScript/Inputs/1.c
@@ -1,0 +1,3 @@
+int exported_symbol(void) { return 42; }
+
+int internal_symbol(void) { return 1; }

--- a/test/Common/standalone/VersionInLinkerScript/Inputs/script.lds
+++ b/test/Common/standalone/VersionInLinkerScript/Inputs/script.lds
@@ -1,0 +1,14 @@
+SECTIONS
+{
+  .text : { *(.text) }
+}
+
+VERSION
+{
+  V1 {
+  global:
+    exported_symbol;
+  local:
+    *;
+  };
+}

--- a/test/Common/standalone/VersionInLinkerScript/VersionInLinkerScript.test
+++ b/test/Common/standalone/VersionInLinkerScript/VersionInLinkerScript.test
@@ -1,0 +1,26 @@
+REQUIRES: symbol_versioning
+#---VersionInLinkerScript.test-------------------------------------------------#
+#BEGIN_COMMENT
+# This test verifies that the linker applies a VERSION{} block that is
+# embedded directly inside a -T linker script (mixed together with
+# SECTIONS), rather than only recognizing VERSION{} in a separate
+# --version-script= file. This is the idiom used by VDSO linker scripts in
+# glibc/musl/the Linux kernel.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -fPIC
+RUN: %link %linkopts -o %t1.1.so %t1.1.o -shared -T %p/Inputs/script.lds
+RUN: %readelf --dyn-syms --version-info %t1.1.so | %filecheck %s
+#END_TEST
+
+CHECK: Symbol table '.dynsym' contains 2 entries:
+CHECK-NOT: internal_symbol
+CHECK: exported_symbol@@V1
+CHECK-NOT: internal_symbol
+
+CHECK: '.gnu.version' contains 2 entries:
+CHECK: 0 (*local*)
+
+CHECK: '.gnu.version_d' contains 2 entries:
+CHECK: Name: {{[^ /\\]+}}1.1.so
+CHECK: Name: V1


### PR DESCRIPTION
ld.eld only applied symbol versioning when passed via --version-script=<file>; a VERSION{} block embedded directly inside a -T linker script (mixed with SECTIONS/PHDRS) was silently ignored -- no .gnu.version/.gnu.version_d sections, and local: *; never demoted non-matching symbols. ld.lld already handles this. This is the idiom used by VDSO linker scripts in glibc, musl, and the Linux kernel.

Track each -T script's parsed VersionScript on Module as it's activated, and register its nodes from parseVersionScript() alongside --version-script= files, via a shared helper. Registration happens later than parsing because the target backend isn't guaranteed to be initialized yet when a -T script is first read.

Add VersionInLinkerScript test covering a -T script with an embedded VERSION{} block.

Fix: qualcomm#1626