### PR TITLE
[linux-kernel] Add kernel-check label to run linux-kernel on a PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 
 on:
   pull_request:
-    # `labeled` so adding `zephyr-check` mid-PR triggers a fresh CI upload.
+    # `labeled` so adding `zephyr-check`/`kernel-check` mid-PR triggers a fresh
+    # CI upload.
     types: [opened, synchronize, reopened, labeled]
     paths-ignore:
       - '.github/workflows/sanitize.yml'
@@ -14,7 +15,9 @@ on:
       - '.github/workflows/DownloadClangCrossToolchain/action.yaml'
       - '.github/workflows/DownloadLatestBusybox/action.yaml'
       - '.github/workflows/busybox.yml'
-      - '.github/workflows/linux-kernel.yml'
+      - '.github/workflows/linux-kernel-nightly.yml'
+      - '.github/workflows/linux-kernel-run.yml'
+      - '.github/workflows/linux-kernel-pr.yml'
       - '.github/workflows/nightly-musl-builder.yml'
       - '.github/workflows/picolibc-builder.yml'
       - '.github/workflows/nightly-test.yml'
@@ -29,10 +32,12 @@ on:
 permissions: {}
 jobs:
   build:
-    # Skip label-triggered runs unless the label is `zephyr-check`.
+    # Skip label-triggered runs unless the label is `zephyr-check` or
+    # `kernel-check`.
     if: |
       github.event.action != 'labeled' ||
-      github.event.label.name == 'zephyr-check'
+      github.event.label.name == 'zephyr-check' ||
+      github.event.label.name == 'kernel-check'
     runs-on: self-hosted
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -171,12 +176,14 @@ jobs:
         working-directory: pr-${{ env.PR_NUMBER }}/obj
         run: ninja check-eld-summary
 
-      # Package the PR-built ld.eld (+ libs) for zephyr-pr.yml. `inst/` layout
-      # matches FetchNightlyToolset (~27MB compressed). Gated on `zephyr-check`.
+      # Package the PR-built ld.eld (+ libs) for zephyr-pr.yml and
+      # linux-kernel-pr.yml. `inst/` layout matches FetchNightlyToolset
+      # (~27MB compressed). Gated on `zephyr-check`/`kernel-check`.
       - name: Package PR ELD toolset
         if: |
           steps.file-check.outputs.skip_build == 'false' &&
-          contains(github.event.pull_request.labels.*.name, 'zephyr-check')
+          (contains(github.event.pull_request.labels.*.name, 'zephyr-check') ||
+           contains(github.event.pull_request.labels.*.name, 'kernel-check'))
         working-directory: pr-${{ env.PR_NUMBER }}
         shell: bash
         run: |
@@ -196,7 +203,8 @@ jobs:
       - name: Upload PR ELD toolset
         if: |
           steps.file-check.outputs.skip_build == 'false' &&
-          contains(github.event.pull_request.labels.*.name, 'zephyr-check')
+          (contains(github.event.pull_request.labels.*.name, 'zephyr-check') ||
+           contains(github.event.pull_request.labels.*.name, 'kernel-check'))
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
           name: pr-eld-toolset

