### PR TITLE
[TLS] Fix TLS template size with multiple padded PT_TLS segments

### DIFF
--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -99,6 +99,7 @@
 #include <chrono>
 #include <climits>
 #include <cstring>
+#include <limits>
 #include <map>
 #include <string>
 #include <vector>
@@ -2599,10 +2600,21 @@ bool GNULDBackend::setupProgramHdrs() {
         elfSegmentTable().getSegments(llvm::ELF::PT_TLS);
     if (!tls_segs.size())
       return true;
-    uint64_t memsz = 0;
-    for (auto &seg : tls_segs)
-      memsz += seg->memsz();
-    setTLSTemplateSize(memsz);
+    // The TLS template size is the memory span covered by all PT_TLS
+    // segments, i.e. from the lowest segment vaddr to the highest
+    // (vaddr + memsz). This must include any alignment padding *between*
+    // segments (e.g. between .tdata and an over-aligned .tbss placed in a
+    // separate PT_TLS segment). Simply summing each segment's memsz would
+    // drop that inter-segment padding and produce a TLS template size that
+    // disagrees with the runtime thread-pointer setup, corrupting every
+    // TP-relative (TPREL) relocation.
+    uint64_t lo = std::numeric_limits<uint64_t>::max();
+    uint64_t hi = 0;
+    for (auto &seg : tls_segs) {
+      lo = std::min(lo, seg->vaddr());
+      hi = std::max(hi, seg->vaddr() + seg->memsz());
+    }
+    setTLSTemplateSize(hi - lo);
   }
   return true;
 }

--- a/test/Hexagon/standalone/TLS/MultipleTLSSegmentsPadding/Inputs/a.s
+++ b/test/Hexagon/standalone/TLS/MultipleTLSSegmentsPadding/Inputs/a.s
@@ -1,0 +1,26 @@
+        .text
+        .globl  main
+        .type   main,@function
+main:
+        jumpr r31
+        .size main, .-main
+
+        .section .tdata,"awT",@progbits
+        .globl a
+        .p2align 2
+a:
+        .word 1
+        .size a, 4
+
+        .section .tbss,"awT",@nobits
+        .globl b
+        .p2align 6
+b:
+        .space 4
+        .size b, 4
+
+        .data
+        .globl refs
+refs:
+        .word a@TPREL
+        .word b@TPREL

--- a/test/Hexagon/standalone/TLS/MultipleTLSSegmentsPadding/Inputs/script.t
+++ b/test/Hexagon/standalone/TLS/MultipleTLSSegmentsPadding/Inputs/script.t
@@ -1,0 +1,12 @@
+PHDRS {
+  text PT_LOAD;
+  data PT_LOAD;
+  tls_init PT_TLS;
+  tls PT_TLS;
+}
+SECTIONS {
+  .text 0x100000 : { *(.text*) } :text
+  .data 0x200000 : { *(.data*) } :data
+  .tdata         : { *(.tdata*) } :data :tls_init
+  .tbss (NOLOAD) : { *(.tbss*) } :tls
+}

--- a/test/Hexagon/standalone/TLS/MultipleTLSSegmentsPadding/MultipleTLSSegmentsPadding.test
+++ b/test/Hexagon/standalone/TLS/MultipleTLSSegmentsPadding/MultipleTLSSegmentsPadding.test
@@ -1,0 +1,37 @@
+#---MultipleTLSSegmentsPadding.test----------------- Executable,LS ------------#
+#BEGIN_COMMENT
+# When there are multiple PT_TLS segments (e.g. .tdata and .tbss placed in
+# separate segments) and one of them is over-aligned, alignment padding is
+# introduced *between* the segments. The TLS template size that the linker
+# uses to resolve TP-relative (TPREL) relocations must be the memory span
+# covered by all PT_TLS segments, i.e. max(vaddr + memsz) - min(vaddr), which
+# includes that inter-segment padding. Summing each segment's memsz would drop
+# the padding and produce a TLS template size that disagrees with the runtime
+# thread-pointer setup, corrupting every TPREL relocation.
+#
+# A ".word sym@TPREL" data relocation resolves to (sym_tls_offset -
+# TLS_template_size), so it directly exposes the computed TLS template size.
+#
+# Layout produced by script.t (a in .tdata, b in .tbss aligned to 64):
+#   .tdata: a at TLS offset 0x00 (vaddr 0x200040)
+#   .tbss : b at TLS offset 0x40 (vaddr 0x200080, 0x3c bytes of padding)
+#   TLS template size (span) = (0x200080 + 4) - 0x200040 = 0x44
+# Hence:
+#   a@TPREL = 0x00 - 0x44 = -0x44 = 0xffffffbc
+#   b@TPREL = 0x40 - 0x44 = -0x04 = 0xfffffffc
+# A gap-less sum (0x4 + 0x4 = 0x8) would instead give a@TPREL = -0x8 and
+# b@TPREL = +0x38, which is the bug this test guards against.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/a.s -o %t.o
+RUN: %link %linkopts %t.o -T %p/Inputs/script.t -o %t.out
+RUN: %readelf -l -W %t.out | %filecheck %s -check-prefix=SEGMENT
+RUN: %objdump -s -j .data %t.out | %filecheck %s -check-prefix=TPREL
+
+# Two separate PT_TLS segments must be present.
+#SEGMENT-COUNT-2: TLS
+
+# Resolved a@TPREL (0xffffffbc) and b@TPREL (0xfffffffc), little-endian, must
+# account for the inter-segment padding in the TLS template size.
+#TPREL: 200000 bcffffff fcffffff
+#END_TEST


### PR DESCRIPTION
setupProgramHdrs() summed each PT_TLS segment's p_memsz to get the TLS template size. When the TLS block spans multiple PT_TLS segments (e.g. picolibc's separate .tdata/.tbss segments) and one is over-aligned, summing drops the alignment padding between them, producing a size that is too small.

That size is subtracted from a symbol's TLS offset when resolving TP-relative relocations (R_HEX_TPREL_*), so an undersized value shifts every thread-local access by the missing padding and disagrees with the runtime thread-pointer setup.

Compute the size as the span across all PT_TLS segments instead: max(vaddr + memsz) - min(vaddr), which includes inter-segment padding.