### PR TITLE
[Reproduce] Support linker scripts resolved through -L

### DIFF
--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -1680,6 +1680,7 @@ bool GnuLdDriver::processReproduceOption(
   if (!Config.options().getDumpResponse())
     os << getProgramName() << " ";
   size_t lastNamespecId = -1;
+  size_t lastScriptId = -1;
 
   auto zArgsRange = Args.filtered(T::dash_z);
   auto zArgIt = zArgsRange.begin();
@@ -1727,7 +1728,6 @@ bool GnuLdDriver::processReproduceOption(
     }
     case T::output_file:
     case T::Map:
-    case T::T:
     case T::R:
     case T::dynamic_list:
     case T::extern_list:
@@ -1735,6 +1735,28 @@ bool GnuLdDriver::processReproduceOption(
       os << arg->getSpelling() << ' ' << outputTar->rewritePath(arg->getValue())
          << ' ';
       break;
+    case T::T: {
+      bool rewritten = false;
+      for (size_t i = lastScriptId + 1; i < actions.size(); ++i) {
+        auto action = actions[i];
+        if (action->getInputActionKind() == eld::InputAction::Script) {
+          lastScriptId = i;
+          auto ipt = action->getInput();
+          if (ipt) {
+            std::string key = ipt->getInputFile()
+                                  ? ipt->getInputFile()->getMappedPath()
+                                  : ipt->getName();
+            os << arg->getSpelling() << ' ' << outputTar->rewritePath(key)
+               << ' ';
+            rewritten = true;
+          }
+          break;
+        }
+      }
+      if (!rewritten)
+        os << arg->getSpelling() << ' ' << arg->getValue() << ' ';
+      break;
+    }
     case T::remap_inputs:
       os << arg->getSpelling() << ' ' << arg->getValue() << ' ';
       break;

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -248,6 +248,10 @@ bool ObjectLinker::readAndActivateLinkerScript(
       return true;
   }
 
+  // Capture scripts during early activation so the response file can rewrite
+  // -T paths that were resolved through a -L search directory.
+  addInputFileToTar(input, eld::MappingFile::LinkerScript);
+
   if (!parseLinkerScript(input))
     return false;
 

--- a/test/Common/standalone/CommandLine/Reproduce/ReproduceLinkerScriptSearchPath.test
+++ b/test/Common/standalone/CommandLine/Reproduce/ReproduceLinkerScriptSearchPath.test
@@ -1,0 +1,22 @@
+#---ReproduceLinkerScriptSearchPath.test----------------- Executable -----------------#
+
+#BEGIN_COMMENT
+# Checks that --reproduce rewrites a linker script found through a -L directory.
+#END_COMMENT
+#START_TEST
+RUN: %rm -rf %t.lib %t.reproduce %t.tar %t.out %t.replay.out
+RUN: %mkdir %t.lib
+RUN: %cp %p/Inputs/script1.t %t.lib/script.t
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.main.o
+RUN: cd %t.lib
+RUN: %link --no-threads -L %t.lib -T script.t %t.main.o -o %t.out --reproduce %t.tar --dump-response-file %t.response
+RUN: %filecheck %s < %t.response
+RUN: %mkdir %t.reproduce
+RUN: %tar %gnutaropts -xf %t.tar -C %t.reproduce --strip-components=1
+RUN: cd %t.reproduce
+RUN: %link --no-threads @response.txt -o %t.replay.out
+RUN: %diff %t.out %t.replay.out
+#END_TEST
+
+CHECK: -T LinkerScript/script.t.{{[0-9]+}}
+CHECK-NOT: -T script.t


### PR DESCRIPTION
Capture linker scripts during early activation and rewrite -T paths to their mapped paths in reproduce response files. Add a regression test covering linker scripts found through a -L search directory.

Resolves #1454