--- a/.github/workflows/linux-kernel-nightly.yml
+++ b/.github/workflows/linux-kernel-nightly.yml
@@ -1,0 +1,128 @@
+name: Linux Kernel Boot Nightly with ELD
+
+# Boot a Linux kernel built with the latest nightly ELD toolset. Depends on
+# nightly-test.yml's toolset and busybox-eld.yml's BusyBox artifact; starts 1h
+# after busybox-eld.yml (0 11 * * *) so that run has finished and published its
+# artifact. The kernel boot body lives in the reusable linux-kernel-run.yml.
+
+on:
+  # pull_request: {} # Uncomment only to test this WF file update.
+  schedule:
+    - cron: "0 12 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  resolve:
+    if: github.repository == 'qualcomm/eld' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    outputs:
+      run_id: ${{ steps.find.outputs.run_id }}
+    steps:
+      - name: Resolve nightly-test.yml run id
+        id: find
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9.0.0
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const resp = await github.rest.actions.listWorkflowRuns({
+              owner, repo,
+              workflow_id: 'nightly-test.yml',
+              status: 'success',
+              per_page: 1, // we only need the latest
+            });
+            const runs = resp.data.workflow_runs || [];
+            if (runs.length === 0) {
+              core.setFailed('No successful nightly-test.yml run found.');
+              return;
+            }
+            const run = runs[0];
+            core.info(`Latest successful nightly-test.yml run: id=${run.id}, run_number=${run.run_number}`);
+            core.setOutput('run_id', String(run.id));
+
+  kernel:
+    needs: resolve
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: riscv32
+            target_triple: riscv32-unknown-linux-musl
+            kbuild_arch: riscv
+            defconfig: rv32_defconfig
+            kernel_image: arch/riscv/boot/Image
+            qemu_bin: qemu-system-riscv32
+            qemu_machine: virt
+            qemu_cpu: ""
+            qemu_bios: /usr/lib/riscv32-linux-gnu/opensbi/generic/fw_dynamic.bin
+            console_device: ttyS0
+            enabled: 1
+          - arch: riscv64
+            target_triple: riscv64-unknown-linux-musl
+            kbuild_arch: riscv
+            defconfig: defconfig
+            kernel_image: arch/riscv/boot/Image
+            qemu_bin: qemu-system-riscv64
+            qemu_machine: virt
+            qemu_cpu: ""
+            qemu_bios: ""
+            console_device: ttyS0
+            enabled: 0
+          - arch: x86_64
+            target_triple: x86_64-unknown-linux-musl
+            kbuild_arch: x86_64
+            defconfig: x86_64_defconfig
+            kernel_image: arch/x86/boot/bzImage
+            qemu_bin: qemu-system-x86_64
+            qemu_machine: pc
+            qemu_cpu: ""
+            qemu_bios: ""
+            console_device: ttyS0
+            enabled: 0
+          - arch: arm
+            target_triple: arm-unknown-linux-musleabi
+            kbuild_arch: arm
+            defconfig: multi_v7_defconfig
+            kernel_image: arch/arm/boot/zImage
+            qemu_bin: qemu-system-arm
+            qemu_machine: virt
+            qemu_cpu: ""
+            qemu_bios: ""
+            console_device: ttyAMA0
+            enabled: 0
+          - arch: aarch64
+            target_triple: aarch64-unknown-linux-musl
+            kbuild_arch: arm64
+            defconfig: defconfig
+            kernel_image: arch/arm64/boot/Image
+            qemu_bin: qemu-system-aarch64
+            qemu_machine: virt
+            qemu_cpu: cortex-a57
+            qemu_bios: ""
+            console_device: ttyAMA0
+            enabled: 0
+    uses: ./.github/workflows/linux-kernel-run.yml
+    with:
+      arch: ${{ matrix.arch }}
+      target_triple: ${{ matrix.target_triple }}
+      kbuild_arch: ${{ matrix.kbuild_arch }}
+      defconfig: ${{ matrix.defconfig }}
+      kernel_image: ${{ matrix.kernel_image }}
+      qemu_bin: ${{ matrix.qemu_bin }}
+      qemu_machine: ${{ matrix.qemu_machine }}
+      qemu_cpu: ${{ matrix.qemu_cpu }}
+      qemu_bios: ${{ matrix.qemu_bios }}
+      console_device: ${{ matrix.console_device }}
+      enabled: ${{ matrix.enabled }}
+      toolset_run_id: ${{ needs.resolve.outputs.run_id }}
+      toolset_artifact: install-nightly-toolchain.tar.xz
+      toolset_tarball: install-nightly-toolchain.tar.xz

