### PR TITLE
[Workflow] Increase Linux kernel workflow timeout

### DIFF
--- a/.github/workflows/linux-kernel-nightly.yml
+++ b/.github/workflows/linux-kernel-nightly.yml
@@ -6,7 +6,7 @@ name: Linux Kernel Boot Nightly with ELD
 # artifact. The kernel boot body lives in the reusable linux-kernel-run.yml.
 
 on:
-  # pull_request: {} # Uncomment only to test this WF file update.
+  pull_request: {} # Uncomment only to test this WF file update.
   schedule:
     - cron: "0 12 * * *"
   workflow_dispatch:

--- a/.github/workflows/linux-kernel-run.yml
+++ b/.github/workflows/linux-kernel-run.yml
@@ -309,7 +309,7 @@ jobs:
             # at an explicit firmware path in that case.
             qemu_args+=(-bios "${QEMU_BIOS}")
           fi
-          timeout -k 1s 60s "${QEMU_BIN}" "${qemu_args[@]}" \
+          timeout -k 1s 240s "${QEMU_BIN}" "${qemu_args[@]}" \
             > /tmp/kernel-boot-output.txt 2>&1 || true
           pkill -KILL -f "${QEMU_BIN}.*${KERNEL_IMAGE}" 2>/dev/null || true
           cat /tmp/kernel-boot-output.txt


### PR DESCRIPTION
Increase the timeout from 60 to 240 seconds.