### PR TITLE
Correctly handle the --no-merge-strings option

### DIFF
--- a/lib/Core/Linker.cpp
+++ b/lib/Core/Linker.cpp
@@ -623,7 +623,7 @@ bool Linker::layout() {
 
   if (ThisModule->getPrinter()->isVerbose())
     ThisConfig->raise(Diag::merging_strings);
-  {
+  if (!ThisConfig->isLinkPartial() && ThisConfig->options().mergeStrings()) {
     eld::RegisterTimer F("Merge strings", "Link Summary",
                          ThisConfig->options().printTimingStats());
     ObjLinker->doMergeStrings();

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -834,8 +834,6 @@ void ObjectLinker::fixMergeStringRelocations() const {
 }
 
 void ObjectLinker::doMergeStrings() {
-  if (ThisConfig.isLinkPartial())
-    return;
   mergeIdenticalStrings();
   fixMergeStringRelocations();
 }

--- a/test/Common/standalone/MergeStrings/Inputs/duplicate.s
+++ b/test/Common/standalone/MergeStrings/Inputs/duplicate.s
@@ -1,0 +1,2 @@
+.section .rodata.str1.1,"aMS",%progbits,1
+.ascii "merge-me\0merge-me\0"

--- a/test/Common/standalone/MergeStrings/NoMergeStrings.test
+++ b/test/Common/standalone/MergeStrings/NoMergeStrings.test
@@ -1,0 +1,13 @@
+#---NoMergeStrings.test--------------------------- Executable -----------------#
+#BEGIN_COMMENT
+# This tests that --no-merge-strings preserves duplicate merge strings.
+#END_COMMENT
+# START_TEST
+RUN: %clang %clangopts -c %p/Inputs/duplicate.s -o %t.o
+RUN: %link %linkopts %t.o -o %t.out --no-merge-strings
+RUN: %readelf -p .rodata %t.out | %filecheck %s
+# END_TEST
+
+CHECK: '.rodata':
+CHECK: merge-me
+CHECK: merge-me


### PR DESCRIPTION
This commit fixes string merging so that it is skipped when `--no-merge-strings` is passed.

Previously, eld parsed the option but still ran the string merging pass during layout. This caused duplicate strings in merge-string sections to be folded even when the user explicitly requested string merging to be disabled.

Resolves #1756