### PR TITLE
[RISCV] Roll back AUIPC+JALR→JAL relaxation if out-of-range after ALIGN

### DIFF
--- a/include/eld/Diagnostics/DiagVerbose.inc
+++ b/include/eld/Diagnostics/DiagVerbose.inc
@@ -31,6 +31,15 @@ DIAG(add_nops, DiagnosticEngine::Verbose,
      "%0 : Need only %1 bytes in section %2+0x%3 file %4")
 DIAG(not_relaxed, DiagnosticEngine::Verbose,
      "%0 : Cannot relax %1 bytes for symbol '%2' in section %3+0x%4 file %5")
+DIAG(relax_call_rolled_back, DiagnosticEngine::Verbose,
+     "RISCV_CALL : Rolled back JAL for symbol '%0' in section %1+0x%2 file %3 "
+     "(out of range after ALIGN)")
+DIAG(relax_cj_rolled_back_to_jal, DiagnosticEngine::Verbose,
+     "RISCV_CALL : Rolled back C.J to JAL for symbol '%0' in section %1+0x%2 "
+     "file %3 (out of C.J range after ALIGN)")
+DIAG(relax_cj_rolled_back_to_call, DiagnosticEngine::Verbose,
+     "RISCV_CALL : Rolled back C.J to AUIPC+JALR for symbol '%0' in section "
+     "%1+0x%2 file %3 (out of JAL range after ALIGN)")
 DIAG(relax_to_compress, DiagnosticEngine::Verbose,
      "%0 : relaxing instruction 0x%1 to compressed instruction 0x%2 for symbol "
      "%3 in section %4+0x%5 file %6")

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -297,6 +297,124 @@ void RISCVLDBackend::reportMissedRelaxation(StringRef Name,
   recordRelaxationStats(Section, 0, NumBytes);
 }
 