--- a/.github/workflows/linux-kernel-pr.yml
+++ b/.github/workflows/linux-kernel-pr.yml
@@ -1,0 +1,204 @@
+name: Linux Kernel Boot on ELD PR
+
+# Boot a Linux kernel built with a PR's own ELD build. Opt-in via the
+# `kernel-check` label (which makes ci.yml package a pr-eld-toolset artifact),
+# or manually with a PR number. The kernel boot body lives in the reusable
+# linux-kernel-run.yml.
+
+on:
+  workflow_run: # zizmor: ignore[dangerous-triggers] read-only token, no secrets, ephemeral runner
+    workflows: [CI]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number (discovers the latest ci.yml run whose pr-eld-toolset artifact is still available)"
+        required: true
+
+# A newer run for the same PR supersedes the previous one.
+concurrency:
+  group: linux-kernel-pr-${{ github.event.inputs.pr_number || github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  resolve:
+    if: |
+      github.repository == 'qualcomm/eld' &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      pull-requests: read
+    outputs:
+      run_id: ${{ steps.find.outputs.run_id }}
+      head_sha: ${{ steps.find.outputs.head_sha }}
+    steps:
+      - name: Resolve ci.yml run id
+        id: find
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9.0.0
+        env:
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const liveToolset = async (runId) => {
+              const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+                owner, repo, run_id: runId, name: 'pr-eld-toolset',
+              });
+              return data.artifacts.some(a => !a.expired);
+            };
+
+            const wr = context.payload.workflow_run;
+            if (wr) {
+              if (await liveToolset(wr.id)) {
+                core.setOutput('run_id', String(wr.id));
+                core.setOutput('head_sha', wr.head_sha);
+              }
+              return;
+            }
+
+            // Manual path: newest ci.yml run for the PR head that still has one.
+            const prNumber = (process.env.PR_NUMBER || '').trim();
+            if (!prNumber) {
+              core.setFailed('Provide a pr_number.');
+              return;
+            }
+            const pr = await github.rest.pulls.get({
+              owner, repo, pull_number: Number(prNumber),
+            });
+            const headSha = pr.data.head.sha;
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
+              {
+                owner, repo,
+                workflow_id: 'ci.yml',
+                event: 'pull_request',
+                head_sha: headSha,
+                per_page: 100,
+              }
+            );
+            runs.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+            for (const run of runs) {
+              if (await liveToolset(run.id)) {
+                core.setOutput('run_id', String(run.id));
+                core.setOutput('head_sha', headSha);
+                return;
+              }
+            }
+            core.setFailed(
+              `No ci.yml run for SHA ${headSha} has an available ` +
+              `pr-eld-toolset artifact. Add the \`kernel-check\` label and ` +
+              `re-run CI (the artifact has retention-days: 1), then dispatch ` +
+              `this workflow again.`);
+
+  kernel:
+    needs: resolve
+    if: needs.resolve.outputs.run_id != ''
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: riscv32
+            target_triple: riscv32-unknown-linux-musl
+            kbuild_arch: riscv
+            defconfig: rv32_defconfig
+            kernel_image: arch/riscv/boot/Image
+            qemu_bin: qemu-system-riscv32
+            qemu_machine: virt
+            qemu_cpu: ""
+            qemu_bios: /usr/lib/riscv32-linux-gnu/opensbi/generic/fw_dynamic.bin
+            console_device: ttyS0
+            enabled: 1
+          - arch: riscv64
+            target_triple: riscv64-unknown-linux-musl
+            kbuild_arch: riscv
+            defconfig: defconfig
+            kernel_image: arch/riscv/boot/Image
+            qemu_bin: qemu-system-riscv64
+            qemu_machine: virt
+            qemu_cpu: ""
+            qemu_bios: ""
+            console_device: ttyS0
+            enabled: 0
+          - arch: x86_64
+            target_triple: x86_64-unknown-linux-musl
+            kbuild_arch: x86_64
+            defconfig: x86_64_defconfig
+            kernel_image: arch/x86/boot/bzImage
+            qemu_bin: qemu-system-x86_64
+            qemu_machine: pc
+            qemu_cpu: ""
+            qemu_bios: ""
+            console_device: ttyS0
+            enabled: 0
+          - arch: arm
+            target_triple: arm-unknown-linux-musleabi
+            kbuild_arch: arm
+            defconfig: multi_v7_defconfig
+            kernel_image: arch/arm/boot/zImage
+            qemu_bin: qemu-system-arm
+            qemu_machine: virt
+            qemu_cpu: ""
+            qemu_bios: ""
+            console_device: ttyAMA0
+            enabled: 0
+          - arch: aarch64
+            target_triple: aarch64-unknown-linux-musl
+            kbuild_arch: arm64
+            defconfig: defconfig
+            kernel_image: arch/arm64/boot/Image
+            qemu_bin: qemu-system-aarch64
+            qemu_machine: virt
+            qemu_cpu: cortex-a57
+            qemu_bios: ""
+            console_device: ttyAMA0
+            enabled: 0
+    uses: ./.github/workflows/linux-kernel-run.yml
+    with:
+      arch: ${{ matrix.arch }}
+      target_triple: ${{ matrix.target_triple }}
+      kbuild_arch: ${{ matrix.kbuild_arch }}
+      defconfig: ${{ matrix.defconfig }}
+      kernel_image: ${{ matrix.kernel_image }}
+      qemu_bin: ${{ matrix.qemu_bin }}
+      qemu_machine: ${{ matrix.qemu_machine }}
+      qemu_cpu: ${{ matrix.qemu_cpu }}
+      qemu_bios: ${{ matrix.qemu_bios }}
+      console_device: ${{ matrix.console_device }}
+      enabled: ${{ matrix.enabled }}
+      toolset_run_id: ${{ needs.resolve.outputs.run_id }}
+      toolset_artifact: pr-eld-toolset
+      toolset_tarball: install-pr-toolset.tar.xz
+
+  # Post the aggregate matrix result on the PR.
+  status:
+    needs: [resolve, kernel]
+    if: |
+      always() && needs.resolve.outputs.run_id != '' &&
+      needs.kernel.result != 'cancelled'
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Report Linux kernel boot result on the PR
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9.0.0
+        env:
+          HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
+          RESULT: ${{ needs.kernel.result }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: process.env.HEAD_SHA,
+              context: 'linux-kernel (informational)',
+              state: process.env.RESULT === 'success' ? 'success' : 'failure',
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });

