### PR TITLE
[ARM] Fix swapped $a/$t mapping symbols in THMToTHMStub veneers

### DIFF
--- a/docs/DeveloperDocs/ARM-Relocations.md
+++ b/docs/DeveloperDocs/ARM-Relocations.md
@@ -265,6 +265,8 @@ The linker selects a veneer template based on link-time options and the target C
 
 For Thumb→Thumb veneers the stub body first switches to ARM mode (`bx pc; nop`) before executing the ABS or PIC template, because the ARM load/branch sequence is simpler. The MOV and THUMB1 templates operate entirely in Thumb-2 or Thumb-1 respectively and therefore do not need that prefix.
 
+Because the ABS/PIC Thumb→Thumb stub body switches ISA partway through, the fragment must carry correct ARM-ELF mapping symbols: `$t` at offset 0 (the `bx pc; nop` preamble, still Thumb) and `$a` at offset 4 (where the ARM-mode `ldr`/`add`/`bx` sequence actually begins). Getting these swapped doesn't corrupt the emitted code (the CPU executes the real bytes regardless) but it does corrupt mode-aware disassembly (`objdump -d`, debuggers) for the stub, since those tools trust the mapping symbols rather than re-deriving the mode.
+
 ---
 
 ## References

--- a/lib/Target/ARM/THMToTHMStub.cpp
+++ b/lib/Target/ARM/THMToTHMStub.cpp
@@ -135,10 +135,10 @@ Stub *THMToTHMStub::clone(InputFile *F, Relocation *, eld::IRBuilder *pBuilder,
   uint32_t DataOffset = 0;
   if (m_Type == ARMGNULDBackend::VENEER_PIC) {
     pBuilder->addLinkerInternalLocalSymbol(
-        F, "$a.t2t." + std::to_string(m_NumStub), eld::make<FragmentRef>(*S, 0),
+        F, "$t.t2t." + std::to_string(m_NumStub), eld::make<FragmentRef>(*S, 0),
         0);
     pBuilder->addLinkerInternalLocalSymbol(
-        F, "$t.t2t." + std::to_string(m_NumStub), eld::make<FragmentRef>(*S, 4),
+        F, "$a.t2t." + std::to_string(m_NumStub), eld::make<FragmentRef>(*S, 4),
         0);
     DataOffset = 16;
   } else if (m_Type == ARMGNULDBackend::VENEER_MOV) {
@@ -153,10 +153,10 @@ Stub *THMToTHMStub::clone(InputFile *F, Relocation *, eld::IRBuilder *pBuilder,
     DataOffset = 8;
   } else {
     pBuilder->addLinkerInternalLocalSymbol(
-        F, "$a.t2t." + std::to_string(m_NumStub), eld::make<FragmentRef>(*S, 0),
+        F, "$t.t2t." + std::to_string(m_NumStub), eld::make<FragmentRef>(*S, 0),
         0);
     pBuilder->addLinkerInternalLocalSymbol(
-        F, "$t.t2t." + std::to_string(m_NumStub), eld::make<FragmentRef>(*S, 4),
+        F, "$a.t2t." + std::to_string(m_NumStub), eld::make<FragmentRef>(*S, 4),
         0);
     DataOffset = 12;
   }

--- a/test/ARM/standalone/MappingSymbolsForVeneers/T2TApplicationDisasm.test
+++ b/test/ARM/standalone/MappingSymbolsForVeneers/T2TApplicationDisasm.test
@@ -1,0 +1,38 @@
+#---T2TApplicationDisasm.test--------- Executable------------------------------#
+#BEGIN_COMMENT
+#Regression test: THMToTHMStub::clone() used to place the $a/$t ARM-ELF
+#mapping symbols backwards for a Thumb-to-Thumb long-branch veneer on a
+#non-microcontroller (application) target, corrupting objdump -d's
+#mode-aware disassembly even though the underlying instruction bytes were
+#always correct. Checks that both the ABS and PIC veneer templates disassemble
+#correctly and that $t/$a mapping symbols land at the correct offsets.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c -mthumb %p/Inputs/1.c -o %t1.t2tdisasm.1.o
+RUN: %link %linkopts %t1.t2tdisasm.1.o -o %t2.t2tdisasm.1.out --defsym bar=0x80000001
+RUN: %objdump -d %t2.t2tdisasm.1.out | %filecheck %s -check-prefix=STATIC
+RUN: %objdump -t %t2.t2tdisasm.1.out | %filecheck %s -check-prefix=STATICSYM
+RUN: %link %linkopts %t1.t2tdisasm.1.o -o %t2.t2tdisasm.2.out --defsym bar=0x80000001 -shared
+RUN: %objdump -d %t2.t2tdisasm.2.out | %filecheck %s -check-prefix=SHARED
+RUN: %objdump -t %t2.t2tdisasm.2.out | %filecheck %s -check-prefix=SHAREDSYM
+
+#STATIC: {{.*}} <__bar_T2T_veneer@island-1>:
+#STATIC:      {{.*}}: 4778          bx      pc
+#STATIC:      {{.*}}: 46c0          mov     r8, r8
+#STATIC:      {{.*}}: e59fc000      ldr     r12, [pc]{{.*}}
+#STATIC:      {{.*}}: e12fff1c      bx      r12
+
+#STATICSYM: $t.t2t.1
+#STATICSYM: $a.t2t.1
+
+#SHARED: {{.*}} <__bar_T2T_veneer@island-1>:
+#SHARED:      {{.*}}: 4778          bx      pc
+#SHARED:      {{.*}}: 46c0          mov     r8, r8
+#SHARED:      {{.*}}: e59fc004      ldr     r12, [pc, #0x4]{{.*}}
+#SHARED:      {{.*}}: e08fc00c      add     r12, pc, r12
+#SHARED:      {{.*}}: e12fff1c      bx      r12
+
+#SHAREDSYM: $t.t2t.1
+#SHAREDSYM: $a.t2t.1
+
+#END_TEST


### PR DESCRIPTION
Fixes `THMToTHMStub::clone()` to emit correct ARM-ELF `$a`/`$t` mapping symbols for Thumb-to-Thumb long-branch veneers. `llvm-objdump -d` (and other disassembly-aware tooling) now decodes Thumb→Thumb veneers correctly instead of showing garbage mnemonics at the stub.

Fix: qualcomm#1710