### PR TITLE
Add support for --default-symver command-line option

### DIFF
--- a/docs/DeveloperDocs/SymbolVersioning.md
+++ b/docs/DeveloperDocs/SymbolVersioning.md
@@ -3,6 +3,38 @@
 All symbol versioning related functionality is guarded by the `ELD_ENABLE_SYMBOL_VERSIONING`
 build macro.
 
+## `--default-symver`
+
+`--default-symver` assigns the output's default version to any exported dynamic
+symbol that does not already have an explicit version. The default version name
+is the output `DT_SONAME` for shared libraries when `-soname` is used;
+otherwise it is the basename of the output file.
+
+When `--default-symver` is active for a supported link mode, eld always creates
+the synthetic default version node. This is true even when no regular dynamic
+symbol is assigned to that version, such as a hidden-only shared library, a
+dynamic executable without `-E`, or a static PIE without `-E`.
+
+The ordinary base version definition is emitted by the existing version
+definition machinery whenever named version definitions are present. This option
+additionally adds the synthetic default version node.
+
+eld models this option as an internal version script node named after the
+default version name with `global: *;`. The node is registered before user
+version scripts so explicit user version-script rules take precedence.
+
+eld creates the default symbol version node for link modes that can produce
+dynamic symbol/version information. These include:
+
+- shared libraries;
+- dynamic executables, including links forced dynamic with `--force-dynamic`;
+- code-independent executables, including PIE and static PIE.
+
+Regular static non-PIE executables do not create the node.
+
+If `ELD_ENABLE_SYMBOL_VERSIONING` is disabled, eld warns that `--default-symver`
+is unsupported and does not synthesize the node.
+
 ## Symbol resolution of versioned symbols
 
 A versioned symbol is of two types:

--- a/include/eld/Config/GeneralOptions.h
+++ b/include/eld/Config/GeneralOptions.h
@@ -556,6 +556,10 @@ public:
 
   bool hasVersionScript() const { return BVersionScript; }
 
+  void setDefaultSymver() { BDefaultSymver = true; }
+
+  bool hasDefaultSymver() const { return BDefaultSymver; }
+
   unsigned int getHashStyle() const { return HashStyle; }
 
   void setHashStyle(std::string HashStyleOption);
@@ -1270,6 +1274,7 @@ private:
   bool BForceDynamic = false;        // --force-dynamic
   bool BDynamicList = false;         // --dynamic-list flag
   bool BVersionScript = false;       // --version-script
+  bool BDefaultSymver = false;       // --default-symver
   bool BHasDyld = false;             // user set dynamic linker ?
   bool NoInhibitExec = false;        //--noinhibit-exec
   bool NoGnuStack = false;           //--nognustack

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -626,6 +626,10 @@ defm no_dynamic_linker
                        "The program does not need a dynamic linker when "
                        "creating static PIE executables">,
       Group<grp_dynlibexec>;
+def default_symver : FF<"default-symver">,
+                      HelpText<"Create a default symbol version node, that is "
+                               "used for unversioned exported symbols">,
+                      Group<grp_dynlibexec>;
 
 //===----------------------------------------------------------------------===//
 /// Dynamic Library Options

--- a/include/eld/Object/ObjectLinker.h
+++ b/include/eld/Object/ObjectLinker.h
@@ -416,6 +416,8 @@ private:
   bool registerVersionScriptNodes(const VersionScript *VS,
                                   llvm::StringRef DecoratedPath);
 
+  void createDefaultSymverNode();
+
   std::unique_ptr<llvm::lto::LTO> ltoInit(llvm::lto::Config Conf,
                                           bool CompileToAssembly);
 

