### PR TITLE
fix: set correct state before writing output

### DIFF
--- a/lib/Core/Linker.cpp
+++ b/lib/Core/Linker.cpp
@@ -193,6 +193,7 @@ bool Linker::link() {
 
   {
     PluginManager &PM = ThisModule->getPluginManager();
+    ThisModule->setLinkState(LinkState::ActBeforePerformingLayout);
     if (!PM.callActBeforePerformingLayoutHook()) {
       // llvm::errs() << "callActBeforePerformingLayoutHook returning false!\n";
       return false;

--- a/lib/Writers/ELFObjectWriter.cpp
+++ b/lib/Writers/ELFObjectWriter.cpp
@@ -203,7 +203,7 @@ ELFObjectWriter::writeObject(llvm::FileOutputBuffer &CurOutput) {
 
   {
     PluginManager &PM = ThisModule.getPluginManager();
-    ThisModule.setLinkState(LinkState::ActBeforePerformingLayout);
+    ThisModule.setLinkState(LinkState::ActBeforeWritingOutput);
     if (!PM.callActBeforeWritingOutputHook()) {
       // Return generic error-code. Actual error is already reported!
       return make_error_code(std::errc::not_supported);

--- a/test/Common/Plugin/ActBeforePerformingLayout/ActBeforePerformingLayoutPlugin.cpp
+++ b/test/Common/Plugin/ActBeforePerformingLayout/ActBeforePerformingLayoutPlugin.cpp
@@ -7,6 +7,11 @@ public:
   ActBeforePerformingLayoutPlugin()
       : eld::plugin::LinkerPlugin("ActBeforePerformingLayoutPlugin") {}
   void ActBeforePerformingLayout() override {
+    if (!getLinker()->isLinkStateActBeforePerformingLayout()) {
+      getLinker()->reportDiag(
+          getLinker()->getErrorDiagID("Incorrect link state"));
+      return;
+    }
     getLinker()->reportDiag(
         getLinker()->getNoteDiagID("In ActBeforePerformingLayout"));
   }

--- a/test/Common/Plugin/ActBeforeWritingOutput/ActBeforeWritingOutput.test
+++ b/test/Common/Plugin/ActBeforeWritingOutput/ActBeforeWritingOutput.test
@@ -1,6 +1,7 @@
 #---ActBeforeWritingOutput.test----------------------- Executable,LS --------------------#
 #BEGIN_COMMENT
-# This tests verifies the behavior of ActBeforeWritingOutput plugin hook.
+# This test verifies the behavior and link state of the
+# ActBeforeWritingOutput plugin hook.
 #END_COMMENT
 #START_TEST
 RUN: %clang %clangopts -o %t1.1.o %p/Inputs/1.c -c
@@ -13,5 +14,3 @@ CHECK: Trace: Calling plugin hook handler ActBeforeWritingOutputPlugin::ActBefor
 CHECK: Verbose: Writing output file {{.*}}1.out
 CHECK: Trace: Calling plugin hook handler ActBeforeWritingOutputPlugin::ActBeforeWritingOutput
 CHECK: ActBeforeWritingOutputPlugin:Note: In ActBeforeWritingOutput
-
-

--- a/test/Common/Plugin/ActBeforeWritingOutput/ActBeforeWritingOutputPlugin.cpp
+++ b/test/Common/Plugin/ActBeforeWritingOutput/ActBeforeWritingOutputPlugin.cpp
@@ -7,6 +7,11 @@ public:
   ActBeforeWritingOutputPlugin()
       : eld::plugin::LinkerPlugin("ActBeforeWritingOutputPlugin") {}
   void ActBeforeWritingOutput() override {
+    if (!getLinker()->isLinkStateActBeforeWritingOutput()) {
+      getLinker()->reportDiag(
+          getLinker()->getErrorDiagID("Incorrect link state"));
+      return;
+    }
     getLinker()->reportDiag(
         getLinker()->getNoteDiagID("In ActBeforeWritingOutput"));
   }


### PR DESCRIPTION
## Summary

- set `LinkState::ActBeforeWritingOutput` before invoking the corresponding plugin hook
- strengthen the existing plugin test so it reports an error when the hook observes any other state

## Testing

- syntax-checked `ELFObjectWriter.cpp` with the generated external-LLVM compile command
- syntax-checked `ActBeforeWritingOutputPlugin.cpp` against LLVM 22.1.8
- external macOS build reaches C++ compilation but is blocked project-wide by the existing ELF `.comment` inline assembly being rejected by the Mach-O assembler

Fixes #1728