--- a/.github/workflows/linux-kernel-run.yml
+++ b/.github/workflows/linux-kernel-run.yml
@@ -1,119 +1,96 @@
-name: Linux Kernel Boot
+name: Linux Kernel Boot (reusable)
 
-# Build a Linux kernel for each architecture in the matrix below, package
-# BusyBox into an initramfs, and boot it in qemu-system-* to confirm ELD can
-# correctly link and run something as structurally complex as a
-# kernel + real userspace.
+# Reusable Linux kernel boot body, called by linux-kernel-nightly.yml and
+# linux-kernel-pr.yml. Builds a Linux kernel for the given architecture with
+# ELD, packages BusyBox into an initramfs, and boots it in qemu-system-* to
+# confirm ELD can correctly link and run something as structurally complex as a
+# kernel + real userspace. Callers resolve a run id and pass the toolset
+# artifact/tarball names; FetchEldToolset normalizes either source to ./inst.
 
 on:
-  workflow_dispatch:
-  # pull_request: {} # Uncomment only to test this WF file update.
-  schedule:
-    # Depends on both nightly-test.yml's toolset and busybox-eld.yml's
-    # BusyBox artifact; starts 1h after busybox-eld.yml (0 11 * * *) so that
-    # run has finished and published its artifact.
-    - cron: "0 12 * * *"
-
-permissions: {}
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  workflow_call:
+    inputs:
+      arch:
+        description: "Arch label, used for ccache keys, artifact names, and build-status records"
+        required: true
+        type: string
+      target_triple:
+        description: "clang-cross toolchain triple (e.g. riscv32-unknown-linux-musl)"
+        required: true
+        type: string
+      kbuild_arch:
+        description: "Kernel ARCH= value (e.g. riscv, x86_64, arm, arm64)"
+        required: true
+        type: string
+      defconfig:
+        description: "Kernel defconfig target (e.g. rv32_defconfig)"
+        required: true
+        type: string
+      kernel_image:
+        description: "Path to the built kernel image, relative to the linux tree"
+        required: true
+        type: string
+      qemu_bin:
+        description: "qemu-system-* binary to boot with"
+        required: true
+        type: string
+      qemu_machine:
+        description: "QEMU -M machine value"
+        required: true
+        type: string
+      qemu_cpu:
+        description: "QEMU -cpu value; may be empty"
+        required: false
+        type: string
+        default: ""
+      qemu_bios:
+        description: "Explicit -bios firmware path; may be empty"
+        required: false
+        type: string
+        default: ""
+      console_device:
+        description: "Kernel console device (e.g. ttyS0, ttyAMA0)"
+        required: true
+        type: string
+      enabled:
+        description: "Whether this arch actually runs (1) or is skipped (0)"
+        required: true
+        type: number
+      toolset_run_id:
+        description: "Workflow run id to download the ELD toolset artifact from"
+        required: true
+        type: string
+      toolset_artifact:
+        description: "Artifact name to download (e.g. pr-eld-toolset or install-nightly-toolchain.tar.xz)"
+        required: true
+        type: string
+      toolset_tarball:
+        description: "Tar filename inside the artifact to extract (e.g. install-pr-toolset.tar.xz)"
+        required: true
+        type: string
 
 env:
   KERNEL_TAG: v7.1
 
 jobs:
   kernel-boot:
