### PR TITLE
[X86] Fix R_X86_64_TPOFF against weak undefined TLS symbols

### DIFF
--- a/lib/Target/X86/x86_64Relocator.cpp
+++ b/lib/Target/X86/x86_64Relocator.cpp
@@ -752,6 +752,13 @@ Relocator::Result eld::relocTPOFF(Relocation &pReloc, x86_64Relocator &pParent,
 
   uint64_t TLSTemplateSize = pParent.getTarget().getTLSTemplateSize();
 
+  ResolveInfo *rsym = pReloc.symInfo();
+  if (rsym && rsym->isWeakUndef() &&
+      (pParent.config().codeGenType() == LinkerConfig::Exec)) {
+    Relocator::DWord A = pReloc.addend();
+    return ApplyReloc(pReloc, A, pRelocDesc, DiagEngine, options, pParent);
+  }
+
   if (TLSTemplateSize == 0) {
     pParent.config().raise(Diag::no_pt_tls_segment);
     return Relocator::BadReloc;

--- a/lib/Target/X86/x86_64Relocator.cpp
+++ b/lib/Target/X86/x86_64Relocator.cpp
@@ -754,7 +754,7 @@ Relocator::Result eld::relocTPOFF(Relocation &pReloc, x86_64Relocator &pParent,
 
   ResolveInfo *rsym = pReloc.symInfo();
   if (rsym && rsym->isWeakUndef() &&
-      (pParent.config().codeGenType() == LinkerConfig::Exec)) {
+      pParent.config().isBuildingExecutable()) {
     Relocator::DWord A = pReloc.addend();
     return ApplyReloc(pReloc, A, pRelocDesc, DiagEngine, options, pParent);
   }

--- a/test/x86_64/linux/WeakUndefTLS/Inputs/weak_tls_defined.s
+++ b/test/x86_64/linux/WeakUndefTLS/Inputs/weak_tls_defined.s
@@ -1,0 +1,11 @@
+.section .tdata, "awT", @progbits
+.align 4
+.global real_tls
+real_tls:
+  .long 0
+
+.section .data
+.align 4
+result:
+  .long 0xdeadbeef
+  .reloc result, R_X86_64_TPOFF32, real_tls

--- a/test/x86_64/linux/WeakUndefTLS/Inputs/weak_tls_ld.s
+++ b/test/x86_64/linux/WeakUndefTLS/Inputs/weak_tls_ld.s
@@ -1,0 +1,6 @@
+.weak weak_tls
+.section .data
+.align 4
+result:
+  .long 0xdeadbeef
+  .reloc result, R_X86_64_DTPOFF32, weak_tls

--- a/test/x86_64/linux/WeakUndefTLS/Inputs/weak_tls_ld64.s
+++ b/test/x86_64/linux/WeakUndefTLS/Inputs/weak_tls_ld64.s
@@ -1,0 +1,6 @@
+.weak weak_tls
+.section .data
+.align 8
+result:
+  .quad 0xdeadbeefdeadbeef
+  .reloc result, R_X86_64_DTPOFF64, weak_tls

--- a/test/x86_64/linux/WeakUndefTLS/Inputs/weak_tls_le.s
+++ b/test/x86_64/linux/WeakUndefTLS/Inputs/weak_tls_le.s
@@ -1,0 +1,6 @@
+.weak weak_tls
+.section .data
+.align 4
+result:
+  .long 0xdeadbeef
+  .reloc result, R_X86_64_TPOFF32, weak_tls

--- a/test/x86_64/linux/WeakUndefTLS/Inputs/weak_tls_le64.s
+++ b/test/x86_64/linux/WeakUndefTLS/Inputs/weak_tls_le64.s
@@ -1,0 +1,6 @@
+.weak weak_tls
+.section .data
+.align 8
+result:
+  .quad 0xdeadbeefdeadbeef
+  .reloc result, R_X86_64_TPOFF64, weak_tls

--- a/test/x86_64/linux/WeakUndefTLS/Inputs/weak_tls_le_addend.s
+++ b/test/x86_64/linux/WeakUndefTLS/Inputs/weak_tls_le_addend.s
@@ -1,0 +1,6 @@
+.weak weak_tls
+.section .data
+.align 4
+result:
+  .long 0xdeadbeef
+  .reloc result, R_X86_64_TPOFF32, weak_tls+2

--- a/test/x86_64/linux/WeakUndefTLS/WeakUndefTLS.test
+++ b/test/x86_64/linux/WeakUndefTLS/WeakUndefTLS.test
@@ -1,0 +1,61 @@
+#--WeakUndefTLS.test----------Executable--------#
+BEGIN_COMMENT
+# Test R_X86_64_TPOFF32/64 and R_X86_64_DTPOFF32/64 relocations against
+# weak undefined TLS symbols. A weak undefined TLS symbol has no TLS slot,
+# so the tpoff formula must not run; the result is the addend only (= 0
+# for the common case). Mirrors lld's R_TPREL guard:
+#   if (sym.isUndefined()) return a;
+# Also verifies that defined TLS symbols are unaffected (regression guard).
+#END_COMMENT
+
+#START_TEST
+
+# Case 1: TPOFF32 + weak-undef -> 0x00000000
+RUN: %clang %clangopts -c %p/Inputs/weak_tls_le.s -o %t.le.o
+RUN: %link %linkopts -static %t.le.o -o %t.le.exe
+RUN: %objdump -s -j .data %t.le.exe | %filecheck %s --check-prefix=LE32
+
+# Case 2: TPOFF64 + weak-undef -> 0x0000000000000000
+RUN: %clang %clangopts -c %p/Inputs/weak_tls_le64.s -o %t.le64.o
+RUN: %link %linkopts -static %t.le64.o -o %t.le64.exe
+RUN: %objdump -s -j .data %t.le64.exe | %filecheck %s --check-prefix=LE64
+
+# Case 3: DTPOFF32 + weak-undef -> 0x00000000
+RUN: %clang %clangopts -c %p/Inputs/weak_tls_ld.s -o %t.ld.o
+RUN: %link %linkopts -static %t.ld.o -o %t.ld.exe
+RUN: %objdump -s -j .data %t.ld.exe | %filecheck %s --check-prefix=LD32
+
+# Case 4: DTPOFF64 + weak-undef -> 0x0000000000000000
+RUN: %clang %clangopts -c %p/Inputs/weak_tls_ld64.s -o %t.ld64.o
+RUN: %link %linkopts -static %t.ld64.o -o %t.ld64.exe
+RUN: %objdump -s -j .data %t.ld64.exe | %filecheck %s --check-prefix=LD64
+
+# Case 5: TPOFF32 + defined symbol -> -4 = 0xfffffffc (regression guard)
+RUN: %clang %clangopts -c %p/Inputs/weak_tls_defined.s -o %t.def.o
+RUN: %link %linkopts -static %t.def.o -o %t.def.exe
+RUN: %objdump -s -j .data %t.def.exe | %filecheck %s --check-prefix=DEFINED
+
+# Case 6: TPOFF32 + weak-undef + addend=2 -> 0x00000002
+RUN: %clang %clangopts -c %p/Inputs/weak_tls_le_addend.s -o %t.addend.o
+RUN: %link %linkopts -static %t.addend.o -o %t.addend.exe
+RUN: %objdump -s -j .data %t.addend.exe | %filecheck %s --check-prefix=ADDEND
+
+LE32:      Contents of section .data:
+LE32-NEXT: {{[0-9a-f]+}} 00000000
+
+LE64:      Contents of section .data:
+LE64-NEXT: {{[0-9a-f]+}} 00000000 00000000
+
+LD32:      Contents of section .data:
+LD32-NEXT: {{[0-9a-f]+}} 00000000
+
+LD64:      Contents of section .data:
+LD64-NEXT: {{[0-9a-f]+}} 00000000 00000000
+
+DEFINED:      Contents of section .data:
+DEFINED-NEXT: {{[0-9a-f]+}} fcffffff
+
+ADDEND:      Contents of section .data:
+ADDEND-NEXT: {{[0-9a-f]+}} 02000000
+
+#END_TEST

--- a/test/x86_64/linux/WeakUndefTLS/WeakUndefTLS.test
+++ b/test/x86_64/linux/WeakUndefTLS/WeakUndefTLS.test
@@ -5,7 +5,8 @@ BEGIN_COMMENT
 # so the tpoff formula must not run; the result is the addend only (= 0
 # for the common case). Mirrors lld's R_TPREL guard:
 #   if (sym.isUndefined()) return a;
-# Also verifies that defined TLS symbols are unaffected (regression guard).
+# Verify this for static and PIE executables, and ensure defined TLS symbols
+# still use the normal TPOFF calculation.
 #END_COMMENT
 
 #START_TEST
@@ -40,6 +41,22 @@ RUN: %clang %clangopts -c %p/Inputs/weak_tls_le_addend.s -o %t.addend.o
 RUN: %link %linkopts -static %t.addend.o -o %t.addend.exe
 RUN: %objdump -s -j .data %t.addend.exe | %filecheck %s --check-prefix=ADDEND
 
+# Case 7: PIE + TPOFF32 + weak-undef -> 0x00000000
+RUN: %link %linkopts -pie %t.le.o -o %t.le.pie
+RUN: %objdump -s -j .data %t.le.pie | %filecheck %s --check-prefix=PIE-LE32
+
+# Case 8: PIE + TPOFF64 + weak-undef -> 0x0000000000000000
+RUN: %link %linkopts -pie %t.le64.o -o %t.le64.pie
+RUN: %objdump -s -j .data %t.le64.pie | %filecheck %s --check-prefix=PIE-LE64
+
+# Case 9: PIE + weak-undef + non-zero addend -> 0x00000002
+RUN: %link %linkopts -pie %t.addend.o -o %t.addend.pie
+RUN: %objdump -s -j .data %t.addend.pie | %filecheck %s --check-prefix=PIE-ADDEND
+
+# Case 10: PIE + defined TLS symbol -> -4 = 0xfffffffc
+RUN: %link %linkopts -pie %t.def.o -o %t.def.pie
+RUN: %objdump -s -j .data %t.def.pie | %filecheck %s --check-prefix=PIE-DEFINED
+
 LE32:      Contents of section .data:
 LE32-NEXT: {{[0-9a-f]+}} 00000000
 
@@ -57,5 +74,17 @@ DEFINED-NEXT: {{[0-9a-f]+}} fcffffff
 
 ADDEND:      Contents of section .data:
 ADDEND-NEXT: {{[0-9a-f]+}} 02000000
+
+PIE-LE32:      Contents of section .data:
+PIE-LE32-NEXT: {{[0-9a-f]+}} 00000000
+
+PIE-LE64:      Contents of section .data:
+PIE-LE64-NEXT: {{[0-9a-f]+}} 00000000 00000000
+
+PIE-ADDEND:      Contents of section .data:
+PIE-ADDEND-NEXT: {{[0-9a-f]+}} 02000000
+
+PIE-DEFINED:      Contents of section .data:
+PIE-DEFINED-NEXT: {{[0-9a-f]+}} fcffffff
 
 #END_TEST


### PR DESCRIPTION
A weak undefined TLS symbol has no slot in the PT_TLS segment, so the thread-pointer-offset formula (S - templateSize) is meaningless for it. Previously relocTPOFF applied that formula with a bogus symbol value, producing an incorrect tpoff (e.g. -3) instead of the correct 0.

Two fixes, comparing lld's R_TPREL handling:

- relocTPOFF (x86_64Relocator.cpp): short-circuit weak undefined symbols in a static executable, returning the addend directly instead of running the tpoff formula.

Add x86_64/linux/WeakUndefTLS covering TPOFF32/64 and DTPOFF32/64 against weak-undef symbols, a defined-symbol regression guard, and a non-zero addend case.

Resolves #1540