### PR TITLE
[RISCV] Re-run ALIGN pass after JAL rollback to fix inline alignment

### DIFF
--- a/include/eld/Diagnostics/DiagVerbose.inc
+++ b/include/eld/Diagnostics/DiagVerbose.inc
@@ -40,6 +40,9 @@ DIAG(relax_cj_rolled_back_to_jal, DiagnosticEngine::Verbose,
 DIAG(relax_cj_rolled_back_to_call, DiagnosticEngine::Verbose,
      "RISCV_CALL : Rolled back C.J to AUIPC+JALR for symbol '%0' in section "
      "%1+0x%2 file %3 (out of JAL range after ALIGN)")
+DIAG(relax_align_undone, DiagnosticEngine::Verbose,
+     "RISCV_ALIGN : Undoing %0 nops / restoring %1 bytes in section %2+0x%3 "
+     "file %4 (re-run after rollback)")
 DIAG(relax_to_compress, DiagnosticEngine::Verbose,
      "%0 : relaxing instruction 0x%1 to compressed instruction 0x%2 for symbol "
      "%3 in section %4+0x%5 file %6")

--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -374,6 +374,7 @@ void RISCVLDBackend::verifyAndRollbackCallRelaxations(bool &pFinished) {
                      ->decoratedPath();
       }
 
+      undoAlignRelaxations();
       pFinished = false;
       continue;
     }
@@ -410,11 +411,34 @@ void RISCVLDBackend::verifyAndRollbackCallRelaxations(bool &pFinished) {
                  ->getInput()
                  ->decoratedPath();
 
-    // Fragment grew by 4 bytes: trigger another layout iteration.
+    undoAlignRelaxations();
     pFinished = false;
   }
 }
 
+void RISCVLDBackend::undoAlignRelaxations() {
+  for (auto &A : llvm::reverse(m_AlignRelaxRecords)) {
+    if (A.bytesDeleted) {
+      uint32_t nopOffset = A.alignReloc->targetRef()->offset();
+      uint32_t insertOffset = nopOffset + A.nopsAdded;
+      A.region->insertInstruction(insertOffset, A.bytesDeleted);
+      A.region->addRequiredNops(insertOffset, A.bytesDeleted);
+      A.alignReloc->targetRef()->setOffset(nopOffset);
+    }
+    A.alignReloc->setType(llvm::ELF::R_RISCV_ALIGN);
+    if (m_Module.getPrinter()->isVerbose())
+      config().raise(Diag::relax_align_undone)
+          << A.nopsAdded << A.bytesDeleted
+          << A.region->getOwningSection()->name()
+          << llvm::utohexstr(A.alignReloc->targetRef()->offset(), true)
+          << A.region->getOwningSection()
+                 ->getInputFile()
+                 ->getInput()
+                 ->decoratedPath();
+  }
+  m_AlignRelaxRecords.clear();
+  m_NeedsAlignRerun = true;
+}
 // Select the matching JVT entry lookup for rd.
 // x0 uses the jump-only table instruction.
 // x1 uses the normal link-register table instruction.
