### PR TITLE
Fix nightly-llvm-test-suite BuildStatusDataRecorder auth failure

### DIFF
--- a/.github/workflows/nightly-llvm-test-suite.yml
+++ b/.github/workflows/nightly-llvm-test-suite.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: llvm-project/llvm/tools/eld
-          persist-credentials: false
+          persist-credentials: true # Required for BuildStatusDataRecorder's git push to dashboard branch
 
       - name: Configure workflow environment variables
         uses: ./llvm-project/llvm/tools/eld/.github/workflows/ConfigureBuildWorkflowENV


### PR DESCRIPTION
Revert to `persist-credentials: true` so `BuildStatusDataRecorder` can authenticate `git push`

The `Record pre-buid entry` step that calls `BuildStatusDataRecorder` currently fails. The reason is setting persist-credentials as false for `Checkout eld` step. This step was added for zizmor/artipacked credential persistence alert. But `BuildStatusDataRecorder` needs to git fetch/push to the dashboard branch which requires credentials. This is safe for this workflow as we only upload `test-output.txt` as artifact, no repo content is uploaded.