### PR TITLE
[workflow] Fix Linux kernel on PR workflow

### DIFF
--- a/.github/workflows/linux-kernel-nightly.yml
+++ b/.github/workflows/linux-kernel-nightly.yml
@@ -18,44 +18,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  resolve:
-    if: github.repository == 'qualcomm/eld' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-    outputs:
-      run_id: ${{ steps.find.outputs.run_id }}
-    steps:
-      - name: Resolve nightly-test.yml run id
-        id: find
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9.0.0
-        with:
-          github-token: ${{ github.token }}
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const resp = await github.rest.actions.listWorkflowRuns({
-              owner, repo,
-              workflow_id: 'nightly-test.yml',
-              status: 'success',
-              per_page: 1, // we only need the latest
-            });
-            const runs = resp.data.workflow_runs || [];
-            if (runs.length === 0) {
-              core.setFailed('No successful nightly-test.yml run found.');
-              return;
-            }
-            const run = runs[0];
-            core.info(`Latest successful nightly-test.yml run: id=${run.id}, run_number=${run.run_number}`);
-            core.setOutput('run_id', String(run.id));
-
   kernel:
-    needs: resolve
+    if: github.repository == 'qualcomm/eld' || github.event_name == 'workflow_dispatch'
     # Must grant at least what the reusable linux-kernel-run.yml kernel-boot job
     # declares; a called job is capped at the caller job's permissions.
     permissions:
       contents: write # BuildStatusDataRecorder pushes to the dashboard branch
       actions: read # list/download artifacts from busybox.yml and the toolset run
+
     strategy:
       fail-fast: false
       matrix:
@@ -128,6 +98,3 @@ jobs:
       qemu_bios: ${{ matrix.qemu_bios }}
       console_device: ${{ matrix.console_device }}
       enabled: ${{ matrix.enabled }}
-      toolset_run_id: ${{ needs.resolve.outputs.run_id }}
-      toolset_artifact: install-nightly-toolchain.tar.xz
-      toolset_tarball: install-nightly-toolchain.tar.xz

--- a/.github/workflows/linux-kernel-run.yml
+++ b/.github/workflows/linux-kernel-run.yml
@@ -57,17 +57,20 @@ on:
         required: true
         type: number
       toolset_run_id:
-        description: "Workflow run id to download the ELD toolset artifact from"
-        required: true
+        description: "Workflow run id to overlay a PR's own ELD toolset from; empty to use the nightly base as-is"
+        required: false
         type: string
+        default: ""
       toolset_artifact:
-        description: "Artifact name to download (e.g. pr-eld-toolset or install-nightly-toolchain.tar.xz)"
-        required: true
+        description: "Artifact name to download (e.g. pr-eld-toolset); unused when toolset_run_id is empty"
+        required: false
         type: string
+        default: ""
       toolset_tarball:
-        description: "Tar filename inside the artifact to extract (e.g. install-pr-toolset.tar.xz)"
-        required: true
+        description: "Tar filename inside the artifact to extract (e.g. install-pr-toolset.tar.xz); unused when toolset_run_id is empty"
+        required: false
         type: string
+        default: ""
 
 env:
   KERNEL_TAG: v7.1
@@ -103,8 +106,12 @@ jobs:
           arch-name: "${{ inputs.arch }}"
           branch-name: "${{env.BUILD_BRANCH}}"
 
-      - name: Fetch ELD toolset
+      - name: Fetch nightly toolchain base
         if: inputs.enabled == 1
+        uses: ./.github/workflows/FetchNightlyToolset
+
+      - name: Overlay ELD toolset
+        if: inputs.enabled == 1 && inputs.toolset_run_id != ''
         uses: ./.github/workflows/FetchEldToolset
         with:
           run-id: ${{ inputs.toolset_run_id }}


### PR DESCRIPTION
The workflow only passes the eld built by the CI workflow causing failures due to missing clang and other LLVM tools. The linux-kernel-run.yml workflow has been updated to fetch the nightly toolset and the eld passed by the linux-kernel-pr.yml workflow is now overlayed on top of the nightly.

linux-kernel-nightly.yml no longer passes any toolset.

Fix: qualcomm#1676