### PR TITLE
[Reproduce] Capture --remap-inputs-file in --reproduce tarballs

### DIFF
--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -1680,6 +1680,36 @@ bool GnuLdDriver::processReproduceOption(
   if (!Config.options().getDumpResponse())
     os << getProgramName() << " ";
   size_t lastNamespecId = -1;
+  size_t lastInputFileId = -1;
+  size_t lastScriptId = -1;
+  size_t lastJustSymbolsId = -1;
+
+  auto getRewrittenActionInputPath =
+      [&](eld::InputAction::InputActionKind kind, size_t &lastActionId,
+          llvm::StringRef fallback) -> std::optional<std::string> {
+    for (size_t i = lastActionId + 1; i < actions.size(); ++i) {
+      auto action = actions[i];
+      if (action->getInputActionKind() != kind)
+        continue;
+      lastActionId = i;
+      auto ipt = action->getInput();
+      if (!ipt)
+        return std::nullopt;
+      std::string key = fallback.str();
+      if (ipt->getInputFile() && ipt->getInputFile()->hasMappedPath())
+        key = ipt->getInputFile()->getMappedPath();
+      else if (!ipt->getName().empty())
+        key = ipt->getName();
+      return outputTar->rewritePath(key);
+    }
+    return outputTar->rewritePath(fallback);
+  };
+
+  auto getRewrittenRemappedPath = [&](llvm::StringRef path) -> std::string {
+    if (auto replacement = Config.options().findRemapInput(path))
+      return outputTar->rewritePath(*replacement);
+    return outputTar->rewritePath(path);
+  };
 
   auto zArgsRange = Args.filtered(T::dash_z);
   auto zArgIt = zArgsRange.begin();
@@ -1713,9 +1743,14 @@ bool GnuLdDriver::processReproduceOption(
       }
       break;
     }
