### PR TITLE
[ARM] Align relocation dispatch with LLVM ARM.def

### DIFF
--- a/lib/Target/ARM/ARMRelocationFunctions.h
+++ b/lib/Target/ARM/ARMRelocationFunctions.h
@@ -14,9 +14,11 @@
 #ifndef ARM_RELOCATION_FUNCTIONS_H
 #define ARM_RELOCATION_FUNCTIONS_H
 
-#define R_ARM_ADD_PREL_20_8 131
-#define R_ARM_ADD_PREL_12_8 132
-#define R_ARM_LDR_PREL_12 133
+// These relocations are used internally when constructing ARM PLT entries.
+// They are kept outside the public relocation IDs defined by LLVM.
+#define R_ARM_ADD_PREL_20_8 0x83
+#define R_ARM_ADD_PREL_12_8 0x8b
+#define R_ARM_LDR_PREL_12 0x8c
 
 #define DECL_ARM_APPLY_RELOC_FUNC(Name)                                        \
   static ARMRelocator::Result Name(Relocation &pEntry, ARMRelocator &pParent);
@@ -55,118 +57,55 @@
   DECL_ARM_APPLY_RELOC_FUNC(relocLDR12)                                        \
   DECL_ARM_APPLY_RELOC_FUNC(unsupport)
 