--- a/lib/LinkerWrapper/GnuLdDriver.cpp
+++ b/lib/LinkerWrapper/GnuLdDriver.cpp
@@ -892,6 +892,10 @@ bool GnuLdDriver::processOptions(llvm::opt::InputArgList &Args) {
   if (Config.options().getVersionScripts().size())
     Config.options().setVersionScript();
 
+  // --default-symver
+  if (Args.hasArg(T::default_symver))
+    Config.options().setDefaultSymver();
+
   // --extern-list
   for (auto *Arg : Args.filtered(T::extern_list))
     Config.options().getExternList().emplace(Arg->getValue());

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -55,6 +55,7 @@
 #include "eld/Script/ScriptFile.h"
 #include "eld/Script/ScriptReader.h"
 #include "eld/Script/ScriptSymbol.h"
+#include "eld/Script/StrToken.h"
 #include "eld/Script/VersionScript.h"
 #include "eld/Support/Memory.h"
 #include "eld/Support/MsgHandling.h"
@@ -352,6 +353,11 @@ bool ObjectLinker::normalize() {
 // FIXME: We should maybe parse version script after reading LTO-generated
 // object files.
 bool ObjectLinker::parseVersionScript() {
+  if (ThisConfig.options().hasDefaultSymver() &&
+      (ThisConfig.isCodeDynamic() || ThisConfig.options().forceDynamic() ||
+       ThisConfig.isCodeIndep()))
+    createDefaultSymverNode();
+
   if (ThisConfig.options().hasVersionScript()) {
     LayoutInfo *layoutInfo = ThisModule->getLayoutInfo();
     for (const auto &List : ThisConfig.options().getVersionScripts()) {
@@ -397,6 +403,28 @@ bool ObjectLinker::parseVersionScript() {
 
   assignVersionNodesToSymbols();
   return true;
+}
+
+void ObjectLinker::createDefaultSymverNode() {
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  InputFile *Input =
+      ThisModule->getInternalInput(Module::InternalInputType::SymbolVersioning);
+  VersionScript *VS = eld::make<VersionScript>(Input);
+  VersionScriptNode *VSN = VS->createVersionScriptNode();
+  const GeneralOptions &Options = ThisConfig.options();
+  std::string VersionName = Options.soname();
+  if (VersionName.empty())
+    VersionName =
+        std::string(llvm::sys::path::filename(Options.outputFileName()));
+
+  VSN->setName(eld::make<StrToken>(VersionName));
+  VSN->switchToGlobal();
+  VSN->addSymbol(eld::make<ScriptSymbol>("*"));
+  ThisModule->addVersionScript(VS);
+  registerVersionScriptNodes(VS, Input->getInput()->decoratedPath());
+#else
+  ThisConfig.raise(Diag::warn_unsupported_option) << "--default-symver";
+#endif
 }
 
 bool ObjectLinker::registerVersionScriptNodes(const VersionScript *VS,

--- a/test/Common/standalone/SymbolVersioning/DefaultSymver/DefaultSymverUnsupported.test
+++ b/test/Common/standalone/SymbolVersioning/DefaultSymver/DefaultSymverUnsupported.test
@@ -1,0 +1,17 @@
+UNSUPPORTED: symbol_versioning
+#---DefaultSymverUnsupported.test----------------------------- SymbolVersioning ------#
+#BEGIN_COMMENT
+# This test verifies that --default-symver warns and does not synthesize a
+# version node when symbol versioning support is disabled. The output must not
+# contain .gnu.version* sections.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.a.o %p/Inputs/default-symver.c -c -fPIC
+RUN: %link %linkopts -o %t1.libdefault.so %t1.a.o -shared --default-symver 2>&1 | %filecheck %s
+RUN: %readelf --sections %t1.libdefault.so | %filecheck %s --check-prefix=NOSECTIONS
+#END_TEST
+
+CHECK: Warning: Unrecognized option `--default-symver'
+
+NOSECTIONS: Section Headers:
+NOSECTIONS-NOT: .gnu.version

--- a/test/Common/standalone/SymbolVersioning/DefaultSymver/DynamicExecutable.test
+++ b/test/Common/standalone/SymbolVersioning/DefaultSymver/DynamicExecutable.test
@@ -1,0 +1,28 @@
+REQUIRES: symbol_versioning
+#---DynamicExecutable.test------------------------------------ SymbolVersioning ------#
+#BEGIN_COMMENT
+# This test verifies that --default-symver creates a default version node for
+# dynamic executables. Without -E the node is still created without exporting
+# regular symbols; with -E exported executable symbols use the default version.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.noexport.o %p/Inputs/no-export.c -c
+RUN: %clang %clangopts -o %t1.main.o %p/Inputs/main.c -c
+
+RUN: %link %linkopts -o %t1.exe %t1.noexport.o --force-dynamic --default-symver
+RUN: %readelf --dyn-syms --version-info %t1.exe | %filecheck %s --check-prefix=EXEC
+
+RUN: %link %linkopts -o %t1.exeE %t1.main.o --force-dynamic -E --default-symver
+RUN: %readelf --dyn-syms --version-info %t1.exeE | %filecheck %s --check-prefix=EXEC-E
+#END_TEST
+
+EXEC: Symbol table '.dynsym' contains 1 entries:
+EXEC: '.gnu.version_d' contains 2 entries:
+EXEC: Name: {{.*}}exe
+EXEC: Name: {{.*}}exe
+
+EXEC-E: foo@@{{.*}}exeE
+EXEC-E: main@@{{.*}}exeE
+EXEC-E: '.gnu.version_d' contains 2 entries:
+EXEC-E: Name: {{.*}}exeE
+EXEC-E: Name: {{.*}}exeE

--- a/test/Common/standalone/SymbolVersioning/DefaultSymver/Inputs/default-symver.c
+++ b/test/Common/standalone/SymbolVersioning/DefaultSymver/Inputs/default-symver.c
@@ -1,0 +1,2 @@
+int foo(void) { return 42; }
+int bar = 1;

--- a/test/Common/standalone/SymbolVersioning/DefaultSymver/Inputs/main.c
+++ b/test/Common/standalone/SymbolVersioning/DefaultSymver/Inputs/main.c
@@ -1,0 +1,2 @@
+int foo(void) { return 1; }
+int main(void) { return foo(); }

--- a/test/Common/standalone/SymbolVersioning/DefaultSymver/Inputs/no-export.c
+++ b/test/Common/standalone/SymbolVersioning/DefaultSymver/Inputs/no-export.c
@@ -1,0 +1,1 @@
+int foo(void) { return 1; }

--- a/test/Common/standalone/SymbolVersioning/DefaultSymver/Inputs/version.t
+++ b/test/Common/standalone/SymbolVersioning/DefaultSymver/Inputs/version.t
@@ -1,0 +1,1 @@
+VERS_1 { global: foo; local: *; };

--- a/test/Common/standalone/SymbolVersioning/DefaultSymver/SharedLibrary.test
+++ b/test/Common/standalone/SymbolVersioning/DefaultSymver/SharedLibrary.test
@@ -1,0 +1,51 @@
+REQUIRES: symbol_versioning
+#---SharedLibrary.test---------------------------------------- SymbolVersioning ------#
+#BEGIN_COMMENT
+# This test verifies --default-symver for shared libraries. The default version
+# name is the DT_SONAME when present and the output filename basename otherwise.
+# It also verifies that an explicit version script overrides the synthetic
+# default-symver node and that the synthetic node is shown in map output.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.a.o %p/Inputs/default-symver.c -c -fPIC
+
+RUN: %link %linkopts -o %t1.libdefault.so %t1.a.o -shared --default-symver -soname libx.so.1
+RUN: %readelf --dyn-syms --version-info %t1.libdefault.so | %filecheck %s --check-prefix=SONAME
+
+RUN: %link %linkopts -o %t1.nosoname.so %t1.a.o -shared --default-symver
+RUN: %readelf --dyn-syms --version-info %t1.nosoname.so | %filecheck %s --check-prefix=OUTPUT
+
+RUN: %link %linkopts -o %t1.libscript.so %t1.a.o -shared --default-symver -soname libx.so.1 --version-script %p/Inputs/version.t
+RUN: %readelf --dyn-syms --version-info %t1.libscript.so | %filecheck %s --check-prefix=SCRIPT
+
+RUN: %link -MapStyle txt %linkopts -o %t1.map.so %t1.a.o -shared --default-symver -soname libmap.so.1 -Map %t1.map.txt
+RUN: %filecheck %s --check-prefix=MAP < %t1.map.txt
+#END_TEST
+
+SONAME: foo@@libx.so.1
+SONAME: bar@@libx.so.1
+SONAME: '.gnu.version_d' contains 2 entries:
+SONAME: Name: libx.so.1
+SONAME: Name: libx.so.1
+
+OUTPUT: foo@@{{.*}}nosoname.so
+OUTPUT: bar@@{{.*}}nosoname.so
+OUTPUT: '.gnu.version_d' contains 2 entries:
+OUTPUT: Name: {{.*}}nosoname.so
+OUTPUT: Name: {{.*}}nosoname.so
+
+SCRIPT-NOT: bar@@
+SCRIPT: foo@@VERS_1
+SCRIPT-NOT: bar@@
+SCRIPT: '.gnu.version_d' contains 3 entries:
+SCRIPT: Name: libx.so.1
+SCRIPT: Name: libx.so.1
+SCRIPT: Name: VERS_1
+
+MAP: Version Script Information
+MAP: Version Script file
+MAP: Symbol Versioning
+MAP: Global:
+MAP: #<Pattern: *>
+MAP: # bar {{.*}}a.o
+MAP: # foo {{.*}}a.o

--- a/test/Common/standalone/SymbolVersioning/DefaultSymver/StaticPIE.test
+++ b/test/Common/standalone/SymbolVersioning/DefaultSymver/StaticPIE.test
@@ -1,0 +1,28 @@
+REQUIRES: symbol_versioning
+#---StaticPIE.test-------------------------------------------- SymbolVersioning ------#
+#BEGIN_COMMENT
+# This test verifies that --default-symver creates a default version node for
+# static PIE outputs. Without -E the node is still created without exporting
+# regular symbols; with -E exported executable symbols use the default version.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -o %t1.noexport.o %p/Inputs/no-export.c -c
+RUN: %clang %clangopts -o %t1.main.o %p/Inputs/main.c -c
+
+RUN: %link %linkopts -o %t1.staticpie %t1.noexport.o -static -pie --default-symver
+RUN: %readelf --dyn-syms --version-info %t1.staticpie | %filecheck %s --check-prefix=STATICPIE
+
+RUN: %link %linkopts -o %t1.staticpieE %t1.main.o -static -pie -E --default-symver
+RUN: %readelf --dyn-syms --version-info %t1.staticpieE | %filecheck %s --check-prefix=STATICPIE-E
+#END_TEST
+
+STATICPIE: Symbol table '.dynsym' contains 1 entries:
+STATICPIE: '.gnu.version_d' contains 2 entries:
+STATICPIE: Name: {{.*}}staticpie
+STATICPIE: Name: {{.*}}staticpie
+
+STATICPIE-E: foo@@{{.*}}staticpieE
+STATICPIE-E: main@@{{.*}}staticpieE
+STATICPIE-E: '.gnu.version_d' contains 2 entries:
+STATICPIE-E: Name: {{.*}}staticpieE
+STATICPIE-E: Name: {{.*}}staticpieE


### PR DESCRIPTION
This commit adds support for `--default-symver` command-line option. This option enables easily create versioned shared libraries, without need for version scripts. It creates a default version node that is used for the exported unversioned symbols.

Resolves #1599