### PR TITLE
[AdvancedLTO] Stop exporting plugin implementation class

### DIFF
--- a/Plugins/AdvancedLTO/AdvancedLTO.cpp
+++ b/Plugins/AdvancedLTO/AdvancedLTO.cpp
@@ -22,9 +22,9 @@
 #include <string>
 #include <unordered_map>
 
-namespace {
-
 using namespace eld::plugin;
+
+namespace {
 
 struct ModuleData {
   explicit ModuleData(BitcodeFile BCF) : BCFile(BCF) {}
@@ -33,7 +33,7 @@ struct ModuleData {
   std::unordered_map<std::string, Section> SectionsByName;
 };
 
-class DLL_A_EXPORT AdvancedLTO : public LinkerPlugin {
+class AdvancedLTO : public LinkerPlugin {
 public:
   AdvancedLTO() : LinkerPlugin("AdvancedLTO") {}
 


### PR DESCRIPTION
Remove DLL_A_EXPORT from the AdvancedLTO class and keep the implementation internal to the translation unit. The plugin loader only needs the exported C entry points provided by ELD_REGISTER_PLUGIN.

This fixes Windows builds where dllexport on the anonymous-namespace class was rejected, and also avoids MSVC exporting implicit copy/assignment members for the unique_ptr-owned module state.