### PR TITLE
[Workflow] Fetch base branch from base repo, not origin, in CI doc-ch…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,8 @@ jobs:
         id: file-check
         working-directory: pr-${{ env.PR_NUMBER }}/llvm-project/llvm/tools/eld
         run: |
-          git fetch origin ${{ env.BASE_BRANCH_NAME }}
-          MERGE_BASE=$(git merge-base origin/${{ env.BASE_BRANCH_NAME }} HEAD)
+          git fetch "https://github.com/${{ github.event.pull_request.base.repo.full_name }}" "${{ env.BASE_BRANCH_NAME }}"
+          MERGE_BASE=$(git merge-base FETCH_HEAD HEAD)
           CHANGED_FILES=$(git diff --name-only "$MERGE_BASE" HEAD)
           echo "Changed files: $CHANGED_FILES"
           for file in $CHANGED_FILES; do


### PR DESCRIPTION
PRs from forks set origin to the head repo, which often lacks the base release branch (e.g. release/23.x), causing "couldn't find remote ref" in the non-doc-change check. Fetch directly from the PR's base repo instead and diff against FETCH_HEAD.