-    case T::INPUT:
-      os << outputTar->rewritePath(arg->getValue()) << ' ';
+    case T::INPUT: {
+      auto path = getRewrittenActionInputPath(eld::InputAction::InputFile,
+                                              lastInputFileId, arg->getValue());
+      if (!path)
+        return false;
+      os << *path << ' ';
       break;
+    }
     case T::plugin_config: {
       const eld::sys::fs::Path *P = Config.directories().findFile(
           "plugin configuration file", arg->getValue(), "");
@@ -1727,21 +1762,45 @@ bool GnuLdDriver::processReproduceOption(
     }
     case T::output_file:
     case T::Map:
-    case T::T:
-    case T::R:
+      os << arg->getSpelling() << ' ' << outputTar->rewritePath(arg->getValue())
+         << ' ';
+      break;
     case T::dynamic_list:
     case T::extern_list:
     case T::version_script:
-      os << arg->getSpelling() << ' ' << outputTar->rewritePath(arg->getValue())
-         << ' ';
+    case T::copy_farcalls_from_file:
+    case T::no_reuse_trampolines_file:
+      os << arg->getSpelling() << ' '
+         << getRewrittenRemappedPath(arg->getValue()) << ' ';
       break;
+    case T::T: {
+      auto path = getRewrittenActionInputPath(eld::InputAction::Script,
+                                              lastScriptId, arg->getValue());
+      if (!path)
+        return false;
+      os << arg->getSpelling() << ' ' << *path << ' ';
+      break;
+    }
+    case T::R: {
+      auto path = getRewrittenActionInputPath(
+          eld::InputAction::JustSymbols, lastJustSymbolsId, arg->getValue());
+      if (!path)
+        return false;
+      os << arg->getSpelling() << ' ' << *path << ' ';
+      break;
+    }
     case T::remap_inputs:
       os << arg->getSpelling() << ' ' << arg->getValue() << ' ';
       break;
-    case T::remap_inputs_file:
+    case T::remap_inputs_file: {
+      const eld::sys::fs::Path *P = Config.directories().findFile(
+          "remap input file", arg->getValue(), "");
+      outputTar->createAndAddConfigFile(arg->getValue(),
+                                        P ? P->getFullPath() : "");
       os << arg->getSpelling() << ' ' << outputTar->rewritePath(arg->getValue())
          << ' ';
       break;
+    }
     case T::dash_z: {
       ASSERT(zArgIt != zArgsRange.end(), "Expected valid z argument iterator!");
       os << arg->getSpelling() << ' ';

--- a/test/Common/standalone/CommandLine/Reproduce/RemapInputsFileCapture.test
+++ b/test/Common/standalone/CommandLine/Reproduce/RemapInputsFileCapture.test
@@ -1,0 +1,41 @@
+#---RemapInputsFileCapture.test---------------- Executable --------------------#
+#BEGIN_COMMENT
+# Confirms --reproduce correctly captures --remap-inputs-file. The response
+# uses the captured replacement object when a remap rule substitutes a
+# positional input, and uses the captured replacement file when remap rules
+# substitute option-backed inputs such as version scripts and symbol lists.
+# It also records the remap file's categorized/hashed tar path
+# (Config/remap.txt.<hash>) instead of a bare basename, mapping.ini lists the
+# remap file under [Config Files], and the extracted reproduce tarball can be
+# replayed in place via its own response.txt to produce a byte-identical link.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.original.o
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t1.replacement.o
+RUN: %clang %clangopts -c %p/Inputs/2.c -o %t1.2.o
+RUN: %echo "%t1.original.o=%t1.replacement.o" > %t1.remap.txt
+RUN: %echo "%t1.original.version=%p/Inputs/versionscript" >> %t1.remap.txt
+RUN: %echo "%t1.original.dynamic=%p/Inputs/list1" >> %t1.remap.txt
+RUN: %echo "%t1.original.extern=%p/Inputs/externlist" >> %t1.remap.txt
+RUN: %link %linkopts %t1.original.o %t1.2.o -o %t1.out --force-dynamic --version-script=%t1.original.version --dynamic-list=%t1.original.dynamic --extern-list=%t1.original.extern --remap-inputs-file=%t1.remap.txt --reproduce %t0.tar --dump-response-file %t1.response
+RUN: %filecheck %s --check-prefix=RESPONSE < %t1.response
+RUN: %mkdir %t1.extract
+RUN: %tar %gnutaropts -xf %t0.tar -C %t1.extract --strip-components=1
+RUN: %filecheck %s --check-prefix=MAPPING < %t1.extract/mapping.ini
+
+RUN: cd %t1.extract
+RUN: %link @%t1.extract/response.txt -o %t1.extract/rep.out
+RUN: %diff %t1.extract/rep.out %t1.out
+
+RESPONSE: --thread-count
+RESPONSE-NOT: original
+RESPONSE: Object{{[^ ]*}}replacement.o{{[^ ]*}}
+RESPONSE: --version-script {{.*}}VersionScript{{.*}}versionscript{{[^ ]*}}
+RESPONSE: --dynamic-list {{.*}}DynamicList{{.*}}list1{{[^ ]*}}
+RESPONSE: --extern-list {{.*}}ExternList{{.*}}externlist{{[^ ]*}}
+RESPONSE-NOT: original
+RESPONSE: --remap-inputs-file {{.*}}Config{{.*}}remap.txt{{.*}}
+RESPONSE-NOT: original
+MAPPING: [Config Files]
+MAPPING-NEXT: {{.*}}remap.txt{{.*}}=Config{{.*}}remap.txt{{.*}}
+#END_TEST


### PR DESCRIPTION
Capture --remap-inputs-file in --reproduce tarballs. Previously, the remap file was not added to the archive, so reproduce
tarballs using this option could not be replayed. Register it with createAndAddConfigFile, mirroring the --plugin-config
handling. 
When a remap rule matched an input, response.txt also retained the original command-line path even though the tarball
contained only the replacement file. Generate response.txt using the resolved remapped paths for positional inputs and input-backed options, including:
  - linker scripts and just-symbols files
  - version scripts
  - dynamic and extern lists
  - trampoline list files

Add regression coverage that verifies the captured paths and successfully replays the extracted tarball.

Fix: qualcomm#1698