### PR TITLE
[workflow] Fix busybox workflow failures

### DIFF
--- a/test/BusyBox/aarch64-gnu/test-failures.txt
+++ b/test/BusyBox/aarch64-gnu/test-failures.txt
@@ -1,10 +1,12 @@
 #BEGIN_COMMENT
-# These 2 printf failures are not a linker issue. They are caused by a stray
-# ENOMEM errno left over from the first heap-growing malloc() in the process
-# (QEMU aarch64 user-mode brk() quirk), which busybox's printf applet
-# misreports as a conversion error despite printing the correct output.
+# These 2 printf tests are flaky, not a linker issue. A stray ENOMEM errno
+# left over from the first heap-growing malloc() in the process (QEMU
+# aarch64 user-mode brk() quirk) sometimes makes busybox's printf applet
+# misreport a conversion error despite printing the correct output, so the
+# PASS:/FAIL: outcome varies between runs. Match on the test name only (no
+# PASS:/FAIL: prefix) so either outcome is accepted.
 #END_COMMENT
-CHECK: FAIL: printf understands %s '"x' "'y" "'zTAIL"
-CHECK: FAIL: printf handles positive numbers for %f
+CHECK: printf understands %s '"x' "'y" "'zTAIL"
+CHECK: printf handles positive numbers for %f
 
 CHECK-NOT: FAIL:


### PR DESCRIPTION
The tests recorded as failures for aarch64-gnu are flaky. Sometimes they pass and sometimes they fail. The check now ignores those test results.

Fix: qualcomm#1681