### PR TITLE
[ELD] Intialize backend in ArchiveParser using bitcode member

### DIFF
--- a/include/eld/Readers/ArchiveParser.h
+++ b/include/eld/Readers/ArchiveParser.h
@@ -115,7 +115,8 @@ private:
   /// It computes symbol information for the provided archive IR member symbols
   /// that are present in the archive symbol table.
   eld::Expected<bool>
-  computeSymInfoTableForIRMember(const llvm::object::IRObjectFile &IRObj,
+  computeSymInfoTableForIRMember(const ArchiveFile &archiveFile,
+                                 const llvm::object::IRObjectFile &IRObj,
                                  const llvm::object::Archive::Child &member,
                                  ArchiveSymbolInfoTable &symbolInfoTable) const;
 

--- a/lib/Readers/ArchiveParser.cpp
+++ b/lib/Readers/ArchiveParser.cpp
@@ -263,8 +263,8 @@ eld::Expected<bool> ArchiveParser::computeSymInfoTableForMember(
     }
   } else if (auto IRObj =
                  llvm::dyn_cast<llvm::object::IRObjectFile>(binaryObj.get())) {
-    eld::Expected<bool> expComputeResult =
-        computeSymInfoTableForIRMember(*IRObj, member, symbolInfoTable);
+    eld::Expected<bool> expComputeResult = computeSymInfoTableForIRMember(
+        archiveFile, *IRObj, member, symbolInfoTable);
     ELDEXP_RETURN_DIAGENTRY_IF_ERROR(expComputeResult);
   } else {
     std::string message =
@@ -330,10 +330,25 @@ eld::Expected<bool> ArchiveParser::computeSymInfoTableForELFMember(
 }
 
 eld::Expected<bool> ArchiveParser::computeSymInfoTableForIRMember(
-    const llvm::object::IRObjectFile &IRObj,
+    const ArchiveFile &archiveFile, const llvm::object::IRObjectFile &IRObj,
     const llvm::object::Archive::Child &member,
     ArchiveSymbolInfoTable &symbolInfoTable) const {
   LinkerConfig &config = m_Module.getConfig();
+
+  if (!m_Module.isBackendInitialized()) {
+    llvm::Triple Triple(IRObj.getTargetTriple());
+    if (!Triple.isLittleEndian())
+      return std::make_unique<plugin::DiagnosticEntry>(
+          plugin::DiagnosticEntry(Diag::fatal_big_endian_target,
+                                  {archiveFile.getInput()->decoratedPath()}));
+
+    uint16_t machine =
+        llvm::ELF::convertTripleArchTypeToEMachine(Triple.getArch());
+    bool is64Bit = Triple.isArch64Bit();
+    if (!m_Module.getLinker()->initializeTarget(machine, is64Bit))
+      return false;
+  }
+
   for (const llvm::object::BasicSymbolRef &sym : IRObj.symbols()) {
     // FIXME: Should we use auto for LLVM APIs?
     // Because if an LLVM API changes, the return type from

--- a/test/Common/standalone/Sniffing/Inputs/mipsel.ir
+++ b/test/Common/standalone/Sniffing/Inputs/mipsel.ir
@@ -1,0 +1,9 @@
+; ModuleID = '1.o'
+source_filename = "1.c"
+target datalayout = "e-m:m-p:32:32-i8:8:32-i16:16:32-i64:64-n32-S64"
+target triple = "mipsel"
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @foo() #0 {
+  ret i32 0
+}

--- a/test/Common/standalone/Sniffing/InvalidInputs.test
+++ b/test/Common/standalone/Sniffing/InvalidInputs.test
@@ -13,6 +13,14 @@ RUN: %not %eld %t1.ppc.o -o %t2.out --verbose 2>&1 | %filecheck %s -check-prefix
 # Sniff using LTO (PPC)
 RUN: %llvm-as %p/Inputs/ppc.ir -o %t1.ppc.bc.o
 RUN: %not %eld %t1.ppc.bc.o -o %t2.out 2>&1 | %filecheck %s -check-prefix=BC
+# Same big-endian bitcode, but as the only member of an archive with no
+# other ELF input and no -m, to exercise archive symbol-table sniffing
+RUN: %ar cr %t1.ppc.bc.a %t1.ppc.bc.o
+RUN: %not %eld %t1.ppc.bc.a -o %t2.out 2>&1 | %filecheck %s -check-prefix=ARCHIVEBC_BE
+# Unsupported little-endian target, as the only member of an archive
+RUN: %llvm-as %p/Inputs/mipsel.ir -o %t1.mipsel.bc.o
+RUN: %ar cr %t1.mipsel.bc.a %t1.mipsel.bc.o
+RUN: %not %eld %t1.mipsel.bc.a -o %t2.out 2>&1 | %filecheck %s -check-prefix=ARCHIVEBC_UNSUP
 # invalid ELF class
 RUN: %echo -e -n "\x7f\x45\x4c\x46\x00\x01\x01\x03\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00" > %t.invalid.o
 RUN: %not %eld %t.invalid.o -o %t2.out --verbose 2>&1 | %filecheck %s -check-prefix=INVALIDFILECLASS
@@ -24,4 +32,6 @@ RUN: %not %eld %t.invalid.o -o %t2.out --verbose 2>&1 | %filecheck %s -check-pre
 #PPC: Target not registered : ppc
 #BE: big-endian targets are not supported: {{.*}}be.o
 #BC: Unsupported architecture powerpc in LLVM Bitcode file : {{.*}}bc.o
+#ARCHIVEBC_BE: big-endian targets are not supported: {{.*}}ppc.bc.a
+#ARCHIVEBC_UNSUP: Target not registered : mips
 #INVALIDFILECLASS: {{.*}}invalid.o : corrupted ELF file: invalid file class

--- a/test/Common/standalone/Sniffing/Sniff.test
+++ b/test/Common/standalone/Sniffing/Sniff.test
@@ -23,8 +23,7 @@ RUN: %ar cr %t.lib1.lto.a %t1.1.lto.o
 # whole-archive sniffing (ELF)
 RUN: %eld --whole-archive %t.lib1.lto.a -o %t2.out --verbose 2>&1 | %filecheck %s -check-prefix=INFERRED
 # only archive sniffing
-RUN: %not %eld %t.lib1.lto.a -o %t2.out 2>&1 | %filecheck %s -check-prefix=CANNOTINFER
+RUN: %eld %t.lib1.lto.a -o %t2.out --verbose 2>&1 | %filecheck %s -check-prefix=INFERRED
 #END_TEST
 
 #INFERRED: {{[hexagon|arm|aarch64|x86_64|riscv]}}
-#CANNOTINFER: target emulation unknown: -m or at least one .o file required


### PR DESCRIPTION
ArchiveParser now Initialize the backend based on target information in bitcode members.

Fix: #1693