### PR TITLE
[linux-kernel] Grant kernel job permissions for reusable workflow call

### DIFF
--- a/.github/workflows/linux-kernel-nightly.yml
+++ b/.github/workflows/linux-kernel-nightly.yml
@@ -51,6 +51,11 @@ jobs:
 
   kernel:
     needs: resolve
+    # Must grant at least what the reusable linux-kernel-run.yml kernel-boot job
+    # declares; a called job is capped at the caller job's permissions.
+    permissions:
+      contents: write # BuildStatusDataRecorder pushes to the dashboard branch
+      actions: read # list/download artifacts from busybox-eld.yml and the toolset run
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linux-kernel-pr.yml
+++ b/.github/workflows/linux-kernel-pr.yml
@@ -100,6 +100,11 @@ jobs:
   kernel:
     needs: resolve
     if: needs.resolve.outputs.run_id != ''
+    # Must grant at least what the reusable linux-kernel-run.yml kernel-boot job
+    # declares; a called job is capped at the caller job's permissions.
+    permissions:
+      contents: write # BuildStatusDataRecorder pushes to the dashboard branch
+      actions: read # list/download artifacts from busybox-eld.yml and the toolset run
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The reusable linux-kernel-run.yml kernel-boot job declares 'contents: write' and 'actions: read', but a called job is capped at the caller job's permissions. Both callers set top-level 'permissions: {}' and the calling 'kernel' job granted none, so the nested job was capped at 'actions: none, contents: none' -- which GitHub rejects statically as an invalid workflow file.

Grant the required permissions on the 'kernel' job in both callers.