@@ -1419,8 +1443,10 @@ bool RISCVLDBackend::doRelaxationAlign(Relocation *pReloc) {
   uint64_t TargetAddress = SymValue;
   alignAddress(TargetAddress, Alignment);
   uint32_t NopBytesToAdd = TargetAddress - SymValue;
-  if (NopBytesToAdd == pReloc->addend())
+  if (NopBytesToAdd == pReloc->addend()) {
+    region->addRequiredNops(offset, NopBytesToAdd);
     return false;
+  }
 
   if (NopBytesToAdd > pReloc->addend()) {
     config().raise(Diag::error_riscv_relaxation_align)
@@ -1443,9 +1469,11 @@ bool RISCVLDBackend::doRelaxationAlign(Relocation *pReloc) {
                ->getInput()
                ->decoratedPath();
 
+  uint32_t BytesDeleted = pReloc->addend() - NopBytesToAdd;
   region->addRequiredNops(offset, NopBytesToAdd);
-  relaxDeleteBytes("RISCV_ALIGN", *region, offset + NopBytesToAdd,
-                   pReloc->addend() - NopBytesToAdd, "");
+  relaxDeleteBytes("RISCV_ALIGN", *region, offset + NopBytesToAdd, BytesDeleted,
+                   "");
+  m_AlignRelaxRecords.push_back({pReloc, region, NopBytesToAdd, BytesDeleted});
   // Set the reloc to do nothing.
   pReloc->setType(llvm::ELF::R_RISCV_NONE);
   return true;
@@ -1800,10 +1828,13 @@ void RISCVLDBackend::mayBeRelax(int relaxation_pass, bool &pFinished) {
   }
 
   if (relaxation_pass >= RELAXATION_PASS_COUNT) {
-    // With final post-ALIGN layout addresses known, reverify every
-    // AUIPC+JALR→JAL relaxation.
-    verifyAndRollbackCallRelaxations(pFinished);
-    return;
+    if (m_NeedsAlignRerun) {
+      m_NeedsAlignRerun = false;
+      relaxation_pass = RELAXATION_ALIGN;
+    } else {
+      verifyAndRollbackCallRelaxations(pFinished);
+      return;
+    }
   }
 
   // retrieve gp value, .data + 0x800

--- a/lib/Target/RISCV/RISCVLDBackend.h
+++ b/lib/Target/RISCV/RISCVLDBackend.h
@@ -302,6 +302,14 @@ private:
 
   void verifyAndRollbackCallRelaxations(bool &pFinished);
 
+  struct AlignRelaxRecord {
+    Relocation *alignReloc;
+    RegionFragmentEx *region;
+    uint32_t nopsAdded;
+    uint32_t bytesDeleted;
+  };
+
+  void undoAlignRelaxations();
   /// getRelEntrySize - the size in BYTE of rela type relocation
   size_t getRelEntrySize() override { return 0; }
 
@@ -409,6 +417,9 @@ private:
 
   // JAL-relaxed call records for post-ALIGN range reverification.
   std::vector<CallRelaxRecord> m_CallRelaxRecords;
+
+  std::vector<AlignRelaxRecord> m_AlignRelaxRecords;
+  bool m_NeedsAlignRerun = false;
 };
 } // namespace eld
 

--- a/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL_ROLLBACK_RISCV_ALIGN/AUIPC_JALR_TO_JAL_ROLLBACK_RISCV_ALIGN.test
+++ b/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL_ROLLBACK_RISCV_ALIGN/AUIPC_JALR_TO_JAL_ROLLBACK_RISCV_ALIGN.test
@@ -1,0 +1,17 @@
+#---AUIPC_JALR_TO_JAL_ROLLBACK_RISCV_ALIGN.test--------- Executable ------------------#
+#START_TEST
+RUN: %clang -target riscv64-linux-gnu -c %p/Inputs/calls.s   -o %t.calls.o
+RUN: %clang -target riscv64-linux-gnu -c %p/Inputs/kobject.s -o %t.kobject.o
+RUN: %clang -target riscv64-linux-gnu -c %p/Inputs/exit.s    -o %t.exit.o
+RUN: %link %linkopts -T %p/Inputs/ls.lds \
+RUN:   %t.calls.o %t.kobject.o %t.exit.o -o %t.out \
+RUN:   --verbose 2>&1 | %filecheck %s --check-prefix=VERBOSE
+RUN: %objdump -d %t.out 2>&1 | %filecheck %s --check-prefix=DUMP
+#END_TEST
+
+VERBOSE: RISCV_ALIGN : Deleting {{[0-9]+}} bytes for symbol '' in section .text.calls
+VERBOSE: RISCV_CALL : Rolled back JAL for symbol 'kobject_put' in section .exit.text+0x{{[[:xdigit:]]+}} file {{.*}}exit.o (out of range after ALIGN)
+
+DUMP-LABEL: <exit_func>:
+DUMP:        auipc
+DUMP-NEXT:   jalr

--- a/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL_ROLLBACK_RISCV_ALIGN/Inputs/calls.s
+++ b/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL_ROLLBACK_RISCV_ALIGN/Inputs/calls.s
@@ -1,0 +1,8 @@
+  .section .text.calls,"ax",@progbits
+  .globl dummy_target
+dummy_target:
+  ret
+  .rept 7
+  call dummy_target
+  .endr
+  .align 3

--- a/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL_ROLLBACK_RISCV_ALIGN/Inputs/exit.s
+++ b/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL_ROLLBACK_RISCV_ALIGN/Inputs/exit.s
@@ -1,0 +1,5 @@
+  .section .exit.text,"ax",@progbits
+  .globl exit_func
+exit_func:
+  call kobject_put
+  ret

--- a/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL_ROLLBACK_RISCV_ALIGN/Inputs/kobject.s
+++ b/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL_ROLLBACK_RISCV_ALIGN/Inputs/kobject.s
@@ -1,0 +1,4 @@
+  .section .text.kobject,"ax",@progbits
+  .globl kobject_put
+kobject_put:
+  ret

--- a/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL_ROLLBACK_RISCV_ALIGN/Inputs/ls.lds
+++ b/test/RISCV/standalone/Relaxation/AUIPC_JALR_TO_JAL_ROLLBACK_RISCV_ALIGN/Inputs/ls.lds
@@ -1,0 +1,7 @@
+SECTIONS {
+  . = 0x0;
+  .text.calls   : { *(.text.calls)   }
+  .text.kobject : { *(.text.kobject) }
+  . = 0x100021;
+  .exit.text    : { *(.exit.text)    }
+}

--- a/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN/Inputs/calls.s
+++ b/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN/Inputs/calls.s
@@ -1,0 +1,7 @@
+  .section .text.calls,"ax",@progbits
+  .globl dummy_target
+dummy_target:
+  ret
+  .rept 256
+  call dummy_target
+  .endr

--- a/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN/Inputs/exit.s
+++ b/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN/Inputs/exit.s
@@ -1,0 +1,9 @@
+  .section .exit.text,"ax",@progbits
+  .globl exit_func
+exit_func:
+  call kobject_put
+  nop
+  .balign 8
+  .globl aligned_label
+aligned_label:
+  ret

--- a/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN/Inputs/kobject.s
+++ b/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN/Inputs/kobject.s
@@ -1,0 +1,4 @@
+  .section .text.kobject,"ax",@progbits
+  .globl kobject_put
+kobject_put:
+  ret

--- a/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN/Inputs/ls.lds
+++ b/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN/Inputs/ls.lds
@@ -1,0 +1,10 @@
+SECTIONS {
+  . = 0x0;
+  . += 0xFF808;
+  .text : {
+    *(.text.calls)
+    *(.text.kobject)
+  }
+  . = ALIGN(1 << 21);
+  .exit.text : { *(.exit.text) }
+}

--- a/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN/JAL_ROLLBACK_ALIGN_RERUN.test
+++ b/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN/JAL_ROLLBACK_ALIGN_RERUN.test
@@ -1,0 +1,15 @@
+#---JAL_ROLLBACK_ALIGN_RERUN.test--------- Executable ------------------#
+#START_TEST
+RUN: %clang -target riscv64-linux-gnu -c %p/Inputs/calls.s   -o %t.calls.o
+RUN: %clang -target riscv64-linux-gnu -c %p/Inputs/kobject.s -o %t.kobject.o
+RUN: %clang -target riscv64-linux-gnu -c %p/Inputs/exit.s    -o %t.exit.o
+RUN: %link %linkopts -T %p/Inputs/ls.lds \
+RUN:   %t.calls.o %t.kobject.o %t.exit.o -o %t.out \
+RUN:   --verbose 2>&1 | %filecheck %s --check-prefix=VERBOSE
+RUN: %readelf -s %t.out 2>&1 | %filecheck %s --check-prefix=SYMS
+#END_TEST
+
+VERBOSE: RISCV_CALL : Rolled back JAL for symbol 'kobject_put' in section .exit.text+0x{{[[:xdigit:]]+}} file {{.*}}exit.o (out of range after ALIGN)
+VERBOSE: RISCV_ALIGN : Undoing {{[0-9]+}} nops / restoring {{[0-9]+}} bytes in section .exit.text+0x{{[[:xdigit:]]+}} file {{.*}}exit.o (re-run after rollback)
+
+SYMS: {{[0-9a-f]*[08]}} {{.*}} aligned_label

--- a/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_CROSS_SECTION/Inputs/calls.s
+++ b/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_CROSS_SECTION/Inputs/calls.s
@@ -1,0 +1,7 @@
+  .section .text.calls,"ax",@progbits
+  .globl dummy_target
+dummy_target:
+  ret
+  .rept 256
+  call dummy_target
+  .endr

--- a/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_CROSS_SECTION/Inputs/exit.s
+++ b/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_CROSS_SECTION/Inputs/exit.s
@@ -1,0 +1,9 @@
+  .section .exit.text,"ax",@progbits
+  .globl exit_func
+exit_func:
+  call kobject_put
+  nop
+  .balign 8
+  .globl aligned_label
+aligned_label:
+  ret

--- a/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_CROSS_SECTION/Inputs/head.s
+++ b/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_CROSS_SECTION/Inputs/head.s
@@ -1,0 +1,12 @@
+  .section .head,"ax",@progbits
+  .globl head_dummy
+head_dummy:
+  ret
+  nop
+  .globl head_start
+head_start:
+  call  head_dummy
+  .balign 4
+  .globl aligned_func
+aligned_func:
+  ret

--- a/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_CROSS_SECTION/Inputs/kobject.s
+++ b/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_CROSS_SECTION/Inputs/kobject.s
@@ -1,0 +1,4 @@
+  .section .text.kobject,"ax",@progbits
+  .globl kobject_put
+kobject_put:
+  ret

--- a/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_CROSS_SECTION/Inputs/ls.lds
+++ b/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_CROSS_SECTION/Inputs/ls.lds
@@ -1,0 +1,8 @@
+SECTIONS {
+  . = 0x0;
+  .head      : { *(.head) }
+  . = 0xFF808;
+  .text      : { *(.text.calls) *(.text.kobject) }
+  . = ALIGN(1 << 21);
+  .exit.text : { *(.exit.text) }
+}

--- a/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_CROSS_SECTION/JAL_ROLLBACK_ALIGN_RERUN_CROSS_SECTION.test
+++ b/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_CROSS_SECTION/JAL_ROLLBACK_ALIGN_RERUN_CROSS_SECTION.test
@@ -1,0 +1,16 @@
+#---JAL_ROLLBACK_ALIGN_RERUN_CROSS_SECTION.test--------- Executable ------------------#
+#START_TEST
+RUN: %clang -target riscv64-linux-gnu -c %p/Inputs/head.s    -o %t.head.o
+RUN: %clang -target riscv64-linux-gnu -c %p/Inputs/calls.s   -o %t.calls.o
+RUN: %clang -target riscv64-linux-gnu -c %p/Inputs/kobject.s -o %t.kobject.o
+RUN: %clang -target riscv64-linux-gnu -c %p/Inputs/exit.s    -o %t.exit.o
+RUN: %link %linkopts -T %p/Inputs/ls.lds \
+RUN:   %t.head.o %t.calls.o %t.kobject.o %t.exit.o -o %t.out \
+RUN:   --verbose 2>&1 | %filecheck %s --check-prefix=VERBOSE
+RUN: %readelf -s %t.out 2>&1 | %filecheck %s --check-prefix=SYMS
+#END_TEST
+
+VERBOSE: RISCV_CALL : Rolled back JAL for symbol 'kobject_put' in section .exit.text+0x{{[[:xdigit:]]+}} file {{.*}}exit.o (out of range after ALIGN)
+VERBOSE: RISCV_ALIGN : Undoing 0 nops / restoring 2 bytes in section .head+0x{{[[:xdigit:]]+}} file {{.*}}head.o (re-run after rollback)
+
+SYMS: {{[0-9a-f]*[048c]}} {{.*}} aligned_func

--- a/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_MULTI_ALIGN/Inputs/calls.s
+++ b/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_MULTI_ALIGN/Inputs/calls.s
@@ -1,0 +1,7 @@
+  .section .text.calls,"ax",@progbits
+  .globl dummy_target
+dummy_target:
+  ret
+  .rept 256
+  call dummy_target
+  .endr

--- a/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_MULTI_ALIGN/Inputs/exit.s
+++ b/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_MULTI_ALIGN/Inputs/exit.s
@@ -1,0 +1,9 @@
+  .section .exit.text,"ax",@progbits
+  .globl exit_func
+exit_func:
+  call kobject_put
+  nop
+  .balign 8
+  .globl aligned_label
+aligned_label:
+  ret

--- a/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_MULTI_ALIGN/Inputs/head.s
+++ b/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_MULTI_ALIGN/Inputs/head.s
@@ -1,0 +1,18 @@
+  .section .head,"ax",@progbits
+  .globl head_dummy
+head_dummy:
+  ret
+  nop
+  .globl head_start
+head_start:
+  call  head_dummy
+  .balign 4
+  .globl aligned_a
+aligned_a:
+  ret
+  nop
+  call  head_dummy
+  .balign 4
+  .globl aligned_b
+aligned_b:
+  ret

--- a/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_MULTI_ALIGN/Inputs/kobject.s
+++ b/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_MULTI_ALIGN/Inputs/kobject.s
@@ -1,0 +1,4 @@
+  .section .text.kobject,"ax",@progbits
+  .globl kobject_put
+kobject_put:
+  ret

--- a/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_MULTI_ALIGN/Inputs/ls.lds
+++ b/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_MULTI_ALIGN/Inputs/ls.lds
@@ -1,0 +1,8 @@
+SECTIONS {
+  . = 0x0;
+  .head      : { *(.head) }
+  . = 0xFF808;
+  .text      : { *(.text.calls) *(.text.kobject) }
+  . = ALIGN(1 << 21);
+  .exit.text : { *(.exit.text) }
+}

--- a/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_MULTI_ALIGN/JAL_ROLLBACK_ALIGN_RERUN_MULTI_ALIGN.test
+++ b/test/RISCV/standalone/Relaxation/JAL_ROLLBACK_ALIGN_RERUN_MULTI_ALIGN/JAL_ROLLBACK_ALIGN_RERUN_MULTI_ALIGN.test
@@ -1,0 +1,18 @@
+#---JAL_ROLLBACK_ALIGN_RERUN_MULTI_ALIGN.test--------- Executable ------------------#
+#START_TEST
+RUN: %clang -target riscv64-linux-gnu -c %p/Inputs/head.s    -o %t.head.o
+RUN: %clang -target riscv64-linux-gnu -c %p/Inputs/calls.s   -o %t.calls.o
+RUN: %clang -target riscv64-linux-gnu -c %p/Inputs/kobject.s -o %t.kobject.o
+RUN: %clang -target riscv64-linux-gnu -c %p/Inputs/exit.s    -o %t.exit.o
+RUN: %link %linkopts -T %p/Inputs/ls.lds \
+RUN:   %t.head.o %t.calls.o %t.kobject.o %t.exit.o -o %t.out \
+RUN:   --verbose 2>&1 | %filecheck %s --check-prefix=VERBOSE
+RUN: %readelf -s %t.out 2>&1 | %filecheck %s --check-prefix=SYMS
+#END_TEST
+
+VERBOSE: RISCV_CALL : Rolled back JAL for symbol 'kobject_put' in section .exit.text+0x{{[[:xdigit:]]+}} file {{.*}}exit.o (out of range after ALIGN)
+VERBOSE: RISCV_ALIGN : Undoing 0 nops / restoring 2 bytes in section .head+0x{{[[:xdigit:]]+}} file {{.*}}head.o (re-run after rollback)
+VERBOSE: RISCV_ALIGN : Undoing 0 nops / restoring 2 bytes in section .head+0x{{[[:xdigit:]]+}} file {{.*}}head.o (re-run after rollback)
+
+SYMS: {{[0-9a-f]*[048c]}} {{.*}} aligned_a
+SYMS: {{[0-9a-f]*[048c]}} {{.*}} aligned_b


### PR DESCRIPTION
When an AUIPC+JALR→JAL relaxation is rolled back post-ALIGN (because the final address distance exceeds ±1MB after deferred deletions), the linker re-inserts 4 bytes into the fragment.

Track each R_RISCV_ALIGN relaxation in the ALIGN pass. When a JAL rollback fires, undoAlignRelaxations() re-inserts the bytes that relaxDeleteBytes removed and restores the reloc type to R_RISCV_ALIGN. A new m_NeedsAlignRerun flag causes the next driver iteration to re-run the ALIGN pass with fresh post-rollback addresses.

Fixes #1678