-#define DECL_ARM_APPLY_RELOC_FUNC_PTRS                                         \
-  {&none, 0, "R_ARM_NONE"}, {&call, 1, "R_ARM_PC24"},                          \
-      {&abs32, 2, "R_ARM_ABS32"}, {&rel32, 3, "R_ARM_REL32"},                  \
-      {&unsupport, 4, "R_ARM_LDR_PC_G0"}, {&unsupport, 5, "R_ARM_ABS16"},      \
-      {&unsupport, 6, "R_ARM_ABS12"}, {&unsupport, 7, "R_ARM_THM_ABS5"},       \
-      {&unsupport, 8, "R_ARM_ABS8"}, {&rel32, 9, "R_ARM_SBREL32"},             \
-      {&thm_call, 10, "R_ARM_THM_CALL"}, {&unsupport, 11, "R_ARM_THM_PC8"},    \
-      {&unsupport, 12, "R_ARM_BREL_ADJ"}, {&unsupport, 13, "R_ARM_TLS_DESC"},  \
-      {&unsupport, 14, "R_ARM_THM_SWI8"}, {&unsupport, 15, "R_ARM_XPC25"},     \
-      {&unsupport, 16, "R_ARM_THM_XPC22"},                                     \
-      {&unsupport, 17, "R_ARM_TLS_DTPMOD32"},                                  \
-      {&unsupport, 18, "R_ARM_TLS_DTPOFF32"},                                  \
-      {&unsupport, 19, "R_ARM_TLS_TPOFF32"}, {&unsupport, 20, "R_ARM_COPY"},   \
-      {&unsupport, 21, "R_ARM_GLOB_DAT"}, {&unsupport, 22, "R_ARM_JUMP_SLOT"}, \
-      {&unsupport, 23, "R_ARM_RELATIVE"}, {&gotoff32, 24, "R_ARM_GOTOFF32"},   \
-      {&base_prel, 25, "R_ARM_BASE_PREL"}, {&got_brel, 26, "R_ARM_GOT_BREL"},  \
-      {&call, 27, "R_ARM_PLT32"}, {&call, 28, "R_ARM_CALL"},                   \
-      {&call, 29, "R_ARM_JUMP24"}, {&thm_call, 30, "R_ARM_THM_JUMP24"},        \
-      {&unsupport, 31, "R_ARM_BASE_ABS"},                                      \
-      {&unsupport, 32, "R_ARM_ALU_PCREL_7_0"},                                 \
-      {&unsupport, 33, "R_ARM_ALU_PCREL_15_8"},                                \
-      {&unsupport, 34, "R_ARM_ALU_PCREL_23_15"},                               \
-      {&unsupport, 35, "R_ARM_LDR_SBREL_11_0_NC"},                             \
-      {&unsupport, 36, "R_ARM_ALU_SBREL_19_12_NC"},                            \
-      {&unsupport, 37, "R_ARM_ALU_SBREL_27_20_CK"},                            \
-      {&abs32, 38, "R_ARM_TARGET1"}, {&unsupport, 39, "R_ARM_SBREL31"},        \
-      {&none, 40, "R_ARM_V4BX"}, {&target2, 41, "R_ARM_TARGET2"},              \
-      {&prel31, 42, "R_ARM_PREL31"}, {&movw_abs_nc, 43, "R_ARM_MOVW_ABS_NC"},  \
-      {&movt_abs, 44, "R_ARM_MOVT_ABS"},                                       \
-      {&movw_prel_nc, 45, "R_ARM_MOVW_PREL_NC"},                               \
-      {&movt_prel, 46, "R_ARM_MOVT_PREL"},                                     \
-      {&thm_movw_abs_nc, 47, "R_ARM_THM_MOVW_ABS_NC"},                         \
-      {&thm_movt_abs, 48, "R_ARM_THM_MOVT_ABS"},                               \
-      {&thm_movw_prel_nc, 49, "R_ARM_THM_MOVW_PREL_NC"},                       \
-      {&thm_movt_prel, 50, "R_ARM_THM_MOVT_PREL"},                             \
-      {&thm_jump19, 51, "R_ARM_THM_JUMP19"},                                   \
-      {&unsupport, 52, "R_ARM_THM_JUMP6"},                                     \
-      {&unsupport, 53, "R_ARM_THM_ALU_PREL_11_0"},                             \
-      {&unsupport, 54, "R_ARM_THM_PC12"}, {&unsupport, 55, "R_ARM_ABS32_NOI"}, \
-      {&unsupport, 56, "R_ARM_REL32_NOI"},                                     \
-      {&unsupport, 57, "R_ARM_ALU_PC_G0_NC"},                                  \
-      {&alu_pc, 58, "R_ARM_ALU_PC_G0"},                                        \
-      {&unsupport, 59, "R_ARM_ALU_PC_G1_NC"},                                  \
-      {&unsupport, 60, "R_ARM_ALU_PC_G1"},                                     \
-      {&unsupport, 61, "R_ARM_ALU_PC_G2"},                                     \
-      {&unsupport, 62, "R_ARM_LDR_PC_G1"},                                     \
-      {&ldr_pc_g2, 63, "R_ARM_LDR_PC_G2"},                                     \
-      {&unsupport, 64, "R_ARM_LDRS_PC_G0"},                                    \
-      {&unsupport, 65, "R_ARM_LDRS_PC_G1"},                                    \
-      {&unsupport, 66, "R_ARM_LDRS_PC_G2"},                                    \
-      {&unsupport, 67, "R_ARM_LDC_PC_G0"},                                     \
-      {&unsupport, 68, "R_ARM_LDC_PC_G1"},                                     \
-      {&unsupport, 69, "R_ARM_LDC_PC_G2"},                                     \
-      {&unsupport, 70, "R_ARM_ALU_SB_G0_NC"},                                  \
-      {&unsupport, 71, "R_ARM_ALU_SB_G0"},                                     \
-      {&unsupport, 72, "R_ARM_ALU_SB_G1_NC"},                                  \
-      {&unsupport, 73, "R_ARM_ALU_SB_G1"},                                     \
-      {&unsupport, 74, "R_ARM_ALU_SB_G2"},                                     \
-      {&unsupport, 75, "R_ARM_LDR_SB_G0"},                                     \
-      {&unsupport, 76, "R_ARM_LDR_SB_G1"},                                     \
-      {&unsupport, 77, "R_ARM_LDR_SB_G2"},                                     \
-      {&unsupport, 78, "R_ARM_LDRS_SB_G0"},                                    \
-      {&unsupport, 79, "R_ARM_LDRS_SB_G1"},                                    \
-      {&unsupport, 80, "R_ARM_LDRS_SB_G2"},                                    \
-      {&unsupport, 81, "R_ARM_LDC_SB_G0"},                                     \
-      {&unsupport, 82, "R_ARM_LDC_SB_G1"},                                     \
-      {&unsupport, 83, "R_ARM_LDC_SB_G2"},                                     \
-      {&unsupport, 84, "R_ARM_MOVW_BREL_NC"},                                  \
-      {&unsupport, 85, "R_ARM_MOVT_BREL"},                                     \
-      {&unsupport, 86, "R_ARM_MOVW_BREL"},                                     \
-      {&thm_movw_brel, 87, "R_ARM_THM_MOVW_BREL_NC"},                          \
-      {&thm_movt_prel, 88, "R_ARM_THM_MOVT_BREL"},                             \
-      {&thm_movw_brel, 89, "R_ARM_THM_MOVW_BREL"},                             \
-      {&unsupport, 90, "R_ARM_TLS_GOTDESC"},                                   \
-      {&unsupport, 91, "R_ARM_TLS_CALL"},                                      \
-      {&unsupport, 92, "R_ARM_TLS_DESCSEQ"},                                   \
-      {&unsupport, 93, "R_ARM_THM_TLS_CALL"},                                  \
-      {&unsupport, 94, "R_ARM_PLT32_ABS"}, {&unsupport, 95, "R_ARM_GOT_ABS"},  \
-      {&got_prel, 96, "R_ARM_GOT_PREL"}, {&unsupport, 97, "R_ARM_GOT_PREL12"}, \
-      {&unsupport, 98, "R_ARM_GOTOFF12"}, {&unsupport, 99, "R_ARM_GOTRELAX"},  \
-      {&unsupport, 100, "R_ARM_GNU_VTENTRY"},                                  \
-      {&unsupport, 101, "R_ARM_GNU_VTINERIT"},                                 \
-      {&thm_jump11, 102, "R_ARM_THM_JUMP11"},                                  \
-      {&thm_jump8, 103, "R_ARM_THM_JUMP8"}, {&tls, 104, "R_ARM_TLS_GD32"},     \
-      {&tls, 105, "R_ARM_TLS_LDM32"}, {&tls_ldo32, 106, "R_ARM_TLS_LDO32"},    \
-      {&tls, 107, "R_ARM_TLS_IE32"}, {&tls_le32, 108, "R_ARM_TLS_LE32"},       \
-      {&unsupport, 109, "R_ARM_TLS_LDO12"},                                    \
-      {&unsupport, 110, "R_ARM_TLS_LE12"},                                     \
-      {&unsupport, 111, "R_ARM_TLS_IE12GP"},                                   \
-      {&unsupport, 112, "R_ARM_PRIVATE_0"},                                    \
-      {&unsupport, 113, "R_ARM_PRIVATE_1"},                                    \
-      {&unsupport, 114, "R_ARM_PRIVATE_2"},                                    \
-      {&unsupport, 115, "R_ARM_PRIVATE_3"},                                    \
-      {&unsupport, 116, "R_ARM_PRIVATE_4"},                                    \
-      {&unsupport, 117, "R_ARM_PRIVATE_5"},                                    \
-      {&unsupport, 118, "R_ARM_PRIVATE_6"},                                    \
-      {&unsupport, 119, "R_ARM_PRIVATE_7"},                                    \
-      {&unsupport, 120, "R_ARM_PRIVATE_8"},                                    \
-      {&unsupport, 121, "R_ARM_PRIVATE_9"},                                    \
-      {&unsupport, 122, "R_ARM_PRIVATE_10"},                                   \
-      {&unsupport, 123, "R_ARM_PRIVATE_11"},                                   \
-      {&unsupport, 124, "R_ARM_PRIVATE_12"},                                   \
-      {&unsupport, 125, "R_ARM_PRIVATE_13"},                                   \
-      {&unsupport, 126, "R_ARM_PRIVATE_14"},                                   \
-      {&unsupport, 127, "R_ARM_PRIVATE_15"},                                   \
-      {&unsupport, 128, "R_ARM_ME_TOO"},                                       \
-      {&unsupport, 129, "R_ARM_THM_TLS_DESCSEQ16"},                            \
-      {&unsupport, 130, "R_ARM_THM_TLS_DESCSEQ32"},                            \
-      {&relocAddPREL1, 131, "R_ARM_ADD_PREL_20_8"},                            \
-      {&relocAddPREL2, 132, "R_ARM_ADD_PREL_12_8"},                            \
-      {&relocLDR12, 133, "R_ARM_LDR_PREL_12"}
-
-#define ARM_MAXRELOCS (R_ARM_LDR_PREL_12 + 1)
+// Handler overrides for relocations whose implementation is available in
+// ELD. All other LLVM-defined ARM relocations default to unsupport().
+// clang-format off
+#define DECL_ARM_APPLY_RELOC_FUNC_OVERRIDES(Func)                              \
+  Func(llvm::ELF::R_ARM_NONE, none, "R_ARM_NONE")                              \
+  Func(llvm::ELF::R_ARM_PC24, call, "R_ARM_PC24")                              \
+  Func(llvm::ELF::R_ARM_ABS32, abs32, "R_ARM_ABS32")                           \
+  Func(llvm::ELF::R_ARM_REL32, rel32, "R_ARM_REL32")                           \
+  Func(llvm::ELF::R_ARM_SBREL32, rel32, "R_ARM_SBREL32")                       \
+  Func(llvm::ELF::R_ARM_THM_CALL, thm_call, "R_ARM_THM_CALL")                  \
+  Func(llvm::ELF::R_ARM_GOTOFF32, gotoff32, "R_ARM_GOTOFF32")                  \
+  Func(llvm::ELF::R_ARM_BASE_PREL, base_prel, "R_ARM_BASE_PREL")               \
+  Func(llvm::ELF::R_ARM_GOT_BREL, got_brel, "R_ARM_GOT_BREL")                  \
+  Func(llvm::ELF::R_ARM_PLT32, call, "R_ARM_PLT32")                            \
+  Func(llvm::ELF::R_ARM_CALL, call, "R_ARM_CALL")                              \
+  Func(llvm::ELF::R_ARM_JUMP24, call, "R_ARM_JUMP24")                          \
+  Func(llvm::ELF::R_ARM_THM_JUMP24, thm_call, "R_ARM_THM_JUMP24")              \
+  Func(llvm::ELF::R_ARM_TARGET1, abs32, "R_ARM_TARGET1")                       \
+  Func(llvm::ELF::R_ARM_V4BX, none, "R_ARM_V4BX")                              \
+  Func(llvm::ELF::R_ARM_TARGET2, target2, "R_ARM_TARGET2")                     \
+  Func(llvm::ELF::R_ARM_PREL31, prel31, "R_ARM_PREL31")                        \
+  Func(llvm::ELF::R_ARM_MOVW_ABS_NC, movw_abs_nc, "R_ARM_MOVW_ABS_NC")         \
+  Func(llvm::ELF::R_ARM_MOVT_ABS, movt_abs, "R_ARM_MOVT_ABS")                  \
+  Func(llvm::ELF::R_ARM_MOVW_PREL_NC, movw_prel_nc, "R_ARM_MOVW_PREL_NC")      \
+  Func(llvm::ELF::R_ARM_MOVT_PREL, movt_prel, "R_ARM_MOVT_PREL")               \
+  Func(llvm::ELF::R_ARM_THM_MOVW_ABS_NC, thm_movw_abs_nc,                      \
+       "R_ARM_THM_MOVW_ABS_NC")                                                \
+  Func(llvm::ELF::R_ARM_THM_MOVT_ABS, thm_movt_abs, "R_ARM_THM_MOVT_ABS")      \
+  Func(llvm::ELF::R_ARM_THM_MOVW_PREL_NC, thm_movw_prel_nc,                    \
+       "R_ARM_THM_MOVW_PREL_NC")                                               \
+  Func(llvm::ELF::R_ARM_THM_MOVT_PREL, thm_movt_prel, "R_ARM_THM_MOVT_PREL")   \
+  Func(llvm::ELF::R_ARM_THM_JUMP19, thm_jump19, "R_ARM_THM_JUMP19")            \
+  Func(llvm::ELF::R_ARM_ALU_PC_G0, alu_pc, "R_ARM_ALU_PC_G0")                  \
+  Func(llvm::ELF::R_ARM_LDR_PC_G2, ldr_pc_g2, "R_ARM_LDR_PC_G2")               \
+  Func(llvm::ELF::R_ARM_THM_MOVW_BREL_NC, thm_movw_brel,                       \
+       "R_ARM_THM_MOVW_BREL_NC")                                               \
+  Func(llvm::ELF::R_ARM_THM_MOVT_BREL, thm_movt_prel, "R_ARM_THM_MOVT_BREL")   \
+  Func(llvm::ELF::R_ARM_THM_MOVW_BREL, thm_movw_brel, "R_ARM_THM_MOVW_BREL")   \
+  Func(llvm::ELF::R_ARM_GOT_PREL, got_prel, "R_ARM_GOT_PREL")                  \
+  Func(llvm::ELF::R_ARM_THM_JUMP11, thm_jump11, "R_ARM_THM_JUMP11")            \
+  Func(llvm::ELF::R_ARM_THM_JUMP8, thm_jump8, "R_ARM_THM_JUMP8")               \
+  Func(llvm::ELF::R_ARM_TLS_GD32, tls, "R_ARM_TLS_GD32")                       \
+  Func(llvm::ELF::R_ARM_TLS_LDM32, tls, "R_ARM_TLS_LDM32")                     \
+  Func(llvm::ELF::R_ARM_TLS_LDO32, tls_ldo32, "R_ARM_TLS_LDO32")               \
+  Func(llvm::ELF::R_ARM_TLS_IE32, tls, "R_ARM_TLS_IE32")                       \
+  Func(llvm::ELF::R_ARM_TLS_LE32, tls_le32, "R_ARM_TLS_LE32")                  \
+  Func(R_ARM_ADD_PREL_20_8, relocAddPREL1, "R_ARM_ADD_PREL_20_8")              \
+  Func(R_ARM_ADD_PREL_12_8, relocAddPREL2, "R_ARM_ADD_PREL_12_8")              \
+  Func(R_ARM_LDR_PREL_12, relocLDR12, "R_ARM_LDR_PREL_12")
+// clang-format on
 
 #endif