+void RISCVLDBackend::recordCallRelaxation(RegionFragmentEx &Region,
+                                          Relocation *Reloc, uint64_t Offset,
+                                          uint32_t AuipcBytes,
+                                          uint32_t JalrBytes,
+                                          uint32_t RelaxedSize) {
+  m_CallRelaxRecords.push_back(
+      {&Region, Reloc, Offset, AuipcBytes, JalrBytes, RelaxedSize});
+}
+
+// After the ALIGN pass commits all deferred deletions, re-verify every
+// AUIPC+JALR→JAL relaxation using the final post-ALIGN symbol addresses.
+// Any relaxation whose final distance exceeds the ±1MB JAL range is undone:
+// the deleted JALR bytes are reinserted, the AUIPC is restored, and the
+// relocation type is changed back to R_RISCV_CALL_PLT.
+void RISCVLDBackend::verifyAndRollbackCallRelaxations(bool &pFinished) {
+  for (auto &R : m_CallRelaxRecords) {
+    if (R.rolledBack)
+      continue;
+
+    Relocator::DWord S = getSymbolValuePLT(*R.reloc);
+    Relocator::DWord A = R.reloc->addend();
+    Relocator::DWord P = R.reloc->place(m_Module);
+    int64_t X = static_cast<int64_t>(S + A - P);
+
+    if (R.relaxedSize == 2) {
+      // C.J/C.JAL path: check if still within ±2KB (12-bit) range.
+      if (llvm::isInt<12>(X))
+        continue;
+
+      unsigned rd = (R.jalrBytes >> 7) & 0x1fu;
+
+      if (llvm::isInt<21>(X)) {
+        // Out of C.J range but still within JAL range: expand C.J → JAL.
+        // C.J is 2B; JAL is 4B. Insert 2 bytes then overwrite with JAL.
+        R.region->insertInstruction(R.relocOffset + 2, 2);
+        uint32_t jal = 0x6fu | rd << 7;
+        R.region->replaceInstruction(R.relocOffset, R.reloc,
+                                     reinterpret_cast<uint8_t *>(&jal), 4);
+        R.reloc->setTargetData(jal);
+        R.reloc->setType(llvm::ELF::R_RISCV_JAL);
+        R.rolledBack = true;
+
+        if (m_Module.getPrinter()->isVerbose())
+          config().raise(Diag::relax_cj_rolled_back_to_jal)
+              << R.reloc->symInfo()->name()
+              << R.region->getOwningSection()->name()
+              << llvm::utohexstr(R.relocOffset)
+              << R.region->getOwningSection()
+                     ->getInputFile()
+                     ->getInput()
+                     ->decoratedPath();
+      } else {
+        // Out of JAL range too: expand C.J → AUIPC+JALR.
+        // C.J is 2B; AUIPC+JALR is 8B. Insert 6 bytes, then restore both.
+        R.region->insertInstruction(R.relocOffset + 2, 6);
+        uint32_t auipcCopy = R.auipcBytes;
+        R.region->replaceInstruction(
+            R.relocOffset, R.reloc, reinterpret_cast<uint8_t *>(&auipcCopy), 4);
+        uint32_t jalrCopy = R.jalrBytes;
+        std::memcpy(const_cast<char *>(R.region->getRegion().data()) +
+                        R.relocOffset + 4,
+                    &jalrCopy, 4);
+        R.reloc->setTargetData(R.auipcBytes);
+        R.reloc->setType(llvm::ELF::R_RISCV_CALL_PLT);
+        R.rolledBack = true;
+
+        if (m_Module.getPrinter()->isVerbose())
+          config().raise(Diag::relax_cj_rolled_back_to_call)
+              << R.reloc->symInfo()->name()
+              << R.region->getOwningSection()->name()
+              << llvm::utohexstr(R.relocOffset)
+              << R.region->getOwningSection()
+                     ->getInputFile()
+                     ->getInput()
+                     ->decoratedPath();
+      }
+
+      pFinished = false;
+      continue;
+    }
+
+    // JAL path (relaxedSize == 4): check if still within ±1MB (21-bit) range.
+    if (llvm::isInt<21>(X))
+      continue; // still in range, keep the JAL relaxation
+
+    // Out of range: undo the JAL relaxation.
+    // The JALR bytes were deleted (committed) at R.relocOffset + 4.
+    // Reinsert 4 bytes at that position and restore original instructions.
+    R.region->insertInstruction(R.relocOffset + 4, 4);
+
+    // Restore AUIPC at R.relocOffset.
+    uint32_t auipcCopy = R.auipcBytes;
+    R.region->replaceInstruction(R.relocOffset, R.reloc,
+                                 reinterpret_cast<uint8_t *>(&auipcCopy), 4);
+    // Write JALR bytes into the reinserted space.
+    uint32_t jalrCopy = R.jalrBytes;
+    std::memcpy(const_cast<char *>(R.region->getRegion().data()) +
+                    R.relocOffset + 4,
+                &jalrCopy, 4);
+
+    R.reloc->setTargetData(R.auipcBytes);
+    R.reloc->setType(llvm::ELF::R_RISCV_CALL_PLT);
+    R.rolledBack = true;
+
+    if (m_Module.getPrinter()->isVerbose())
+      config().raise(Diag::relax_call_rolled_back)
+          << R.reloc->symInfo()->name() << R.region->getOwningSection()->name()
+          << llvm::utohexstr(R.relocOffset)
+          << R.region->getOwningSection()
+                 ->getInputFile()
+                 ->getInput()
+                 ->decoratedPath();
+
+    // Fragment grew by 4 bytes: trigger another layout iteration.
+    pFinished = false;
+  }
+}
+
 // Select the matching JVT entry lookup for rd.
 // x0 uses the jump-only table instruction.
 // x1 uses the normal link-register table instruction.
