### PR TITLE
Reject local-exec TLS relocations in shared libraries

### DIFF
--- a/include/eld/Diagnostics/DiagRelocations.inc
+++ b/include/eld/Diagnostics/DiagRelocations.inc
@@ -82,3 +82,5 @@ DIAG(warn_unsupported_reloc_for_ifunc, DiagnosticEngine::Warning,
      "Unsupported relocation %0 used for STT_GNU_IFUNC symbol '%1'")
 DIAG(warn_invalid_reloc_for_ifunc, DiagnosticEngine::Warning,
      "Invalid relocation %0 used for STT_GNU_IFUNC symbol '%1'")
+DIAG(tls_le_relocation_in_shared, DiagnosticEngine::Fatal,
+     "relocation %0 against %1 referred from %2 cannot be used with -shared")

--- a/include/eld/Target/Relocator.h
+++ b/include/eld/Target/Relocator.h
@@ -138,6 +138,12 @@ public:
   bool checkDynamicRelocAllowed(const Relocation &reloc,
                                 const ELFSection &section, bool isAbs) const;
 
+  bool isTLSRelocTypeSupported(const Relocation &reloc) const;
+
+  virtual bool isTLSLocalExecReloc(const Relocation &reloc) const {
+    return false;
+  }
+
   /// Get Symbol Name
   std::string getSymbolName(const ResolveInfo *R) const;
 

--- a/lib/Target/AArch64/AArch64Relocator.cpp
+++ b/lib/Target/AArch64/AArch64Relocator.cpp
@@ -177,6 +177,32 @@ bool AArch64Relocator::isPICRelocTypeSupported(const Relocation &reloc) const {
   return true;
 }
 
+bool AArch64Relocator::isTLSLocalExecReloc(const Relocation &reloc) const {
+  switch (reloc.type()) {
+  case llvm::ELF::R_AARCH64_TLSLE_MOVW_TPREL_G2:
+  case llvm::ELF::R_AARCH64_TLSLE_MOVW_TPREL_G1:
+  case llvm::ELF::R_AARCH64_TLSLE_MOVW_TPREL_G1_NC:
+  case llvm::ELF::R_AARCH64_TLSLE_MOVW_TPREL_G0:
+  case llvm::ELF::R_AARCH64_TLSLE_MOVW_TPREL_G0_NC:
+  case llvm::ELF::R_AARCH64_TLSLE_ADD_TPREL_HI12:
+  case llvm::ELF::R_AARCH64_TLSLE_ADD_TPREL_LO12:
+  case llvm::ELF::R_AARCH64_TLSLE_ADD_TPREL_LO12_NC:
+  case llvm::ELF::R_AARCH64_TLSLE_LDST8_TPREL_LO12:
+  case llvm::ELF::R_AARCH64_TLSLE_LDST8_TPREL_LO12_NC:
+  case llvm::ELF::R_AARCH64_TLSLE_LDST16_TPREL_LO12:
+  case llvm::ELF::R_AARCH64_TLSLE_LDST16_TPREL_LO12_NC:
+  case llvm::ELF::R_AARCH64_TLSLE_LDST32_TPREL_LO12:
+  case llvm::ELF::R_AARCH64_TLSLE_LDST32_TPREL_LO12_NC:
+  case llvm::ELF::R_AARCH64_TLSLE_LDST64_TPREL_LO12:
+  case llvm::ELF::R_AARCH64_TLSLE_LDST64_TPREL_LO12_NC:
+  case llvm::ELF::R_AARCH64_TLSLE_LDST128_TPREL_LO12:
+  case llvm::ELF::R_AARCH64_TLSLE_LDST128_TPREL_LO12_NC:
+    return true;
+  default:
+    return false;
+  }
+}
+
 bool AArch64Relocator::relocNeedsDynRel(Relocation &pReloc) const {
   ResolveInfo *rsym = pReloc.symInfo();
   // Need dynamic relocations to sign pointers at runtime

--- a/lib/Target/AArch64/AArch64Relocator.h
+++ b/lib/Target/AArch64/AArch64Relocator.h
@@ -77,6 +77,7 @@ public:
                              const ELFSection &pSection) override;
 
 private:
