### PR TITLE
Correctly handle merge string symbols with out-of-bounds values

### DIFF
--- a/include/eld/Diagnostics/DiagCommonKinds.inc
+++ b/include/eld/Diagnostics/DiagCommonKinds.inc
@@ -194,3 +194,6 @@ DIAG(err_remap_inputs_bad_format, DiagnosticEngine::Error,
      "invalid --remap-inputs value %0: expected pattern=filename")
 DIAG(err_remap_inputs_file_not_found, DiagnosticEngine::Error,
      "cannot open --remap-inputs-file %0: %1")
+DIAG(warn_merge_string_offset_beyond_end, DiagnosticEngine::Warning,
+     "Offset %0 is past the %1 section size (%2); clamped the value to the "
+     "output section '%3' end")

--- a/lib/Fragment/FragmentRef.cpp
+++ b/lib/Fragment/FragmentRef.cpp
@@ -140,6 +140,19 @@ FragmentRef::Offset FragmentRef::getOutputOffset(Module &M) const {
   if (ThisFragment->isMergeStr()) {
     auto *MSF = llvm::cast<MergeStringFragment>(ThisFragment);
     OutputSectionEntry *O = getOutputSection();
+    /// A symbol defined in a merge string section may have a value at or beyond
+    /// the end of the section (e.g. an end-of-section marker). Match GNU ld:
+    /// clamp the offset to the end of the output section and warn if it points
+    /// to more than 1-byte past the input merge section.
+    uint64_t SectionSize = MSF->getOwningSection()->size();
+    if (ThisOffset >= SectionSize) {
+      if (ThisOffset > SectionSize)
+        M.getConfig().raise(Diag::warn_merge_string_offset_beyond_end)
+            << ThisOffset
+            << MSF->getOwningSection()->getLocation(0, M.getConfig().options())
+            << SectionSize << O->getSection()->name();
+      return O->getSection()->size();
+    }
     const MergeableString *S = MSF->findString(ThisOffset);
     assert(S);
     /// The target string could be a suffix

--- a/lib/Fragment/MergeStringFragment.cpp
+++ b/lib/Fragment/MergeStringFragment.cpp
@@ -69,9 +69,7 @@ size_t MergeStringFragment::size() const {
 }
 
 const MergeableString *MergeStringFragment::findString(uint64_t Offset) const {
-  /// FIXME: This case should ideally assert or error rather than return nullptr
-  if (Offset >= getOwningSection()->size())
-    return nullptr;
+  assert(Offset < getOwningSection()->size());
   return &llvm::partition_point(Strings, [Offset](const MergeableString &S) {
             return S.InputOffset <= Offset;
           })[-1];

--- a/test/x86_64/linux/MergeStrOffsetBeyondEnd/Inputs/beyond.s
+++ b/test/x86_64/linux/MergeStrOffsetBeyondEnd/Inputs/beyond.s
@@ -1,0 +1,7 @@
+	.section	.rodata.str1.1,"aMS",@progbits,1
+.Lstr:
+	.asciz	"hello"
+	.globl	way_past
+way_past = .Lstr + 100
+	.globl	midsym
+midsym = .Lstr + 2

--- a/test/x86_64/linux/MergeStrOffsetBeyondEnd/Inputs/second.s
+++ b/test/x86_64/linux/MergeStrOffsetBeyondEnd/Inputs/second.s
@@ -1,0 +1,5 @@
+	.section	.rodata.str1.1,"aMS",@progbits,1
+.L2:
+	.asciz	"a much longer distinct string here"
+	.globl	other
+other = .L2

--- a/test/x86_64/linux/MergeStrOffsetBeyondEnd/MergeStrOffsetBeyondEnd.test
+++ b/test/x86_64/linux/MergeStrOffsetBeyondEnd/MergeStrOffsetBeyondEnd.test
@@ -1,0 +1,37 @@
+#--MergeStrOffsetBeyondEnd.test---------------- Shared Library ----------------#
+#BEGIN_COMMENT
+# A symbol defined in a SHF_MERGE|SHF_STRINGS section may have a value at or
+# beyond the end of that section (e.g. an end-of-section marker, or an
+# out-of-bounds symbol). The linker must not crash: matching GNU ld; clamp
+# the offset to the end of the OUTPUT section and warns only when the offset is
+# more than 1-byte past the input merge section.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/beyond.s -o %t.beyond.o
+RUN: %clang %clangopts -c %p/Inputs/second.s -o %t.second.o
+
+# Single input: out-of-range 'way_past' clamps to section end and warns;
+# in-range 'midsym' resolves normally with no warning.
+RUN: %link %linkopts -shared -o %t.one.so %t.beyond.o 2>&1 \
+RUN:   | %filecheck %s --check-prefix=WARN
+RUN: %readelf -S -s -W %t.one.so | %filecheck %s --check-prefix=ONE
+
+# Multiple inputs sharing the output section: 'way_past' (from the first
+# fragment) must clamp to the OUTPUT section end, past 'other' (second frag).
+RUN: %link %linkopts -shared -o %t.multi.so %t.beyond.o %t.second.o
+RUN: %readelf -S -s -W %t.multi.so | %filecheck %s --check-prefix=MULTI
+#END_TEST
+
+WARN: Warning: Offset 100 is past the {{.*}}beyond.o:(.rodata.str1.1) section size (6); clamped the value to the output section '.rodata' end
+
+# Section addr + size == section end. way_past clamps to the end; midsym is at +2.
+ONE: .rodata {{.*}} [[#%x,SADDR:]] {{[0-9a-f]+}} [[#%x,SSIZE:]] {{.*}} AMS
+ONE-DAG: {{0*}}[[#%x,SADDR+SSIZE]] {{.*}} way_past
+ONE-DAG: {{0*}}[[#%x,SADDR+2]] {{.*}} midsym
+
+# Output .rodata is 0x29 (6 + "a much...here\0"). way_past clamps to section
+# end (addr+0x29); other (second fragment) sits at addr+6; midsym at addr+2.
+MULTI: .rodata {{.*}} [[#%x,MADDR:]] {{[0-9a-f]+}} [[#%x,MSIZE:]] {{.*}} AMS
+MULTI-DAG: {{0*}}[[#%x,MADDR+MSIZE]] {{.*}} way_past
+MULTI-DAG: {{0*}}[[#%x,MADDR+2]] {{.*}} midsym
+MULTI-DAG: {{0*}}[[#%x,MADDR+6]] {{.*}} other

--- a/test/x86_64/linux/MergeStrOffsetBeyondEnd/MergeStrOffsetBeyondEndPartialLink.test
+++ b/test/x86_64/linux/MergeStrOffsetBeyondEnd/MergeStrOffsetBeyondEndPartialLink.test
@@ -1,0 +1,20 @@
+#--MergeStrOffsetBeyondEndPartialLink.test------------ Partial Link -----------#
+#BEGIN_COMMENT
+# Partial link (-r) of an object with a symbol whose value is at/beyond the end
+# of a SHF_MERGE|SHF_STRINGS section. String merging is not applied in a partial
+# link, so the out-of-range symbol keeps its input value. The linker must not
+# crash and must emit no clamp warning (no output layout exists yet).
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/beyond.s -o %t.beyond.o
+RUN: %link %linkopts -r -o %t.part.o %t.beyond.o 2>&1 \
+RUN:   | %filecheck %s --check-prefix=NOWARN --allow-empty
+RUN: %readelf -s -W %t.part.o | %filecheck %s --check-prefix=PART
+#END_TEST
+
+NOWARN-NOT: clamped the value to the output section
+
+# The out-of-range 'way_past' (input value 0x64) and in-range 'midsym' (0x2)
+# keep their input values in the relocatable output.
+PART-DAG: {{0*}}64 {{.*}} way_past
+PART-DAG: {{0*}}2 {{.*}} midsym


### PR DESCRIPTION
This commit fixes a linker crash that occurred when a symbol defined in a SHF_MERGE|SHF_STRINGS section had a value at or beyond the end of that section, such as an end-of-section marker. Until now the linker asserted while resolving the output value of such a symbol and aborted the link.

The linker now matches GNU ld: instead of failing, it clamps the symbol value to the end of the output section and continues. A warning is reported only when the value is greater than 1-byte past the input merge section, so the common one-past-the-end marker case stays silent.

This change is scoped to symbol values; relocations into merge string sections are unaffected.

Resolves #1764