### PR TITLE
[ELD] Fix ARM OVERLAY VMA/LMA layout

### DIFF
--- a/lib/Script/ScriptFile.cpp
+++ b/lib/Script/ScriptFile.cpp
@@ -150,6 +150,12 @@ eld::Expected<void> ScriptFile::activate(Module &CurModule,
   // Resolve OVERLAY member names to OutputSectionEntry pointers so that layout
   // can discover overlay membership from the output-section entries.
   for (auto *O : OverlayDescs) {
+    // Overlay expressions are evaluated during layout; retain the script path
+    // for diagnostics produced at that point.
+    if (O->hasStart())
+      O->start()->setContext(getPath().str());
+    if (O->hasLMA())
+      O->lma()->setContext(getPath().str());
     for (const StrToken *NameTok : O->pendingMemberNames()) {
       if (!NameTok)
         continue;

--- a/lib/Target/CreateProgramHeaders.hpp
+++ b/lib/Target/CreateProgramHeaders.hpp
@@ -278,8 +278,42 @@ bool GNULDBackend::createProgramHdrs() {
     // Linker script overriding below.
     std::optional<uint64_t> scriptvma;
     bool doAlign = true;
+    OverlayDesc *overlay = (*out)->getOverlayDesc();
+    bool isOverlayMember = overlay != nullptr;
+    bool isFirstOverlayMember = isOverlayMember &&
+                                !overlay->members().empty() &&
+                                overlay->members().front() == *out;
+    OutputSectionEntry *previousOverlayMember = nullptr;
+    if (isOverlayMember && !isFirstOverlayMember) {
+      for (auto *Member : overlay->members()) {
+        if (Member == *out)
+          break;
+        previousOverlayMember = Member;
+      }
+    }
+
+    // OVERLAY members share one VMA, while their LMAs are consecutive. The
+    // member output-section descriptors intentionally have no VMA/LMA
+    // prologue; those values belong to the enclosing OverlayDesc.
+    if (isOverlayMember) {
+      if (overlay->hasStart()) {
+        overlay->start()->evaluateAndRaiseError();
+        scriptvma = overlay->start()->result();
+      } else if (isFirstOverlayMember) {
+        // With no explicit start, the overlay begins at the current dot.
+        scriptvma = dotSymbol->value();
+      } else {
+        // All members use the first member's VMA, including when that member
+        // is empty and therefore does not become the global previous section.
+        scriptvma = overlay->members().front()->getSection()->addr();
+      }
+      if (isCurAlloc)
+        dotSymbol->setValue(*scriptvma);
+      doAlign = false;
+    }
+
     // If the output section specified a VMA value.
-    if ((*out)->prolog().hasVMA()) {
+    if (!isOverlayMember && (*out)->prolog().hasVMA()) {
       (*out)->prolog().vma().evaluateAndRaiseError();
       // If the output section descriptor has an alignment specified
       // honor the alignment specified, the alignment would have been
@@ -345,7 +379,9 @@ bool GNULDBackend::createProgramHdrs() {
     // if this is the first section and the VMA was forced then
     // set PMA = VMA. For all sections following the first section
     // PMA will be calculated separately below
-    if ((*out)->prolog().hasLMA()) {
+    if (isOverlayMember) {
+      disconnect_lma_vma = true;
+    } else if ((*out)->prolog().hasLMA()) {
       useSetLMA = true;
       disconnect_lma_vma = true;
     }
@@ -460,7 +496,21 @@ bool GNULDBackend::createProgramHdrs() {
       cur->setAddr(vma);
       // Handle setting LMA and alignment of LMA
       // Explicitly align LMA to make the code easy to read
-      if (useSetLMA) {
+      if (isOverlayMember) {
+        // Only the first member consumes OVERLAY AT(...); later members are
+        // consecutive in load memory.
+        if (isFirstOverlayMember) {
+          if (overlay->hasLMA()) {
+            overlay->lma()->evaluateAndRaiseError();
+            pma = overlay->lma()->result();
+          } else {
+            pma = vma;
+          }
+        } else {
+          pma = previousOverlayMember->getSection()->pAddr() +
+                previousOverlayMember->getSection()->size();
+        }
+      } else if (useSetLMA) {
         (*out)->prolog().lma().evaluateAndRaiseError();
         pma = (*out)->prolog().lma().result();
       } else if (hasVMARegion || hasLMARegion) {
@@ -572,7 +622,19 @@ bool GNULDBackend::createProgramHdrs() {
         alignAddress(vma, cur->getAddrAlign());
       cur->setAddr(vma);
       // FIXME : de-duplicate this case.
-      if (useSetLMA) {
+      if (isOverlayMember) {
+        if (isFirstOverlayMember) {
+          if (overlay->hasLMA()) {
+            overlay->lma()->evaluateAndRaiseError();
+            pma = overlay->lma()->result();
+          } else {
+            pma = vma;
+          }
+        } else {
+          pma = previousOverlayMember->getSection()->pAddr() +
+                previousOverlayMember->getSection()->size();
+        }
+      } else if (useSetLMA) {
         (*out)->prolog().lma().evaluateAndRaiseError();
         pma = (*out)->prolog().lma().result();
       } else if (hasVMARegion || hasLMARegion) {

--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -64,6 +64,7 @@
 #include "eld/Readers/EhFrameHdrSection.h"
 #include "eld/Script/MemoryCmd.h"
 #include "eld/Script/OutputSectDesc.h"
+#include "eld/Script/OverlayDesc.h"
 #include "eld/Script/StrToken.h"
 #include "eld/Script/StringList.h"
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
@@ -3541,6 +3542,15 @@ void GNULDBackend::checkOverlap(llvm::StringRef name,
     SectionOffset b = sections[i];
     if (b.offset >= a.offset + a.sec->size())
       continue;
+
+    // OVERLAY members intentionally share a VMA; permit that overlap only for
+    // sections belonging to the same overlay.
+    OutputSectionEntry *A = a.sec->getOutputSection();
+    OutputSectionEntry *B = b.sec->getOutputSection();
+    if (isVirtualAddr && A && B && A->hasOverlayDesc() &&
+        A->getOverlayDesc() == B->getOverlayDesc())
+      continue;
+
     config().raise(Diag::error_section_overlap)
         << a.sec->name() << std::string(name) << b.sec->name() << a.sec->name()
         << rangeToString(a.offset, a.sec->size()) << b.sec->name()

--- a/test/ARM/standalone/linkerscript/OverlayArmKernelLayout/Inputs/arm-overlay.lds
+++ b/test/ARM/standalone/linkerscript/OverlayArmKernelLayout/Inputs/arm-overlay.lds
@@ -1,0 +1,30 @@
+OUTPUT_ARCH(arm)
+ENTRY(_start)
+
+SECTIONS
+{
+  . = 0xc1c00000;
+  .text : { *(.text) }
+  . = ALIGN(0x1000);
+
+  __vectors_lma = .;
+  OVERLAY 0xffff0000 : NOCROSSREFS AT(__vectors_lma)
+  {
+    .vectors { KEEP(*(.vectors)) }
+    .vectors.bhb.loop8 { KEEP(*(.vectors.bhb.loop8)) }
+    .vectors.bhb.bpiall { KEEP(*(.vectors.bhb.bpiall)) }
+  }
+
+  . = __vectors_lma + SIZEOF(.vectors) +
+      SIZEOF(.vectors.bhb.loop8) + SIZEOF(.vectors.bhb.bpiall);
+
+  __stubs_lma = .;
+  .stubs ADDR(.vectors) + 0x1000 : AT(__stubs_lma)
+  {
+    *(.stubs)
+  }
+
+  . = __stubs_lma + SIZEOF(.stubs);
+  . = ALIGN(8);
+  .init.text : AT(ADDR(.init.text)) { *(.init.text) }
+}

--- a/test/ARM/standalone/linkerscript/OverlayArmKernelLayout/Inputs/inputs.s
+++ b/test/ARM/standalone/linkerscript/OverlayArmKernelLayout/Inputs/inputs.s
@@ -1,0 +1,19 @@
+.syntax unified
+.arm
+
+.section .vectors, "ax", %progbits
+  .space 0x20
+
+.section .vectors.bhb.loop8, "ax", %progbits
+  .space 0x40
+
+.section .vectors.bhb.bpiall, "ax", %progbits
+  .space 0x60
+
+.section .stubs, "ax", %progbits
+  .space 0x350
+
+.section .init.text, "ax", %progbits
+.global _start
+_start:
+  .space 0x1000

--- a/test/ARM/standalone/linkerscript/OverlayArmKernelLayout/Inputs/overlay-edge-cases.lds
+++ b/test/ARM/standalone/linkerscript/OverlayArmKernelLayout/Inputs/overlay-edge-cases.lds
@@ -1,0 +1,17 @@
+OUTPUT_ARCH(arm)
+ENTRY(_start)
+
+SECTIONS
+{
+  . = 0xc1c00000;
+  .text : { *(.text) }
+  . = ALIGN(0x1000);
+
+  OVERLAY : AT(0xc1c01000)
+  {
+    .empty { }
+    .vectors { KEEP(*(.vectors)) }
+    .vectors.bhb.loop8 { KEEP(*(.vectors.bhb.loop8)) }
+    .vectors.bhb.bpiall { KEEP(*(.vectors.bhb.bpiall)) }
+  }
+}

--- a/test/ARM/standalone/linkerscript/OverlayArmKernelLayout/Inputs/overlay-reversed.lds
+++ b/test/ARM/standalone/linkerscript/OverlayArmKernelLayout/Inputs/overlay-reversed.lds
@@ -1,0 +1,16 @@
+OUTPUT_ARCH(arm)
+ENTRY(_start)
+
+SECTIONS
+{
+  . = 0xc1c00000;
+  .text : { *(.text) }
+  . = ALIGN(0x1000);
+
+  OVERLAY 0xffff0000 : AT(0xc1c00000)
+  {
+    .vectors.bhb.bpiall { KEEP(*(.vectors.bhb.bpiall)) }
+    .vectors.bhb.loop8 { KEEP(*(.vectors.bhb.loop8)) }
+    .vectors { KEEP(*(.vectors)) }
+  }
+}

--- a/test/ARM/standalone/linkerscript/OverlayArmKernelLayout/OverlayArmKernelLayout.test
+++ b/test/ARM/standalone/linkerscript/OverlayArmKernelLayout/OverlayArmKernelLayout.test
@@ -1,0 +1,47 @@
+#---OverlayArmKernelLayout.test--------------------- Executable,LS------------------#
+#BEGIN_COMMENT
+# This reproduces the ARM Linux kernel linker-script layout that places .stubs
+# at a separate VMA after an OVERLAY. Overlay members must share the overlay
+# VMA, while .stubs and .init.text must retain their explicitly assigned VMAs.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -target arm-linux-gnueabi -c %p/Inputs/inputs.s -o %t.o
+RUN: %link %linkopts -EL -m armelf_linux_eabi -T %p/Inputs/arm-overlay.lds %t.o -o %t.out
+RUN: %readelf -SW %t.out | %filecheck %s
+RUN: %readelf -l -W %t.out | %filecheck %s --check-prefix=PHDR
+RUN: %link %linkopts -EL -m armelf_linux_eabi -T %p/Inputs/overlay-edge-cases.lds %t.o -o %t.edge.out
+RUN: %readelf -SW %t.edge.out | %filecheck %s --check-prefix=EDGE
+RUN: %readelf -l -W %t.edge.out | %filecheck %s --check-prefix=EDGE-PHDR
+RUN: %link %linkopts -EL -m armelf_linux_eabi -T %p/Inputs/overlay-reversed.lds %t.o -o %t.reversed.out
+RUN: %readelf -SW %t.reversed.out | %filecheck %s --check-prefix=REVERSED
+RUN: %readelf -l -W %t.reversed.out | %filecheck %s --check-prefix=REVERSED-PHDR
+#END_TEST
+
+# CHECK:      .vectors PROGBITS ffff0000 {{.*}} 000020 {{.*}} AX
+# CHECK:      .vectors.bhb.loop8 PROGBITS ffff0000 {{.*}} 000040 {{.*}} AX
+# CHECK:      .vectors.bhb.bpiall PROGBITS ffff0000 {{.*}} 000060 {{.*}} AX
+# CHECK:      .stubs PROGBITS ffff1000 {{.*}} 000350 {{.*}} AX
+# CHECK:      .init.text PROGBITS c1c00410 {{.*}} 001000 {{.*}} AX
+
+# PHDR:      LOAD {{.*}} 0xffff0000 0xc1c00000 0x00020 0x00020 R E
+# PHDR-NEXT: LOAD {{.*}} 0xffff0000 0xc1c00020 0x00040 0x00040 R E
+# PHDR-NEXT: LOAD {{.*}} 0xffff0000 0xc1c00060 0x00060 0x00060 R E
+# PHDR-NEXT: LOAD {{.*}} 0xffff1000 0xc1c000c0 0x00350 0x00350 R E
+# PHDR-NEXT: LOAD {{.*}} 0xc1c00410 0xc1c00410 0x01000 0x01000 R E
+
+# The first member is empty and omitted from the ELF section table, but still
+# supplies the initial overlay LMA. With no explicit start, the overlay VMA is
+# the current location counter.
+# EDGE:      .vectors PROGBITS c1c00000 {{.*}} 000020 {{.*}} AX
+# EDGE-NEXT: .vectors.bhb.loop8 PROGBITS c1c00000 {{.*}} 000040 {{.*}} AX
+# EDGE-NEXT: .vectors.bhb.bpiall PROGBITS c1c00000 {{.*}} 000060 {{.*}} AX
+# EDGE-PHDR: LOAD {{.*}} 0xc1c00000 0xc1c01000 0x00020 0x00020 R E
+# EDGE-PHDR-NEXT: LOAD {{.*}} 0xc1c00000 0xc1c01020 0x00040 0x00040 R E
+# EDGE-PHDR-NEXT: LOAD {{.*}} 0xc1c00000 0xc1c01060 0x013b0 0x013b0 R E
+
+# REVERSED:      .vectors.bhb.bpiall PROGBITS ffff0000 {{.*}} 000060 {{.*}} AX
+# REVERSED-NEXT: .vectors.bhb.loop8 PROGBITS ffff0000 {{.*}} 000040 {{.*}} AX
+# REVERSED-NEXT: .vectors PROGBITS ffff0000 {{.*}} 000020 {{.*}} AX
+# REVERSED-PHDR: LOAD {{.*}} 0xffff0000 0xc1c00000 0x00060 0x00060 R E
+# REVERSED-PHDR-NEXT: LOAD {{.*}} 0xffff0000 0xc1c00060 0x00040 0x00040 R E
+# REVERSED-PHDR-NEXT: LOAD {{.*}} 0xffff0000 0xc1c000a0 {{.*}} R E


### PR DESCRIPTION
Handle OVERLAY members at their shared VMA, assign the first member's AT() LMA, and place subsequent members consecutively. Allow intentional virtual-address overlap between members of the same OVERLAY.

Add an ARM Linux kernel linker-script regression test covering section addresses and program-header VMAs/LMAs.

Fix: qualcomm#1724