+  bool isTLSLocalExecReloc(const Relocation &reloc) const override;
   bool isPICRelocTypeSupported(const Relocation &reloc) const override;
   bool isRelocSupported(Relocation &pReloc) const;
   bool relocNeedsDynRel(Relocation &pReloc) const;

--- a/lib/Target/ARM/ARMRelocator.cpp
+++ b/lib/Target/ARM/ARMRelocator.cpp
@@ -310,6 +310,16 @@ bool ARMRelocator::isPICRelocTypeSupported(const Relocation &reloc) const {
   }
 }
 
+bool ARMRelocator::isTLSLocalExecReloc(const Relocation &reloc) const {
+  switch (reloc.type()) {
+  case llvm::ELF::R_ARM_TLS_LE12:
+  case llvm::ELF::R_ARM_TLS_LE32:
+    return true;
+  default:
+    return false;
+  }
+}
+
 Relocator::Result ARMRelocator::applyRelocation(Relocation &pRelocation) {
   Relocation::Type type = pRelocation.type();
   if (type >= ApplyFunctions.size() || !ApplyFunctions[type].func) {

--- a/lib/Target/ARM/ARMRelocator.h
+++ b/lib/Target/ARM/ARMRelocator.h
@@ -72,6 +72,7 @@ public:
   }
 
 private:
+  bool isTLSLocalExecReloc(const Relocation &reloc) const override;
   bool isPICRelocTypeSupported(const Relocation &reloc) const override;
   void scanLocalReloc(InputFile &pInput, Relocation::Type, Relocation &pReloc,
                       const ELFSection &pSection);

--- a/lib/Target/Hexagon/HexagonRelocator.cpp
+++ b/lib/Target/Hexagon/HexagonRelocator.cpp
@@ -268,6 +268,21 @@ bool HexagonRelocator::isPICRelocTypeSupported(const Relocation &reloc) const {
   }
 }
 
+bool HexagonRelocator::isTLSLocalExecReloc(const Relocation &reloc) const {
+  switch (reloc.type()) {
+  case llvm::ELF::R_HEX_TPREL_LO16:
+  case llvm::ELF::R_HEX_TPREL_HI16:
+  case llvm::ELF::R_HEX_TPREL_32:
+  case llvm::ELF::R_HEX_TPREL_16:
+  case llvm::ELF::R_HEX_TPREL_32_6_X:
+  case llvm::ELF::R_HEX_TPREL_16_X:
+  case llvm::ELF::R_HEX_TPREL_11_X:
+    return true;
+  default:
+    return false;
+  }
+}
+
 bool HexagonRelocator::isRelocSupported(Relocation &pReloc) const {
   return pReloc.type() < HEXAGON_MAXRELOCS;
 }

--- a/lib/Target/Hexagon/HexagonRelocator.h
+++ b/lib/Target/Hexagon/HexagonRelocator.h
@@ -74,6 +74,7 @@ protected:
                             HexagonLDBackend &pTarget);
 
 private:
+  bool isTLSLocalExecReloc(const Relocation &reloc) const override;
   bool isPICRelocTypeSupported(const Relocation &reloc) const override;
   virtual void scanLocalReloc(InputFile &pInput, Relocation &pReloc,
                               eld::IRBuilder &pBuilder, ELFSection &pSection);

--- a/lib/Target/RISCV/RISCVRelocator.cpp
+++ b/lib/Target/RISCV/RISCVRelocator.cpp
@@ -402,6 +402,18 @@ bool RISCVRelocator::isPICRelocTypeSupported(const Relocation &reloc) const {
   }
 }
 