-    if: github.repository == 'qualcomm/eld'
     runs-on: ubuntu-latest
     permissions:
       contents: write # BuildStatusDataRecorder pushes to the dashboard branch
-      actions: read # list/download artifacts from busybox-eld.yml and the nightly toolset run
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: riscv32
-            target_triple: riscv32-unknown-linux-musl
-            kbuild_arch: riscv
-            defconfig: rv32_defconfig
-            kernel_image: arch/riscv/boot/Image
-            qemu_bin: qemu-system-riscv32
-            qemu_machine: virt
-            qemu_cpu: ""
-            qemu_bios: /usr/lib/riscv32-linux-gnu/opensbi/generic/fw_dynamic.bin
-            console_device: ttyS0
-            enabled: 1
-          - arch: riscv64
-            target_triple: riscv64-unknown-linux-musl
-            kbuild_arch: riscv
-            defconfig: defconfig
-            kernel_image: arch/riscv/boot/Image
-            qemu_bin: qemu-system-riscv64
-            qemu_machine: virt
-            qemu_cpu: ""
-            qemu_bios: ""
-            console_device: ttyS0
-            enabled: 0
-          - arch: x86_64
-            target_triple: x86_64-unknown-linux-musl
-            kbuild_arch: x86_64
-            defconfig: x86_64_defconfig
-            kernel_image: arch/x86/boot/bzImage
-            qemu_bin: qemu-system-x86_64
-            qemu_machine: pc
-            qemu_cpu: ""
-            qemu_bios: ""
-            console_device: ttyS0
-            enabled: 0
-          - arch: arm
-            target_triple: arm-unknown-linux-musleabi
-            kbuild_arch: arm
-            defconfig: multi_v7_defconfig
-            kernel_image: arch/arm/boot/zImage
-            qemu_bin: qemu-system-arm
-            qemu_machine: virt
-            qemu_cpu: ""
-            qemu_bios: ""
-            console_device: ttyAMA0
-            enabled: 0
-          - arch: aarch64
-            target_triple: aarch64-unknown-linux-musl
-            kbuild_arch: arm64
-            defconfig: defconfig
-            kernel_image: arch/arm64/boot/Image
-            qemu_bin: qemu-system-aarch64
-            qemu_machine: virt
-            qemu_cpu: cortex-a57
-            qemu_bios: ""
-            console_device: ttyAMA0
-            enabled: 0
+      actions: read # list/download artifacts from busybox-eld.yml and the toolset run
     env:
-      KERNEL_IMAGE: ${{ matrix.kernel_image }}
+      KERNEL_IMAGE: ${{ inputs.kernel_image }}
     steps:
       - name: Checkout eld
-        if: matrix.enabled == 1 && github.event_name != 'pull_request'
+        if: inputs.enabled == 1
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: qualcomm/eld
-          ref: main
-          fetch-depth: 1
-
-      - name: Checkout eld PR branch
-        if: matrix.enabled == 1 && github.event_name == 'pull_request'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 1
 
       - name: Configure workflow environment variables
-        if: matrix.enabled == 1
+        if: inputs.enabled == 1
         uses: ./.github/workflows/ConfigureBuildWorkflowENV
 
       - name: Record pre-build entry
-        if: github.event_name == 'schedule' && matrix.enabled == 1
+        if: github.event_name == 'schedule' && inputs.enabled == 1
         uses: ./.github/workflows/BuildStatusDataRecorder
         with:
           enabled: true
@@ -123,15 +100,19 @@ jobs:
           record-mode: "record"
           status: "fail"
           run-id: ${{github.run_id}}
-          arch-name: "${{ matrix.arch }}"
+          arch-name: "${{ inputs.arch }}"
           branch-name: "${{env.BUILD_BRANCH}}"
 
