### PR TITLE
[GC] Hoist reached-list lookups

### DIFF
--- a/lib/GarbageCollection/GarbageCollection.cpp
+++ b/lib/GarbageCollection/GarbageCollection.cpp
@@ -301,6 +301,13 @@ void GarbageCollection::setUpReachedSectionsAndSymbols() {
         *stream << "\n" << name;
       }
 
+      // Reached symbols from section.
+      SymbolListTy *ReachedSyms =
+          &MSectionReachedListMap.getReachedSymbolList(*ApplySect);
+      // Reached sections from section.
+      SectionListTy *ReachedSects =
+          &MSectionReachedListMap.getReachedList(*ApplySect);
+
       for (auto &Reloc : ApplySect->getRelocations()) {
         auto RecordOneRef = [&](Relocation *Reloc) -> void {
           ResolveInfo *Sym = Reloc->symInfo();
@@ -309,13 +316,6 @@ void GarbageCollection::setUpReachedSectionsAndSymbols() {
           // reference
           if (nullptr == Sym)
             return;
-
-          // Reached symbols from section.
-          SymbolListTy *ReachedSyms =
-              &MSectionReachedListMap.getReachedSymbolList(*ApplySect);
-          // Reached sections from section.
-          SectionListTy *ReachedSects =
-              &MSectionReachedListMap.getReachedList(*ApplySect);
 
           if (Sym->isBitCode()) {
             InputFile *Input = Sym->resolvedOrigin();


### PR DESCRIPTION
Move reached symbol and section list lookups out of the per-relocation path.

On a Release ELD + Release Clang benchmark linking with
--gc-sections over 100 runs, Garbage Collection runtime improved from
0.4516s to 0.4365s.

Resolves #1754