### PR TITLE
[RISCV] Fix post-ALIGN JAL rollback to use post-ALIGN layout

### DIFF
--- a/lib/Target/RISCV/RISCVLDBackend.cpp
+++ b/lib/Target/RISCV/RISCVLDBackend.cpp
@@ -1799,11 +1799,10 @@ void RISCVLDBackend::mayBeRelax(int relaxation_pass, bool &pFinished) {
     return;
   }
 
-  // RELAXATION_ALIGN pass, which is the last pass, will set pFinished to
-  // false if it has made changes. It is needed to call createProgramHdrs()
-  // again in the outer loop. Therefore, this function may be entered once more,
-  // for no good reason.
   if (relaxation_pass >= RELAXATION_PASS_COUNT) {
+    // With final post-ALIGN layout addresses known, reverify every
+    // AUIPC+JALR→JAL relaxation.
+    verifyAndRollbackCallRelaxations(pFinished);
     return;
   }
 
@@ -1948,12 +1947,6 @@ void RISCVLDBackend::mayBeRelax(int relaxation_pass, bool &pFinished) {
   // R_RISCV_ALIGN will cause another empty pass if it made changes.
   if (relaxation_pass < llvm::ELF::R_RISCV_ALIGN)
     pFinished = false;
-
-  if (relaxation_pass == RELAXATION_ALIGN) {
-    // With final layout addresses known, reverify every AUIPC+JALR→JAL
-    // relaxation from pass 0.  Any whose distance now exceeds ±1MB is undone
-    verifyAndRollbackCallRelaxations(pFinished);
-  }
 }
 
 /// finalizeSymbol - finalize the symbol value


### PR DESCRIPTION
The ALIGN pass commits byte deletions inline (via
deleteInstruction), shrinking fragments and shifting VMAs, but createProgramHdrs() is not called again until the next outer-loop iteration. So the range check (isInt<21>(X)) saw pre-ALIGN VMAs and missed calls that were actually out of range after the ALIGN deletions.

Fixes #1688