-      - name: Fetch latest nightly toolset
-        if: matrix.enabled == 1
-        uses: ./.github/workflows/FetchNightlyToolset
+      - name: Fetch ELD toolset
+        if: inputs.enabled == 1
+        uses: ./.github/workflows/FetchEldToolset
+        with:
+          run-id: ${{ inputs.toolset_run_id }}
+          artifact-name: ${{ inputs.toolset_artifact }}
+          tarball: ${{ inputs.toolset_tarball }}
 
       - name: Install kernel build dependencies
-        if: matrix.enabled == 1
+        if: inputs.enabled == 1
         shell: bash
         run: |
           sudo apt update
@@ -139,32 +120,32 @@ jobs:
             qemu-system-misc qemu-system-x86 qemu-system-arm opensbi cpio ccache
 
       - name: Download latest BusyBox binary
-        if: matrix.enabled == 1
+        if: inputs.enabled == 1
         uses: ./.github/workflows/DownloadLatestBusybox
         with:
-          arch: ${{ matrix.arch }}
+          arch: ${{ inputs.arch }}
           path: busybox-dl
 
       - name: Download clang-cross toolchain
-        if: matrix.enabled == 1
+        if: inputs.enabled == 1
         uses: ./.github/workflows/DownloadClangCrossToolchain
         with:
           workspace: ${{ github.workspace }}
-          assets: ${{ matrix.target_triple }}.tar.xz
+          assets: ${{ inputs.target_triple }}.tar.xz
 
       - name: Clone Linux kernel
-        if: matrix.enabled == 1
+        if: inputs.enabled == 1
         shell: bash
         run: |
           git clone --depth 1 --branch "${KERNEL_TAG}" \
             https://github.com/torvalds/linux.git
 
       - name: Configure kernel
-        if: matrix.enabled == 1
+        if: inputs.enabled == 1
         shell: bash
         env:
-          KBUILD_ARCH: ${{ matrix.kbuild_arch }}
-          DEFCONFIG: ${{ matrix.defconfig }}
+          KBUILD_ARCH: ${{ inputs.kbuild_arch }}
+          DEFCONFIG: ${{ inputs.defconfig }}
         run: |
           set -euo pipefail
           cd linux
@@ -184,21 +165,21 @@ jobs:
           make ARCH="${KBUILD_ARCH}" olddefconfig
 
       - name: Restore linux kernel ccache
-        if: matrix.enabled == 1
+        if: inputs.enabled == 1
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           path: ${{ github.workspace }}/ccache-linux
-          key: kernel-boot-linux-ccache-${{ matrix.arch }}-${{ runner.os }}-${{ github.run_id }}
+          key: kernel-boot-linux-ccache-${{ inputs.arch }}-${{ runner.os }}-${{ github.run_id }}
           restore-keys: |
-            kernel-boot-linux-ccache-${{ matrix.arch }}-${{ runner.os }}-
+            kernel-boot-linux-ccache-${{ inputs.arch }}-${{ runner.os }}-
 
       - name: Build kernel with ELD
-        if: matrix.enabled == 1
+        if: inputs.enabled == 1
         shell: bash
         env:
           CCACHE_DIR: ${{ github.workspace }}/ccache-linux
-          KBUILD_ARCH: ${{ matrix.kbuild_arch }}
-          TARGET_TRIPLE: ${{ matrix.target_triple }}
+          KBUILD_ARCH: ${{ inputs.kbuild_arch }}
+          TARGET_TRIPLE: ${{ inputs.target_triple }}
         run: |
           set -euo pipefail
           command -v clang
@@ -220,23 +201,23 @@ jobs:
           ccache -s
 
       - name: Prune linux kernel ccache before save
-        if: matrix.enabled == 1 && always()
+        if: inputs.enabled == 1 && always()
         env:
           CCACHE_DIR: ${{ github.workspace }}/ccache-linux
         run: ccache --evict-older-than 7200s
 
       - name: Save linux kernel ccache
-        if: matrix.enabled == 1 && always()
+        if: inputs.enabled == 1 && always()
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0
         with:
           path: ${{ github.workspace }}/ccache-linux
-          key: kernel-boot-linux-ccache-${{ matrix.arch }}-${{ runner.os }}-${{ github.run_id }}
+          key: kernel-boot-linux-ccache-${{ inputs.arch }}-${{ runner.os }}-${{ github.run_id }}
 
       - name: Upload vmlinux and linker map
