### PR TITLE
[Reproduce] Fix thin archive member reproducer paths

### DIFF
--- a/lib/Input/ArchiveMemberInput.cpp
+++ b/lib/Input/ArchiveMemberInput.cpp
@@ -25,7 +25,7 @@ ArchiveMemberInput::ArchiveMemberInput(DiagnosticEngine *DiagEngine,
   setMemberName(Name);
   setMemArea(Data);
   // Update the Hash values.
-  ResolvedPathHash = llvm::hash_combine(ResolvedPath->native());
+  ResolvedPathHash = llvm::hash_combine(ResolvedPath->native(),Name);
   MemberNameHash = llvm::hash_combine(Name);
 }
 

--- a/lib/Support/OutputTarWriter.cpp
+++ b/lib/Support/OutputTarWriter.cpp
@@ -74,10 +74,17 @@ void OutputTarWriter::addInputFile(const InputFile *File, bool IsLTOObject) {
 }
 
 std::string OutputTarWriter::getHashAndExtension(const Input *Ipt) const {
+  uint64_t InputHash = Ipt->getResolvedPathHash();
+  if (const auto *ArchiveMember = llvm::dyn_cast<ArchiveMemberInput>(Ipt))
+    // Thin archive members share the parent archive's resolved path. Include
+    // the member identity so members with the same basename cannot collide.
+    InputHash = llvm::hash_combine(InputHash, ArchiveMember->getMemberName(),
+                                   ArchiveMember->getChildOffset());
+
   // Returns filename passed to the linker along with the file hash.
   return std::string(
              llvm::sys::path::filename(Ipt->getInputFile()->getMappedPath())) +
-         "." + std::to_string(Ipt->getResolvedPathHash());
+         "." + std::to_string(InputHash);
 }
 
 /// Create mapping.ini file of input filepath to its sha2 hash + file extension

--- a/lib/Support/OutputTarWriter.cpp
+++ b/lib/Support/OutputTarWriter.cpp
@@ -74,7 +74,6 @@ void OutputTarWriter::addInputFile(const InputFile *File, bool IsLTOObject) {
 }
 
 std::string OutputTarWriter::getHashAndExtension(const Input *Ipt) const {
-  // Returns filename passed to the linker along with the file hash.
   return std::string(
              llvm::sys::path::filename(Ipt->getInputFile()->getMappedPath())) +
          "." + std::to_string(Ipt->getResolvedPathHash());

--- a/test/Common/standalone/CommandLine/Reproduce/Inputs/a/foo.c
+++ b/test/Common/standalone/CommandLine/Reproduce/Inputs/a/foo.c
@@ -1,0 +1,1 @@
+int only_a(void) { return 1; }

--- a/test/Common/standalone/CommandLine/Reproduce/Inputs/b/foo.c
+++ b/test/Common/standalone/CommandLine/Reproduce/Inputs/b/foo.c
@@ -1,0 +1,1 @@
+int only_b(void) { return 2; }

--- a/test/Common/standalone/CommandLine/Reproduce/Inputs/thin-main.c
+++ b/test/Common/standalone/CommandLine/Reproduce/Inputs/thin-main.c
@@ -1,0 +1,4 @@
+extern int only_a(void);
+extern int only_b(void);
+
+int main(void) { return only_a() + only_b(); }

--- a/test/Common/standalone/CommandLine/Reproduce/ReproduceThinArchiveSameBasename.test
+++ b/test/Common/standalone/CommandLine/Reproduce/ReproduceThinArchiveSameBasename.test
@@ -1,0 +1,28 @@
+#---ReproduceThinArchiveSameBasename.test----------------- Executable -----------------#
+
+#BEGIN_COMMENT
+# Checks that --reproduce preserves thin-archive members with the same basename.
+#END_COMMENT
+#START_TEST
+RUN: %rm -rf %t.tmpdir
+RUN: %mkdir %t.tmpdir
+RUN: %mkdir %t.tmpdir/a
+RUN: %mkdir %t.tmpdir/b
+RUN: %clang %clangopts -c %p/Inputs/a/foo.c -o %t.tmpdir/a/foo.o
+RUN: %clang %clangopts -c %p/Inputs/b/foo.c -o %t.tmpdir/b/foo.o
+RUN: %clang %clangopts -c %p/Inputs/thin-main.c -o %t.tmpdir/main.o
+RUN: cd %t.tmpdir
+RUN: %ar cr %aropts --thin %t.tmpdir/libsame.a a/foo.o b/foo.o
+RUN: %link --no-threads %t.tmpdir/main.o %t.tmpdir/libsame.a -o %t.same.out \
+RUN:   --reproduce %t.repro.tar --dump-mapping-file %t.mapping.ini \
+RUN:   --dump-response-file %t.response
+RUN: %filecheck %s < %t.mapping.ini
+RUN: %mkdir %t.replay
+RUN: cd %t.replay
+RUN: %tar %gnutaropts -xf %t.repro.tar --strip-components=1
+RUN: %link --no-threads @response.txt -o %t.same.replay.out
+RUN: %diff %t.same.out %t.same.replay.out
+#END_TEST
+
+CHECK-DAG: Object/foo.o.{{[0-9]+}}
+CHECK-DAG: Object/foo.o.{{[0-9]+}}

--- a/test/Common/standalone/CommandLine/Reproduce/ReproduceThinArchiveSameBasename.test
+++ b/test/Common/standalone/CommandLine/Reproduce/ReproduceThinArchiveSameBasename.test
@@ -1,0 +1,27 @@
+#---ReproduceThinArchiveSameBasename.test----------------- Executable -----------------#
+
+#BEGIN_COMMENT
+# Checks that --reproduce preserves thin-archive members with the same basename.
+#END_COMMENT
+#START_TEST
+RUN: %rm -rf %t.tmpdir
+RUN: %mkdir %t.tmpdir
+RUN: %mkdir %t.tmpdir/a
+RUN: %mkdir %t.tmpdir/b
+RUN: %clang %clangopts -c %p/Inputs/a/foo.c -o %t.tmpdir/a/foo.o
+RUN: %clang %clangopts -c %p/Inputs/b/foo.c -o %t.tmpdir/b/foo.o
+RUN: %clang %clangopts -c %p/Inputs/thin-main.c -o %t.tmpdir/main.o
+RUN: cd %t.tmpdir
+RUN: %ar cr %aropts --thin %t.tmpdir/libsame.a a/foo.o b/foo.o
+RUN: %link --no-threads %t.tmpdir/main.o %t.tmpdir/libsame.a -o %t.same.out \
+RUN:   --reproduce %t.repro.tar --dump-mapping-file %t.mapping.ini
+RUN: %filecheck %s < %t.mapping.ini
+RUN: %mkdir %t.replay
+RUN: %tar %gnutaropts -xf %t.repro.tar -C %t.replay --strip-components=1
+RUN: cd %t.replay
+RUN: %python -c "import shlex, subprocess; args = shlex.split(open('response.txt').read())[1:]; args[args.index('-o') + 1] = r'%t.same.replay.out'; subprocess.check_call(shlex.split(r'%link') + args)"
+RUN: %diff %t.same.out %t.same.replay.out
+#END_TEST
+
+CHECK-DAG: Object/foo.o.{{[0-9]+}}
+CHECK-DAG: Object/foo.o.{{[0-9]+}}


### PR DESCRIPTION
Include the thin archive member name and child offset in the generated input identity. This prevents members with identical basenames from colliding in --reproduce archives and preserves both files during replay.

Resolves #1737