### PR TITLE
Add --trace=plugin=<name> scoped plugin tracing

### DIFF
--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -142,6 +142,8 @@ public:
 
   bool traceReloc(std::string const &RelocName) const;
 
+  bool tracePlugin(std::string const &PluginName) const;
+
   bool traceLTO(void) const;
 
   bool codegenOpts(void) const;
@@ -948,6 +950,10 @@ public:
 
   bool isSectionTracingRequested() const { return SectionTracingRequested; }
 
+  void setPluginTracingRequested() { PluginTracingRequested = true; }
+
+  bool isPluginTracingRequested() const { return PluginTracingRequested; }
+
   // --------------Dynamic Linker-------------------------
   bool hasDynamicLinker() const { return BDynamicLinker; }
 
@@ -1273,9 +1279,11 @@ private:
   std::vector<llvm::Regex> SymbolTrace;
   std::vector<llvm::Regex> RelocTrace;
   std::vector<llvm::Regex> SectionTrace;
+  std::vector<llvm::Regex> PluginTrace;
   std::vector<std::string> SymbolsToTrace;
   std::vector<std::string> SectionsToTrace;
   std::vector<std::string> RelocsToTrace;
+  std::vector<std::string> PluginsToTrace;
   std::vector<llvm::Regex> MergeStrSectionsToTrace;
   MergeStrTraceType MergeStrTraceValue = MergeStrTraceType::NONE;
   std::set<std::string> RelocVerify;
@@ -1309,6 +1317,7 @@ private:
   llvm::StringRef TrampolineMapFile; // TrampolineMap
   bool SymbolTracingRequested = false;
   bool SectionTracingRequested = false;
+  bool PluginTracingRequested = false;
   std::vector<llvm::StringRef> RequestedTimeRegions;
   DiagnosticEngine *DiagEngine = nullptr;
   bool BDynamicLinker = true;

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -659,6 +659,7 @@ defm trace
           "\t\t\t --trace=garbage-collection : trace linker garbage "
           "collection\n"
           "\t\t\t --trace=plugin : trace plugin\n"
+          "\t\t\t --trace=plugin=<plugin-name> : trace a single plugin\n"
           "\t\t\t --trace=threads : trace threads\n"
           "\t\t\t --trace=assignments : trace symbol assignments\n"
           "\t\t\t --trace=command-line : trace header info\n"

--- a/include/eld/Script/Plugin.h
+++ b/include/eld/Script/Plugin.h
@@ -61,6 +61,10 @@ public:
 
   std::string getPluginOptions() const { return PluginOptions; }
 
+  /// Returns true if diagnostics should be traced for this plugin, honoring
+  /// both bare --trace=plugin and scoped --trace=plugin=<name>.
+  bool isTraced() const;
+
   plugin::PluginBase *getLinkerPlugin() const { return UserPluginHandle; }
 
   void *getLibraryHandle() const { return PluginLibraryHandle; }

