### PR TITLE
[Testing] Increase lit timeout

### DIFF
--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -1,7 +1,7 @@
 name: Windows Arm64/x86_64 CI/Nightly
 
 on:
-  # pull_request: {} # Uncomment to run in CI mode to build ELD PR branch.
+  pull_request: {} # Uncomment to run in CI mode to build ELD PR branch.
   schedule:
     # 9:00 PM Central
     - cron: '0 2 * * *'

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -42,7 +42,7 @@ def which(cmdline):
 config.name = 'eld'
 
 # Default per-test timeout in seconds.
-config.maxIndividualTestTime = 120
+config.maxIndividualTestTime = 300
 
 # testFormat: The test format to use to interpret tests.
 #


### PR DESCRIPTION
Increase the timeout to 5 minutes to fix failing Windows runs.

Fix: qualcomm#1773