### PR TITLE
Use correct base branch for checking non-doc changes in PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,10 @@ jobs:
         id: file-check
         working-directory: pr-${{ env.PR_NUMBER }}/llvm-project/llvm/tools/eld
         run: |
-          git fetch origin ${{ env.BASE_BRANCH_NAME }}
-          MERGE_BASE=$(git merge-base origin/${{ env.BASE_BRANCH_NAME }} HEAD)
+          # We need to use base branch from qualcomm/eld
+          git remote add QC https://github.com/qualcomm/eld.git
+          git fetch QC ${{ env.BASE_BRANCH_NAME }} --depth=1
+          MERGE_BASE=$(git merge-base QC/${{ env.BASE_BRANCH_NAME }} HEAD)
           CHANGED_FILES=$(git diff --name-only "$MERGE_BASE" HEAD)
           echo "Changed files: $CHANGED_FILES"
           for file in $CHANGED_FILES; do


### PR DESCRIPTION
This commit fixes the pull-request CI workflow to use the correct base branch when checking for non-doc changes in pull-request CI.

Until now, if a pull-request was created for qualcomm/eld/release/23.x branch using parth/eld/SomeFeature branch, then the 'Check for non-doc changes' step in pull-request CI will take parth/eld/SomeFeature branch as the HEAD commit and parth/eld/release/23.x branch as the base. The base used here is wrong and should instead be
qualcomm/eld/release/23.x.

Using incorrect base has two key issues:

- If the repository of the branch using which PR is created does not have a branch named as the ${BASE_BRANCH} then the `git diff ...` command will error out and the workflow will fail.
- A more serious issue is that the PR author can update his/her ${REPO}/eld/${BASE_BRANCH} such that the 'check for non-doc changes' returns no diff and the workflow incorrectly passes without building/running tests.