--- a/lib/Config/GeneralOptions.cpp
+++ b/lib/Config/GeneralOptions.cpp
@@ -198,6 +198,13 @@ eld::Expected<void> GeneralOptions::setTrace(const char *PTraceType) {
     std::string Sym = TraceType.substr(Pos + 1).str();
     SectionTrace.emplace_back(llvm::Regex(Sym));
     SectionsToTrace.emplace_back(Sym);
+  } else if (TraceType.starts_with("plugin") && TraceType.contains('=')) {
+    setPluginTracingRequested();
+    TraceMe = DiagEngine->getPrinter()->TracePlugin;
+    size_t Pos = TraceType.find_last_of('=');
+    std::string PluginName = TraceType.substr(Pos + 1).str();
+    PluginTrace.emplace_back(llvm::Regex(PluginName));
+    PluginsToTrace.emplace_back(PluginName);
   } else if (TraceType.starts_with("merge-strings")) {
     size_t Pos = TraceType.find_last_of('=');
     std::string Arg = TraceType.substr(Pos + 1).str();
@@ -381,6 +388,20 @@ bool GeneralOptions::traceReloc(std::string const &RelocName) const {
                       [&](const std::string &S) { return S == RelocName; }) ||
          llvm::any_of(RelocTrace, [&](const llvm::Regex &Regex) {
            return Regex.match(RelocRef);
+         });
+}
+
+bool GeneralOptions::tracePlugin(std::string const &PluginName) const {
+  if (!DiagEngine->getPrinter()->tracePlugins())
+    return false;
+  // Bare "--trace=plugin" (no scoped names given): trace every plugin.
+  if (!PluginTracingRequested)
+    return true;
+  StringRef PluginRef(PluginName);
+  return llvm::any_of(PluginsToTrace,
+                      [&](const std::string &S) { return S == PluginName; }) ||
+         llvm::any_of(PluginTrace, [&](const llvm::Regex &Regex) {
+           return Regex.match(PluginRef);
          });
 }
 

