### PR TITLE
Fix llvm-test-suite workflow: missing libunwind RPATH

### DIFF
--- a/.github/workflows/nightly-llvm-test-suite.yml
+++ b/.github/workflows/nightly-llvm-test-suite.yml
@@ -57,6 +57,7 @@ jobs:
         run: |
           ELD_BIN=$(which ld.eld)
           LIB_DIR="$(dirname "$ELD_BIN")/../lib"
+          RT_LIB_DIR="$LIB_DIR/x86_64-unknown-linux-gnu"
           # TEST_SUITE_SUBDIRS is left unset, so llvm-test-suite/CMakeLists.txt
           # runs its own auto-discovery.
           # That resolves to:
@@ -93,7 +94,7 @@ jobs:
             -DCMAKE_CXX_COMPILER=$(which clang++) \
             -DCMAKE_C_FLAGS="--ld-path=$ELD_BIN" \
             -DCMAKE_CXX_FLAGS="--ld-path=$ELD_BIN -stdlib=libc++" \
-            -DCMAKE_EXE_LINKER_FLAGS="--ld-path=$ELD_BIN -stdlib=libc++ -Wl,-rpath,$LIB_DIR" \
+            -DCMAKE_EXE_LINKER_FLAGS="--ld-path=$ELD_BIN -stdlib=libc++ -Wl,-rpath,$LIB_DIR -Wl,-rpath,$RT_LIB_DIR" \
             -DTEST_SUITE_RUN_TYPE=nightly
 
       - name: Build test suite
@@ -102,6 +103,7 @@ jobs:
 
       - name: Run tests
         run: |
+          set -o pipefail
           lit -j$(nproc) build-llvm-test-suite 2>&1 | tee test-output.txt
 
       - name: Upload test output


### PR DESCRIPTION
`libunwind.so.1` exists under `lib/x86_64-unknown-linux-gnu`, not the top-level lib dir that the current rpath pointed at. This lead to several failures in the test suite. Also added `set -o pipefail` so a failing lit run is not hidden like earlier due to tee's own exit code.