### PR TITLE
[SymbolVersioning] fix version-script input ordering

### DIFF
--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -599,9 +599,6 @@ public:
   const DynListType &getDynList() const { return DynList; }
   DynListType &getDynList() { return DynList; }
 
-  const DynListType &getVersionScripts() const { return VersionScripts; }
-  DynListType &getVersionScripts() { return VersionScripts; }
-
   // ---- remap input file names ---- //
   const RemapInputsType &getRemapInputs() const { return RemapInputs; }
   RemapInputsType &getRemapInputs() { return RemapInputs; }
@@ -1354,7 +1351,6 @@ private:
   UndefSymListType UndefSymList;     // -u
   UndefSymListType ExportDynSymList; // --export-dynamic-symbol
   DynListType DynList;               // --dynamic-list files
-  DynListType VersionScripts;        // --version-script files
   DynListType ExternList;            // --extern-list files
   RemapInputsType RemapInputs;       // --remap-inputs entries
   std::string Filter;

--- a/include/eld/Core/Module.h
+++ b/include/eld/Core/Module.h
@@ -607,19 +607,6 @@ public:
     return VersionScripts;
   }
 
-  // Tracks VersionScript objects parsed from a VERSION{} block embedded
-  // directly inside a -T linker script, as opposed to a standalone
-  // --version-script= file. These still need their nodes registered via
-  // ObjectLinker::parseVersionScript(), just not re-parsed from scratch.
-  void addLinkerScriptVersionScript(const VersionScript *VerScr) {
-    LinkerScriptVersionScripts.push_back(VerScr);
-  }
-
-  const llvm::SmallVectorImpl<const VersionScript *> &
-  getLinkerScriptVersionScripts() const {
-    return LinkerScriptVersionScripts;
-  }
-
   bool isLinkStateBeforeLayout() const {
     return getState() == LinkState::BeforeLayout;
   }
@@ -732,7 +719,6 @@ private:
       DynamicListFileToScriptSymbolsMap;
   llvm::StringSet<> OutputSectDescNameSet;
   llvm::SmallVector<const VersionScript *> VersionScripts;
-  llvm::SmallVector<const VersionScript *> LinkerScriptVersionScripts;
   llvm::DenseMap<Fragment *, uint64_t> FragmentPaddingValues;
   PluginManager PM;
   NamePool SymbolNamePool;