--- a/lib/Plugin/PluginManager.cpp
+++ b/lib/Plugin/PluginManager.cpp
@@ -111,7 +111,7 @@ bool PluginManager::callVisitSymbolHook(LDSymbol *Sym, llvm::StringRef SymName,
 
 void PluginManager::addSymbolVisitor(eld::Plugin *P) {
   SymbolVisitors.insert(P);
-  if (DE.getPrinter()->tracePlugins())
+  if (P->isTraced())
     DE.raise(Diag::trace_plugin_enable_visit_symbol) << P->getPluginName();
 }
 
@@ -136,7 +136,7 @@ void PluginManager::setAuxiliarySymbolNameMap(
     const ObjectFile::AuxiliarySymbolNameMap &AuxSymNameMap, const Plugin *P) {
   ObjFile->setAuxiliarySymbolNameMap(AuxSymNameMap);
   AuxSymNameMapProvider[ObjFile] = P;
-  if (DE.getPrinter()->tracePlugins())
+  if (P->isTraced())
     DE.raise(Diag::trace_set_aux_sym_name_map)
         << P->getPluginName() << ObjFile->getInput()->decoratedPath();
 }

--- a/lib/Script/Plugin.cpp
+++ b/lib/Script/Plugin.cpp
@@ -49,6 +49,10 @@ Plugin::Plugin(plugin::Plugin::Type T, std::string LibraryName,
       ThisModule(Module), ThisConfig(Module.getConfig()),
       IsDefaultPlugin(DefaultPlugin) {}
 
+bool Plugin::isTraced() const {
+  return ThisConfig.options().tracePlugin(getPluginType());
+}
+
 std::string Plugin::resolvePath(const LinkerConfig &PConfig) {
   // Library already loaded!
   if (PluginLibraryHandle)
@@ -79,7 +83,7 @@ std::string Plugin::resolvePath(const LinkerConfig &PConfig) {
 
   if (nullptr != NS) {
     PluginLibraryName = NS->getFullPath();
-    if (ThisModule.getPrinter()->tracePlugins())
+    if (isTraced())
       ThisConfig.raise(Diag::using_plugin) << PluginLibraryName << Name;
   }
   return PluginLibraryName;
@@ -135,7 +139,7 @@ bool Plugin::setFunctions() {
     return false;
   }
 
-  if (ThisModule.getPrinter()->tracePlugins()) {
+  if (isTraced()) {
     ThisConfig.raise(Diag::found_register_function) << Register << LibraryName;
     ThisConfig.raise(Diag::found_function_for_plugintype)
         << PluginFunc << LibraryName;
@@ -143,7 +147,7 @@ bool Plugin::setFunctions() {
 
   std::string PluginCleanupFunc = "Cleanup";
   void *C = DynamicLibrary::GetFunction(PluginLibraryHandle, PluginCleanupFunc);
-  if (C && ThisModule.getPrinter()->tracePlugins()) {
+  if (C && isTraced()) {
     ThisConfig.raise(Diag::found_cleanup_function)
         << PluginCleanupFunc << LibraryName;
   }
@@ -166,7 +170,7 @@ bool Plugin::setFunctions() {
 bool Plugin::getUserPlugin() {
   std::string LibraryName = DynamicLibrary::getLibraryName(Name);
 
-  if (ThisModule.getPrinter()->tracePlugins())
+  if (isTraced())
     ThisConfig.raise(Diag::registering_all_functions);
 
   UserPluginHandle = (*GetPluginFunction)(getPluginType().c_str());
@@ -176,7 +180,7 @@ bool Plugin::getUserPlugin() {
     return false;
   }
 
-  if (ThisModule.getPrinter()->tracePlugins())
+  if (isTraced())
     ThisConfig.raise(Diag::found_plugin_handler)
         << getPluginType() << LibraryName;
 
@@ -195,7 +199,7 @@ bool Plugin::init(eld::OutputTarWriter *OutputTar) {
     return false;
   eld::RegisterTimer T(
       "Init", ThisModule.saveString(UserPluginHandle->GetName()), Stats);
-  if (ThisModule.getPrinter()->tracePlugins())
+  if (isTraced())
     ThisConfig.raise(Diag::initializing_plugin)
         << getPluginType() << DynamicLibrary::getLibraryName(Name)
         << UserPluginHandle->GetName();
@@ -219,14 +223,14 @@ bool Plugin::run(std::vector<Plugin *> &Plugins) {
     return false;
   eld::RegisterTimer T(
       "Run", ThisModule.saveString(UserPluginHandle->GetName()), Stats);
-  if (ThisModule.getPrinter()->tracePlugins())
+  if (isTraced())
     ThisConfig.raise(Diag::running_plugin)
         << getPluginType() << DynamicLibrary::getLibraryName(Name)
         << UserPluginHandle->GetName();
   Plugins.push_back(this);
   Running R(this);
   plugin::Plugin *P = llvm::cast<plugin::Plugin>(UserPluginHandle);
-  plugin::Plugin::Status S = P->Run(ThisModule.getPrinter()->tracePlugins());
+  plugin::Plugin::Status S = P->Run(isTraced());
   if (S == plugin::Plugin::Status::ERROR || P->GetLastError()) {
     ThisConfig.raise(Diag::plugin_has_error)
         << getPluginType() << DynamicLibrary::getLibraryName(Name)
@@ -274,7 +278,7 @@ bool Plugin::destroy() {
     return false;
   eld::RegisterTimer T(
       "Destroy", ThisModule.saveString(UserPluginHandle->GetName()), Stats);
-  if (ThisModule.getPrinter()->tracePlugins())
+  if (isTraced())
     ThisConfig.raise(Diag::plugin_destroy) << getPluginType();
   plugin::Plugin *P = llvm::cast<plugin::Plugin>(UserPluginHandle);
   P->Destroy();
@@ -316,7 +320,7 @@ bool Plugin::check() {
     return false;
   }
 
-  if (ThisModule.getPrinter()->tracePlugins())
+  if (isTraced())
     ThisConfig.raise(Diag::note_plugin_version)
         << PluginMajor << PluginMinor << DynamicLibrary::getLibraryName(Name)
         << getPluginType();
@@ -506,7 +510,7 @@ void Plugin::callInitHook() {
   plugin::LinkerPlugin *P = llvm::cast<plugin::LinkerPlugin>(UserPluginHandle);
   RegisterTimer T("Init", ThisModule.saveString(UserPluginHandle->GetName()),
                   Stats);
-  if (ThisModule.getPrinter()->tracePlugins())
+  if (isTraced())
     ThisConfig.raise(Diag::trace_plugin_init) << getPluginName();
   P->Init(PluginOptions);
 }
@@ -515,7 +519,7 @@ void Plugin::callDestroyHook() {
   plugin::LinkerPlugin *P = llvm::cast<plugin::LinkerPlugin>(UserPluginHandle);
   RegisterTimer T("Destroy", ThisModule.saveString(UserPluginHandle->GetName()),
                   Stats);
-  if (ThisModule.getPrinter()->tracePlugins())
+  if (isTraced())
     ThisConfig.raise(Diag::trace_plugin_destroy) << getPluginName();
   P->Destroy();
 }
@@ -523,7 +527,7 @@ void Plugin::callDestroyHook() {
 void Plugin::registerCommandLineOption(
     const std::string &Option, bool HasValue,
     const CommandLineOptionSpec::OptionHandlerType &OptionHandler) {
-  if (ThisModule.getPrinter()->tracePlugins()) {
+  if (isTraced()) {
     if (HasValue)
       ThisConfig.raise(Diag::trace_plugin_register_opt_with_val)
           << getPluginName() << Option;
@@ -552,7 +556,7 @@ void Plugin::callVisitSectionsHook(InputFile &IF) {
   plugin::LinkerPlugin *P = llvm::cast<plugin::LinkerPlugin>(UserPluginHandle);
   RegisterTimer T("VisitSections",
                   ThisModule.saveString(UserPluginHandle->GetName()), Stats);
-  if (ThisModule.getPrinter()->tracePlugins())
+  if (isTraced())
     ThisConfig.raise(Diag::trace_plugin_visit_sections)
         << getPluginName() << IF.getInput()->decoratedPath();
   P->VisitSections(plugin::InputFile(&IF));
@@ -563,7 +567,7 @@ void Plugin::callVisitSymbolHook(LDSymbol *Sym, llvm::StringRef SymName,
   plugin::LinkerPlugin *P = llvm::cast<plugin::LinkerPlugin>(UserPluginHandle);
   RegisterTimer T("VisitSymbol",
                   ThisModule.saveString(UserPluginHandle->GetName()), Stats);
-  if (ThisModule.getPrinter()->tracePlugins())
+  if (isTraced())
     ThisConfig.raise(Diag::trace_plugin_visit_symbol)
         << getPluginName() << SymName;
   std::unique_ptr<SymbolInfo> UpSymInfo = std::make_unique<SymbolInfo>(SymInfo);
@@ -577,7 +581,7 @@ void Plugin::callActBeforeRuleMatchingHook() {
   plugin::LinkerPlugin *P = llvm::cast<plugin::LinkerPlugin>(UserPluginHandle);
   RegisterTimer T(HookName, ThisModule.saveString(UserPluginHandle->GetName()),
                   Stats);
-  if (ThisModule.getPrinter()->tracePlugins())
+  if (isTraced())
     ThisConfig.raise(Diag::trace_plugin_hook) << getPluginName() << HookName;
   P->ActBeforeRuleMatching();
 }
@@ -587,7 +591,7 @@ void Plugin::callActBeforeSectionMergingHook() {
   plugin::LinkerPlugin *P = llvm::cast<plugin::LinkerPlugin>(UserPluginHandle);
   RegisterTimer T(HookName, ThisModule.saveString(UserPluginHandle->GetName()),
                   Stats);
-  if (ThisModule.getPrinter()->tracePlugins())
+  if (isTraced())
     ThisConfig.raise(Diag::trace_plugin_hook) << getPluginName() << HookName;
   P->ActBeforeSectionMerging();
 }
@@ -597,7 +601,7 @@ void Plugin::callActBeforePerformingLayoutHook() {
   plugin::LinkerPlugin *P = llvm::cast<plugin::LinkerPlugin>(UserPluginHandle);
   RegisterTimer T(HookName, ThisModule.saveString(UserPluginHandle->GetName()),
                   Stats);
-  if (ThisModule.getPrinter()->tracePlugins())
+  if (isTraced())
     ThisConfig.raise(Diag::trace_plugin_hook) << getPluginName() << HookName;
   P->ActBeforePerformingLayout();
 }
@@ -607,7 +611,7 @@ void Plugin::callActBeforeWritingOutputHook() {
   plugin::LinkerPlugin *P = llvm::cast<plugin::LinkerPlugin>(UserPluginHandle);
   RegisterTimer T(HookName, ThisModule.saveString(UserPluginHandle->GetName()),
                   Stats);
-  if (ThisModule.getPrinter()->tracePlugins())
+  if (isTraced())
     ThisConfig.raise(Diag::trace_plugin_hook) << getPluginName() << HookName;
   P->ActBeforeWritingOutput();
 }

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -4344,7 +4344,7 @@ bool GNULDBackend::RunPluginsAndProcessHelper(
         return false;
       }
 
-      if (m_Module.getPrinter()->tracePlugins())
+      if (O->prolog().getPlugin()->isTraced())
         config().raise(Diag::allocating_memory) << S->size() << S->name();
 
       MemoryRegion mr(reinterpret_cast<uint8_t *>(MB.base()),
@@ -4357,10 +4357,10 @@ bool GNULDBackend::RunPluginsAndProcessHelper(
           return false;
         }
       }
-      if (m_Module.getPrinter()->tracePlugins())
+      if (O->prolog().getPlugin()->isTraced())
         config().raise(Diag::applying_relocations) << S->name();
       m_Module.getLinker()->getObjLinker()->relocation(false);
-      if (m_Module.getPrinter()->tracePlugins())
+      if (O->prolog().getPlugin()->isTraced())
         config().raise(Diag::syncing_relocations) << S->name();
       m_Module.getLinker()->getObjLinker()->syncRelocations(
           reinterpret_cast<uint8_t *>(MB.base()));
@@ -4386,7 +4386,7 @@ bool GNULDBackend::RunPluginsAndProcessHelper(
       B.Name = std::string(S->name());
 
       // Add the Memory Block.
-      if (m_Module.getPrinter()->tracePlugins())
+      if (O->prolog().getPlugin()->isTraced())
         config().raise(Diag::adding_memory_blocks) << S->name();
 
       // Add Memory Blocks.
@@ -4395,7 +4395,7 @@ bool GNULDBackend::RunPluginsAndProcessHelper(
       else
         FOP->AddBlocks(std::move(B));
 
-      if (m_Module.getPrinter()->tracePlugins())
+      if (O->prolog().getPlugin()->isTraced())
         config().raise(Diag::calling_handler) << S->name();
 
       // Run the algorithm.
@@ -4407,7 +4407,7 @@ bool GNULDBackend::RunPluginsAndProcessHelper(
 
       auto RB = MatchSections ? VAP->GetBlocks() : FOP->GetBlocks();
 
-      if (m_Module.getPrinter()->tracePlugins())
+      if (O->prolog().getPlugin()->isTraced())
         config().raise(Diag::plugin_returned_blocks) << RB.size() << S->name();
 
       ELFSection *OutputSection = S;


### PR DESCRIPTION
    Add --trace=plugin=<name> scoped plugin tracing

    Extend --trace=<category>[=<name>] (mirroring symbol=/section=/reloc=)
    to plugins, so an individual plugin's diagnostics can be enabled
    without tracing every plugin. GeneralOptions::tracePlugin() checks an
    exact-string/regex allowlist populated by the new plugin=<name> case,
    falling back to "trace everything" for the pre-existing bare
    --trace=plugin.

    Plugin::isTraced() wraps this check and replaces every
    tracePlugins()-gated call site in Plugin.cpp, PluginManager.cpp, and
    GNULDBackend::RunPluginsAndProcessHelper with per-plugin gating via
    O->prolog().getPlugin()->isTraced().