-        if: matrix.enabled == 1 && always()
+        if: inputs.enabled == 1 && always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
-          name: kernel-boot-${{ matrix.arch }}-vmlinux
+          name: kernel-boot-${{ inputs.arch }}-vmlinux
           retention-days: 1
           path: |
             linux/vmlinux
@@ -244,10 +225,10 @@ jobs:
           if-no-files-found: warn
 
       - name: Build initramfs
-        if: matrix.enabled == 1
+        if: inputs.enabled == 1
         shell: bash
         env:
-          TARGET_TRIPLE: ${{ matrix.target_triple }}
+          TARGET_TRIPLE: ${{ inputs.target_triple }}
         run: |
           set -euo pipefail
           chmod +x busybox-dl/busybox
@@ -295,14 +276,14 @@ jobs:
           ( cd initramfs && find . | cpio -o -H newc ) | gzip -9 > initramfs.cpio.gz
 
       - name: Boot kernel in QEMU
-        if: matrix.enabled == 1
+        if: inputs.enabled == 1
         shell: bash
         env:
-          QEMU_BIN: ${{ matrix.qemu_bin }}
-          QEMU_MACHINE: ${{ matrix.qemu_machine }}
-          QEMU_CPU: ${{ matrix.qemu_cpu }}
-          QEMU_BIOS: ${{ matrix.qemu_bios }}
-          CONSOLE_DEVICE: ${{ matrix.console_device }}
+          QEMU_BIN: ${{ inputs.qemu_bin }}
+          QEMU_MACHINE: ${{ inputs.qemu_machine }}
+          QEMU_CPU: ${{ inputs.qemu_cpu }}
+          QEMU_BIOS: ${{ inputs.qemu_bios }}
+          CONSOLE_DEVICE: ${{ inputs.console_device }}
         run: |
           set -euo pipefail
           qemu_args=(
@@ -330,21 +311,21 @@ jobs:
           cat /tmp/kernel-boot-output.txt
 
       - name: Upload boot log
-        if: matrix.enabled == 1 && always()
+        if: inputs.enabled == 1 && always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
-          name: kernel-boot-${{ matrix.arch }}-log
+          name: kernel-boot-${{ inputs.arch }}-log
           retention-days: 1
           path: /tmp/kernel-boot-output.txt
 
       - name: Validate boot log with FileCheck
-        if: matrix.enabled == 1
+        if: inputs.enabled == 1
         shell: bash
         run: |
-          FileCheck --input-file=/tmp/kernel-boot-output.txt "${{ github.workspace }}/test/LinuxKernel/${{ matrix.arch }}/test-failures.txt"
+          FileCheck --input-file=/tmp/kernel-boot-output.txt "${{ github.workspace }}/test/LinuxKernel/${{ inputs.arch }}/test-failures.txt"
 
       - name: Update build entry
-        if: matrix.enabled == 1 && success() && github.event_name == 'schedule'
+        if: inputs.enabled == 1 && success() && github.event_name == 'schedule'
         uses: ./.github/workflows/BuildStatusDataRecorder
         with:
           enabled: true
@@ -354,5 +335,5 @@ jobs:
           record-mode: "update"
           status: "pass"
           run-id: ${{github.run_id}}
-          arch-name: "${{ matrix.arch }}"
+          arch-name: "${{ inputs.arch }}"
           branch-name: "${{env.BUILD_BRANCH}}"


### PR DESCRIPTION
Split the single linux-kernel.yml into the same 3-file layout as the Zephyr workflows so a PR can boot a Linux kernel built with its own ELD:

- linux-kernel-run.yml     reusable body (workflow_call); fetches the ELD
                           toolset via FetchEldToolset so the caller chooses
                           the nightly or PR-built toolset
- linux-kernel-nightly.yml scheduled caller (renamed from linux-kernel.yml),
                           feeds the nightly toolset
- linux-kernel-pr.yml      PR caller, opt-in via the `kernel-check` label,
                           consumes ci.yml's pr-eld-toolset artifact and posts
                           a `linux-kernel (informational)` commit status

ci.yml now also packages/uploads the pr-eld-toolset artifact for the `kernel-check` label (previously only `zephyr-check`), and its paths-ignore list is updated for the renamed and new workflow files.

Only riscv32 runs today; the other arches keep enabled: 0 in the matrix.