### PR TITLE
[AArch64] Fix IE->LE TLS relaxation for global symbols in static executables

### DIFF
--- a/lib/Target/AArch64/AArch64Relocator.cpp
+++ b/lib/Target/AArch64/AArch64Relocator.cpp
@@ -543,11 +543,12 @@ void AArch64Relocator::scanGlobalReloc(InputFile &pInput, Relocation &pReloc,
     // return if we already create GOT for this symbol
     if (rsym->reserved() & ReserveGOT)
       return;
-
+    if (config().isCodeStatic())
+      return;
     // set up the got and the corresponding rel entry
     AArch64GOT *G = m_Target.createGOT(GOT::TLS_IE, Obj, rsym);
-    if (config().isCodeStatic() || (config().isBuildingExecutable() &&
-                                    !m_Target.isSymbolPreemptible(*rsym))) {
+    if (config().isBuildingExecutable() &&
+        !m_Target.isSymbolPreemptible(*rsym)) {
       rsym->setReserved(rsym->reserved() | ReserveGOT);
       G->setValueType(GOT::TLSStaticSymbolValue);
       return;

--- a/lib/Target/AArch64/AArch64Relocator.cpp
+++ b/lib/Target/AArch64/AArch64Relocator.cpp
@@ -543,7 +543,9 @@ void AArch64Relocator::scanGlobalReloc(InputFile &pInput, Relocation &pReloc,
     // return if we already create GOT for this symbol
     if (rsym->reserved() & ReserveGOT)
       return;
-
+   
+    if (config().isCodeStatic())
+      return;
     // set up the got and the corresponding rel entry
     AArch64GOT *G = m_Target.createGOT(GOT::TLS_IE, Obj, rsym);
     if (config().isCodeStatic() || (config().isBuildingExecutable() &&
@@ -1185,7 +1187,8 @@ Relocator::Result tls_gottprel_page(Relocation &pReloc,
   DiagnosticEngine *DiagEngine = pParent.config().getDiagEngine();
   Relocator::DWord A = pReloc.addend();
 
-  if (!(pReloc.symInfo()->reserved() & Relocator::ReserveGOT)) {
+  if (!(pReloc.symInfo()->reserved() & Relocator::ReserveGOT) ||
+      pParent.config().isCodeStatic()) {
     Relocator::DWord X =
         pParent.getSymValue(&pReloc) + AArch64LDBackend::getStaticTCBSize();
     // Convert to movz
@@ -1210,7 +1213,8 @@ Relocator::Result tls_gottprel_lo(Relocation &pReloc,
                                   AArch64Relocator &pParent) {
   Relocator::DWord A = pReloc.addend();
 
-  if (!(pReloc.symInfo()->reserved() & Relocator::ReserveGOT)) {
+  if (!(pReloc.symInfo()->reserved() & Relocator::ReserveGOT) ||
+      pParent.config().isCodeStatic()) {
     Relocator::DWord X =
         pParent.getSymValue(&pReloc) + AArch64LDBackend::getStaticTCBSize();
     // Convert to movk

--- a/test/AArch64/RunTests/TLS_IE/Inputs/tls_ie.c
+++ b/test/AArch64/RunTests/TLS_IE/Inputs/tls_ie.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+__thread int tls_global = 42;
+static __thread int tls_local = 100;
+
+int main() {
+  printf("tls_global = %d\n", tls_global);
+  printf("tls_local = %d\n", tls_local);
+  tls_global = 99;
+  printf("tls_global after write = %d\n", tls_global);
+  return 0;
+}

--- a/test/AArch64/RunTests/TLS_IE/TLS_IE.test
+++ b/test/AArch64/RunTests/TLS_IE/TLS_IE.test
@@ -1,0 +1,16 @@
+REQUIRES: run_test
+#---TLS_IE.test--------------------- Executable------------------#
+#BEGIN_COMMENT
+# Verify IE->LE TLS relaxation works correctly at runtime for
+# both global and local TLS symbols in static executables.
+# Regression test for issue #1004.
+#END_COMMENT
+#START_TEST
+RUN: %run_cc -o %t.o %p/Inputs/tls_ie.c -c -ftls-model=initial-exec -fPIC
+RUN: %run_cc -o %t.out %t.o -static
+RUN: %run %t.out | %filecheck %s
+#END_TEST
+
+CHECK: tls_global = 42
+CHECK: tls_local = 100
+CHECK: tls_global after write = 99

--- a/test/AArch64/standalone/TLS_IE/IE.test
+++ b/test/AArch64/standalone/TLS_IE/IE.test
@@ -8,8 +8,8 @@ RUN: %clang %clangopts -target aarch64 %p/Inputs/f.c -c -o %t3.o
 RUN: %link %linkopts -static -march aarch64 %t2.o %t3.o -z max-page-size=0x1000 -o %t2.out
 
 CHECK: _test_tls_IE
-CHECK: b0000000       adrp
-CHECK: f9400000       ldr
+CHECK: d2a00000       movz
+CHECK: f2800200       movk
 CHECK: _test_tls_IE_local
 CHECK: d2a00000       movz
 CHECK: f2800280       movk

--- a/test/AArch64/standalone/TLS_IE_ALIGN/IEAlign.test
+++ b/test/AArch64/standalone/TLS_IE_ALIGN/IEAlign.test
@@ -1,8 +1,11 @@
 #---IEAlign.test----------------------------------------------------------#
-# Check that TLS IE GOT entries account for TLS block alignment padding.
+# Check that TLS IE relaxation accounts for TLS block alignment padding.
+# For static targets, IE relaxes to LE (movz+movk) with correct offsets.
+# Variable 'b' has 128-byte alignment so its TP-relative offset is 0x80.
 RUN: %clang %clangopts -target aarch64 -c %p/Inputs/ie-align.c -o %t.o -fPIC -ftls-model=initial-exec
 RUN: %link %linkopts -march aarch64 %t.o -o %t.out --no-threads
-RUN: %readelf -x .got %t.out | %filecheck %s
+RUN: llvm-objdump --triple=aarch64 -d %t.out | %filecheck %s
 
-CHECK: .got
-CHECK: 80000000 00000000
+# Variable 'b' has 128-byte alignment, TP-relative offset = 0x80
+CHECK: movz
+CHECK: movk    x{{[0-9]+}}, #0x80

--- a/test/AArch64/standalone/TLS_IE_GOT_Offsets/TLS_IE_GOT_Offsets.test
+++ b/test/AArch64/standalone/TLS_IE_GOT_Offsets/TLS_IE_GOT_Offsets.test
@@ -1,22 +1,13 @@
 #---TLS_IE_GOT_Offsets.test------------------------------------------------#
-# Check that TLS IE GOT entries have the correct offsets (0x10 and 0x14)
-# for two thread-local variables using the initial-exec model.
-#
-# The test verifies that:
-# - Variable 'b' (first TLS variable) gets GOT entry with offset 0x10
-# - Variable 'c' (second TLS variable) gets GOT entry with offset 0x14
-#
-# These offsets account for the TLS block alignment padding. The TLS segment
-# has alignment 0x4, and with the AArch64 TLS layout, the offsets include
-# the necessary padding to align the TLS block properly (0x10 = 16 bytes of
-# padding, then 'b' at offset 0x10, 'c' at offset 0x14).
-
+# Check that TLS IE relaxation produces correct TP-relative offsets.
+# For static targets, IE relaxes to LE (movz+movk) with correct offsets.
+# Variable 'b' gets offset 0x10, variable 'c' gets offset 0x14.
 RUN: %clang %clangopts -target aarch64 -c %p/Inputs/hw1.c -o %t.o \
 RUN: -fPIC -ftls-model=initial-exec -fdata-sections
 RUN: %link %linkopts -march aarch64 %t.o -o %t.out --no-threads
-RUN: %readelf -x .got %t.out | %filecheck %s
+RUN: llvm-objdump --triple=aarch64 -d %t.out | %filecheck %s
 
-# The .got section should contain two TLS IE entries with offsets 0x10 and 0x14
-# in little-endian format (10000000 00000000 = 0x10, 14000000 00000000 = 0x14)
-CHECK: .got
-CHECK: 10000000 00000000 14000000 00000000
+# Variable 'b' has TP-relative offset 0x10
+CHECK: movk    x{{[0-9]+}}, #0x10
+# Variable 'c' has TP-relative offset 0x14
+CHECK: movk    x{{[0-9]+}}, #0x14

--- a/test/AArch64/standalone/TLS_IE_Global/Inputs/ie.s
+++ b/test/AArch64/standalone/TLS_IE_Global/Inputs/ie.s
@@ -1,0 +1,11 @@
+        .global tlsievar
+        .section        .tbss,"awT",%nobits
+        .align  2
+        .type   tlsievar, %object
+        .size   tlsievar, 4
+tlsievar:
+        .zero   4
+.text
+_test_tls_ie_global:
+        adrp x0, :gottprel:tlsievar
+        ldr  x0, [x0, :gottprel_lo12:tlsievar]

--- a/test/AArch64/standalone/TLS_IE_Global/TLS_IE_Global.test
+++ b/test/AArch64/standalone/TLS_IE_Global/TLS_IE_Global.test
@@ -1,0 +1,7 @@
+RUN: %clangas %clangasopts -filetype obj -target-cpu generic -target-feature +neon -mrelax-all %p/Inputs/ie.s -o %t.o
+RUN: %link %linkopts -march aarch64 -static -z max-page-size=0x1000 %t.o -o %t.out
+RUN: llvm-objdump -d %t.out | %filecheck %s
+
+CHECK: _test_tls_ie_global
+CHECK: d2a00000       movz
+CHECK: f2800200       movk


### PR DESCRIPTION
IE->LE TLS relaxation was only applied to local symbols. Global TLS symbols in static executables were incorrectly doing a GOT-relative  load (adrp + ldr) instead of relaxing to direct TP-relative instructions (movz + movk).

part of #1004