--- a/lib/Target/ARM/ARMRelocationFunctions.h
+++ b/lib/Target/ARM/ARMRelocationFunctions.h
@@ -14,9 +14,11 @@
 #ifndef ARM_RELOCATION_FUNCTIONS_H
 #define ARM_RELOCATION_FUNCTIONS_H
 
-#define R_ARM_ADD_PREL_20_8 131
-#define R_ARM_ADD_PREL_12_8 132
-#define R_ARM_LDR_PREL_12 133
+// These relocations are used internally when constructing ARM PLT entries.
+// They are kept outside the public relocation IDs defined by LLVM.
+#define R_ARM_ADD_PREL_20_8 0x83
+#define R_ARM_ADD_PREL_12_8 0x8b
+#define R_ARM_LDR_PREL_12 0x8c
 
 #define DECL_ARM_APPLY_RELOC_FUNC(Name)                                        \
   static ARMRelocator::Result Name(Relocation &pEntry, ARMRelocator &pParent);
@@ -54,118 +56,54 @@
   DECL_ARM_APPLY_RELOC_FUNC(relocLDR12)                                        \
   DECL_ARM_APPLY_RELOC_FUNC(unsupport)
 
-#define DECL_ARM_APPLY_RELOC_FUNC_PTRS                                         \
-  {&none, 0, "R_ARM_NONE"}, {&call, 1, "R_ARM_PC24"},                          \
-      {&abs32, 2, "R_ARM_ABS32"}, {&rel32, 3, "R_ARM_REL32"},                  \
-      {&unsupport, 4, "R_ARM_LDR_PC_G0"}, {&unsupport, 5, "R_ARM_ABS16"},      \
-      {&unsupport, 6, "R_ARM_ABS12"}, {&unsupport, 7, "R_ARM_THM_ABS5"},       \
-      {&unsupport, 8, "R_ARM_ABS8"}, {&rel32, 9, "R_ARM_SBREL32"},             \
-      {&thm_call, 10, "R_ARM_THM_CALL"}, {&unsupport, 11, "R_ARM_THM_PC8"},    \
-      {&unsupport, 12, "R_ARM_BREL_ADJ"}, {&unsupport, 13, "R_ARM_TLS_DESC"},  \
-      {&unsupport, 14, "R_ARM_THM_SWI8"}, {&unsupport, 15, "R_ARM_XPC25"},     \
-      {&unsupport, 16, "R_ARM_THM_XPC22"},                                     \
-      {&unsupport, 17, "R_ARM_TLS_DTPMOD32"},                                  \
-      {&unsupport, 18, "R_ARM_TLS_DTPOFF32"},                                  \
-      {&unsupport, 19, "R_ARM_TLS_TPOFF32"}, {&unsupport, 20, "R_ARM_COPY"},   \
-      {&unsupport, 21, "R_ARM_GLOB_DAT"}, {&unsupport, 22, "R_ARM_JUMP_SLOT"}, \
-      {&unsupport, 23, "R_ARM_RELATIVE"}, {&gotoff32, 24, "R_ARM_GOTOFF32"},   \
-      {&base_prel, 25, "R_ARM_BASE_PREL"}, {&got_brel, 26, "R_ARM_GOT_BREL"},  \
-      {&call, 27, "R_ARM_PLT32"}, {&call, 28, "R_ARM_CALL"},                   \
-      {&call, 29, "R_ARM_JUMP24"}, {&thm_call, 30, "R_ARM_THM_JUMP24"},        \
-      {&unsupport, 31, "R_ARM_BASE_ABS"},                                      \
-      {&unsupport, 32, "R_ARM_ALU_PCREL_7_0"},                                 \
-      {&unsupport, 33, "R_ARM_ALU_PCREL_15_8"},                                \
-      {&unsupport, 34, "R_ARM_ALU_PCREL_23_15"},                               \
-      {&unsupport, 35, "R_ARM_LDR_SBREL_11_0_NC"},                             \
-      {&unsupport, 36, "R_ARM_ALU_SBREL_19_12_NC"},                            \
-      {&unsupport, 37, "R_ARM_ALU_SBREL_27_20_CK"},                            \
-      {&abs32, 38, "R_ARM_TARGET1"}, {&unsupport, 39, "R_ARM_SBREL31"},        \
-      {&none, 40, "R_ARM_V4BX"}, {&target2, 41, "R_ARM_TARGET2"},              \
-      {&prel31, 42, "R_ARM_PREL31"}, {&movw_abs_nc, 43, "R_ARM_MOVW_ABS_NC"},  \
-      {&movt_abs, 44, "R_ARM_MOVT_ABS"},                                       \
-      {&movw_prel_nc, 45, "R_ARM_MOVW_PREL_NC"},                               \
-      {&movt_prel, 46, "R_ARM_MOVT_PREL"},                                     \
-      {&thm_movw_abs_nc, 47, "R_ARM_THM_MOVW_ABS_NC"},                         \
-      {&thm_movt_abs, 48, "R_ARM_THM_MOVT_ABS"},                               \
-      {&thm_movw_prel_nc, 49, "R_ARM_THM_MOVW_PREL_NC"},                       \
-      {&thm_movt_prel, 50, "R_ARM_THM_MOVT_PREL"},                             \
-      {&thm_jump19, 51, "R_ARM_THM_JUMP19"},                                   \
-      {&unsupport, 52, "R_ARM_THM_JUMP6"},                                     \
-      {&unsupport, 53, "R_ARM_THM_ALU_PREL_11_0"},                             \
-      {&unsupport, 54, "R_ARM_THM_PC12"}, {&unsupport, 55, "R_ARM_ABS32_NOI"}, \
-      {&unsupport, 56, "R_ARM_REL32_NOI"},                                     \
-      {&unsupport, 57, "R_ARM_ALU_PC_G0_NC"},                                  \
-      {&alu_pc, 58, "R_ARM_ALU_PC_G0"},                                        \
-      {&unsupport, 59, "R_ARM_ALU_PC_G1_NC"},                                  \
-      {&unsupport, 60, "R_ARM_ALU_PC_G1"},                                     \
-      {&unsupport, 61, "R_ARM_ALU_PC_G2"},                                     \
-      {&unsupport, 62, "R_ARM_LDR_PC_G1"},                                     \
-      {&unsupport, 63, "R_ARM_LDR_PC_G2"},                                     \
-      {&unsupport, 64, "R_ARM_LDRS_PC_G0"},                                    \
-      {&unsupport, 65, "R_ARM_LDRS_PC_G1"},                                    \
-      {&unsupport, 66, "R_ARM_LDRS_PC_G2"},                                    \
-      {&unsupport, 67, "R_ARM_LDC_PC_G0"},                                     \
-      {&unsupport, 68, "R_ARM_LDC_PC_G1"},                                     \
-      {&unsupport, 69, "R_ARM_LDC_PC_G2"},                                     \
-      {&unsupport, 70, "R_ARM_ALU_SB_G0_NC"},                                  \
-      {&unsupport, 71, "R_ARM_ALU_SB_G0"},                                     \
-      {&unsupport, 72, "R_ARM_ALU_SB_G1_NC"},                                  \
-      {&unsupport, 73, "R_ARM_ALU_SB_G1"},                                     \
-      {&unsupport, 74, "R_ARM_ALU_SB_G2"},                                     \
-      {&unsupport, 75, "R_ARM_LDR_SB_G0"},                                     \
-      {&unsupport, 76, "R_ARM_LDR_SB_G1"},                                     \
-      {&unsupport, 77, "R_ARM_LDR_SB_G2"},                                     \
-      {&unsupport, 78, "R_ARM_LDRS_SB_G0"},                                    \
-      {&unsupport, 79, "R_ARM_LDRS_SB_G1"},                                    \
-      {&unsupport, 80, "R_ARM_LDRS_SB_G2"},                                    \
-      {&unsupport, 81, "R_ARM_LDC_SB_G0"},                                     \
-      {&unsupport, 82, "R_ARM_LDC_SB_G1"},                                     \
-      {&unsupport, 83, "R_ARM_LDC_SB_G2"},                                     \
-      {&unsupport, 84, "R_ARM_MOVW_BREL_NC"},                                  \
-      {&unsupport, 85, "R_ARM_MOVT_BREL"},                                     \
-      {&unsupport, 86, "R_ARM_MOVW_BREL"},                                     \
-      {&thm_movw_brel, 87, "R_ARM_THM_MOVW_BREL_NC"},                          \
-      {&thm_movt_prel, 88, "R_ARM_THM_MOVT_BREL"},                             \
-      {&thm_movw_brel, 89, "R_ARM_THM_MOVW_BREL"},                             \
-      {&unsupport, 90, "R_ARM_TLS_GOTDESC"},                                   \
-      {&unsupport, 91, "R_ARM_TLS_CALL"},                                      \
-      {&unsupport, 92, "R_ARM_TLS_DESCSEQ"},                                   \
-      {&unsupport, 93, "R_ARM_THM_TLS_CALL"},                                  \
-      {&unsupport, 94, "R_ARM_PLT32_ABS"}, {&unsupport, 95, "R_ARM_GOT_ABS"},  \
-      {&got_prel, 96, "R_ARM_GOT_PREL"}, {&unsupport, 97, "R_ARM_GOT_PREL12"}, \
-      {&unsupport, 98, "R_ARM_GOTOFF12"}, {&unsupport, 99, "R_ARM_GOTRELAX"},  \
-      {&unsupport, 100, "R_ARM_GNU_VTENTRY"},                                  \
-      {&unsupport, 101, "R_ARM_GNU_VTINERIT"},                                 \
-      {&thm_jump11, 102, "R_ARM_THM_JUMP11"},                                  \
-      {&thm_jump8, 103, "R_ARM_THM_JUMP8"}, {&tls, 104, "R_ARM_TLS_GD32"},     \
-      {&tls, 105, "R_ARM_TLS_LDM32"}, {&tls_ldo32, 106, "R_ARM_TLS_LDO32"},    \
-      {&tls, 107, "R_ARM_TLS_IE32"}, {&tls_le32, 108, "R_ARM_TLS_LE32"},       \
-      {&unsupport, 109, "R_ARM_TLS_LDO12"},                                    \
-      {&unsupport, 110, "R_ARM_TLS_LE12"},                                     \
-      {&unsupport, 111, "R_ARM_TLS_IE12GP"},                                   \
-      {&unsupport, 112, "R_ARM_PRIVATE_0"},                                    \
-      {&unsupport, 113, "R_ARM_PRIVATE_1"},                                    \
-      {&unsupport, 114, "R_ARM_PRIVATE_2"},                                    \
-      {&unsupport, 115, "R_ARM_PRIVATE_3"},                                    \
-      {&unsupport, 116, "R_ARM_PRIVATE_4"},                                    \
-      {&unsupport, 117, "R_ARM_PRIVATE_5"},                                    \
-      {&unsupport, 118, "R_ARM_PRIVATE_6"},                                    \
-      {&unsupport, 119, "R_ARM_PRIVATE_7"},                                    \
-      {&unsupport, 120, "R_ARM_PRIVATE_8"},                                    \
-      {&unsupport, 121, "R_ARM_PRIVATE_9"},                                    \
-      {&unsupport, 122, "R_ARM_PRIVATE_10"},                                   \
-      {&unsupport, 123, "R_ARM_PRIVATE_11"},                                   \
-      {&unsupport, 124, "R_ARM_PRIVATE_12"},                                   \
-      {&unsupport, 125, "R_ARM_PRIVATE_13"},                                   \
-      {&unsupport, 126, "R_ARM_PRIVATE_14"},                                   \
-      {&unsupport, 127, "R_ARM_PRIVATE_15"},                                   \
-      {&unsupport, 128, "R_ARM_ME_TOO"},                                       \
-      {&unsupport, 129, "R_ARM_THM_TLS_DESCSEQ16"},                            \
-      {&unsupport, 130, "R_ARM_THM_TLS_DESCSEQ32"},                            \
-      {&relocAddPREL1, 131, "R_ARM_ADD_PREL_20_8"},                            \
-      {&relocAddPREL2, 132, "R_ARM_ADD_PREL_12_8"},                            \
-      {&relocLDR12, 133, "R_ARM_LDR_PREL_12"}
-
-#define ARM_MAXRELOCS (R_ARM_LDR_PREL_12 + 1)
+// Handler overrides for relocations whose implementation is available in
+// ELD. All other LLVM-defined ARM relocations default to unsupport().
+// clang-format off
+#define DECL_ARM_APPLY_RELOC_FUNC_OVERRIDES(Func)                              \
+  Func(llvm::ELF::R_ARM_NONE, none, "R_ARM_NONE")                              \
+  Func(llvm::ELF::R_ARM_PC24, call, "R_ARM_PC24")                              \
+  Func(llvm::ELF::R_ARM_ABS32, abs32, "R_ARM_ABS32")                           \
+  Func(llvm::ELF::R_ARM_REL32, rel32, "R_ARM_REL32")                           \
+  Func(llvm::ELF::R_ARM_SBREL32, rel32, "R_ARM_SBREL32")                       \
+  Func(llvm::ELF::R_ARM_THM_CALL, thm_call, "R_ARM_THM_CALL")                  \
+  Func(llvm::ELF::R_ARM_GOTOFF32, gotoff32, "R_ARM_GOTOFF32")                  \
+  Func(llvm::ELF::R_ARM_BASE_PREL, base_prel, "R_ARM_BASE_PREL")               \
+  Func(llvm::ELF::R_ARM_GOT_BREL, got_brel, "R_ARM_GOT_BREL")                  \
+  Func(llvm::ELF::R_ARM_PLT32, call, "R_ARM_PLT32")                            \
+  Func(llvm::ELF::R_ARM_CALL, call, "R_ARM_CALL")                              \
+  Func(llvm::ELF::R_ARM_JUMP24, call, "R_ARM_JUMP24")                          \
+  Func(llvm::ELF::R_ARM_THM_JUMP24, thm_call, "R_ARM_THM_JUMP24")              \
+  Func(llvm::ELF::R_ARM_TARGET1, abs32, "R_ARM_TARGET1")                       \
+  Func(llvm::ELF::R_ARM_V4BX, none, "R_ARM_V4BX")                              \
+  Func(llvm::ELF::R_ARM_TARGET2, target2, "R_ARM_TARGET2")                     \
+  Func(llvm::ELF::R_ARM_PREL31, prel31, "R_ARM_PREL31")                        \
+  Func(llvm::ELF::R_ARM_MOVW_ABS_NC, movw_abs_nc, "R_ARM_MOVW_ABS_NC")         \
+  Func(llvm::ELF::R_ARM_MOVT_ABS, movt_abs, "R_ARM_MOVT_ABS")                  \
+  Func(llvm::ELF::R_ARM_MOVW_PREL_NC, movw_prel_nc, "R_ARM_MOVW_PREL_NC")      \
+  Func(llvm::ELF::R_ARM_MOVT_PREL, movt_prel, "R_ARM_MOVT_PREL")               \
+  Func(llvm::ELF::R_ARM_THM_MOVW_ABS_NC, thm_movw_abs_nc,                      \
+       "R_ARM_THM_MOVW_ABS_NC")                                                \
+  Func(llvm::ELF::R_ARM_THM_MOVT_ABS, thm_movt_abs, "R_ARM_THM_MOVT_ABS")      \
+  Func(llvm::ELF::R_ARM_THM_MOVW_PREL_NC, thm_movw_prel_nc,                    \
+       "R_ARM_THM_MOVW_PREL_NC")                                               \
+  Func(llvm::ELF::R_ARM_THM_MOVT_PREL, thm_movt_prel, "R_ARM_THM_MOVT_PREL")   \
+  Func(llvm::ELF::R_ARM_THM_JUMP19, thm_jump19, "R_ARM_THM_JUMP19")            \
+  Func(llvm::ELF::R_ARM_ALU_PC_G0, alu_pc, "R_ARM_ALU_PC_G0")                  \
+  Func(llvm::ELF::R_ARM_THM_MOVW_BREL_NC, thm_movw_brel,                       \
+       "R_ARM_THM_MOVW_BREL_NC")                                               \
+  Func(llvm::ELF::R_ARM_THM_MOVT_BREL, thm_movt_prel, "R_ARM_THM_MOVT_BREL")   \
+  Func(llvm::ELF::R_ARM_THM_MOVW_BREL, thm_movw_brel, "R_ARM_THM_MOVW_BREL")   \
+  Func(llvm::ELF::R_ARM_GOT_PREL, got_prel, "R_ARM_GOT_PREL")                  \
+  Func(llvm::ELF::R_ARM_THM_JUMP11, thm_jump11, "R_ARM_THM_JUMP11")            \
+  Func(llvm::ELF::R_ARM_THM_JUMP8, thm_jump8, "R_ARM_THM_JUMP8")               \
+  Func(llvm::ELF::R_ARM_TLS_GD32, tls, "R_ARM_TLS_GD32")                       \
+  Func(llvm::ELF::R_ARM_TLS_LDM32, tls, "R_ARM_TLS_LDM32")                     \
+  Func(llvm::ELF::R_ARM_TLS_LDO32, tls_ldo32, "R_ARM_TLS_LDO32")               \
+  Func(llvm::ELF::R_ARM_TLS_IE32, tls, "R_ARM_TLS_IE32")                       \
+  Func(llvm::ELF::R_ARM_TLS_LE32, tls_le32, "R_ARM_TLS_LE32")                  \
+  Func(R_ARM_ADD_PREL_20_8, relocAddPREL1, "R_ARM_ADD_PREL_20_8")              \
+  Func(R_ARM_ADD_PREL_12_8, relocAddPREL2, "R_ARM_ADD_PREL_12_8")              \
+  Func(R_ARM_LDR_PREL_12, relocLDR12, "R_ARM_LDR_PREL_12")
+// clang-format on
 
 #endif