@@ -399,6 +517,7 @@ bool RISCVLDBackend::doRelaxationCall(Relocation *reloc) {
   const char *msgC = (rd == 1) ? "RISCV_CALL_JAL" : "RISCV_CALL_J";
   if (canRelaxCJ) {
     uint16_t c_j = (rd == 1) ? 0x2001u : 0xa001;
+    uint32_t auipcBytes = static_cast<uint32_t>(reloc->target());
 
     if (m_Module.getPrinter()->isVerbose())
       config().raise(Diag::relax_to_compress)
@@ -417,6 +536,8 @@ bool RISCVLDBackend::doRelaxationCall(Relocation *reloc) {
     reloc->setType(llvm::ELF::R_RISCV_RVC_JUMP);
     relaxDeleteBytes("RISCV_CALL_C", *region, offset + 2, 6,
                      reloc->symInfo()->name());
+
+    recordCallRelaxation(*region, reloc, offset, auipcBytes, jalr_instr, 2);
 
     return true;
   }
@@ -442,15 +563,22 @@ bool RISCVLDBackend::doRelaxationCall(Relocation *reloc) {
   }
 
   if (canRelaxJal) {
+    // Save original bytes before we overwrite them, so we can roll back
+    // this relaxation post-ALIGN if the final distance exceeds ±1MB.
+    uint32_t auipcBytes = static_cast<uint32_t>(reloc->target());
+
     // Replace the instruction to JAL
     uint32_t jal = 0x6fu | rd << 7;
 
     region->replaceInstruction(offset, reloc, reinterpret_cast<uint8_t *>(&jal), 4);
     reloc->setTargetData(jal);
     reloc->setType(llvm::ELF::R_RISCV_JAL);
-    // Delete the next instruction
+    // Delete the next instruction (deferred)
     relaxDeleteBytes("RISCV_CALL", *region, offset + 4, 4,
                      reloc->symInfo()->name());
+
+    // Record this relaxation for post-ALIGN reverification.
+    recordCallRelaxation(*region, reloc, offset, auipcBytes, jalr_instr, 4);
 
     // Report missed relaxation as we could still do a `C.J`/`C.JAL`
     reportMissedRelaxation("RISCV_CALL_C", *region, offset, 2,
@@ -1664,8 +1792,12 @@ void RISCVLDBackend::mayBeRelax(int relaxation_pass, bool &pFinished) {
   pFinished = true;
 
   // TLSDESC relaxations only apply to executables.
-  if (relaxation_pass == RELAXATION_TLSDESC && !config().isBuildingExecutable())
+  if (relaxation_pass == RELAXATION_TLSDESC &&
+      !config().isBuildingExecutable()) {
+    pFinished =
+        false; // ALIGN pass must still run to commit deferred deletions.
     return;
+  }
 
   // RELAXATION_ALIGN pass, which is the last pass, will set pFinished to
   // false if it has made changes. It is needed to call createProgramHdrs()
@@ -1704,7 +1836,6 @@ void RISCVLDBackend::mayBeRelax(int relaxation_pass, bool &pFinished) {
             pFinished = false;
           continue;
         }
-
         if (relaxation_pass == RELAXATION_TLSDESC) {
           // doRelaxationTLSDESC is used for both TLSDESC optimizations and
           // relaxations, therefore this function should be called regardless
@@ -1817,6 +1948,12 @@ void RISCVLDBackend::mayBeRelax(int relaxation_pass, bool &pFinished) {
   // R_RISCV_ALIGN will cause another empty pass if it made changes.
   if (relaxation_pass < llvm::ELF::R_RISCV_ALIGN)
     pFinished = false;
+
+  if (relaxation_pass == RELAXATION_ALIGN) {
+    // With final layout addresses known, reverify every AUIPC+JALR→JAL
+    // relaxation from pass 0.  Any whose distance now exceeds ±1MB is undone
+    verifyAndRollbackCallRelaxations(pFinished);
+  }
 }
 
 /// finalizeSymbol - finalize the symbol value

--- a/lib/Target/RISCV/RISCVLDBackend.h
+++ b/lib/Target/RISCV/RISCVLDBackend.h
@@ -16,7 +16,9 @@
 #include "eld/SymbolResolver/IRBuilder.h"
 #include "eld/Target/GNULDBackend.h"
 #include "llvm/ADT/DenseSet.h"
+#include <cstdint>
 #include <unordered_set>
+#include <vector>
 
 namespace eld {
 
@@ -281,6 +283,25 @@ private:
 
   bool doRelaxationTLSDESC(Relocation &R, bool Relax);
 
+  // Records a call relaxation (AUIPC+JALR → C.J/JAL) so it can be reversed
+  // post-ALIGN if the final distance no longer fits the relaxed form.
+  struct CallRelaxRecord {
+    RegionFragmentEx *region;
+    Relocation *reloc;
+    uint64_t relocOffset; // fragment-relative offset of the AUIPC instruction
+    uint32_t auipcBytes;  // original AUIPC instruction bytes
+    uint32_t jalrBytes;   // original JALR instruction bytes (at relocOffset+4)
+    uint32_t
+        relaxedSize; // size in bytes of the relaxed instruction (2=C.J, 4=JAL)
+    bool rolledBack = false;
+  };
+
+  void recordCallRelaxation(RegionFragmentEx &Region, Relocation *Reloc,
+                            uint64_t Offset, uint32_t AuipcBytes,
+                            uint32_t JalrBytes, uint32_t RelaxedSize);
+
+  void verifyAndRollbackCallRelaxations(bool &pFinished);
+
   /// getRelEntrySize - the size in BYTE of rela type relocation
   size_t getRelEntrySize() override { return 0; }
 
@@ -385,6 +406,9 @@ private:
       m_BaseRelocRefs;
 
   llvm::DenseSet<const Relocation *> m_RelaxedGOTLoadRelocs;
+
+  // JAL-relaxed call records for post-ALIGN range reverification.
+  std::vector<CallRelaxRecord> m_CallRelaxRecords;
 };
 } // namespace eld
 

--- a/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_CJ_ROLLBACK_ALIGN/AUIPC_JALR_TO_CJ_ROLLBACK_ALIGN.test
+++ b/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_CJ_ROLLBACK_ALIGN/AUIPC_JALR_TO_CJ_ROLLBACK_ALIGN.test
@@ -1,0 +1,31 @@
+#---AUIPC_JALR_TO_CJ_ROLLBACK_ALIGN.test---------- Executable ------------------#
+#START_TEST
+# This test exercises the C.JAL relaxation recording path introduced alongside
+# the JAL rollback mechanism.  The C.JAL instructions remain in range after the
+# small ALIGN(16) in the linker script, so no rollback occurs here; the test
+# verifies that recording does not corrupt the output.
+#
+# NOTE: constructing a test that actually triggers C.J/C.JAL rollback is
+# geometrically difficult.  The conservative MaxAlignment slack in
+# doRelaxationCall is derived from the ELF section sh_addralign, not from the
+# linker-script ALIGN() expression.  For C.JAL relaxation to fire the distance
+# including that slack must already be <2KB.  A linker-script ALIGN larger than
+# 2KB places the sections too far apart for C.JAL to be chosen at layout time;
+# an ALIGN smaller than 2KB adds <2KB of padding and the final distance stays
+# in range.  The rollback path does handle the case correctly but requires a
+# compound scenario (e.g. a prior JAL rollback inserting bytes between the two
+# sections) that is not easily reproduced in a standalone test.
+RUN: %clang -target riscv32-linux-gnu -c %p/Inputs/calls.s   -o %t.calls.o
+RUN: %clang -target riscv32-linux-gnu -c %p/Inputs/kobject.s -o %t.kobject.o
+RUN: %clang -target riscv32-linux-gnu -c %p/Inputs/exit.s    -o %t.exit.o
+RUN: %link %linkopts --image-base 0 -T %p/Inputs/ls.lds \
+RUN:   %t.calls.o %t.kobject.o %t.exit.o -o %t.out \
+RUN:   --verbose 2>&1 | %filecheck %s --check-prefix=VERBOSE
+RUN: %objdump -d %t.out 2>&1 | %filecheck %s --check-prefix=DUMP
+#END_TEST
+
+VERBOSE: RISCV_CALL_JAL : relaxing instruction {{.*}} to compressed instruction 0x2001 for symbol kobject_put in section .exit.text+0x0 file {{.*}}exit.o
+
+DUMP-LABEL: <exit_func>:
+DUMP:        jal
+DUMP-NEXT:   ret

--- a/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_CJ_ROLLBACK_ALIGN/Inputs/calls.s
+++ b/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_CJ_ROLLBACK_ALIGN/Inputs/calls.s
@@ -1,0 +1,7 @@
+  .section .text.calls,"ax",@progbits
+  .globl dummy_target
+dummy_target:
+  ret
+  .rept 32
+  call dummy_target
+  .endr

--- a/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_CJ_ROLLBACK_ALIGN/Inputs/exit.s
+++ b/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_CJ_ROLLBACK_ALIGN/Inputs/exit.s
@@ -1,0 +1,5 @@
+  .section .exit.text,"ax",@progbits
+  .globl exit_func
+exit_func:
+  call kobject_put
+  ret

--- a/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_CJ_ROLLBACK_ALIGN/Inputs/kobject.s
+++ b/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_CJ_ROLLBACK_ALIGN/Inputs/kobject.s
@@ -1,0 +1,4 @@
+  .section .text.kobject,"ax",@progbits
+  .globl kobject_put
+kobject_put:
+  ret

--- a/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_CJ_ROLLBACK_ALIGN/Inputs/ls.lds
+++ b/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_CJ_ROLLBACK_ALIGN/Inputs/ls.lds
@@ -1,0 +1,9 @@
+SECTIONS {
+  . = 0x0;
+  .text : {
+    *(.text.calls)
+    *(.text.kobject)
+  }
+  . = ALIGN(16);
+  .exit.text : { *(.exit.text) }
+}

--- a/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL_ROLLBACK_ALIGN/AUIPC_JALR_TO_JAL_ROLLBACK_ALIGN.test
+++ b/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL_ROLLBACK_ALIGN/AUIPC_JALR_TO_JAL_ROLLBACK_ALIGN.test
@@ -1,0 +1,16 @@
+#---AUIPC_JALR_TO_JAL_ROLLBACK_ALIGN.test--------- Executable ------------------#
+#START_TEST
+RUN: %clang -target riscv64-linux-gnu -c %p/Inputs/calls.s   -o %t.calls.o
+RUN: %clang -target riscv64-linux-gnu -c %p/Inputs/kobject.s -o %t.kobject.o
+RUN: %clang -target riscv64-linux-gnu -c %p/Inputs/exit.s    -o %t.exit.o
+RUN: %link %linkopts --image-base 0 --no-relax-c -T %p/Inputs/ls.lds \
+RUN:   %t.calls.o %t.kobject.o %t.exit.o -o %t.out \
+RUN:   --verbose 2>&1 | %filecheck %s --check-prefix=VERBOSE
+RUN: %objdump -d %t.out 2>&1 | %filecheck %s --check-prefix=DUMP
+#END_TEST
+
+VERBOSE: RISCV_CALL : Rolled back JAL for symbol 'kobject_put' in section .exit.text+0x{{[[:xdigit:]]+}} file {{.*}}exit.o (out of range after ALIGN)
+
+DUMP-LABEL: <exit_func>:
+DUMP:        auipc
+DUMP-NEXT:   jalr

--- a/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL_ROLLBACK_ALIGN/Inputs/calls.s
+++ b/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL_ROLLBACK_ALIGN/Inputs/calls.s
@@ -1,0 +1,7 @@
+  .section .text.calls,"ax",@progbits
+  .globl dummy_target
+dummy_target:
+  ret
+  .rept 256
+  call dummy_target
+  .endr

--- a/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL_ROLLBACK_ALIGN/Inputs/exit.s
+++ b/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL_ROLLBACK_ALIGN/Inputs/exit.s
@@ -1,0 +1,5 @@
+  .section .exit.text,"ax",@progbits
+  .globl exit_func
+exit_func:
+  call kobject_put
+  ret

--- a/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL_ROLLBACK_ALIGN/Inputs/kobject.s
+++ b/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL_ROLLBACK_ALIGN/Inputs/kobject.s
@@ -1,0 +1,4 @@
+  .section .text.kobject,"ax",@progbits
+  .globl kobject_put
+kobject_put:
+  ret

--- a/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL_ROLLBACK_ALIGN/Inputs/ls.lds
+++ b/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL_ROLLBACK_ALIGN/Inputs/ls.lds
@@ -1,0 +1,10 @@
+SECTIONS {
+  . = 0x0;
+  . += 0xFF800;
+  .text : {
+    *(.text.calls)
+    *(.text.kobject)
+  }
+  . = ALIGN(1 << 21);
+  .exit.text : { *(.exit.text) }
+}


### PR DESCRIPTION
R_RISCV_ALIGN can delete nop bytes between the call site and its target, changing the final PC-relative distance after the call relaxation pass has already decided to relax.

This handles call relaxations.

Fixes #1659