### PR TITLE
[Workflow] Fix DownloadLatestBusybox action

### DIFF
--- a/.github/workflows/DownloadLatestBusybox/action.yaml
+++ b/.github/workflows/DownloadLatestBusybox/action.yaml
@@ -1,5 +1,5 @@
 name: DownloadLatestBusybox
-description: Download the BusyBox binary artifact from the latest successful busybox-eld.yml run
+description: Download the BusyBox binary artifact from the latest successful busybox.yml run
 
 inputs:
   arch:
@@ -18,7 +18,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Resolve busybox-eld.yml run id
+    - name: Resolve busybox.yml run id
       id: resolve
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9.0.0
       with:
@@ -28,17 +28,17 @@ runs:
           const repo = context.repo.repo;
           const resp = await github.rest.actions.listWorkflowRuns({
             owner, repo,
-            workflow_id: 'busybox-eld.yml',
+            workflow_id: 'busybox.yml',
             status: 'success',
             per_page: 1, // we only need the latest
           });
           const runs = resp.data.workflow_runs || [];
           if (runs.length === 0) {
-            core.setFailed('No successful busybox-eld.yml run found.');
+            core.setFailed('No successful busybox.yml run found.');
             return;
           }
           const run = runs[0];
-          core.info(`Latest successful busybox-eld.yml run: id=${run.id}, run_number=${run.run_number}`);
+          core.info(`Latest successful busybox.yml run: id=${run.id}, run_number=${run.run_number}`);
           core.setOutput('run_id', String(run.id));
 
     - name: Download BusyBox binary

--- a/.github/workflows/linux-kernel-nightly.yml
+++ b/.github/workflows/linux-kernel-nightly.yml
@@ -1,8 +1,8 @@
 name: Linux Kernel Boot Nightly with ELD
 
 # Boot a Linux kernel built with the latest nightly ELD toolset. Depends on
-# nightly-test.yml's toolset and busybox-eld.yml's BusyBox artifact; starts 1h
-# after busybox-eld.yml (0 11 * * *) so that run has finished and published its
+# nightly-test.yml's toolset and busybox.yml's BusyBox artifact; starts 1h
+# after busybox.yml (0 11 * * *) so that run has finished and published its
 # artifact. The kernel boot body lives in the reusable linux-kernel-run.yml.
 
 on:
@@ -55,7 +55,7 @@ jobs:
     # declares; a called job is capped at the caller job's permissions.
     permissions:
       contents: write # BuildStatusDataRecorder pushes to the dashboard branch
-      actions: read # list/download artifacts from busybox-eld.yml and the toolset run
+      actions: read # list/download artifacts from busybox.yml and the toolset run
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linux-kernel-pr.yml
+++ b/.github/workflows/linux-kernel-pr.yml
@@ -104,7 +104,7 @@ jobs:
     # declares; a called job is capped at the caller job's permissions.
     permissions:
       contents: write # BuildStatusDataRecorder pushes to the dashboard branch
-      actions: read # list/download artifacts from busybox-eld.yml and the toolset run
+      actions: read # list/download artifacts from busybox.yml and the toolset run
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linux-kernel-run.yml
+++ b/.github/workflows/linux-kernel-run.yml
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # BuildStatusDataRecorder pushes to the dashboard branch
-      actions: read # list/download artifacts from busybox-eld.yml and the toolset run
+      actions: read # list/download artifacts from busybox.yml and the toolset run
     env:
       KERNEL_IMAGE: ${{ inputs.kernel_image }}
     steps:


### PR DESCRIPTION
The DownloadLatestBusybox action was looking for busybox-eld.yml but that file got renamed to busybox.yml. This was causing failures on all workflows that relied on this action, like the nightly Linux kernel workflow.

Fix: qualcomm#1670