--- a/include/eld/Input/LinkerScriptFile.h
+++ b/include/eld/Input/LinkerScriptFile.h
@@ -24,7 +24,8 @@ class ScriptFile;
 
 class LinkerScriptFile : public InputFile {
 public:
-  LinkerScriptFile(Input *I, DiagnosticEngine *DiagEngine);
+  LinkerScriptFile(Input *I, DiagnosticEngine *DiagEngine,
+                   ScriptFile::Kind ScriptKind = ScriptFile::LDScript);
 
   /// Casting support.
   static bool classof(const InputFile *I) {
@@ -58,9 +59,16 @@ public:
 
   ScriptFile *getScript() const { return Script; }
 
+  ScriptFile::Kind getScriptKind() const { return ScriptKind; }
+
+  bool isVersionScript() const {
+    return ScriptKind == ScriptFile::VersionScript;
+  }
+
 private:
   ScriptFile *Script = nullptr;
   std::vector<Node *> Nodes;
+  ScriptFile::Kind ScriptKind = ScriptFile::LDScript;
   bool Parsed = false;
   bool EarlyActivated = false;
   bool FullyActivated = false;

--- a/include/eld/Object/ObjectLinker.h
+++ b/include/eld/Object/ObjectLinker.h
@@ -300,6 +300,8 @@ public:
   bool readAndActivateLinkerScript(InputFile *I,
                                    ScriptFile::ScriptActivationKind Kind);
 
+  bool readVersionScriptFile(InputFile *I);
+
   bool readInputs(const std::vector<Node *> &N);
 
   bool getInputs(std::vector<InputFile *> &Inputs);

--- a/include/eld/Object/ObjectLinker.h
+++ b/include/eld/Object/ObjectLinker.h
@@ -98,6 +98,8 @@ public:
 
   bool parseVersionScript();
 
+  bool readVersionScriptFile(InputFile *I);
+
   /// linkable - check the linkability of current LinkerConfig
   ///  Check list:
   ///  - check the Attributes are not violate the constaint

--- a/lib/Core/Linker.cpp
+++ b/lib/Core/Linker.cpp
@@ -268,9 +268,11 @@ bool Linker::activateInputs(std::vector<InputAction *> &Actions) {
     }
     if (!Action->activate(IR->getInputBuilder()))
       return false;
-    if (!ObjLinker->readAndActivateLinkerScript(
-            llvm::dyn_cast<eld::ScriptAction>(Action)->getLinkerScriptFile(),
-            ScriptFile::ScriptActivationKind::Early)) {
+    auto *SA = llvm::dyn_cast<eld::ScriptAction>(Action);
+    if (SA->kind() != eld::ScriptFile::VersionScript &&
+        !ObjLinker->readAndActivateLinkerScript(
+                   SA->getLinkerScriptFile(),
+                   ScriptFile::ScriptActivationKind::Early)) {
       ThisModule->setFailure(true);
       return false;
     }

--- a/lib/Core/Linker.cpp
+++ b/lib/Core/Linker.cpp
@@ -268,9 +268,15 @@ bool Linker::activateInputs(std::vector<InputAction *> &Actions) {
     }
     if (!Action->activate(IR->getInputBuilder()))
       return false;
-    if (!ObjLinker->readAndActivateLinkerScript(
-            llvm::dyn_cast<eld::ScriptAction>(Action)->getLinkerScriptFile(),
-            ScriptFile::ScriptActivationKind::Early)) {
+    auto *SA = llvm::dyn_cast<eld::ScriptAction>(Action);
+    if (SA->kind() == eld::ScriptFile::VersionScript) {
+      if (!ObjLinker->readVersionScriptFile(SA->getLinkerScriptFile())) {
+        ThisModule->setFailure(true);
+        return false;
+      }
+    } else if (!ObjLinker->readAndActivateLinkerScript(
+                   SA->getLinkerScriptFile(),
+                   ScriptFile::ScriptActivationKind::Early)) {
       ThisModule->setFailure(true);
       return false;
     }

--- a/lib/Input/LinkerScriptFile.cpp
+++ b/lib/Input/LinkerScriptFile.cpp
@@ -9,8 +9,10 @@
 
 using namespace eld;
 
-LinkerScriptFile::LinkerScriptFile(Input *I, DiagnosticEngine *DiagEngine)
-    : InputFile(I, DiagEngine, InputFile::GNULinkerScriptKind) {
+LinkerScriptFile::LinkerScriptFile(Input *I, DiagnosticEngine *DiagEngine,
+                                   ScriptFile::Kind ScriptKind)
+    : InputFile(I, DiagEngine, InputFile::GNULinkerScriptKind),
+      ScriptKind(ScriptKind) {
   if (I->getSize())
     Contents = I->getFileContents();
 }

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -886,12 +886,6 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
   if (Config.options().getDynList().size())
     Config.options().setDynamicList();
 
-  // --version-script
-  for (auto *Arg : Args.filtered(T::version_script))
-    Config.options().getVersionScripts().emplace(Arg->getValue());
-  if (Config.options().getVersionScripts().size())
-    Config.options().setVersionScript();
-
   // --extern-list
   for (auto *Arg : Args.filtered(T::extern_list))
     Config.options().getExternList().emplace(Arg->getValue());
@@ -1365,6 +1359,13 @@ bool GnuLdDriver::createInputActions(llvm::opt::InputArgList &Args,
           arg->getValue(), eld::ScriptFile::LDScript, Config,
           Config.getPrinter()));
       ++input_num;
+    } break;
+
+    case T::version_script: {
+      actions.push_back(eld::make<eld::ScriptAction>(
+          arg->getValue(), eld::ScriptFile::VersionScript, Config,
+          Config.getPrinter()));
+      Config.options().setVersionScript();
     } break;
 
     case T::R: {

--- a/lib/Object/GroupReader.cpp
+++ b/lib/Object/GroupReader.cpp
@@ -52,13 +52,25 @@ bool GroupReader::readGroup(InputBuilder::InputIteratorT &CurNode,
     if (!Input->resolvePath(PConfig))
       return false;
 
+    if (Input->getInputFile() &&
+        Input->getInputFile()->getKind() == InputFile::GNULinkerScriptKind) {
+      auto *LSFile =
+          llvm::dyn_cast<eld::LinkerScriptFile>(Input->getInputFile());
+      if (LSFile->isVersionScript()) {
+        if (!MObjLinker->readVersionScriptFile(LSFile))
+          return false;
+        ++CurNode;
+        continue;
+      }
+    }
     if (!MObjLinker->readAndProcessInput(Input, IsPostLtoPhase))
       return false;
-
-    if (Input->getInputFile()->getKind() == InputFile::GNULinkerScriptKind) {
-      if (!MObjLinker->readInputs(
-              llvm::dyn_cast<eld::LinkerScriptFile>(Input->getInputFile())
-                  ->getNodes()))
+    if (Input->getInputFile() &&
+        Input->getInputFile()->getKind() == InputFile::GNULinkerScriptKind) {
+      auto *LSFile =
+          llvm::dyn_cast<eld::LinkerScriptFile>(Input->getInputFile());
+      if (!LSFile->isVersionScript() &&
+          !MObjLinker->readInputs(LSFile->getNodes()))
         return false;
     }
 

--- a/lib/Object/LibReader.cpp
+++ b/lib/Object/LibReader.cpp
@@ -15,6 +15,7 @@
 #include "eld/Config/LinkerConfig.h"
 #include "eld/Input/Input.h"
 #include "eld/Input/InputTree.h"
+#include "eld/Input/LinkerScriptFile.h"
 #include "eld/Object/ObjectLinker.h"
 #include "eld/Support/MemoryArea.h"
 #include "eld/Support/RegisterTimer.h"
@@ -82,6 +83,29 @@ bool LibReader::readLib(InputBuilder::InputIteratorT &CurNode,
     Input *Input = Node->getInput();
     if (!Input->resolvePath(Config))
       return false;
+
+    if (Input->getInputFile() &&
+        Input->getInputFile()->getKind() == InputFile::GNULinkerScriptKind) {
+      auto *LSFile = llvm::cast<eld::LinkerScriptFile>(Input->getInputFile());
+      if (LSFile->isVersionScript()) {
+        if (!MObjLinker->readVersionScriptFile(LSFile))
+          return false;
+        ++CurNode;
+        continue;
+      }
+    }
+
+    if (Input->getInputFile() &&
+        Input->getInputFile()->getKind() == InputFile::GNULinkerScriptKind) {
+      auto *LSFile = llvm::cast<eld::LinkerScriptFile>(Input->getInputFile());
+      if (!MObjLinker->readAndProcessInput(Input, IsPostLtoPhase))
+        return false;
+      if (!LSFile->isVersionScript() &&
+          !MObjLinker->readInputs(LSFile->getNodes()))
+        return false;
+      ++CurNode;
+      continue;
+    }
 
     if (IsThin)
       MemberNames.push_back(Input->getResolvedPath().getFullPath());

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -259,12 +259,38 @@ bool ObjectLinker::readAndActivateLinkerScript(
       return false;
   }
 
+  // Register an embedded VERSION{} block when the script is first activated
+  // so it remains ordered with standalone --version-script inputs.
+  if (S->getVersionScript() &&
+      (kind == ScriptFile::ScriptActivationKind::Early ||
+       !linkerScriptFile->isEarlyActivated()))
+    ThisModule->addVersionScript(S->getVersionScript());
+
   if (kind == ScriptFile::ScriptActivationKind::Early)
     linkerScriptFile->setEarlyActivated();
   else
     linkerScriptFile->setFullyActivated();
 
   input->setUsed(true);
+  return true;
+}
+
+bool ObjectLinker::readVersionScriptFile(InputFile *Input) {
+  LinkerScriptFile *LSFile = llvm::dyn_cast<eld::LinkerScriptFile>(Input);
+  if (LSFile->isParsed())
+    return true;
+  LayoutInfo *layoutInfo = ThisModule->getLayoutInfo();
+  addInputFileToTar(Input, eld::MappingFile::VersionScript);
+  if (layoutInfo)
+    layoutInfo->recordVersionScript(Input->getInput()->decoratedPath());
+  ScriptFile VSReader(ScriptFile::VersionScript, *ThisModule, *LSFile,
+                      ThisModule->getIRBuilder()->getInputBuilder());
+  if (!getScriptReader()->readScript(ThisConfig, VSReader))
+    return false;
+  LSFile->setParsed();
+  Input->setToSkip();
+  if (VSReader.getVersionScript())
+    ThisModule->addVersionScript(VSReader.getVersionScript());
   return true;
 }
 
@@ -352,49 +378,11 @@ bool ObjectLinker::normalize() {
 // FIXME: We should maybe parse version script after reading LTO-generated
 // object files.
 bool ObjectLinker::parseVersionScript() {
-  if (ThisConfig.options().hasVersionScript()) {
-    LayoutInfo *layoutInfo = ThisModule->getLayoutInfo();
-    for (const auto &List : ThisConfig.options().getVersionScripts()) {
-      Input *VersionScriptInput =
-          eld::make<Input>(List, ThisConfig.getDiagEngine(), Input::Script);
-      if (!VersionScriptInput->resolvePath(ThisConfig))
-        return false;
-      // Create an Input file and set the input file to be of kind DynamicList
-      InputFile *VersionScriptInputFile =
-          InputFile::create(VersionScriptInput, InputFile::GNULinkerScriptKind,
-                            ThisConfig.getDiagEngine());
-      addInputFileToTar(VersionScriptInputFile,
-                        eld::MappingFile::VersionScript);
-      VersionScriptInput->setInputFile(VersionScriptInputFile);
-      // Record the dynamic list script in the Map file.
-      if (layoutInfo)
-        layoutInfo->recordVersionScript(List);
-      // Read the dynamic List file
-      ScriptFile VersionScriptReader(
-          ScriptFile::VersionScript, *ThisModule,
-          *(llvm::dyn_cast<eld::LinkerScriptFile>(VersionScriptInputFile)),
-          ThisModule->getIRBuilder()->getInputBuilder());
-      bool SuccessFullInParse =
-          getScriptReader()->readScript(ThisConfig, VersionScriptReader);
-      if (!SuccessFullInParse)
-        return false;
-      ThisModule->addVersionScript(VersionScriptReader.getVersionScript());
-      if (!registerVersionScriptNodes(VersionScriptReader.getVersionScript(),
-                                      VersionScriptInput->decoratedPath()))
-        return false;
-    }
-  }
-
-  // VersionScript objects parsed from a VERSION{} block embedded directly
-  // inside a -T linker script (recorded by readLinkerScript(), which runs
-  // before the target backend is guaranteed to exist). Process them here,
-  // where registerVersionScriptNodes() can safely touch the backend.
-  for (const VersionScript *VS : ThisModule->getLinkerScriptVersionScripts()) {
+  for (const VersionScript *VS : ThisModule->getVersionScripts()) {
     if (!registerVersionScriptNodes(
             VS, VS->getInputFile()->getInput()->decoratedPath()))
       return false;
   }
-
   assignVersionNodesToSymbols();
   return true;
 }

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -259,12 +259,42 @@ bool ObjectLinker::readAndActivateLinkerScript(
       return false;
   }
 
+  if (S->getVersionScript() && kind == ScriptFile::ScriptActivationKind::Full)
+    ThisModule->addVersionScript(S->getVersionScript());
+
   if (kind == ScriptFile::ScriptActivationKind::Early)
     linkerScriptFile->setEarlyActivated();
   else
     linkerScriptFile->setFullyActivated();
 
   input->setUsed(true);
+  return true;
+}
+
+bool ObjectLinker::readVersionScriptFile(InputFile *Input) {
+  auto *LSFile = llvm::cast<eld::LinkerScriptFile>(Input);
+  assert(LSFile->isVersionScript() && "Expected version script input");
+
+  if (LSFile->isParsed())
+    return true;
+
+  LayoutInfo *layoutInfo = ThisModule->getLayoutInfo();
+  addInputFileToTar(Input, eld::MappingFile::VersionScript);
+  if (layoutInfo) {
+    const eld::Input *I = Input->getInput();
+    layoutInfo->recordVersionScript(I->wasRemapped() ? I->getOriginalFileName()
+                                                     : I->getFileName());
+  }
+
+  ScriptFile VSReader(ScriptFile::VersionScript, *ThisModule, *LSFile,
+                      ThisModule->getIRBuilder()->getInputBuilder());
+  if (!getScriptReader()->readScript(ThisConfig, VSReader))
+    return false;
+
+  LSFile->setParsed();
+  Input->setToSkip();
+  if (VSReader.getVersionScript())
+    ThisModule->addVersionScript(VSReader.getVersionScript());
   return true;
 }
 
@@ -278,18 +308,20 @@ bool ObjectLinker::readInputs(const std::vector<Node *> &InputVector) {
       eld::RegisterTimer T("Read Start Group and End Group",
                            "Read all Input files",
                            ThisConfig.options().printTimingStats());
-      getGroupReader()->readGroup(Begin,
-                                  ThisModule->getIRBuilder()->getInputBuilder(),
-                                  ThisConfig, MPostLtoPhase);
+      if (!getGroupReader()->readGroup(
+              Begin, ThisModule->getIRBuilder()->getInputBuilder(), ThisConfig,
+              MPostLtoPhase))
+        return false;
       continue;
     }
 
     if ((*Begin)->kind() == Node::LibStart) {
       eld::RegisterTimer T("Read Start Lib and End Lib", "Read all Input files",
                            ThisConfig.options().printTimingStats());
-      getLibReader()->readLib(Begin,
-                              ThisModule->getIRBuilder()->getInputBuilder(),
-                              ThisConfig, MPostLtoPhase);
+      if (!getLibReader()->readLib(
+              Begin, ThisModule->getIRBuilder()->getInputBuilder(), ThisConfig,
+              MPostLtoPhase))
+        return false;
       continue;
     }
 
@@ -304,13 +336,23 @@ bool ObjectLinker::readInputs(const std::vector<Node *> &InputVector) {
       ThisModule->setFailure(true);
       return false;
     }
+    if (Input->getInputFile() &&
+        Input->getInputFile()->getKind() == InputFile::GNULinkerScriptKind) {
+      auto *LSFile =
+          llvm::dyn_cast<eld::LinkerScriptFile>(Input->getInputFile());
+      if (LSFile->isVersionScript()) {
+        if (!readVersionScriptFile(LSFile))
+          return false;
+        continue;
+      }
+    }
     if (!readAndProcessInput(Input, MPostLtoPhase))
       return false;
-    if (Input->getInputFile()->getKind() == InputFile::GNULinkerScriptKind) {
-      // Read inputs that the script contains.
-      if (!readInputs(
-              llvm::dyn_cast<eld::LinkerScriptFile>(Input->getInputFile())
-                  ->getNodes()))
+    if (Input->getInputFile() &&
+        Input->getInputFile()->getKind() == InputFile::GNULinkerScriptKind) {
+      auto *LSFile =
+          llvm::dyn_cast<eld::LinkerScriptFile>(Input->getInputFile());
+      if (!LSFile->isVersionScript() && !readInputs(LSFile->getNodes()))
         return false;
     }
   } // end of for
@@ -352,49 +394,11 @@ bool ObjectLinker::normalize() {
 // FIXME: We should maybe parse version script after reading LTO-generated
 // object files.
 bool ObjectLinker::parseVersionScript() {
-  if (ThisConfig.options().hasVersionScript()) {
-    LayoutInfo *layoutInfo = ThisModule->getLayoutInfo();
-    for (const auto &List : ThisConfig.options().getVersionScripts()) {
-      Input *VersionScriptInput =
-          eld::make<Input>(List, ThisConfig.getDiagEngine(), Input::Script);
-      if (!VersionScriptInput->resolvePath(ThisConfig))
-        return false;
-      // Create an Input file and set the input file to be of kind DynamicList
-      InputFile *VersionScriptInputFile =
-          InputFile::create(VersionScriptInput, InputFile::GNULinkerScriptKind,
-                            ThisConfig.getDiagEngine());
-      addInputFileToTar(VersionScriptInputFile,
-                        eld::MappingFile::VersionScript);
-      VersionScriptInput->setInputFile(VersionScriptInputFile);
-      // Record the dynamic list script in the Map file.
-      if (layoutInfo)
-        layoutInfo->recordVersionScript(List);
-      // Read the dynamic List file
-      ScriptFile VersionScriptReader(
-          ScriptFile::VersionScript, *ThisModule,
-          *(llvm::dyn_cast<eld::LinkerScriptFile>(VersionScriptInputFile)),
-          ThisModule->getIRBuilder()->getInputBuilder());
-      bool SuccessFullInParse =
-          getScriptReader()->readScript(ThisConfig, VersionScriptReader);
-      if (!SuccessFullInParse)
-        return false;
-      ThisModule->addVersionScript(VersionScriptReader.getVersionScript());
-      if (!registerVersionScriptNodes(VersionScriptReader.getVersionScript(),
-                                      VersionScriptInput->decoratedPath()))
-        return false;
-    }
-  }
-
-  // VersionScript objects parsed from a VERSION{} block embedded directly
-  // inside a -T linker script (recorded by readLinkerScript(), which runs
-  // before the target backend is guaranteed to exist). Process them here,
-  // where registerVersionScriptNodes() can safely touch the backend.
-  for (const VersionScript *VS : ThisModule->getLinkerScriptVersionScripts()) {
+  for (const VersionScript *VS : ThisModule->getVersionScripts()) {
     if (!registerVersionScriptNodes(
             VS, VS->getInputFile()->getInput()->decoratedPath()))
       return false;
   }
-
   assignVersionNodesToSymbols();
   return true;
 }

--- a/lib/Script/ScriptAction.cpp
+++ b/lib/Script/ScriptAction.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 #include "eld/Script/ScriptAction.h"
 #include "eld/Config/LinkerConfig.h"
+#include "eld/Input/InputBuilder.h"
 #include "eld/Input/LinkerScriptFile.h"
 #include "eld/Input/SearchDirs.h"
 #include "eld/Support/MsgHandling.h"
@@ -59,7 +60,7 @@ bool ScriptAction::activate(InputBuilder &PBuilder) {
     Path = Res->native();
   }
   setFileName(Path);
-  InputFileAction::activate(PBuilder);
+  I = PBuilder.createInputNode(Name);
 
   // Resolve the path so that the appropriate file has been read and the memory
   // area created for it.
@@ -68,7 +69,8 @@ bool ScriptAction::activate(InputBuilder &PBuilder) {
 
   // Create an InputFile and set the Input back.
   LinkerScriptFile *LSFile =
-      make<eld::LinkerScriptFile>(I, ThisConfig.getDiagEngine());
+      make<eld::LinkerScriptFile>(I, ThisConfig.getDiagEngine(),
+                                  ScriptFileKind);
   I->setInputFile(LSFile);
 
   return true;

--- a/lib/Script/ScriptFile.cpp
+++ b/lib/Script/ScriptFile.cpp
@@ -170,12 +170,6 @@ eld::Expected<void> ScriptFile::activate(Module &CurModule,
       ELDEXP_RETURN_DIAGENTRY_IF_ERROR(Sym->activate());
   }
 
-  // A -T script may embed its own VERSION{} block. Record it now so
-  // parseVersionScript() can register its nodes later, once the target
-  // backend is guaranteed to be initialized, which is not yet the case here.
-  if (getVersionScript())
-    CurModule.addLinkerScriptVersionScript(getVersionScript());
-
   return eld::Expected<void>();
 }
 

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -830,7 +830,7 @@ bool GNULDBackend::canSkipSymbolFromExport(ResolveInfo *R, bool isEntry) const {
 bool GNULDBackend::applyVersionScriptScopes() {
   eld::RegisterTimer T("Apply Version Script Scopes", "Output Symbols",
                        m_Module.getConfig().options().printTimingStats());
-  if (!config().options().hasVersionScript())
+  if (m_Module.getVersionScriptNodes().empty())
     return true;
   for (auto &I : m_Module.getNamePool().getGlobals()) {
     ResolveInfo *R = I.getValue();

--- a/test/Common/standalone/VersionScriptInputOrder/Inputs/a_second
+++ b/test/Common/standalone/VersionScriptInputOrder/Inputs/a_second
@@ -1,0 +1,6 @@
+AV {
+  global:
+    a*;
+  local:
+    *;
+};

--- a/test/Common/standalone/VersionScriptInputOrder/Inputs/script_b.lds
+++ b/test/Common/standalone/VersionScriptInputOrder/Inputs/script_b.lds
@@ -1,0 +1,14 @@
+SECTIONS
+{
+  .text : { *(.text) }
+}
+
+VERSION
+{
+  VER_B {
+  global:
+    a*;
+  local:
+    *;
+  };
+}

--- a/test/Common/standalone/VersionScriptInputOrder/Inputs/script_local.lds
+++ b/test/Common/standalone/VersionScriptInputOrder/Inputs/script_local.lds
@@ -1,0 +1,14 @@
+SECTIONS
+{
+  .text : { *(.text) }
+}
+
+VERSION
+{
+  {
+  global:
+    alpha_one;
+  local:
+    *;
+  };
+}

--- a/test/Common/standalone/VersionScriptInputOrder/Inputs/symbols.c
+++ b/test/Common/standalone/VersionScriptInputOrder/Inputs/symbols.c
@@ -1,0 +1,3 @@
+int alpha_one(void) { return 1; }
+int alpha_two(void) { return 2; }
+int beta_one(void) { return 3; }

--- a/test/Common/standalone/VersionScriptInputOrder/Inputs/vs_a
+++ b/test/Common/standalone/VersionScriptInputOrder/Inputs/vs_a
@@ -1,0 +1,4 @@
+VER_A {
+  global:
+    alpha*;
+};

--- a/test/Common/standalone/VersionScriptInputOrder/Inputs/z_first
+++ b/test/Common/standalone/VersionScriptInputOrder/Inputs/z_first
@@ -1,0 +1,4 @@
+ZV {
+  global:
+    alpha*;
+};

--- a/test/Common/standalone/VersionScriptInputOrder/VersionScriptInputOrder.test
+++ b/test/Common/standalone/VersionScriptInputOrder/VersionScriptInputOrder.test
@@ -1,0 +1,63 @@
+REQUIRES: symbol_versioning
+#---VersionScriptInputOrder.test-----------------------------------------------#
+#BEGIN_COMMENT
+# Verify that version nodes from --version-script files and VERSION{} blocks
+# embedded in -T linker scripts are ordered by command-line position.
+# Overlapping wildcards use last-wins; the winning node name reveals order.
+# Also verify --version-script is not added as a --start-lib/--end-lib member.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c -fpic -O2 %p/Inputs/symbols.c -o %t.o
+
+RUN: %link %linkopts -shared -o %t.vsfirst.so %t.o \
+RUN:   --version-script=%p/Inputs/vs_a -T %p/Inputs/script_b.lds
+RUN: %readelf --dyn-syms %t.vsfirst.so | %filecheck --check-prefix=VSFIRST %s
+
+RUN: %link %linkopts -shared -o %t.tfirst.so %t.o \
+RUN:   -T %p/Inputs/script_b.lds --version-script=%p/Inputs/vs_a
+RUN: %readelf --dyn-syms %t.tfirst.so | %filecheck --check-prefix=TFIRST %s
+
+RUN: %link %linkopts -shared -o %t.multivs.so %t.o \
+RUN:   --version-script=%p/Inputs/z_first \
+RUN:   --version-script=%p/Inputs/a_second
+RUN: %readelf --dyn-syms %t.multivs.so | %filecheck --check-prefix=MULTIVS %s
+
+RUN: %link %linkopts -shared -o %t.multivs2.so %t.o \
+RUN:   --version-script=%p/Inputs/a_second \
+RUN:   --version-script=%p/Inputs/z_first
+RUN: %readelf --dyn-syms %t.multivs2.so | %filecheck --check-prefix=MULTIVS2 %s
+
+RUN: %link %linkopts -shared -o %t.embedonly.so %t.o \
+RUN:   -T %p/Inputs/script_local.lds
+RUN: %readelf --dyn-syms %t.embedonly.so | %filecheck --check-prefix=EMBEDONLY %s
+
+RUN: %link %linkopts -shared --whole-archive --start-lib %t.o \
+RUN:   --version-script=%p/Inputs/vs_a --end-lib --no-whole-archive \
+RUN:   -o %t.startlib.so
+RUN: %readelf --dyn-syms %t.startlib.so | %filecheck --check-prefix=STARTLIB %s
+
+RUN: %link %linkopts -shared --start-group %t.o \
+RUN:   --version-script=%p/Inputs/vs_a --end-group -o %t.startgroup.so
+RUN: %readelf --dyn-syms %t.startgroup.so | %filecheck --check-prefix=STARTGROUP %s
+#END_TEST
+
+VSFIRST-DAG: alpha_one@@VER_B
+VSFIRST-DAG: alpha_two@@VER_B
+
+TFIRST-DAG: alpha_one@@VER_A
+TFIRST-DAG: alpha_two@@VER_A
+
+MULTIVS-DAG: alpha_one@@AV
+MULTIVS-DAG: alpha_two@@AV
+
+MULTIVS2-DAG: alpha_one@@ZV
+MULTIVS2-DAG: alpha_two@@ZV
+
+EMBEDONLY: alpha_one
+EMBEDONLY-NOT: beta_one
+
+STARTLIB-DAG: alpha_one@@VER_A
+STARTLIB-DAG: alpha_two@@VER_A
+
+STARTGROUP-DAG: alpha_one@@VER_A
+STARTGROUP-DAG: alpha_two@@VER_A

--- a/test/Common/standalone/VersionScriptInputOrder/VersionScriptInputOrder.test
+++ b/test/Common/standalone/VersionScriptInputOrder/VersionScriptInputOrder.test
@@ -1,0 +1,47 @@
+REQUIRES: symbol_versioning
+#---VersionScriptInputOrder.test-----------------------------------------------#
+#BEGIN_COMMENT
+# Verify that version nodes from --version-script files and VERSION{} blocks
+# embedded in -T linker scripts are ordered by command-line position.
+# Overlapping wildcards use last-wins; the winning node name reveals order.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c -fpic -O2 %p/Inputs/symbols.c -o %t.o
+
+RUN: %link %linkopts -shared -o %t.vsfirst.so %t.o \
+RUN:   --version-script=%p/Inputs/vs_a -T %p/Inputs/script_b.lds
+RUN: %readelf --dyn-syms %t.vsfirst.so | %filecheck --check-prefix=VSFIRST %s
+
+RUN: %link %linkopts -shared -o %t.tfirst.so %t.o \
+RUN:   -T %p/Inputs/script_b.lds --version-script=%p/Inputs/vs_a
+RUN: %readelf --dyn-syms %t.tfirst.so | %filecheck --check-prefix=TFIRST %s
+
+RUN: %link %linkopts -shared -o %t.multivs.so %t.o \
+RUN:   --version-script=%p/Inputs/z_first \
+RUN:   --version-script=%p/Inputs/a_second
+RUN: %readelf --dyn-syms %t.multivs.so | %filecheck --check-prefix=MULTIVS %s
+
+RUN: %link %linkopts -shared -o %t.multivs2.so %t.o \
+RUN:   --version-script=%p/Inputs/a_second \
+RUN:   --version-script=%p/Inputs/z_first
+RUN: %readelf --dyn-syms %t.multivs2.so | %filecheck --check-prefix=MULTIVS2 %s
+
+RUN: %link %linkopts -shared -o %t.embedonly.so %t.o \
+RUN:   -T %p/Inputs/script_local.lds
+RUN: %readelf --dyn-syms %t.embedonly.so | %filecheck --check-prefix=EMBEDONLY %s
+#END_TEST
+
+VSFIRST-DAG: alpha_one@@VER_B
+VSFIRST-DAG: alpha_two@@VER_B
+
+TFIRST-DAG: alpha_one@@VER_A
+TFIRST-DAG: alpha_two@@VER_A
+
+MULTIVS-DAG: alpha_one@@AV
+MULTIVS-DAG: alpha_two@@AV
+
+MULTIVS2-DAG: alpha_one@@ZV
+MULTIVS2-DAG: alpha_two@@ZV
+
+EMBEDONLY: alpha_one
+EMBEDONLY-NOT: beta_one


### PR DESCRIPTION
ELD's version-script node order did not follow command-line order; GNU ld processes both -T and --version-script inline in a single option loop, so node order always equals CLI order.

Move --version-script into createInputActions() as a ScriptAction (VersionScript) at its exact CLI position. Add readVersionScriptFile() to parse it during activateInputs(), mark it setToSkip() to prevent reprocessing in normalize(), and append to Module::VersionScripts.

readLinkerScript() appends embedded VERSION{} blocks to the same list via addVersionScript(). Module::LinkerScriptVersionScripts, GeneralOptions::VersionScripts, and their accessors are removed. Module::VersionScripts is now the single ordered list for both sources.

parseVersionScript() collapses to one loop over getVersionScripts() calling registerVersionScriptNodes(). Registration stays deferred as getTargetBackend() is unsafe during activateInputs().

applyVersionScriptScopes() guard changed from hasVersionScript() to getVersionScriptNodes().empty(). readVersionScriptFile() sets setParsed()/setToSkip() only after successful parse and null-guards getVersionScript() before addVersionScript().

Add test VersionScriptInputOrder covering --version-script before/after -T, two --version-script files in both orders, and embedded-only VERSION{} local scope.

Resolves #1636 