### PR TITLE
Fix layout order of symbol versioning sections

### DIFF
--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -1563,6 +1563,15 @@ unsigned int GNULDBackend::getSectionOrder(const ELFSection &pSectHdr) const {
     return SHO_UNDEFINED;
 
   case LDFileFormat::NamePool:
+    // .gnu.version/.gnu.version_d/.gnu.version_r are ALLOC read-only sections
+    // that belong with the dynamic name-pool region next to .dynsym, matching
+    // GNU ld/lld. Without this case they fall through to SHO_UNDEFINED and get
+    // placed after .data/.bss, stranding a read-only LOAD segment past the last
+    // writable segment and corrupting the program break / load layout in the
+    // older qemu versions.
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  case LDFileFormat::SymbolVersion:
+#endif
     return SHO_NAMEPOOL;
   case LDFileFormat::Relocation:
   case LDFileFormat::DynamicRelocation:

--- a/test/Common/standalone/SymbolVersioning/SymbolVersionSectionOrder/Inputs/1.c
+++ b/test/Common/standalone/SymbolVersioning/SymbolVersionSectionOrder/Inputs/1.c
@@ -1,0 +1,10 @@
+// Large, highly-aligned .bss object plus a small .data object. The high
+// alignment forces .bss to a large virtual address, so if the read-only
+// .gnu.version* sections were ranked after .data/.bss they would strand a
+// read-only LOAD segment past the last writable segment.
+float Input[4] __attribute__((aligned(65536)));
+int initialized = 7;
+
+int foo() { return 1; }
+int bar() { return 3; }
+int baz() { return 5; }

--- a/test/Common/standalone/SymbolVersioning/SymbolVersionSectionOrder/Inputs/vs.t
+++ b/test/Common/standalone/SymbolVersioning/SymbolVersionSectionOrder/Inputs/vs.t
@@ -1,0 +1,7 @@
+V1 {
+  global:
+    foo;
+    bar;
+  local:
+    baz;
+};

--- a/test/Common/standalone/SymbolVersioning/SymbolVersionSectionOrder/SymbolVersionSectionOrder.test
+++ b/test/Common/standalone/SymbolVersioning/SymbolVersionSectionOrder/SymbolVersionSectionOrder.test
@@ -1,0 +1,24 @@
+REQUIRES: symbol_versioning
+#---SymbolVersionSectionOrder.test-------------------- SymbolVersioning ------#
+#BEGIN_COMMENT
+# Verify that the symbol-versioning sections (.gnu.version, .gnu.version_d,
+# .gnu.version_r) are laid out with the read-only dynamic name-pool region,
+# i.e. before the writable .data/.bss sections. If they are ranked after
+# .data/.bss they strand a read-only LOAD segment past the last writable
+# segment, which corrupts the program break and crashes at run time in older
+# qemu versions (qemu 5.0 in particular)
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -fPIC
+RUN: %link %linkopts -o %t1.lib1.so %t1.1.o -shared --version-script %p/Inputs/vs.t
+RUN: %readelf -S %t1.lib1.so | %filecheck %s
+#END_TEST
+
+# .gnu.version* must come before .data and .bss in section (layout) order.
+CHECK-NOT: .data
+CHECK-NOT: .bss
+CHECK: .gnu.version
+CHECK: .gnu.version_d
+CHECK: .data
+CHECK: .bss
+CHECK-NOT: .gnu.version

--- a/test/Common/standalone/SymbolVersioning/SymbolVersionSectionOrderOrdinary/Inputs/1.c
+++ b/test/Common/standalone/SymbolVersioning/SymbolVersionSectionOrderOrdinary/Inputs/1.c
@@ -1,0 +1,6 @@
+extern int provider_fn(void);
+int g_data = 42;
+int g_bss[16];
+int foo() { return provider_fn() + g_data; }
+int bar() { return g_bss[0]; }
+int baz() { return 5; }

--- a/test/Common/standalone/SymbolVersioning/SymbolVersionSectionOrderOrdinary/Inputs/prov.c
+++ b/test/Common/standalone/SymbolVersioning/SymbolVersionSectionOrderOrdinary/Inputs/prov.c
@@ -1,0 +1,1 @@
+int provider_fn() { return 7; }

--- a/test/Common/standalone/SymbolVersioning/SymbolVersionSectionOrderOrdinary/Inputs/prov.t
+++ b/test/Common/standalone/SymbolVersioning/SymbolVersionSectionOrderOrdinary/Inputs/prov.t
@@ -1,0 +1,1 @@
+PROV_1 { global: provider_fn; local: *; };

--- a/test/Common/standalone/SymbolVersioning/SymbolVersionSectionOrderOrdinary/Inputs/vs.t
+++ b/test/Common/standalone/SymbolVersioning/SymbolVersionSectionOrderOrdinary/Inputs/vs.t
@@ -1,0 +1,1 @@
+V1 { global: foo; bar; local: baz; };

--- a/test/Common/standalone/SymbolVersioning/SymbolVersionSectionOrderOrdinary/SymbolVersionSectionOrderOrdinary.test
+++ b/test/Common/standalone/SymbolVersioning/SymbolVersionSectionOrderOrdinary/SymbolVersionSectionOrderOrdinary.test
@@ -1,0 +1,29 @@
+REQUIRES: symbol_versioning
+#---SymbolVersionSectionOrderOrdinary.test------------ SymbolVersioning ------#
+#BEGIN_COMMENT
+# Same as SymbolVersionSectionOrder, but with .text/.data/.bss of ordinary
+# size and alignment, and linking against a versioned DSO so that all three
+# symbol-versioning sections (.gnu.version, .gnu.version_d, .gnu.version_r)
+# are emitted. They must all be laid out with the read-only dynamic name-pool
+# region, i.e. before .text/.data/.bss and never after them.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.prov.o %p/Inputs/prov.c -c -fPIC
+RUN: %link %linkopts -o %t1.libprov.so %t1.prov.o -shared --version-script %p/Inputs/prov.t
+RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c -fPIC
+RUN: %link %linkopts -o %t1.lib1.so %t1.1.o %t1.libprov.so -shared --version-script %p/Inputs/vs.t
+RUN: %readelf --sections %t1.lib1.so | %filecheck %s
+#END_TEST
+
+# All three .gnu.version* sections must come before .text/.data/.bss and not
+# reappear after them.
+CHECK-NOT: .text
+CHECK-NOT: .data
+CHECK-NOT: .bss
+CHECK: .gnu.version
+CHECK: .gnu.version_d
+CHECK: .gnu.version_r
+CHECK: .text
+CHECK: .data
+CHECK: .bss
+CHECK-NOT: .gnu.version


### PR DESCRIPTION
This commit fixes the placement of the `.gnu.version`, `.gnu.version_d`, and `.gnu.version_r` sections, which were being laid out after the writable `.data` and `.bss` sections instead of alongside the read-only dynamic name-pool region next to `.dynsym`.

The root cause was that these allocatable sections were not assigned a section order and fell through to the default, and hence got placed last among allocatable sections. This cause issues with older qemu versions which used to set the program break as the end of the last writeable segment. This causes any loadable segment placed after the last writeable segment to get corrupted when heap memory is requested using `brk`.

The versioning setions are now ordered with the other dynamic name-pool sections, matching the layout produced by GNU ld and lld.

Resolves #1707