### PR TITLE
Remove `tar ... -C <dir>` usage from tests enabled for Windows

### DIFF
--- a/test/Common/standalone/CommandLine/Reproduce/ReproduceSharedLibSoname.test
+++ b/test/Common/standalone/CommandLine/Reproduce/ReproduceSharedLibSoname.test
@@ -11,8 +11,8 @@ RUN:   --dump-response-file %t.a.response -o %t.a.out
 RUN: %filecheck %s --check-prefix=MAPPING < %t.a.mapping
 # Replaying the response file must succeed.
 RUN: %rm -rf %t.rep && %mkdir %t.rep
-RUN: %tar %gnutaropts -xf %t.a.tar -C %t.rep --strip-components=1
 RUN: cd %t.rep
+RUN: %tar %gnutaropts -xf %t.a.tar --strip-components=1
 RUN: %link @response.txt
 
 RUN: cd ..
@@ -24,8 +24,8 @@ RUN:   --dump-response-file %t.b.response -o %t.b.out
 RUN: %filecheck %s --check-prefix=MAPPING_NAMESPEC < %t.b.mapping
 # Replaying the response file must succeed.
 RUN: %rm -rf %t.rep && %mkdir %t.rep
-RUN: %tar %gnutaropts -xf %t.b.tar -C %t.rep --strip-components=1
 RUN: cd %t.rep
+RUN: %tar %gnutaropts -xf %t.b.tar --strip-components=1
 RUN: %link @response.txt
 
 MAPPING: {{.*}}2.o=Object/

--- a/test/Common/standalone/CommandLine/Reproduce/SysrootMarker.test
+++ b/test/Common/standalone/CommandLine/Reproduce/SysrootMarker.test
@@ -17,6 +17,6 @@ MAPPING-DAG: =/lib.so=SharedLibrary/
 
 # Replaying the response file must succeed.
 RUN: %rm -rf %t.rep && %mkdir %t.rep
-RUN: %tar %gnutaropts -xf %t.tar -C %t.rep --strip-components=1
 RUN: cd %t.rep
+RUN: %tar %gnutaropts -xf %t.tar --strip-components=1
 RUN: %link @response.txt


### PR DESCRIPTION
This commit modifies the tests which were enabled for Windows to not use `-C <dir>` tar option. `tar ... -C <dir>` command fails on Windows builders because the `...\Git\bin\tar.exe` does not correctly handle the Windows-style path with the `-C` option.

We should later debug exactly why tar is failing here and if we can use some other tar on Windows builders so that such errors are not encountered in the future.