### PR TITLE
[linker-script] NFC : Simplify expression evaluation

### DIFF
--- a/include/eld/Script/Expression.h
+++ b/include/eld/Script/Expression.h
@@ -366,17 +366,46 @@ private:
 };
 
 //===----------------------------------------------------------------------===//
-/** \class Add
- *  \brief This class extends an Expression to an Add operator.
+/** \class BinaryOp
+ *  \brief Unified binary operator expression (arithmetic, bitwise, relational,
+ *         logical, and min/max). The operator semantics are determined by the
+ *         expression Type.
  */
-class Add : public Expression {
+class BinaryOp : public Expression {
 public:
-  Add(Module &Module, Expression &Left, Expression &Right)
-      : Expression("+", Expression::ADD, Module), LeftExpression(Left),
+  BinaryOp(llvm::StringRef OpName, Expression::Type T, Module &Module,
+           Expression &Left, Expression &Right)
+      : Expression(OpName.str(), T, Module), LeftExpression(Left),
         RightExpression(Right) {}
 
   // Casting support
-  static bool classof(const Expression *Exp) { return Exp->isAdd(); }
+  static bool classof(const Expression *Exp) {
+    switch (Exp->type()) {
+    case ADD:
+    case SUBTRACT:
+    case MODULO:
+    case MULTIPLY:
+    case DIVIDE:
+    case BITWISE_RS:
+    case BITWISE_LS:
+    case GT:
+    case LT:
+    case GTE:
+    case LTE:
+    case EQ:
+    case NEQ:
+    case LOGICAL_OR:
+    case LOGICAL_AND:
+    case BITWISE_AND:
+    case BITWISE_XOR:
+    case BITWISE_OR:
+    case MAX:
+    case MIN:
+      return true;
+    default:
+      return false;
+    }
+  }
 
 private:
   bool hasDot() const override;
@@ -388,117 +417,16 @@ private:
   Expression *getLeftExpression() const override { return &LeftExpression; }
   Expression *getRightExpression() const override { return &RightExpression; }
 
-  Expression &LeftExpression;  /// represents the left hand operand.
-  Expression &RightExpression; /// represents the right hand operand.
+  Expression &LeftExpression;
+  Expression &RightExpression;
 };
 
-//===----------------------------------------------------------------------===//
-/** \class Subtract
- *  \brief This class extends an Expression to a Subtraction operator.
- */
-class Subtract : public Expression {
-public:
-  Subtract(Module &Module, Expression &Left, Expression &Right)
-      : Expression("-", Expression::SUBTRACT, Module), LeftExpression(Left),
-        RightExpression(Right) {}
-
-  // Casting support
-  static bool classof(const Expression *Exp) { return Exp->isSubtract(); }
-
-private:
-  bool hasDot() const override;
-  void commit() override;
-  void dump(llvm::raw_ostream &Outs, bool WithValues = true) const override;
-  eld::Expected<uint64_t> evalImpl() override;
-  void getSymbols(std::vector<ResolveInfo *> &Symbols) override;
-  void getSymbolNames(std::unordered_set<std::string> &SymbolTokens) override;
-  Expression *getLeftExpression() const override { return &LeftExpression; }
-  Expression *getRightExpression() const override { return &RightExpression; }
-
-  Expression &LeftExpression;  /// represents the left hand operand.
-  Expression &RightExpression; /// represents the right hand operand.
-};
-
-//===----------------------------------------------------------------------===//
-/** \class Modulo
- *  \brief This class extends an Expression to a Modulus operator.
- */
-class Modulo : public Expression {
-public:
-  Modulo(Module &Module, Expression &Left, Expression &Right)
-      : Expression("%", Expression::MODULO, Module), LeftExpression(Left),
-        RightExpression(Right) {}
-
-  // Casting support
-  static bool classof(const Expression *Exp) { return Exp->isModulo(); }
-
-private:
-  bool hasDot() const override;
-  void commit() override;
-  void dump(llvm::raw_ostream &Outs, bool WithValues = true) const override;
-  eld::Expected<uint64_t> evalImpl() override;
-  void getSymbols(std::vector<ResolveInfo *> &Symbols) override;
-  void getSymbolNames(std::unordered_set<std::string> &SymbolTokens) override;
-  Expression *getLeftExpression() const override { return &LeftExpression; }
-  Expression *getRightExpression() const override { return &RightExpression; }
-
-  Expression &LeftExpression;  /// represents the left hand operand.
-  Expression &RightExpression; /// represents the right hand operand.
-};
-
-//===----------------------------------------------------------------------===//
-/** \class Multiply
- *  \brief This class extends an Expression to a Multiply operator.
- */
-class Multiply : public Expression {
-public:
-  Multiply(Module &Module, Expression &Left, Expression &Right)
-      : Expression("*", Expression::MULTIPLY, Module), LeftExpression(Left),
-        RightExpression(Right) {}
-
-  // Casting support
-  static bool classof(const Expression *Exp) { return Exp->isMultiply(); }
-
-private:
-  bool hasDot() const override;
-  void commit() override;
-  void dump(llvm::raw_ostream &Outs, bool WithValues = true) const override;
-  eld::Expected<uint64_t> evalImpl() override;
-  void getSymbols(std::vector<ResolveInfo *> &Symbols) override;
-  void getSymbolNames(std::unordered_set<std::string> &SymbolTokens) override;
-  Expression *getLeftExpression() const override { return &LeftExpression; }
-  Expression *getRightExpression() const override { return &RightExpression; }
-
-  Expression &LeftExpression;  /// represents the left hand operand.
-  Expression &RightExpression; /// represents the right hand operand.
-};
-
-//===----------------------------------------------------------------------===//
-/** \class Divide
- *  \brief This class extends an Expression to a Divide operator.
- */
-class Divide : public Expression {
-public:
-  Divide(Module &Module, Expression &Left, Expression &Right)
-      : Expression("/", Expression::DIVIDE, Module), LeftExpression(Left),
-        RightExpression(Right) {}
-
-  // Casting support
-  static bool classof(const Expression *Exp) { return Exp->isDivide(); }
-
-private:
-  bool hasDot() const override;
-  void commit() override;
-  void dump(llvm::raw_ostream &Outs, bool WithValues = true) const override;
-  eld::Expected<uint64_t> evalImpl() override;
-  void getSymbols(std::vector<ResolveInfo *> &Symbols) override;
-  void getSymbolNames(std::unordered_set<std::string> &SymbolTokens) override;
-  Expression *getLeftExpression() const override { return &LeftExpression; }
-  Expression *getRightExpression() const override { return &RightExpression; }
-
-  Expression &LeftExpression;  /// represents the left hand operand.
-  Expression &RightExpression; /// represents the right hand operand.
-};
+// Type aliases kept for call-site compatibility.
+using Add = BinaryOp;
+using Subtract = BinaryOp;
+using Modulo = BinaryOp;
+using Multiply = BinaryOp;
+using Divide = BinaryOp;
 
 //===----------------------------------------------------------------------===//
 /** \class SizeOf
@@ -738,183 +666,37 @@ private:
   Expression &RightExpression;     /// represents the right hand expression.
 };
 
-//===----------------------------------------------------------------------===//
-/** \class ConditionGT
- *  \brief This class extends an Expression to a GreaterThan operator.
- */
-class ConditionGT : public Expression {
-public:
-  ConditionGT(Module &Module, Expression &Left, Expression &Right)
-      : Expression(">", Expression::GT, Module), LeftExpression(Left),
-        RightExpression(Right) {}
-
-  // Casting support
-  static bool classof(const Expression *Exp) { return Exp->isGreater(); }
-
-private:
-  bool hasDot() const override;
-  void commit() override;
-  void dump(llvm::raw_ostream &Outs, bool WithValues = true) const override;
-  eld::Expected<uint64_t> evalImpl() override;
-  void getSymbols(std::vector<ResolveInfo *> &Symbols) override;
-  void getSymbolNames(std::unordered_set<std::string> &SymbolTokens) override;
-  Expression *getLeftExpression() const override { return &LeftExpression; }
-  Expression *getRightExpression() const override { return &RightExpression; }
-
-  Expression &LeftExpression;  /// represents the left hand expression.
-  Expression &RightExpression; /// represents the right hand expression.
-};
+// Condition operator aliases — all implemented by BinaryOp.
+using ConditionGT = BinaryOp;
+using ConditionLT = BinaryOp;
+using ConditionEQ = BinaryOp;
+using ConditionGTE = BinaryOp;
+using ConditionLTE = BinaryOp;
+using ConditionNEQ = BinaryOp;
 
 //===----------------------------------------------------------------------===//
-/** \class ConditionLT
- *  \brief This class extends an Expression to a LessThan operator.
+/** \class UnaryOp
+ *  \brief Unified unary operator expression (complement, unary plus/minus/not).
+ *         The operator semantics are determined by the expression Type.
  */
-class ConditionLT : public Expression {
+class UnaryOp : public Expression {
 public:
-  ConditionLT(Module &Module, Expression &Left, Expression &Right)
-      : Expression("<", Expression::LT, Module), LeftExpression(Left),
-        RightExpression(Right) {}
-
-  // Casting support
-  static bool classof(const Expression *Exp) { return Exp->isLessThan(); }
-
-private:
-  bool hasDot() const override;
-  void commit() override;
-  void dump(llvm::raw_ostream &Outs, bool WithValues = true) const override;
-  eld::Expected<uint64_t> evalImpl() override;
-  void getSymbols(std::vector<ResolveInfo *> &Symbols) override;
-  void getSymbolNames(std::unordered_set<std::string> &SymbolTokens) override;
-  Expression *getLeftExpression() const override { return &LeftExpression; }
-  Expression *getRightExpression() const override { return &RightExpression; }
-
-  Expression &LeftExpression;  /// represents the left hand expression.
-  Expression &RightExpression; /// represents the right hand expression.
-};
-
-//===----------------------------------------------------------------------===//
-/** \class ConditionEQ
- *  \brief This class extends an Expression to an EqualTo operator.
- */
-class ConditionEQ : public Expression {
-public:
-  ConditionEQ(Module &Module, Expression &Left, Expression &Right)
-      : Expression("==", Expression::EQ, Module), LeftExpression(Left),
-        RightExpression(Right) {}
-
-  // Casting support
-  static bool classof(const Expression *Exp) { return Exp->isEqual(); }
-
-private:
-  bool hasDot() const override;
-  void commit() override;
-  void dump(llvm::raw_ostream &Outs, bool WithValues = true) const override;
-  eld::Expected<uint64_t> evalImpl() override;
-  void getSymbols(std::vector<ResolveInfo *> &Symbols) override;
-  void getSymbolNames(std::unordered_set<std::string> &SymbolTokens) override;
-  Expression *getLeftExpression() const override { return &LeftExpression; }
-  Expression *getRightExpression() const override { return &RightExpression; }
-
-  Expression &LeftExpression;  /// represents the left hand expression.
-  Expression &RightExpression; /// represents the right hand expression.
-};
-
-//===----------------------------------------------------------------------===//
-/** \class ConditionGTE
- *  \brief This class extends an Expression to a GreaterThanEqual operator.
- */
-class ConditionGTE : public Expression {
-public:
-  ConditionGTE(Module &Module, Expression &Left, Expression &Right)
-      : Expression(">=", Expression::GTE, Module), LeftExpression(Left),
-        RightExpression(Right) {}
+  UnaryOp(llvm::StringRef OpName, Expression::Type T, Module &Module,
+          Expression &Expr)
+      : Expression(OpName.str(), T, Module), ExpressionToEvaluate(Expr) {}
 
   // Casting support
   static bool classof(const Expression *Exp) {
-    return Exp->isGreaterThanOrEqual();
+    switch (Exp->type()) {
+    case COM:
+    case UNARYPLUS:
+    case UNARYMINUS:
+    case UNARYNOT:
+      return true;
+    default:
+      return false;
+    }
   }
-
-private:
-  bool hasDot() const override;
-  void commit() override;
-  void dump(llvm::raw_ostream &Outs, bool WithValues = true) const override;
-  eld::Expected<uint64_t> evalImpl() override;
-  void getSymbols(std::vector<ResolveInfo *> &Symbols) override;
-  void getSymbolNames(std::unordered_set<std::string> &SymbolTokens) override;
-  Expression *getLeftExpression() const override { return &LeftExpression; }
-  Expression *getRightExpression() const override { return &RightExpression; }
-
-  Expression &LeftExpression;  /// represents the left hand expression.
-  Expression &RightExpression; /// represents the right hand expression.
-};
-
-//===----------------------------------------------------------------------===//
-/** \class ConditionLTE
- *  \brief This class extends an Expression to a LessThanEqual operator.
- */
-class ConditionLTE : public Expression {
-public:
-  ConditionLTE(Module &Module, Expression &Left, Expression &Right)
-      : Expression("<=", Expression::LTE, Module), LeftExpression(Left),
-        RightExpression(Right) {}
-
-  // Casting support
-  static bool classof(const Expression *Exp) {
-    return Exp->isLesserThanOrEqual();
-  }
-
-private:
-  bool hasDot() const override;
-  void commit() override;
-  void dump(llvm::raw_ostream &Outs, bool WithValues = true) const override;
-  eld::Expected<uint64_t> evalImpl() override;
-  void getSymbols(std::vector<ResolveInfo *> &Symbols) override;
-  void getSymbolNames(std::unordered_set<std::string> &SymbolTokens) override;
-  Expression *getLeftExpression() const override { return &LeftExpression; }
-  Expression *getRightExpression() const override { return &RightExpression; }
-
-  Expression &LeftExpression;  /// represents the left hand expression.
-  Expression &RightExpression; /// represents the right hand expression.
-};
-
-//===----------------------------------------------------------------------===//
-/** \class ConditionNEQ
- *  \brief This class extends an Expression to an NotEqualTo operator.
- */
-class ConditionNEQ : public Expression {
-public:
-  ConditionNEQ(Module &Module, Expression &Left, Expression &Right)
-      : Expression("!=", Expression::NEQ, Module), LeftExpression(Left),
-        RightExpression(Right) {}
-
-  // Casting support
-  static bool classof(const Expression *Exp) { return Exp->isNotEqual(); }
-
-private:
-  bool hasDot() const override;
-  void commit() override;
-  void dump(llvm::raw_ostream &Outs, bool WithValues = true) const override;
-  eld::Expected<uint64_t> evalImpl() override;
-  void getSymbols(std::vector<ResolveInfo *> &Symbols) override;
-  void getSymbolNames(std::unordered_set<std::string> &SymbolTokens) override;
-  Expression *getLeftExpression() const override { return &LeftExpression; }
-  Expression *getRightExpression() const override { return &RightExpression; }
-
-  Expression &LeftExpression;  /// represents the left hand expression.
-  Expression &RightExpression; /// represents the right hand expression.
-};
-
-//===----------------------------------------------------------------------===//
-/** \class Complement
- *  \brief This class extends an Expression to a Complement operator.
- */
-class Complement : public Expression {
-public:
-  Complement(Module &Module, Expression &Expr)
-      : Expression("~", Expression::COM, Module), ExpressionToEvaluate(Expr) {}
-
-  // Casting support
-  static bool classof(const Expression *Exp) { return Exp->isComplement(); }
 
 private:
   bool hasDot() const override;
@@ -928,92 +710,14 @@ private:
     return &ExpressionToEvaluate;
   }
 
-  Expression &ExpressionToEvaluate; /// represents the expression to complement
+  Expression &ExpressionToEvaluate;
 };
 
-//===----------------------------------------------------------------------===//
-/** \class UnaryPlus
- *  \brief This class extends an Expression to a UnaryPlus operator.
- */
-class UnaryPlus : public Expression {
-public:
-  UnaryPlus(Module &Module, Expression &Expr)
-      : Expression("+", Expression::UNARYMINUS, Module),
-        ExpressionToEvaluate(Expr) {}
-
-  // Casting support
-  static bool classof(const Expression *Exp) { return Exp->isUnaryPlus(); }
-
-private:
-  bool hasDot() const override;
-  void commit() override;
-  void dump(llvm::raw_ostream &Outs, bool WithValues = true) const override;
-  eld::Expected<uint64_t> evalImpl() override;
-  void getSymbols(std::vector<ResolveInfo *> &Symbols) override;
-  void getSymbolNames(std::unordered_set<std::string> &SymbolTokens) override;
-  Expression *getLeftExpression() const override { return nullptr; }
-  Expression *getRightExpression() const override {
-    return &ExpressionToEvaluate;
-  }
-
-  Expression &ExpressionToEvaluate; /// represents the expression to complement
-};
-
-//===----------------------------------------------------------------------===//
-/** \class UnaryMinus
- *  \brief This class extends an Expression to a UnaryMinus operator.
- */
-class UnaryMinus : public Expression {
-public:
-  UnaryMinus(Module &Module, Expression &Expr)
-      : Expression("-", Expression::UNARYMINUS, Module),
-        ExpressionToEvaluate(Expr) {}
-
-  // Casting support
-  static bool classof(const Expression *Exp) { return Exp->isUnaryMinus(); }
-
-private:
-  bool hasDot() const override;
-  void commit() override;
-  void dump(llvm::raw_ostream &Outs, bool WithValues = true) const override;
-  eld::Expected<uint64_t> evalImpl() override;
-  void getSymbols(std::vector<ResolveInfo *> &Symbols) override;
-  void getSymbolNames(std::unordered_set<std::string> &SymbolTokens) override;
-  Expression *getLeftExpression() const override { return nullptr; }
-  Expression *getRightExpression() const override {
-    return &ExpressionToEvaluate;
-  }
-
-  Expression &ExpressionToEvaluate; /// represents the expression to complement
-};
-
-//===----------------------------------------------------------------------===//
-/** \class UnaryNot
- *  \brief This class extends an Expression to a UnaryNot operator.
- */
-class UnaryNot : public Expression {
-public:
-  UnaryNot(Module &Module, Expression &Expr)
-      : Expression("!", Expression::UNARYNOT, Module),
-        ExpressionToEvaluate(Expr) {}
-
-  // Casting support
-  static bool classof(const Expression *Exp) { return Exp->isUnaryNot(); }
-
-private:
-  bool hasDot() const override;
-  void commit() override;
-  void dump(llvm::raw_ostream &Outs, bool WithValues = true) const override;
-  eld::Expected<uint64_t> evalImpl() override;
-  void getSymbols(std::vector<ResolveInfo *> &Symbols) override;
-  void getSymbolNames(std::unordered_set<std::string> &SymbolTokens) override;
-  Expression *getLeftExpression() const override { return nullptr; }
-  Expression *getRightExpression() const override {
-    return &ExpressionToEvaluate;
-  }
-
-  Expression &ExpressionToEvaluate; /// represents the expression to complement
-};
+// Unary operator aliases — all implemented by UnaryOp.
+using Complement = UnaryOp;
+using UnaryPlus = UnaryOp;
+using UnaryMinus = UnaryOp;
+using UnaryNot = UnaryOp;
 //===----------------------------------------------------------------------===//
 /** \class Constant
  *  \brief This class extends an Expression to a Constant operator.
@@ -1134,143 +838,13 @@ private:
   std::vector<uint64_t> ArgValues;
 };
 
-/** \class RightShift
- *  \brief This class extends an Expression to a Right Shift operator.
- */
-class RightShift : public Expression {
-public:
-  RightShift(Module &Module, Expression &Left, Expression &Right)
-      : Expression(">>", Expression::BITWISE_RS, Module), LeftExpression(Left),
-        RightExpression(Right) {}
-
-  // Casting support
-  static bool classof(const Expression *Exp) {
-    return Exp->isBitWiseRightShift();
-  }
-
-private:
-  bool hasDot() const override;
-  void commit() override;
-  void dump(llvm::raw_ostream &Outs, bool WithValues = true) const override;
-  eld::Expected<uint64_t> evalImpl() override;
-  void getSymbols(std::vector<ResolveInfo *> &Symbols) override;
-  void getSymbolNames(std::unordered_set<std::string> &SymbolTokens) override;
-  Expression *getLeftExpression() const override { return &LeftExpression; }
-  Expression *getRightExpression() const override { return &RightExpression; }
-
-  Expression &LeftExpression;  /// represents the left hand operand.
-  Expression &RightExpression; /// represents the right hand operand.
-};
-
-//===----------------------------------------------------------------------===//
-/** \class LeftShift
- *  \brief This class extends an Expression to a Left Shift operator.
- */
-class LeftShift : public Expression {
-public:
-  LeftShift(Module &Module, Expression &Left, Expression &Right)
-      : Expression("<<", Expression::BITWISE_LS, Module), LeftExpression(Left),
-        RightExpression(Right) {}
-
-  // Casting support
-  static bool classof(const Expression *Exp) {
-    return Exp->isBitWiseLeftShift();
-  }
-
-private:
-  bool hasDot() const override;
-  void commit() override;
-  void dump(llvm::raw_ostream &Outs, bool WithValues = true) const override;
-  eld::Expected<uint64_t> evalImpl() override;
-  void getSymbols(std::vector<ResolveInfo *> &Symbols) override;
-  void getSymbolNames(std::unordered_set<std::string> &SymbolTokens) override;
-  Expression *getLeftExpression() const override { return &LeftExpression; }
-  Expression *getRightExpression() const override { return &RightExpression; }
-
-  Expression &LeftExpression;  /// represents the left hand operand.
-  Expression &RightExpression; /// represents the right hand operand.
-};
-
-//===----------------------------------------------------------------------===//
-/** \class BitwiseOr
- *  \brief This class extends an Expression to a Bitwise Or operator.
- */
-class BitwiseOr : public Expression {
-public:
-  BitwiseOr(Module &Module, Expression &Left, Expression &Right)
-      : Expression("|", Expression::BITWISE_OR, Module), LeftExpression(Left),
-        RightExpression(Right) {}
-
-  // Casting support
-  static bool classof(const Expression *Exp) { return Exp->isBitWiseOR(); }
-
-private:
-  bool hasDot() const override;
-  void commit() override;
-  void dump(llvm::raw_ostream &Outs, bool WithValues = true) const override;
-  eld::Expected<uint64_t> evalImpl() override;
-  void getSymbols(std::vector<ResolveInfo *> &Symbols) override;
-  void getSymbolNames(std::unordered_set<std::string> &SymbolTokens) override;
-  Expression *getLeftExpression() const override { return &LeftExpression; }
-  Expression *getRightExpression() const override { return &RightExpression; }
-
-  Expression &LeftExpression;  /// represents the left hand operand.
-  Expression &RightExpression; /// represents the right hand operand.
-};
-
-//===----------------------------------------------------------------------===//
-/** \class BitwiseAnd
- *  \brief This class extends an Expression to a Bitwise And operator.
- */
-class BitwiseAnd : public Expression {
-public:
-  BitwiseAnd(Module &Module, Expression &Left, Expression &Right)
-      : Expression("&", Expression::BITWISE_AND, Module), LeftExpression(Left),
-        RightExpression(Right) {}
-
-  // Casting support
-  static bool classof(const Expression *Exp) { return Exp->isBitWiseAND(); }
-
-private:
-  bool hasDot() const override;
-  void commit() override;
-  void dump(llvm::raw_ostream &Outs, bool WithValues = true) const override;
-  eld::Expected<uint64_t> evalImpl() override;
-  void getSymbols(std::vector<ResolveInfo *> &Symbols) override;
-  void getSymbolNames(std::unordered_set<std::string> &SymbolTokens) override;
-  Expression *getLeftExpression() const override { return &LeftExpression; }
-  Expression *getRightExpression() const override { return &RightExpression; }
-
-  Expression &LeftExpression;  /// represents the left hand operand.
-  Expression &RightExpression; /// represents the right hand operand.
-};
-
-//===----------------------------------------------------------------------===//
-/** \class BitwiseXor
- *  \brief This class extends an Expression to a Bitwise Xor operator.
- */
-class BitwiseXor : public Expression {
-public:
-  BitwiseXor(Module &Module, Expression &Left, Expression &Right)
-      : Expression("^", Expression::BITWISE_XOR, Module), LeftExpression(Left),
-        RightExpression(Right) {}
-
-  // Casting support
-  static bool classof(const Expression *Exp) { return Exp->isBitWiseXOR(); }
-
-private:
-  bool hasDot() const override;
-  void commit() override;
-  void dump(llvm::raw_ostream &Outs, bool WithValues = true) const override;
-  eld::Expected<uint64_t> evalImpl() override;
-  void getSymbols(std::vector<ResolveInfo *> &Symbols) override;
-  void getSymbolNames(std::unordered_set<std::string> &SymbolTokens) override;
-  Expression *getLeftExpression() const override { return &LeftExpression; }
-  Expression *getRightExpression() const override { return &RightExpression; }
-
-  Expression &LeftExpression;  /// represents the left hand operand.
-  Expression &RightExpression; /// represents the right hand operand.
-};
+// Bitwise and logical operator aliases — all implemented by BinaryOp.
+using RightShift = BinaryOp;
+using LeftShift = BinaryOp;
+using BitwiseOr = BinaryOp;
+using BitwiseAnd = BinaryOp;
+using BitwiseXor = BinaryOp;
+using LogicalOp = BinaryOp;
 
 //===----------------------------------------------------------------------===//
 /** \class Defined
@@ -1390,61 +964,9 @@ private:
 };
 
 //===----------------------------------------------------------------------===//
-/** \class Max
- *  \brief This class extends an Expression to a Max operator.
- */
-class Max : public Expression {
-public:
-  Max(Module &Module, Expression &Left, Expression &Right)
-      : Expression("MAX", Expression::MAX, Module), LeftExpression(Left),
-        RightExpression(Right) {}
-
-  // Casting support
-  static bool classof(const Expression *Exp) { return Exp->isMax(); }
-
-private:
-  bool hasDot() const override;
-  void commit() override;
-  void dump(llvm::raw_ostream &Outs, bool WithValues = true) const override;
-  eld::Expected<uint64_t> evalImpl() override;
-  void getSymbols(std::vector<ResolveInfo *> &Symbols) override;
-  void getSymbolNames(std::unordered_set<std::string> &SymbolTokens) override;
-  Expression *getLeftExpression() const override { return &LeftExpression; }
-  Expression *getRightExpression() const override { return &RightExpression; }
-
-  Expression &LeftExpression;  /// represents the left hand operand.
-  Expression &RightExpression; /// represents the right hand operand.
-};
-
-//===----------------------------------------------------------------------===//
-/** \class Min
- *  \brief This class extends an Expression to a Min operator.
- */
-class Min : public Expression {
-public:
-  Min(Module &Module, Expression &Left, Expression &Right)
-      : Expression("MIN", Expression::MIN, Module), LeftExpression(Left),
-        RightExpression(Right) {}
-
-  // Casting support
-  static bool classof(const Expression *Exp) { return Exp->isMin(); }
-
-private:
-  bool hasDot() const override;
-  void commit() override;
-  void dump(llvm::raw_ostream &Outs, bool WithValues = true) const override;
-  eld::Expected<uint64_t> evalImpl() override;
-  void getSymbols(std::vector<ResolveInfo *> &Symbols) override;
-  void getSymbolNames(std::unordered_set<std::string> &SymbolTokens) override;
-  Expression *getLeftExpression() const override { return &LeftExpression; }
-  Expression *getRightExpression() const override { return &RightExpression; }
-
-  Expression &LeftExpression;  /// represents the left hand operand.
-  Expression &RightExpression; /// represents the right hand operand.
-};
-
-/** \class Fill
- *  \brief This class extends an Expression to a Fill operator.
+/** \class QueryMemory Command support  (ORIGIN/LENGTH)
+ *  \brief This class extends an Expression to support memory command query
+ *  capabiliites
  */
 class Fill : public Expression {
 public:
@@ -1498,41 +1020,9 @@ private:
   Expression &ExpressionToEvaluate; /// represents the expression to complement
 };
 
-//===----------------------------------------------------------------------===//
-/** \class LogicalOp (&& | ||)
- *  \brief This class extends an Expression to a logical operator.
- */
-class LogicalOp : public Expression {
-public:
-  LogicalOp(Expression::Type Type, Module &Module, Expression &Left,
-            Expression &Right)
-      : Expression("LogicalOperator", Type, Module), LeftExpression(Left),
-        RightExpression(Right) {}
-
-  // Casting support
-  static bool classof(const Expression *Exp) {
-    return Exp->isLogicalAnd() || Exp->isLogicalOR();
-  }
-
-private:
-  bool hasDot() const override;
-  void commit() override;
-  void dump(llvm::raw_ostream &Outs, bool WithValues = true) const override;
-  eld::Expected<uint64_t> evalImpl() override;
-  void getSymbols(std::vector<ResolveInfo *> &Symbols) override;
-  void getSymbolNames(std::unordered_set<std::string> &SymbolTokens) override;
-  Expression *getLeftExpression() const override { return &LeftExpression; }
-  Expression *getRightExpression() const override { return &RightExpression; }
-
-  Expression &LeftExpression;  /// represents the left hand operand.
-  Expression &RightExpression; /// represents the right hand operand.
-};
-
-//===----------------------------------------------------------------------===//
-/** \class QueryMemory Command support  (ORIGIN/LENGTH)
- *  \brief This class extends an Expression to support memory command query
- *  capabiliites
- */
+// Max and Min aliases — all implemented by BinaryOp.
+using Max = BinaryOp;
+using Min = BinaryOp;
 class QueryMemory : public Expression {
 public:
   QueryMemory(Expression::Type Type, Module &Module, const std::string &Name);

--- a/lib/Script/Expression.cpp
+++ b/lib/Script/Expression.cpp
@@ -205,242 +205,125 @@ void Integer::getSymbols(std::vector<ResolveInfo *> &Symbols) {}
 void Integer::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {}
 
 //===----------------------------------------------------------------------===//
-/// Add Operator
-void Add::commit() {
+/// BinaryOp — unified binary operator implementation
+void BinaryOp::commit() {
   LeftExpression.commit();
   RightExpression.commit();
   Expression::commit();
 }
-void Add::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  // format output for operator
+
+void BinaryOp::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   if (ExpressionHasParenthesis)
     Outs << "(";
-  if (!hasAssign()) {
+  switch (type()) {
+  case MAX:
+    Outs << Name << "(";
     LeftExpression.dump(Outs, WithValues);
-    Outs << " " << Name << " ";
-  }
-  RightExpression.dump(Outs, WithValues);
-  if (ExpressionHasParenthesis)
+    Outs << ",";
+    RightExpression.dump(Outs, WithValues);
     Outs << ")";
-}
-eld::Expected<uint64_t> Add::evalImpl() {
-  // evaluate sub expressions
-  auto Left = LeftExpression.eval();
-  if (!Left)
-    return Left;
-  auto Right = RightExpression.eval();
-  if (!Right)
-    return Right;
-  if (!ThisModule.getScript().phdrsSpecified() &&
-      RightExpression.isSizeOfHeaders()) {
-    if (ThisModule.getDotSymbol() &&
-        ThisModule.getDotSymbol()->value() ==
-            getTargetBackend().getImageStartVMA()) {
-      // Load file headers and program header
-      getTargetBackend().setNeedEhdr();
-      getTargetBackend().setNeedPhdr();
+    break;
+  default:
+    if (!hasAssign()) {
+      LeftExpression.dump(Outs, WithValues);
+      Outs << " " << Name << " ";
     }
+    RightExpression.dump(Outs, WithValues);
+    break;
   }
-  return Left.value() + Right.value();
-}
-
-bool Add::hasDot() const {
-  return LeftExpression.hasDot() || RightExpression.hasDot();
-}
-
-void Add::getSymbols(std::vector<ResolveInfo *> &Symbols) {
-  LeftExpression.getSymbols(Symbols);
-  RightExpression.getSymbols(Symbols);
-}
-
-void Add::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {
-  LeftExpression.getSymbolNames(SymbolTokens);
-  RightExpression.getSymbolNames(SymbolTokens);
-}
-
-//===----------------------------------------------------------------------===//
-/// Subtract Operator
-void Subtract::commit() {
-  LeftExpression.commit();
-  RightExpression.commit();
-  Expression::commit();
-}
-void Subtract::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  if (ExpressionHasParenthesis)
-    Outs << "(";
-  if (!hasAssign()) {
-    // format output for operator
-    LeftExpression.dump(Outs, WithValues);
-    Outs << " " << Name << " ";
-  }
-  RightExpression.dump(Outs, WithValues);
   if (ExpressionHasParenthesis)
     Outs << ")";
 }
-eld::Expected<uint64_t> Subtract::evalImpl() {
-  // evaluate sub expressions
+
+eld::Expected<uint64_t> BinaryOp::evalImpl() {
   auto Left = LeftExpression.eval();
   if (!Left)
     return Left;
   auto Right = RightExpression.eval();
   if (!Right)
     return Right;
-  return Left.value() - Right.value();
+  uint64_t L = Left.value(), R = Right.value();
+  switch (type()) {
+  case ADD:
+    if (!ThisModule.getScript().phdrsSpecified() &&
+        RightExpression.isSizeOfHeaders()) {
+      if (ThisModule.getDotSymbol() &&
+          ThisModule.getDotSymbol()->value() ==
+              getTargetBackend().getImageStartVMA()) {
+        getTargetBackend().setNeedEhdr();
+        getTargetBackend().setNeedPhdr();
+      }
+    }
+    return L + R;
+  case SUBTRACT:
+    return L - R;
+  case MULTIPLY:
+    return L * R;
+  case DIVIDE:
+    if (R == 0) {
+      std::string ErrorString;
+      llvm::raw_string_ostream SS(ErrorString);
+      dump(SS);
+      return std::make_unique<plugin::DiagnosticEntry>(
+          Diag::fatal_divide_by_zero, std::vector<std::string>{SS.str()});
+    }
+    return L / R;
+  case MODULO:
+    if (R == 0) {
+      std::string ErrorString;
+      llvm::raw_string_ostream SS(ErrorString);
+      dump(SS);
+      return std::make_unique<plugin::DiagnosticEntry>(
+          Diag::fatal_modulo_by_zero, std::vector<std::string>{SS.str()});
+    }
+    return L % R;
+  case BITWISE_LS:
+    return L << R;
+  case BITWISE_RS:
+    return L >> R;
+  case LT:
+    return L < R;
+  case GT:
+    return L > R;
+  case GTE:
+    return L >= R;
+  case LTE:
+    return L <= R;
+  case EQ:
+    return L == R;
+  case NEQ:
+    return L != R;
+  case LOGICAL_AND:
+    return L && R;
+  case LOGICAL_OR:
+    return L || R;
+  case BITWISE_AND:
+    return L & R;
+  case BITWISE_XOR:
+    return L ^ R;
+  case BITWISE_OR:
+    return L | R;
+  case MAX:
+    return L > R ? L : R;
+  case MIN:
+    return L < R ? L : R;
+  default:
+    llvm_unreachable("BinaryOp: unknown operator type");
+  }
 }
-void Subtract::getSymbols(std::vector<ResolveInfo *> &Symbols) {
+
+bool BinaryOp::hasDot() const {
+  return LeftExpression.hasDot() || RightExpression.hasDot();
+}
+
+void BinaryOp::getSymbols(std::vector<ResolveInfo *> &Symbols) {
   LeftExpression.getSymbols(Symbols);
   RightExpression.getSymbols(Symbols);
 }
 
-void Subtract::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {
+void BinaryOp::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {
   LeftExpression.getSymbolNames(SymbolTokens);
   RightExpression.getSymbolNames(SymbolTokens);
-}
-bool Subtract::hasDot() const {
-  return LeftExpression.hasDot() || RightExpression.hasDot();
-}
-
-//===----------------------------------------------------------------------===//
-/// Modulo Operator
-void Modulo::commit() {
-  LeftExpression.commit();
-  RightExpression.commit();
-  Expression::commit();
-}
-void Modulo::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  if (ExpressionHasParenthesis)
-    Outs << "(";
-  // format output for operator
-  LeftExpression.dump(Outs, WithValues);
-  Outs << " " << Name << " ";
-  RightExpression.dump(Outs, WithValues);
-  if (ExpressionHasParenthesis)
-    Outs << ")";
-}
-eld::Expected<uint64_t> Modulo::evalImpl() {
-  // evaluate sub expressions
-  auto Left = LeftExpression.eval();
-  if (!Left)
-    return Left;
-  auto Right = RightExpression.eval();
-  if (!Right)
-    return Right;
-  if (Right.value() == 0) {
-    std::string ErrorString;
-    llvm::raw_string_ostream ErrorStringStream(ErrorString);
-    dump(ErrorStringStream);
-    return std::make_unique<plugin::DiagnosticEntry>(
-        Diag::fatal_modulo_by_zero,
-        std::vector<std::string>{ErrorStringStream.str()});
-  }
-  return Left.value() % Right.value();
-}
-void Modulo::getSymbols(std::vector<ResolveInfo *> &Symbols) {
-  LeftExpression.getSymbols(Symbols);
-  RightExpression.getSymbols(Symbols);
-}
-
-void Modulo::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {
-  LeftExpression.getSymbolNames(SymbolTokens);
-  RightExpression.getSymbolNames(SymbolTokens);
-}
-
-bool Modulo::hasDot() const {
-  return LeftExpression.hasDot() || RightExpression.hasDot();
-}
-
-//===----------------------------------------------------------------------===//
-/// Multiply Operator
-void Multiply::commit() {
-  LeftExpression.commit();
-  RightExpression.commit();
-  Expression::commit();
-}
-void Multiply::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  if (ExpressionHasParenthesis)
-    Outs << "(";
-  if (!hasAssign()) {
-    // format output for operator
-    LeftExpression.dump(Outs, WithValues);
-    Outs << " " << Name << " ";
-  }
-  RightExpression.dump(Outs, WithValues);
-  if (ExpressionHasParenthesis)
-    Outs << ")";
-}
-eld::Expected<uint64_t> Multiply::evalImpl() {
-  // evaluate sub expressions
-  auto Left = LeftExpression.eval();
-  if (!Left)
-    return Left;
-  auto Right = RightExpression.eval();
-  if (!Right)
-    return Right;
-  return Left.value() * Right.value();
-}
-void Multiply::getSymbols(std::vector<ResolveInfo *> &Symbols) {
-  LeftExpression.getSymbols(Symbols);
-  RightExpression.getSymbols(Symbols);
-}
-
-void Multiply::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {
-  LeftExpression.getSymbolNames(SymbolTokens);
-  RightExpression.getSymbolNames(SymbolTokens);
-}
-
-bool Multiply::hasDot() const {
-  return LeftExpression.hasDot() || RightExpression.hasDot();
-}
-
-//===----------------------------------------------------------------------===//
-/// Divide Operator
-void Divide::commit() {
-  LeftExpression.commit();
-  RightExpression.commit();
-  Expression::commit();
-}
-void Divide::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  if (ExpressionHasParenthesis)
-    Outs << "(";
-  if (!hasAssign()) {
-    // format output for operator
-    LeftExpression.dump(Outs, WithValues);
-    Outs << " " << Name << " ";
-  }
-  RightExpression.dump(Outs, WithValues);
-  if (ExpressionHasParenthesis)
-    Outs << ")";
-}
-eld::Expected<uint64_t> Divide::evalImpl() {
-  // evaluate sub expressions
-  auto Left = LeftExpression.eval();
-  if (!Left)
-    return Left;
-  auto Right = RightExpression.eval();
-  if (!Right)
-    return Right;
-  if (Right.value() == 0) {
-    std::string ErrorString;
-    llvm::raw_string_ostream ErrorStringStream(ErrorString);
-    dump(ErrorStringStream);
-    return std::make_unique<plugin::DiagnosticEntry>(
-        Diag::fatal_divide_by_zero,
-        std::vector<std::string>{ErrorStringStream.str()});
-  }
-  return Left.value() / Right.value();
-}
-void Divide::getSymbols(std::vector<ResolveInfo *> &Symbols) {
-  LeftExpression.getSymbols(Symbols);
-  RightExpression.getSymbols(Symbols);
-}
-
-void Divide::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {
-  LeftExpression.getSymbolNames(SymbolTokens);
-  RightExpression.getSymbolNames(SymbolTokens);
-}
-
-bool Divide::hasDot() const {
-  return LeftExpression.hasDot() || RightExpression.hasDot();
 }
 
 //===----------------------------------------------------------------------===//
@@ -804,361 +687,44 @@ void Absolute::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {
 bool Absolute::hasDot() const { return ExpressionToEvaluate.hasDot(); }
 
 //===----------------------------------------------------------------------===//
-/// ConditionGT Operator
-void ConditionGT::commit() {
-  LeftExpression.commit();
-  RightExpression.commit();
-  Expression::commit();
-}
-void ConditionGT::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  if (ExpressionHasParenthesis)
-    Outs << "(";
-  // format output for operator
-  LeftExpression.dump(Outs, WithValues);
-  Outs << " " << Name << " ";
-  RightExpression.dump(Outs, WithValues);
-  if (ExpressionHasParenthesis)
-    Outs << ")";
-}
-eld::Expected<uint64_t> ConditionGT::evalImpl() {
-  auto Left = LeftExpression.eval();
-  if (!Left)
-    return Left;
-  auto Right = RightExpression.eval();
-  if (!Right)
-    return Right;
-  return Left.value() > Right.value();
-}
-void ConditionGT::getSymbols(std::vector<ResolveInfo *> &Symbols) {
-  LeftExpression.getSymbols(Symbols);
-  RightExpression.getSymbols(Symbols);
-}
-
-void ConditionGT::getSymbolNames(
-    std::unordered_set<std::string> &SymbolTokens) {
-  LeftExpression.getSymbolNames(SymbolTokens);
-  RightExpression.getSymbolNames(SymbolTokens);
-}
-
-bool ConditionGT::hasDot() const {
-  return LeftExpression.hasDot() || RightExpression.hasDot();
-}
-
-//===----------------------------------------------------------------------===//
-/// ConditionLT Operator
-void ConditionLT::commit() {
-  LeftExpression.commit();
-  RightExpression.commit();
-  Expression::commit();
-}
-void ConditionLT::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  if (ExpressionHasParenthesis)
-    Outs << "(";
-  // format output for operator
-  LeftExpression.dump(Outs, WithValues);
-  Outs << " " << Name << " ";
-  RightExpression.dump(Outs, WithValues);
-  if (ExpressionHasParenthesis)
-    Outs << ")";
-}
-eld::Expected<uint64_t> ConditionLT::evalImpl() {
-  // evaluate sub expressions
-  auto Left = LeftExpression.eval();
-  if (!Left)
-    return Left;
-  auto Right = RightExpression.eval();
-  if (!Right)
-    return Right;
-  return Left.value() < Right.value();
-}
-void ConditionLT::getSymbols(std::vector<ResolveInfo *> &Symbols) {
-  LeftExpression.getSymbols(Symbols);
-  RightExpression.getSymbols(Symbols);
-}
-
-void ConditionLT::getSymbolNames(
-    std::unordered_set<std::string> &SymbolTokens) {
-  LeftExpression.getSymbolNames(SymbolTokens);
-  RightExpression.getSymbolNames(SymbolTokens);
-}
-
-bool ConditionLT::hasDot() const {
-  return LeftExpression.hasDot() || RightExpression.hasDot();
-}
-
-//===----------------------------------------------------------------------===//
-/// ConditionEQ Operator
-void ConditionEQ::commit() {
-  LeftExpression.commit();
-  RightExpression.commit();
-  Expression::commit();
-}
-void ConditionEQ::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  if (ExpressionHasParenthesis)
-    Outs << "(";
-  // format output for operator
-  LeftExpression.dump(Outs, WithValues);
-  Outs << " " << Name << " ";
-  RightExpression.dump(Outs, WithValues);
-  if (ExpressionHasParenthesis)
-    Outs << ")";
-}
-eld::Expected<uint64_t> ConditionEQ::evalImpl() {
-  // evaluate sub expressions
-  auto Left = LeftExpression.eval();
-  if (!Left)
-    return Left;
-  auto Right = RightExpression.eval();
-  if (!Right)
-    return Right;
-  return Left.value() == Right.value();
-}
-void ConditionEQ::getSymbols(std::vector<ResolveInfo *> &Symbols) {
-  LeftExpression.getSymbols(Symbols);
-  RightExpression.getSymbols(Symbols);
-}
-
-void ConditionEQ::getSymbolNames(
-    std::unordered_set<std::string> &SymbolTokens) {
-  LeftExpression.getSymbolNames(SymbolTokens);
-  RightExpression.getSymbolNames(SymbolTokens);
-}
-
-bool ConditionEQ::hasDot() const {
-  return LeftExpression.hasDot() || RightExpression.hasDot();
-}
-
-//===----------------------------------------------------------------------===//
-/// ConditionGTE Operator
-void ConditionGTE::commit() {
-  LeftExpression.commit();
-  RightExpression.commit();
-  Expression::commit();
-}
-void ConditionGTE::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  if (ExpressionHasParenthesis)
-    Outs << "(";
-  // format output for operator
-  LeftExpression.dump(Outs, WithValues);
-  Outs << " " << Name << " ";
-  RightExpression.dump(Outs, WithValues);
-  if (ExpressionHasParenthesis)
-    Outs << ")";
-}
-eld::Expected<uint64_t> ConditionGTE::evalImpl() {
-  // evaluate sub expressions
-  auto Left = LeftExpression.eval();
-  if (!Left)
-    return Left;
-  auto Right = RightExpression.eval();
-  if (!Right)
-    return Right;
-  return Left.value() >= Right.value();
-}
-void ConditionGTE::getSymbols(std::vector<ResolveInfo *> &Symbols) {
-  LeftExpression.getSymbols(Symbols);
-  RightExpression.getSymbols(Symbols);
-}
-
-void ConditionGTE::getSymbolNames(
-    std::unordered_set<std::string> &SymbolTokens) {
-  LeftExpression.getSymbolNames(SymbolTokens);
-  RightExpression.getSymbolNames(SymbolTokens);
-}
-
-bool ConditionGTE::hasDot() const {
-  return LeftExpression.hasDot() || RightExpression.hasDot();
-}
-
-//===----------------------------------------------------------------------===//
-/// ConditionLTE Operator
-void ConditionLTE::commit() {
-  LeftExpression.commit();
-  RightExpression.commit();
-  Expression::commit();
-}
-void ConditionLTE::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  if (ExpressionHasParenthesis)
-    Outs << "(";
-  // format output for operator
-  LeftExpression.dump(Outs, WithValues);
-  Outs << " " << Name << " ";
-  RightExpression.dump(Outs, WithValues);
-  if (ExpressionHasParenthesis)
-    Outs << ")";
-}
-eld::Expected<uint64_t> ConditionLTE::evalImpl() {
-  // evaluate sub expressions
-  auto Left = LeftExpression.eval();
-  if (!Left)
-    return Left;
-  auto Right = RightExpression.eval();
-  if (!Right)
-    return Right;
-  return Left.value() <= Right.value();
-}
-void ConditionLTE::getSymbols(std::vector<ResolveInfo *> &Symbols) {
-  LeftExpression.getSymbols(Symbols);
-  RightExpression.getSymbols(Symbols);
-}
-
-void ConditionLTE::getSymbolNames(
-    std::unordered_set<std::string> &SymbolTokens) {
-  LeftExpression.getSymbolNames(SymbolTokens);
-  RightExpression.getSymbolNames(SymbolTokens);
-}
-
-bool ConditionLTE::hasDot() const {
-  return LeftExpression.hasDot() || RightExpression.hasDot();
-}
-
-//===----------------------------------------------------------------------===//
-/// ConditionNEQ Operator
-void ConditionNEQ::commit() {
-  LeftExpression.commit();
-  RightExpression.commit();
-  Expression::commit();
-}
-void ConditionNEQ::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  if (ExpressionHasParenthesis)
-    Outs << "(";
-  // format output for operator
-  LeftExpression.dump(Outs, WithValues);
-  Outs << " " << Name << " ";
-  RightExpression.dump(Outs, WithValues);
-  if (ExpressionHasParenthesis)
-    Outs << ")";
-}
-eld::Expected<uint64_t> ConditionNEQ::evalImpl() {
-  // evaluate sub expressions
-  auto Left = LeftExpression.eval();
-  if (!Left)
-    return Left;
-  auto Right = RightExpression.eval();
-  if (!Right)
-    return Right;
-  return Left.value() != Right.value();
-}
-void ConditionNEQ::getSymbols(std::vector<ResolveInfo *> &Symbols) {
-  LeftExpression.getSymbols(Symbols);
-  RightExpression.getSymbols(Symbols);
-}
-
-void ConditionNEQ::getSymbolNames(
-    std::unordered_set<std::string> &SymbolTokens) {
-  LeftExpression.getSymbolNames(SymbolTokens);
-  RightExpression.getSymbolNames(SymbolTokens);
-}
-
-bool ConditionNEQ::hasDot() const {
-  return LeftExpression.hasDot() || RightExpression.hasDot();
-}
-
-//===----------------------------------------------------------------------===//
-/// Complement Operator
-void Complement::commit() {
+/// UnaryOp — unified unary operator implementation
+void UnaryOp::commit() {
   ExpressionToEvaluate.commit();
   Expression::commit();
 }
-void Complement::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  // format output for operator
+
+void UnaryOp::dump(llvm::raw_ostream &Outs, bool WithValues) const {
   Outs << Name;
   ExpressionToEvaluate.dump(Outs, WithValues);
 }
-eld::Expected<uint64_t> Complement::evalImpl() {
-  // evaluate sub expressions
+
+eld::Expected<uint64_t> UnaryOp::evalImpl() {
   auto Expr = ExpressionToEvaluate.eval();
   if (!Expr)
     return Expr;
-  return ~Expr.value();
+  switch (type()) {
+  case COM:
+    return ~Expr.value();
+  case UNARYPLUS:
+    return Expr.value();
+  case UNARYMINUS:
+    return -Expr.value();
+  case UNARYNOT:
+    return !Expr.value();
+  default:
+    llvm_unreachable("UnaryOp: unknown operator type");
+  }
 }
-void Complement::getSymbols(std::vector<ResolveInfo *> &Symbols) {
+
+bool UnaryOp::hasDot() const { return ExpressionToEvaluate.hasDot(); }
+
+void UnaryOp::getSymbols(std::vector<ResolveInfo *> &Symbols) {
   ExpressionToEvaluate.getSymbols(Symbols);
 }
 
-void Complement::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {
+void UnaryOp::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {
   ExpressionToEvaluate.getSymbolNames(SymbolTokens);
 }
-
-bool Complement::hasDot() const { return ExpressionToEvaluate.hasDot(); }
-
-//===----------------------------------------------------------------------===//
-/// Unary plus operator
-void UnaryPlus::commit() {
-  ExpressionToEvaluate.commit();
-  Expression::commit();
-}
-void UnaryPlus::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  // format output for operator
-  Outs << Name;
-  ExpressionToEvaluate.dump(Outs, WithValues);
-}
-eld::Expected<uint64_t> UnaryPlus::evalImpl() {
-  return ExpressionToEvaluate.eval();
-}
-void UnaryPlus::getSymbols(std::vector<ResolveInfo *> &Symbols) {
-  ExpressionToEvaluate.getSymbols(Symbols);
-}
-
-void UnaryPlus::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {
-  ExpressionToEvaluate.getSymbolNames(SymbolTokens);
-}
-
-bool UnaryPlus::hasDot() const { return ExpressionToEvaluate.hasDot(); }
-//===----------------------------------------------------------------------===//
-/// Unary minus operator
-void UnaryMinus::commit() {
-  ExpressionToEvaluate.commit();
-  Expression::commit();
-}
-void UnaryMinus::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  // format output for operator
-  Outs << "-";
-  ExpressionToEvaluate.dump(Outs, WithValues);
-}
-eld::Expected<uint64_t> UnaryMinus::evalImpl() {
-  // evaluate sub expressions
-  auto Expr = ExpressionToEvaluate.eval();
-  if (!Expr)
-    return Expr;
-  return -Expr.value();
-}
-void UnaryMinus::getSymbols(std::vector<ResolveInfo *> &Symbols) {
-  ExpressionToEvaluate.getSymbols(Symbols);
-}
-
-void UnaryMinus::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {
-  ExpressionToEvaluate.getSymbolNames(SymbolTokens);
-}
-
-bool UnaryMinus::hasDot() const { return ExpressionToEvaluate.hasDot(); }
-//===----------------------------------------------------------------------===//
-/// Unary not operator
-void UnaryNot::commit() {
-  ExpressionToEvaluate.commit();
-  Expression::commit();
-}
-void UnaryNot::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  // format output for operator
-  Outs << Name;
-  ExpressionToEvaluate.dump(Outs, WithValues);
-}
-eld::Expected<uint64_t> UnaryNot::evalImpl() {
-  // evaluate sub expressions
-  auto Expr = ExpressionToEvaluate.eval();
-  if (!Expr)
-    return Expr;
-  return !Expr.value();
-}
-void UnaryNot::getSymbols(std::vector<ResolveInfo *> &Symbols) {
-  ExpressionToEvaluate.getSymbols(Symbols);
-}
-
-void UnaryNot::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {
-  ExpressionToEvaluate.getSymbolNames(SymbolTokens);
-}
-
-bool UnaryNot::hasDot() const { return ExpressionToEvaluate.hasDot(); }
 //===----------------------------------------------------------------------===//
 /// Constant Operator
 void Constant::dump(llvm::raw_ostream &Outs, bool WithValues) const {
@@ -1494,221 +1060,6 @@ bool PrintCmd::hasDot() const {
 }
 
 //===----------------------------------------------------------------------===//
-/// RightShift Operator
-void RightShift::commit() {
-  LeftExpression.commit();
-  RightExpression.commit();
-  Expression::commit();
-}
-void RightShift::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  if (ExpressionHasParenthesis)
-    Outs << "(";
-  if (!hasAssign()) {
-    // format output for operator
-    LeftExpression.dump(Outs, WithValues);
-    Outs << " " << Name << " ";
-  }
-  RightExpression.dump(Outs, WithValues);
-  if (ExpressionHasParenthesis)
-    Outs << ")";
-}
-eld::Expected<uint64_t> RightShift::evalImpl() {
-  // evaluate sub expressions
-  auto Left = LeftExpression.eval();
-  if (!Left)
-    return Left;
-  auto Right = RightExpression.eval();
-  if (!Right)
-    return Right;
-  return Left.value() >> Right.value();
-}
-
-void RightShift::getSymbols(std::vector<ResolveInfo *> &Symbols) {
-  LeftExpression.getSymbols(Symbols);
-  RightExpression.getSymbols(Symbols);
-}
-
-void RightShift::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {
-  LeftExpression.getSymbolNames(SymbolTokens);
-  RightExpression.getSymbolNames(SymbolTokens);
-}
-
-bool RightShift::hasDot() const {
-  return LeftExpression.hasDot() || RightExpression.hasDot();
-}
-
-//===----------------------------------------------------------------------===//
-/// LeftShift Operator
-void LeftShift::commit() {
-  LeftExpression.commit();
-  RightExpression.commit();
-  Expression::commit();
-}
-void LeftShift::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  if (ExpressionHasParenthesis)
-    Outs << "(";
-  if (!hasAssign()) {
-    // format output for operator
-    LeftExpression.dump(Outs, WithValues);
-    Outs << " " << Name << " ";
-  }
-  RightExpression.dump(Outs, WithValues);
-  if (ExpressionHasParenthesis)
-    Outs << ")";
-}
-eld::Expected<uint64_t> LeftShift::evalImpl() {
-  // evaluate sub expressions
-  auto Left = LeftExpression.eval();
-  if (!Left)
-    return Left;
-  auto Right = RightExpression.eval();
-  if (!Right)
-    return Right;
-  return Left.value() << Right.value();
-}
-void LeftShift::getSymbols(std::vector<ResolveInfo *> &Symbols) {
-  LeftExpression.getSymbols(Symbols);
-  RightExpression.getSymbols(Symbols);
-}
-
-void LeftShift::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {
-  LeftExpression.getSymbolNames(SymbolTokens);
-  RightExpression.getSymbolNames(SymbolTokens);
-}
-
-bool LeftShift::hasDot() const {
-  return LeftExpression.hasDot() || RightExpression.hasDot();
-}
-
-//===----------------------------------------------------------------------===//
-/// BitwiseOr Operator
-void BitwiseOr::commit() {
-  LeftExpression.commit();
-  RightExpression.commit();
-  Expression::commit();
-}
-void BitwiseOr::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  if (ExpressionHasParenthesis)
-    Outs << "(";
-  if (!hasAssign()) {
-    // format output for operator
-    LeftExpression.dump(Outs, WithValues);
-    Outs << " " << Name << " ";
-  }
-  RightExpression.dump(Outs, WithValues);
-  if (ExpressionHasParenthesis)
-    Outs << ")";
-}
-eld::Expected<uint64_t> BitwiseOr::evalImpl() {
-  // evaluate sub expressions
-  auto Left = LeftExpression.eval();
-  if (!Left)
-    return Left;
-  auto Right = RightExpression.eval();
-  if (!Right)
-    return Right;
-  return Left.value() | Right.value();
-}
-void BitwiseOr::getSymbols(std::vector<ResolveInfo *> &Symbols) {
-  LeftExpression.getSymbols(Symbols);
-  RightExpression.getSymbols(Symbols);
-}
-
-void BitwiseOr::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {
-  LeftExpression.getSymbolNames(SymbolTokens);
-  RightExpression.getSymbolNames(SymbolTokens);
-}
-
-bool BitwiseOr::hasDot() const {
-  return LeftExpression.hasDot() || RightExpression.hasDot();
-}
-
-//===----------------------------------------------------------------------===//
-/// BitwiseXor Operator
-void BitwiseXor::commit() {
-  LeftExpression.commit();
-  RightExpression.commit();
-  Expression::commit();
-}
-void BitwiseXor::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  if (ExpressionHasParenthesis)
-    Outs << "(";
-  if (!hasAssign()) {
-    // format output for operator
-    LeftExpression.dump(Outs, WithValues);
-    Outs << " " << Name << " ";
-  }
-  RightExpression.dump(Outs, WithValues);
-  if (ExpressionHasParenthesis)
-    Outs << ")";
-}
-eld::Expected<uint64_t> BitwiseXor::evalImpl() {
-  // evaluate sub expressions
-  auto Left = LeftExpression.eval();
-  if (!Left)
-    return Left;
-  auto Right = RightExpression.eval();
-  if (!Right)
-    return Right;
-  return Left.value() ^ Right.value();
-}
-void BitwiseXor::getSymbols(std::vector<ResolveInfo *> &Symbols) {
-  LeftExpression.getSymbols(Symbols);
-  RightExpression.getSymbols(Symbols);
-}
-
-void BitwiseXor::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {
-  LeftExpression.getSymbolNames(SymbolTokens);
-  RightExpression.getSymbolNames(SymbolTokens);
-}
-
-bool BitwiseXor::hasDot() const {
-  return LeftExpression.hasDot() || RightExpression.hasDot();
-}
-
-//===----------------------------------------------------------------------===//
-/// BitwiseAnd Operator
-void BitwiseAnd::commit() {
-  LeftExpression.commit();
-  RightExpression.commit();
-  Expression::commit();
-}
-void BitwiseAnd::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  if (ExpressionHasParenthesis)
-    Outs << "(";
-  if (!hasAssign()) {
-    // format output for operator
-    LeftExpression.dump(Outs, WithValues);
-    Outs << " " << Name << " ";
-  }
-  RightExpression.dump(Outs, WithValues);
-  if (ExpressionHasParenthesis)
-    Outs << ")";
-}
-eld::Expected<uint64_t> BitwiseAnd::evalImpl() {
-  // evaluate sub expressions
-  auto Left = LeftExpression.eval();
-  if (!Left)
-    return Left;
-  auto Right = RightExpression.eval();
-  if (!Right)
-    return Right;
-  return Left.value() & Right.value();
-}
-void BitwiseAnd::getSymbols(std::vector<ResolveInfo *> &Symbols) {
-  LeftExpression.getSymbols(Symbols);
-  RightExpression.getSymbols(Symbols);
-}
-
-void BitwiseAnd::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {
-  LeftExpression.getSymbolNames(SymbolTokens);
-  RightExpression.getSymbolNames(SymbolTokens);
-}
-
-bool BitwiseAnd::hasDot() const {
-  return LeftExpression.hasDot() || RightExpression.hasDot();
-}
-
 //===----------------------------------------------------------------------===//
 /// Defined Operator
 void Defined::dump(llvm::raw_ostream &Outs, bool WithValues) const {
@@ -1861,90 +1212,6 @@ void DataSegmentEnd::getSymbolNames(
 bool DataSegmentEnd::hasDot() const { return ExpressionToEvaluate.hasDot(); }
 
 //===----------------------------------------------------------------------===//
-/// Max Operator
-void Max::commit() {
-  LeftExpression.commit();
-  RightExpression.commit();
-  Expression::commit();
-}
-void Max::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  if (ExpressionHasParenthesis)
-    Outs << "(";
-  Outs << Name << "(";
-  // format output for operator
-  LeftExpression.dump(Outs, WithValues);
-  Outs << ",";
-  RightExpression.dump(Outs, WithValues);
-  Outs << ")";
-  if (ExpressionHasParenthesis)
-    Outs << ")";
-}
-eld::Expected<uint64_t> Max::evalImpl() {
-  // evaluate sub expressions
-  auto Left = LeftExpression.eval();
-  if (!Left)
-    return Left;
-  auto Right = RightExpression.eval();
-  if (!Right)
-    return Right;
-
-  return Left.value() > Right.value() ? Left.value() : Right.value();
-}
-void Max::getSymbols(std::vector<ResolveInfo *> &Symbols) {
-  LeftExpression.getSymbols(Symbols);
-  RightExpression.getSymbols(Symbols);
-}
-
-void Max::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {
-  LeftExpression.getSymbolNames(SymbolTokens);
-  RightExpression.getSymbolNames(SymbolTokens);
-}
-
-bool Max::hasDot() const {
-  return LeftExpression.hasDot() || RightExpression.hasDot();
-}
-
-//===----------------------------------------------------------------------===//
-/// Min Operator
-void Min::commit() {
-  LeftExpression.commit();
-  RightExpression.commit();
-  Expression::commit();
-}
-void Min::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  if (ExpressionHasParenthesis)
-    Outs << "(";
-  // format output for operator
-  LeftExpression.dump(Outs, WithValues);
-  Outs << " " << Name << " ";
-  RightExpression.dump(Outs, WithValues);
-  if (ExpressionHasParenthesis)
-    Outs << ")";
-}
-eld::Expected<uint64_t> Min::evalImpl() {
-  // evaluate sub expressions
-  auto Left = LeftExpression.eval();
-  if (!Left)
-    return Left;
-  auto Right = RightExpression.eval();
-  if (!Right)
-    return Right;
-  return Left.value() < Right.value() ? Left.value() : Right.value();
-}
-void Min::getSymbols(std::vector<ResolveInfo *> &Symbols) {
-  LeftExpression.getSymbols(Symbols);
-  RightExpression.getSymbols(Symbols);
-}
-
-void Min::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {
-  LeftExpression.getSymbolNames(SymbolTokens);
-  RightExpression.getSymbolNames(SymbolTokens);
-}
-bool Min::hasDot() const {
-  return LeftExpression.hasDot() || RightExpression.hasDot();
-}
-
-//===----------------------------------------------------------------------===//
 /// Fill
 void Fill::commit() {
   ExpressionToEvaluate.commit();
@@ -1999,60 +1266,6 @@ void Log2Ceil::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {
 
 bool Log2Ceil::hasDot() const { return ExpressionToEvaluate.hasDot(); }
 
-//===----------------------------------------------------------------------===//
-/// LogicalOp Operator
-void LogicalOp::commit() {
-  LeftExpression.commit();
-  RightExpression.commit();
-  Expression::commit();
-}
-
-void LogicalOp::dump(llvm::raw_ostream &Outs, bool WithValues) const {
-  if (ExpressionHasParenthesis)
-    Outs << "(";
-  if (!hasAssign()) {
-    // format output for operator
-    LeftExpression.dump(Outs, WithValues);
-    if (isLogicalAnd())
-      Outs << " "
-           << "&&"
-           << " ";
-    if (isLogicalOR())
-      Outs << " "
-           << "||"
-           << " ";
-  }
-  RightExpression.dump(Outs, WithValues);
-  if (ExpressionHasParenthesis)
-    Outs << ")";
-}
-eld::Expected<uint64_t> LogicalOp::evalImpl() {
-  // evaluate sub expressions
-  auto Left = LeftExpression.eval();
-  if (!Left)
-    return Left;
-  auto Right = RightExpression.eval();
-  if (!Right)
-    return Right;
-  if (isLogicalAnd())
-    return Left.value() && Right.value();
-  ASSERT(isLogicalOR(), "logical operator can be || or && only");
-  return Left.value() || Right.value();
-}
-
-void LogicalOp::getSymbols(std::vector<ResolveInfo *> &Symbols) {
-  LeftExpression.getSymbols(Symbols);
-  RightExpression.getSymbols(Symbols);
-}
-
-void LogicalOp::getSymbolNames(std::unordered_set<std::string> &SymbolTokens) {
-  LeftExpression.getSymbolNames(SymbolTokens);
-  RightExpression.getSymbolNames(SymbolTokens);
-}
-
-bool LogicalOp::hasDot() const {
-  return LeftExpression.hasDot() || RightExpression.hasDot();
-}
 //===----------------------------------------------------------------------===//
 /// QueryMemory support
 QueryMemory::QueryMemory(Expression::Type Type, Module &Module,

--- a/lib/ScriptParser/ScriptParser.cpp
+++ b/lib/ScriptParser/ScriptParser.cpp
@@ -205,47 +205,47 @@ eld::Expression &ScriptParser::combine(llvm::StringRef Op, eld::Expression &L,
                                        eld::Expression &R) {
   Module &Module = ThisScriptFile.module();
   if (Op == "+")
-    return *(make<Add>(Module, L, R));
+    return *(make<BinaryOp>("+", Expression::ADD, Module, L, R));
   if (Op == "-")
-    return *(make<Subtract>(Module, L, R));
+    return *(make<BinaryOp>("-", Expression::SUBTRACT, Module, L, R));
   if (Op == "*")
-    return *(make<Multiply>(Module, L, R));
+    return *(make<BinaryOp>("*", Expression::MULTIPLY, Module, L, R));
   if (Op == "/") {
     // FIXME: It be useful to pass current location for reporting
     // division by zero error!
-    return *(make<Divide>(Module, L, R));
+    return *(make<BinaryOp>("/", Expression::DIVIDE, Module, L, R));
   }
   if (Op == "%") {
     // FIXME: It be useful to pass current location for reporting
     // modulo by zero error!
-    return *(make<Modulo>(Module, L, R));
+    return *(make<BinaryOp>("%", Expression::MODULO, Module, L, R));
   }
   if (Op == "<<")
-    return *(make<LeftShift>(Module, L, R));
+    return *(make<BinaryOp>("<<", Expression::BITWISE_LS, Module, L, R));
   if (Op == ">>")
-    return *(make<RightShift>(Module, L, R));
+    return *(make<BinaryOp>(">>", Expression::BITWISE_RS, Module, L, R));
   if (Op == "<")
-    return *(make<ConditionLT>(Module, L, R));
+    return *(make<BinaryOp>("<", Expression::LT, Module, L, R));
   if (Op == ">")
-    return *(make<ConditionGT>(Module, L, R));
+    return *(make<BinaryOp>(">", Expression::GT, Module, L, R));
   if (Op == ">=")
-    return *(make<ConditionGTE>(Module, L, R));
+    return *(make<BinaryOp>(">=", Expression::GTE, Module, L, R));
   if (Op == "<=")
-    return *(make<ConditionLTE>(Module, L, R));
+    return *(make<BinaryOp>("<=", Expression::LTE, Module, L, R));
   if (Op == "==")
-    return *(make<ConditionEQ>(Module, L, R));
+    return *(make<BinaryOp>("==", Expression::EQ, Module, L, R));
   if (Op == "!=")
-    return *(make<ConditionNEQ>(Module, L, R));
+    return *(make<BinaryOp>("!=", Expression::NEQ, Module, L, R));
   if (Op == "||")
-    return *(make<LogicalOp>(Expression::LOGICAL_OR, Module, L, R));
+    return *(make<BinaryOp>("||", Expression::LOGICAL_OR, Module, L, R));
   if (Op == "&&")
-    return *(make<LogicalOp>(Expression::LOGICAL_AND, Module, L, R));
+    return *(make<BinaryOp>("&&", Expression::LOGICAL_AND, Module, L, R));
   if (Op == "&")
-    return *(make<BitwiseAnd>(Module, L, R));
+    return *(make<BinaryOp>("&", Expression::BITWISE_AND, Module, L, R));
   if (Op == "^")
-    return *(make<BitwiseXor>(Module, L, R));
+    return *(make<BinaryOp>("^", Expression::BITWISE_XOR, Module, L, R));
   if (Op == "|")
-    return *(make<BitwiseOr>(Module, L, R));
+    return *(make<BinaryOp>("|", Expression::BITWISE_OR, Module, L, R));
   llvm_unreachable("invalid operator");
 }
 
@@ -256,19 +256,19 @@ eld::Expression *ScriptParser::readPrimary() {
   Module &Module = ThisScriptFile.module();
   if (consume("~")) {
     Expression *E = readPrimary();
-    return make<Complement>(Module, *E);
+    return make<UnaryOp>("~", Expression::COM, Module, *E);
   }
   if (consume("!")) {
     Expression *E = readPrimary();
-    return make<UnaryNot>(Module, *E);
+    return make<UnaryOp>("!", Expression::UNARYNOT, Module, *E);
   }
   if (consume("-")) {
     Expression *E = readPrimary();
-    return make<UnaryMinus>(Module, *E);
+    return make<UnaryOp>("-", Expression::UNARYMINUS, Module, *E);
   }
   if (consume("+")) {
     Expression *E = readPrimary();
-    return make<UnaryPlus>(Module, *E);
+    return make<UnaryOp>("+", Expression::UNARYPLUS, Module, *E);
   }
 
   StringRef Tok = next();
@@ -366,8 +366,8 @@ eld::Expression *ScriptParser::readPrimary() {
     Expression *E2 = readExpr();
     expect(")");
     if (Tok == "MIN")
-      return make<Min>(Module, *E1, *E2);
-    return make<Max>(Module, *E1, *E2);
+      return make<BinaryOp>("MIN", Expression::MIN, Module, *E1, *E2);
+    return make<BinaryOp>("MAX", Expression::MAX, Module, *E1, *E2);
   }
   if (Tok == "ORIGIN") {
     StringRef Name = readParenLiteral();
@@ -488,31 +488,31 @@ bool ScriptParser::readSymbolAssignment(StringRef Tok,
     char SubOp = Op[0];
     switch (SubOp) {
     case '*':
-      E = make<Multiply>(Module, *S, *E);
+      E = make<BinaryOp>("*", Expression::MULTIPLY, Module, *S, *E);
       break;
     case '/':
-      E = make<Divide>(Module, *S, *E);
+      E = make<BinaryOp>("/", Expression::DIVIDE, Module, *S, *E);
       break;
     case '+':
-      E = make<Add>(Module, *S, *E);
+      E = make<BinaryOp>("+", Expression::ADD, Module, *S, *E);
       break;
     case '-':
-      E = make<Subtract>(Module, *S, *E);
+      E = make<BinaryOp>("-", Expression::SUBTRACT, Module, *S, *E);
       break;
     case '<':
-      E = make<LeftShift>(Module, *S, *E);
+      E = make<BinaryOp>("<<", Expression::BITWISE_LS, Module, *S, *E);
       break;
     case '>':
-      E = make<RightShift>(Module, *S, *E);
+      E = make<BinaryOp>(">>", Expression::BITWISE_RS, Module, *S, *E);
       break;
     case '&':
-      E = make<BitwiseAnd>(Module, *S, *E);
+      E = make<BinaryOp>("&", Expression::BITWISE_AND, Module, *S, *E);
       break;
     case '|':
-      E = make<BitwiseOr>(Module, *S, *E);
+      E = make<BinaryOp>("|", Expression::BITWISE_OR, Module, *S, *E);
       break;
     case '^':
-      E = make<BitwiseXor>(Module, *S, *E);
+      E = make<BinaryOp>("^", Expression::BITWISE_XOR, Module, *S, *E);
       break;
     default:
       llvm_unreachable("");


### PR DESCRIPTION
Replace 16 individual binary operator subclasses (Add, Subtract, Modulo, Multiply, Divide, ConditionGT/LT/EQ/GTE/LTE/NEQ, RightShift, LeftShift, BitwiseOr/And/Xor, LogicalOp, Max, Min) with a single BinaryOp class that dispatches on Expression::Type. Similarly replace Complement, UnaryPlus, UnaryMinus, UnaryNot with a single UnaryOp class.