--- a/lib/Target/ARM/ARMRelocator.cpp
+++ b/lib/Target/ARM/ARMRelocator.cpp
@@ -23,6 +23,7 @@
 #include "llvm/ADT/Twine.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/Support/MathExtras.h"
+#include <array>
 
 // ApplyReloc Mutex.
 namespace {
@@ -250,16 +251,36 @@ DECL_ARM_APPLY_RELOC_FUNCS
 typedef Relocator::Result (*ApplyFunctionType)(Relocation &pReloc,
                                                ARMRelocator &pParent);
 
-// the table entry of applying functions
-struct ApplyFunctionTriple {
+// The table entry of applying functions.
+struct ApplyFunctionEntry {
+  ApplyFunctionEntry() : func(nullptr), name(nullptr) {}
+  ApplyFunctionEntry(ApplyFunctionType pFunc, const char *pName)
+      : func(pFunc), name(pName) {}
   ApplyFunctionType func;
-  unsigned int type;
   const char *name;
 };
 
-// declare the table of applying functions
-static const ApplyFunctionTriple ApplyFunctions[] = {
-    DECL_ARM_APPLY_RELOC_FUNC_PTRS};
+static constexpr size_t ARM_MAXRELOCS = llvm::ELF::R_ARM_TLS_IE32_FDPIC + 1;
+
+static std::array<ApplyFunctionEntry, ARM_MAXRELOCS> createApplyFunctions() {
+  std::array<ApplyFunctionEntry, ARM_MAXRELOCS> Functions{};
+
+  // ARM.def is the source of truth for public relocation names and values.
+#define ELF_RELOC(Name, Value)                                                 \
+  Functions[Value] = ApplyFunctionEntry(&unsupport, #Name);
+#include "llvm/BinaryFormat/ELFRelocs/ARM.def"
+#undef ELF_RELOC
+
+  // Replace the default handler for relocations implemented by ELD.
+#define ADD_ARM_RELOC_OVERRIDE(Type, Func, Name)                               \
+  Functions[Type] = ApplyFunctionEntry(&Func, Name);
+  DECL_ARM_APPLY_RELOC_FUNC_OVERRIDES(ADD_ARM_RELOC_OVERRIDE)
+#undef ADD_ARM_RELOC_OVERRIDE
+
+  return Functions;
+}
+
+static const auto ApplyFunctions = createApplyFunctions();
 
 //===--------------------------------------------------------------------===//
 // ARMRelocator
@@ -291,7 +312,7 @@ bool ARMRelocator::isPICRelocTypeSupported(const Relocation &reloc) const {
 
 Relocator::Result ARMRelocator::applyRelocation(Relocation &pRelocation) {
   Relocation::Type type = pRelocation.type();
-  if (type > 133) { // 131-255 doesn't noted in ARM spec
+  if (type >= ApplyFunctions.size() || !ApplyFunctions[type].func) {
     return Relocator::Unknown;
   }
 
@@ -314,10 +335,12 @@ Relocator::Result ARMRelocator::applyRelocation(Relocation &pRelocation) {
 }
 
 const char *ARMRelocator::getName(Relocator::Type pType) const {
-  return ApplyFunctions[pType].name;
+  return pType >= ApplyFunctions.size() || !ApplyFunctions[pType].name
+             ? "INVALID_RELOC"
+             : ApplyFunctions[pType].name;
 }
 
-uint32_t ARMRelocator::getNumRelocs() const { return ARM_MAXRELOCS; }
+uint32_t ARMRelocator::getNumRelocs() const { return ApplyFunctions.size(); }
 
 Relocator::Size ARMRelocator::getSize(Relocation::Type pType) const {
   return 32;

--- a/lib/Target/ARM/ARMRelocator.cpp
+++ b/lib/Target/ARM/ARMRelocator.cpp
@@ -23,6 +23,7 @@
 #include "llvm/ADT/Twine.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/Support/MathExtras.h"
+#include <array>
 
 // ApplyReloc Mutex.
 namespace {
@@ -238,16 +239,36 @@ DECL_ARM_APPLY_RELOC_FUNCS
 typedef Relocator::Result (*ApplyFunctionType)(Relocation &pReloc,
                                                ARMRelocator &pParent);
 
-// the table entry of applying functions
-struct ApplyFunctionTriple {
+// The table entry of applying functions.
+struct ApplyFunctionEntry {
+  ApplyFunctionEntry() : func(nullptr), name(nullptr) {}
+  ApplyFunctionEntry(ApplyFunctionType pFunc, const char *pName)
+      : func(pFunc), name(pName) {}
   ApplyFunctionType func;
-  unsigned int type;
   const char *name;
 };
 
-// declare the table of applying functions
-static const ApplyFunctionTriple ApplyFunctions[] = {
-    DECL_ARM_APPLY_RELOC_FUNC_PTRS};
+static constexpr size_t ARM_MAXRELOCS = llvm::ELF::R_ARM_TLS_IE32_FDPIC + 1;
+
+static std::array<ApplyFunctionEntry, ARM_MAXRELOCS> createApplyFunctions() {
+  std::array<ApplyFunctionEntry, ARM_MAXRELOCS> Functions{};
+
+  // ARM.def is the source of truth for public relocation names and values.
+#define ELF_RELOC(Name, Value)                                                 \
+  Functions[Value] = ApplyFunctionEntry(&unsupport, #Name);
+#include "llvm/BinaryFormat/ELFRelocs/ARM.def"
+#undef ELF_RELOC
+
+  // Replace the default handler for relocations implemented by ELD.
+#define ADD_ARM_RELOC_OVERRIDE(Type, Func, Name)                               \
+  Functions[Type] = ApplyFunctionEntry(&Func, Name);
+  DECL_ARM_APPLY_RELOC_FUNC_OVERRIDES(ADD_ARM_RELOC_OVERRIDE)
+#undef ADD_ARM_RELOC_OVERRIDE
+
+  return Functions;
+}
+
+static const auto ApplyFunctions = createApplyFunctions();
 
 //===--------------------------------------------------------------------===//
 // ARMRelocator
@@ -279,7 +300,7 @@ bool ARMRelocator::isPICRelocTypeSupported(const Relocation &reloc) const {
 
 Relocator::Result ARMRelocator::applyRelocation(Relocation &pRelocation) {
   Relocation::Type type = pRelocation.type();
-  if (type > 133) { // 131-255 doesn't noted in ARM spec
+  if (type >= ApplyFunctions.size() || !ApplyFunctions[type].func) {
     return Relocator::Unknown;
   }
 
@@ -302,10 +323,12 @@ Relocator::Result ARMRelocator::applyRelocation(Relocation &pRelocation) {
 }
 
 const char *ARMRelocator::getName(Relocator::Type pType) const {
-  return ApplyFunctions[pType].name;
+  return pType >= ApplyFunctions.size() || !ApplyFunctions[pType].name
+             ? "INVALID_RELOC"
+             : ApplyFunctions[pType].name;
 }
 
-uint32_t ARMRelocator::getNumRelocs() const { return ARM_MAXRELOCS; }
+uint32_t ARMRelocator::getNumRelocs() const { return ApplyFunctions.size(); }
 
 Relocator::Size ARMRelocator::getSize(Relocation::Type pType) const {
   return 32;


### PR DESCRIPTION
Generate ARM relocation metadata from LLVM’s sparse ARM.def definitions, preserve ELD handler overrides, move internal PLT relocations to reserved IDs, and safely handle unknown relocation types.

Fix: qualcomm#1491