+bool RISCVRelocator::isTLSLocalExecReloc(const Relocation &reloc) const {
+  switch (reloc.type()) {
+  case llvm::ELF::R_RISCV_TPREL_HI20:
+  case llvm::ELF::R_RISCV_TPREL_LO12_I:
+  case llvm::ELF::R_RISCV_TPREL_LO12_S:
+  case llvm::ELF::R_RISCV_TPREL_ADD:
+    return true;
+  default:
+    return false;
+  }
+}
+
 void RISCVRelocator::scanRelocation(Relocation &pReloc, eld::IRBuilder &pLinker,
                                     ELFSection &pSection, InputFile &pInputFile,
                                     CopyRelocs &CopyRelocs) {

--- a/lib/Target/RISCV/RISCVRelocator.h
+++ b/lib/Target/RISCV/RISCVRelocator.h
@@ -49,6 +49,7 @@ public:
   bool is32bit() const { return config().targets().is32Bits(); }
 
 private:
+  bool isTLSLocalExecReloc(const Relocation &reloc) const override;
   bool isPICRelocTypeSupported(const Relocation &reloc) const override;
 
   virtual void scanLocalReloc(InputFile &pInput, Relocation &pReloc,

--- a/lib/Target/Relocator.cpp
+++ b/lib/Target/Relocator.cpp
@@ -292,6 +292,8 @@ bool Relocator::reportNonPICRelocation(const Relocation &reloc) const {
 }
 
 bool Relocator::checkPICRelocSupported(const Relocation &reloc) const {
+  if (!isTLSRelocTypeSupported(reloc))
+    return false;
   if (!config().isCodeIndep())
     return true;
   if (isPICRelocTypeSupported(reloc))
@@ -320,6 +322,26 @@ bool Relocator::checkDynamicRelocAllowed(const Relocation &reloc,
   return true;
 }
 
+bool Relocator::isTLSRelocTypeSupported(const Relocation &reloc) const {
+  if (!config().options().hasShared())
+    return true;
+
+  if (!isTLSLocalExecReloc(reloc))
+    return true;
+
+  FragmentRef *Ref = reloc.targetRef();
+  std::string Location = reloc.getSourcePath(config().options());
+  if (Ref && Ref->frag() && Ref->frag()->getOwningSection())
+    Location = Ref->frag()->getOwningSection()->getLocation(Ref->offset(),
+                                                            config().options());
+  ResolveInfo *sym = reloc.symInfo();
+  config().raise(Diag::tls_le_relocation_in_shared)
+      << getName(reloc.type()) << (sym ? getSymbolName(sym) : "<unknown>")
+      << Location;
+
+  m_Module.setFailure(true);
+  return false;
+}
 bool Relocator::doDeMangle() const {
   return m_Config.options().shouldDemangle();
 }

--- a/lib/Target/X86/x86_64Relocator.cpp
+++ b/lib/Target/X86/x86_64Relocator.cpp
@@ -99,6 +99,16 @@ bool x86_64Relocator::isRelocSupported(const Relocation &pReloc) const {
   }
 }
 
+bool x86_64Relocator::isTLSLocalExecReloc(const Relocation &reloc) const {
+  switch (reloc.type()) {
+  case llvm::ELF::R_X86_64_TPOFF32:
+  case llvm::ELF::R_X86_64_TPOFF64:
+    return true;
+  default:
+    return false;
+  }
+}
+
 void x86_64Relocator::scanRelocation(Relocation &pReloc,
                                      eld::IRBuilder &pLinker,
                                      ELFSection &pSection,

--- a/lib/Target/X86/x86_64Relocator.h
+++ b/lib/Target/X86/x86_64Relocator.h
@@ -71,6 +71,7 @@ private:
                                CopyRelocs &);
 
   bool isRelocSupported(const Relocation &pReloc) const;
+  bool isTLSLocalExecReloc(const Relocation &reloc) const override;
 
   x86_64GOT *getTLSModuleID(ResolveInfo *R, bool isStatic = false);
 

--- a/test/ARM/standalone/RecompileWithFpicErr/RecompileWithFpicErr.test
+++ b/test/ARM/standalone/RecompileWithFpicErr/RecompileWithFpicErr.test
@@ -17,6 +17,6 @@ RUN: %link %linkopts -shared %t2pic.o  -o %tlib.so.3 2>&1
 RUN: %link %linkopts -Bdynamic %t1.o %tlib.so.3 --noinhibit-exec -o %t.out 2>&1
 RUN: %readelf -r %t.out
 
-#IEERR:  recompile with -fPIC
-#LEERR:  recompile with -fPIC
+#IEERR: Fatal: relocation R_ARM_TLS_LE32 against baz referred from {{.*\(.*\+0x[0-9a-f]+\)}} cannot be used with -shared
+#LEERR: Fatal: relocation R_ARM_TLS_LE32 against baz referred from {{.*\(.*\+0x[0-9a-f]+\)}} cannot be used with -shared
 #CHECK: TPREL

--- a/test/Common/standalone/TLSLocalExecShared/Inputs/tls.c
+++ b/test/Common/standalone/TLSLocalExecShared/Inputs/tls.c
@@ -1,0 +1,2 @@
+__thread int tls_var;
+int get_tls(void) { return tls_var; }

--- a/test/Common/standalone/TLSLocalExecShared/Inputs/tls_hidden.c
+++ b/test/Common/standalone/TLSLocalExecShared/Inputs/tls_hidden.c
@@ -1,0 +1,2 @@
+__attribute__((visibility("hidden"))) __thread int hidden_tls_var;
+int get_tls(void) { return hidden_tls_var; }

--- a/test/Common/standalone/TLSLocalExecShared/TLSLocalExecShared.test
+++ b/test/Common/standalone/TLSLocalExecShared/TLSLocalExecShared.test
@@ -1,0 +1,21 @@
+#---TLSLocalExecShared.test---------------------- Shared Library --------------#
+#BEGIN_COMMENT
+# Verify that TLS local-exec relocations are rejected when creating a shared
+# library.
+#END_COMMENT
+#START_TEST
+
+RUN: %clang %clangopts -ftls-model=local-exec -c \
+RUN:   %p/Inputs/tls.c -o %t.tls.o
+RUN: %not %link %linkopts -shared %t.tls.o -o %t.tls.so 2>&1 \
+RUN:   | %filecheck %s --check-prefix=TLS
+
+RUN: %clang %clangopts -ftls-model=local-exec -c \
+RUN:   %p/Inputs/tls_hidden.c -o %t.hidden.o
+RUN: %not %link %linkopts -shared %t.hidden.o -o %t.hidden.so 2>&1 \
+RUN:   | %filecheck %s --check-prefix=HIDDEN
+
+#END_TEST
+
+TLS: Fatal: relocation {{R_.*(TLS|TPREL|TPOFF).*}} against tls_var referred from {{.*\(.*\+0x[0-9a-f]+\)}} cannot be used with -shared
+HIDDEN: Fatal: relocation {{R_.*(TLS|TPREL|TPOFF).*}} against hidden_tls_var referred from {{.*\(.*\+0x[0-9a-f]+\)}} cannot be used with -shared

--- a/test/Hexagon/TLS/RecompileWithFpicErr/RecompileWithFpicErr.test
+++ b/test/Hexagon/TLS/RecompileWithFpicErr/RecompileWithFpicErr.test
@@ -18,6 +18,8 @@ RUN: %link %linkopts -shared %t2pic.o  -o %tlib.so.3 2>&1
 RUN: %link %linkopts -Bdynamic %t1.o %tlib.so.3 -o %t.out 2>&1
 RUN: %readelf -r %t.out
 
-#IEERR:  recompile with -fPIC
-#LEERR:  recompile with -fPIC
+#IEERR: Fatal: relocation {{R_HEX_TPREL_.*}} against baz referred from {{.*2IE\.o.*\+0x[0-9a-f]+\)}} cannot be used with -shared
+#IEERR: Fatal: relocation {{R_HEX_TPREL_.*}} against baz referred from {{.*2IE\.o.*\+0x[0-9a-f]+\)}} cannot be used with -shared
+#LEERR: Fatal: relocation {{R_HEX_TPREL_.*}} against baz referred from {{.*2LE\.o.*\+0x[0-9a-f]+\)}} cannot be used with -shared
+#LEERR: Fatal: relocation {{R_HEX_TPREL_.*}} against baz referred from {{.*2LE\.o.*\+0x[0-9a-f]+\)}} cannot be used with -shared
 #CHECK: TPREL

--- a/test/Hexagon/TLS/TPREL/tprel.test
+++ b/test/Hexagon/TLS/TPREL/tprel.test
@@ -7,7 +7,7 @@ RUN: %link %linkopts  -o %t.out %t1.o %t2.o -G0 2>&1
 RUN: %not %link %linkopts -shared -o %t.so %t1.pic.o %t2.pic.o -G0 2>&1 | %filecheck %s --check-prefix="ERR"
 RUN: %readelf -l -S -s -W %t.out |   %filecheck %s
 
-#ERR: recompile with -fPIC
+#ERR: Fatal: relocation {{R_HEX_TPREL_.*}} against {{(src1|src2|dst)}} referred from {{.*\+0x[0-9a-f]+\)}} cannot be used with -shared
 # CHECK:  .tdata            PROGBITS        {{[x0-9a-z]+}} {{[x0-9a-z]+}} 000008 00 WAT
 # CHECK:  .tbss             NOBITS          {{[x0-9a-z]+}} {{[x0-9a-z]+}} 000004 00 WAT
 # CHECK:  00000008     4 TLS     GLOBAL DEFAULT    {{[0-9]}} dst

--- a/test/Hexagon/linux/TLS/RecompileWithFpicErr/RecompileWithFpicErr.test
+++ b/test/Hexagon/linux/TLS/RecompileWithFpicErr/RecompileWithFpicErr.test
@@ -18,6 +18,6 @@ RUN: %link %linkopts -shared %t2pic.o  -o %tlib.so.3 2>&1
 RUN: %link %linkopts -Bdynamic %t1.o %tlib.so.3 -o %t.out 2>&1
 RUN: %readelf -r %t.out
 
-#IEERR:  recompile with -fPIC
-#LEERR:  recompile with -fPIC
+#IEERR: Fatal: relocation {{R_HEX_TPREL_.*}} against baz referred from {{.*2IE\.o.*\+0x[0-9a-f]+\)}} cannot be used with -shared
+#LEERR: Fatal: relocation {{R_HEX_TPREL_.*}} against baz referred from {{.*2LE\.o.*\+0x[0-9a-f]+\)}} cannot be used with -shared
 #CHECK: TPREL

--- a/test/Hexagon/linux/TLS/TPREL/tprel.test
+++ b/test/Hexagon/linux/TLS/TPREL/tprel.test
@@ -7,7 +7,7 @@ RUN: %link %linkopts  -o %t.out %t1.o %t2.o -G0 2>&1
 RUN: %not %link %linkopts -shared -o %t.so %t1.pic.o %t2.pic.o -G0 2>&1 | %filecheck %s --check-prefix="ERR"
 RUN: %readelf -l -S -s -W %t.out |   %filecheck %s
 
-#ERR: recompile with -fPIC
+#ERR: Fatal: relocation {{R_HEX_TPREL_.*}} against {{(src1|src2|dst)}} referred from {{.*\+0x[0-9a-f]+\)}} cannot be used with -shared
 # CHECK:  .tdata            PROGBITS        {{[x0-9a-z]+}} {{[x0-9a-z]+}} 000008 00 WAT
 # CHECK:  .tbss             NOBITS          {{[x0-9a-z]+}} {{[x0-9a-z]+}} 000004 00 WAT
 # CHECK:  00000008     4 TLS     GLOBAL DEFAULT    {{[0-9]}} dst

--- a/test/Hexagon/standalone/TLS/RecompileWithFpicErr/RecompileWithFpicErr.test
+++ b/test/Hexagon/standalone/TLS/RecompileWithFpicErr/RecompileWithFpicErr.test
@@ -14,6 +14,8 @@ RUN: %clang %clangopts -c %clangg0opts -fpic %p/Inputs/2.c -ftls-model=initial-e
 RUN: %not %link %linkopts -shared %t2IE.o -o %tlib.so.1 2>&1 | %filecheck %s --check-prefix="IEERR"
 RUN: %not %link %linkopts -shared %t2LE.o -o %tlib.so.2 2>&1 | %filecheck %s --check-prefix="LEERR"
 
-#IEERR:  recompile with -fPIC
-#LEERR:  recompile with -fPIC
+#IEERR: Fatal: relocation {{R_HEX_TPREL_.*}} against baz referred from {{.*2IE\.o.*\+0x[0-9a-f]+\)}} cannot be used with -shared
+#IEERR: Fatal: relocation {{R_HEX_TPREL_.*}} against baz referred from {{.*2IE\.o.*\+0x[0-9a-f]+\)}} cannot be used with -shared
+#LEERR: Fatal: relocation {{R_HEX_TPREL_.*}} against baz referred from {{.*2LE\.o.*\+0x[0-9a-f]+\)}} cannot be used with -shared
+#LEERR: Fatal: relocation {{R_HEX_TPREL_.*}} against baz referred from {{.*2LE\.o.*\+0x[0-9a-f]+\)}} cannot be used with -shared
 #CHECK: TPREL

--- a/test/x86_64/linux/TLSLocalExecShared/Inputs/tpoff32.s
+++ b/test/x86_64/linux/TLSLocalExecShared/Inputs/tpoff32.s
@@ -1,0 +1,11 @@
+.section .tdata,"awT",@progbits
+.align 4
+.globl tls_var32
+tls_var32:
+  .long 0
+
+.text
+.globl get_tls32
+get_tls32:
+  movl tls_var32@TPOFF, %eax
+  ret

--- a/test/x86_64/linux/TLSLocalExecShared/Inputs/tpoff64.s
+++ b/test/x86_64/linux/TLSLocalExecShared/Inputs/tpoff64.s
@@ -1,0 +1,10 @@
+.section .tdata,"awT",@progbits
+.align 8
+.globl tls_var64
+tls_var64:
+  .quad 0
+
+.section .data
+.align 8
+result64:
+  .quad tls_var64@TPOFF

--- a/test/x86_64/linux/TLSLocalExecShared/TLSLocalExecShared.test
+++ b/test/x86_64/linux/TLSLocalExecShared/TLSLocalExecShared.test
@@ -1,0 +1,19 @@
+#--TLSLocalExecShared.test---------------------- Shared Library --------------#
+#BEGIN_COMMENT
+# Verify that direct x86-64 local-exec TLS relocations are rejected when
+# creating a shared library.
+#END_COMMENT
+#START_TEST
+
+RUN: %clang %clangopts -c %p/Inputs/tpoff32.s -o %t.tpoff32.o
+RUN: %not %link %linkopts -shared %t.tpoff32.o -o %t.tpoff32.so 2>&1 \
+RUN:   | %filecheck %s --check-prefix=TPOFF32
+
+RUN: %clang %clangopts -c %p/Inputs/tpoff64.s -o %t.tpoff64.o
+RUN: %not %link %linkopts -shared %t.tpoff64.o -o %t.tpoff64.so 2>&1 \
+RUN:   | %filecheck %s --check-prefix=TPOFF64
+
+#END_TEST
+
+TPOFF32: Fatal: relocation R_X86_64_TPOFF32 against {{.*}} referred from {{.*\(.*\+0x[0-9a-f]+\)}} cannot be used with -shared
+TPOFF64: Fatal: relocation R_X86_64_TPOFF64 against {{.*}} referred from {{.*\(.*\)}} cannot be used with -shared


### PR DESCRIPTION
Classify target-specific local-exec TLS relocations and report an error when they are used with -shared. Add regression tests for all supported targets.

Resolves #1780