### PR TITLE
[Driver] Group never-read options as ignored; alias --library-path to -L

### DIFF
--- a/include/eld/Driver/ARMLinkerOptions.td
+++ b/include/eld/Driver/ARMLinkerOptions.td
@@ -26,12 +26,6 @@ def use_mov_veneer
       Group<grp_arm_linker>;
 def grp_arm_linker_only : OptionGroup<"opts">,
                           HelpText<"ARM Linker Option ONLY">;
-def fix_cortex_a8 : Flag<["--"], "fix-cortex-a8">,
-                    HelpText<"Fix the Cortex A8 bug">,
-                    Group<grp_arm_linker_only>;
-def no_fix_cortex_a8 : Flag<["--"], "no-fix-cortex-a8">,
-                       HelpText<"Dont Fix the Cortex A8 bug">,
-                       Group<grp_arm_linker_only>;
 def fix_cortex_a53_843419 : Flag<["-", "--"], "fix-cortex-a53-843419">,
                             HelpText<"Fix the cortex a53 errata 843419">,
                             Group<grp_arm_linker_only>;
@@ -66,3 +60,9 @@ def gpsize_alias : JoinedOrSeparate<["-"], "G">,
                    MetaVarName<"<maxsize>">,
                    Group<grp_compatorignoredopts>,
                    Alias<gpsize>;
+def fix_cortex_a8 : Flag<["--"], "fix-cortex-a8">,
+                    HelpText<"Fix the Cortex A8 bug">,
+                    Group<grp_compatorignoredopts>;
+def no_fix_cortex_a8 : Flag<["--"], "no-fix-cortex-a8">,
+                       HelpText<"Dont Fix the Cortex A8 bug">,
+                       Group<grp_compatorignoredopts>;

--- a/include/eld/Driver/GnuLinkerOptions.td
+++ b/include/eld/Driver/GnuLinkerOptions.td
@@ -403,11 +403,6 @@ defm default_script : mDashDeprEqWithOpt<"default-script", "default_script",
 defm Ttext : mDashCompEq<"Ttext", "Specify an address for the .text section">,
              MetaVarName<"<address>">,
              Group<grp_scriptopts>;
-defm Ttext_segment : mDashCompEqWithOpt<"Ttext-segment", "Ttext_segment",
-                                          "Specify an address for the "
-                                          ".text-segment segment">,
-                     MetaVarName<"<address>">,
-                     Group<grp_scriptopts>;
 defm Tdata : mDashCompEq<"Tdata", "Specify an address for the .data section">,
              MetaVarName<"<address>">,
              Group<grp_scriptopts>;
@@ -423,11 +418,6 @@ defm extern_list : mDashDeprEqWithOpt<"extern-list", "extern_list",
                                       "Specify a list of symbols that exists "
                                       "as external dependencies">,
                    MetaVarName<"<list-of-symbols>">,
-                   Group<grp_scriptopts>;
-defm map_section : mDashEq<"map-section", "map_section",
-                           "Specify a input section that maps to a output "
-                           "section">,
-                   MetaVarName<"<section>">,
                    Group<grp_scriptopts>;
 defm section_start : mDashDeprEqWithOpt<"section-start", "section_start",
                                         "Specify a virtual output section "
@@ -526,10 +516,15 @@ def namespec : JJ<"library=">,
                MetaVarName<"<namespec>">,
                HelpText<"library to use">,
                Group<grp_main>;
-defm library_path : mDashEq<"library-path", "library_path",
-                            "Path to search for libraries or linker scripts">,
-                    MetaVarName<"<path>">,
-                    Group<grp_main>;
+def library_path : Separate<["--"], "library-path">,
+                   MetaVarName<"<path>">,
+                   HelpText<"Path to search for libraries or linker scripts">,
+                   Alias<L>,
+                   Group<grp_main>;
+def library_path_eq : JJ<"library-path=">,
+                      MetaVarName<"<path>">,
+                      Alias<L>,
+                      Group<grp_main>;
 defm Y : sDashDeprEq<"Y", "Add path to the default library search path">,
          MetaVarName<"<path>">,
          Group<grp_main>;
@@ -598,10 +593,6 @@ defm rpath : mDashCompEq<"rpath",
                          "Add a path to the runtime library search path">,
              MetaVarName<"<path>">,
              Group<grp_dynlibexec>;
-defm rpath_link : mDashCompEqWithOpt<"rpath-link", "rpath_link",
-                                     "Specifies the path to search">,
-                  MetaVarName<"<path>">,
-                  Group<grp_dynlibexec>;
 defm export_dynamic : mDashDeprWithOpt<"export-dynamic", "export_dynamic",
                                        "Add all symbols to the dynamic symbol "
                                        "table when creating executables">,
@@ -645,15 +636,6 @@ def soname_h : JoinedOrSeparate<["-"], "h">,
                Alias<soname>,
                MetaVarName<"<name>">,
                Group<grp_dynlib>;
-def dash_g : Flag<["-"], "g">,
-             HelpText<"Enable debug output when building shared libraries or "
-                      "executables">,
-             Group<grp_dynlib>;
-defm hash_size : mDashEq<"hash-size", "hash_size",
-                         "Specify a hash size when creating the hash sections "
-                         "for the dynamic loader">,
-                 MetaVarName<"<size>">,
-                 Group<grp_dynlib>;
 defm hash_style : mDashDeprEqWithOpt<"hash-style", "hash_style",
                                      "Specify a hash style when creating the "
                                      "hash sections for the dynamic loader">,
@@ -744,15 +726,6 @@ def push_state : FF<"push-state">,
 def pop_state : FF<"pop-state">,
                 HelpText<"Restore previously saved input handling flags">,
                 Group<grp_resolveropt>;
-defm allow_shlib_undefs
-    : mDashDeprWithOpt<"allow-shlib-undefined", "allow_shlib_undefs",
-                       "Allow undefined symbols from dynamic library when "
-                       "creating executables">,
-      Group<grp_resolveropt>;
-def use_shlib_undefs
-    : FF<"use-shlib-undefines">,
-      HelpText<"Resolve undefined symbols from dynamic libraries">,
-      Group<grp_resolveropt>;
 def allow_multiple_definition : FF<"allow-multiple-definition">,
                                 HelpText<"Allow multiple definitions">,
                                 Group<grp_resolveropt>;
@@ -1271,6 +1244,38 @@ def thin_archive_rule_matching_compatibility
       HelpText<"Provides rule-matching compatibility when fat archives are\n"
                "\t\t\tconverted to thin archives">,
       Group<grp_compatorignoredopts>;
+defm allow_shlib_undefs
+    : mDashDeprWithOpt<"allow-shlib-undefined", "allow_shlib_undefs",
+                       "Allow undefined symbols from dynamic library when "
+                       "creating executables">,
+      Group<grp_compatorignoredopts>;
+def use_shlib_undefs
+    : FF<"use-shlib-undefines">,
+      HelpText<"Resolve undefined symbols from dynamic libraries">,
+      Group<grp_compatorignoredopts>;
+defm rpath_link : mDashCompEqWithOpt<"rpath-link", "rpath_link",
+                                     "Specifies the path to search">,
+                  MetaVarName<"<path>">,
+                  Group<grp_compatorignoredopts>;
+defm Ttext_segment : mDashCompEqWithOpt<"Ttext-segment", "Ttext_segment",
+                                          "Specify an address for the "
+                                          ".text-segment segment">,
+                     MetaVarName<"<address>">,
+                     Group<grp_compatorignoredopts>;
+defm map_section : mDashEq<"map-section", "map_section",
+                           "Specify a input section that maps to a output "
+                           "section">,
+                   MetaVarName<"<section>">,
+                   Group<grp_compatorignoredopts>;
+defm hash_size : mDashEq<"hash-size", "hash_size",
+                         "Specify a hash size when creating the hash sections "
+                         "for the dynamic loader">,
+                 MetaVarName<"<size>">,
+                 Group<grp_compatorignoredopts>;
+def dash_g : Flag<["-"], "g">,
+             HelpText<"Enable debug output when building shared libraries or "
+                      "executables">,
+             Group<grp_compatorignoredopts>;
 
 //===----------------------------------------------------------------------===//
 /// LTO options

--- a/test/Common/standalone/CommandLine/PrintHelp/PrintModHelp.test
+++ b/test/Common/standalone/CommandLine/PrintHelp/PrintModHelp.test
@@ -6,9 +6,16 @@
 RUN: %link --help 2>&1 | %filecheck %s
 
 #CHECK:   --add-needed
+#CHECK:   --allow-shlib-undefined
+#CHECK:   -allow-shlib-undefined
 #CHECK:   --copy-dt-needed-entries
 #CHECK:   -EL
+#CHECK:   -g
+#CHECK:   --hash-size=<size>
+#CHECK:   --hash-size <size>
 #CHECK:   --ignore-unknown-opts
+#CHECK:   --map-section=<section>
+#CHECK:   --map-section <section>
 #CHECK:   --nmagic
 #CHECK:   --no-add-needed
 #CHECK:   --no-allow-shlib-undefined
@@ -23,7 +30,16 @@ RUN: %link --help 2>&1 | %filecheck %s
 #CHECK:   --plugin <pluginfile>
 #CHECK:   -plugin <pluginfile>
 #CHECK:   -Qy
+#CHECK:   --rpath-link=<path>
+#CHECK:   -rpath-link=<path>
+#CHECK:   --rpath-link <path>
+#CHECK:   -rpath-link <path>
 #CHECK:   -thin-archive-rule-matching-compatibility
+#CHECK:   --Ttext-segment=<address>
+#CHECK:   -Ttext-segment=<address>
+#CHECK:   --Ttext-segment <address>
+#CHECK:   -Ttext-segment <address>
+#CHECK:   --use-shlib-undefines
 #CHECK:   --color=<never/always/auto>
 #CHECK:   -color=<never/always/auto>
 #CHECK:   --color <never/always/auto>
@@ -104,9 +120,6 @@ RUN: %link --help 2>&1 | %filecheck %s
 #CHECK:   --Bsymbolic
 #CHECK:   -Bsymbolic
 #CHECK:   -fPIC
-#CHECK:   -g
-#CHECK:   --hash-size=<size>
-#CHECK:   --hash-size <size>
 #CHECK:   --hash-style=<hashstyle>
 #CHECK:   -hash-style=<hashstyle>
 #CHECK:   --hash-style <hashstyle>
@@ -133,10 +146,6 @@ RUN: %link --help 2>&1 | %filecheck %s
 #CHECK:   -force-dynamic
 #CHECK:   --no-dynamic-linker
 #CHECK:   -no-dynamic-linker
-#CHECK:   --rpath-link=<path>
-#CHECK:   -rpath-link=<path>
-#CHECK:   --rpath-link <path>
-#CHECK:   -rpath-link <path>
 #CHECK:   --rpath=<path>
 #CHECK:   -rpath=<path>
 #CHECK:   --rpath <path>
@@ -440,8 +449,6 @@ RUN: %link --help 2>&1 | %filecheck %s
 #CHECK:   --extern-list <list-of-symbols>
 #CHECK:   -extern-list <list-of-symbols>
 #CHECK:   --global-merge-non-alloc-strings
-#CHECK:   --map-section=<section>
-#CHECK:   --map-section <section>
 #CHECK:   --no-check-sections
 #CHECK:   --orphan-handling=<mode>
 #CHECK:   -orphan-handling=<mode>
@@ -467,10 +474,6 @@ RUN: %link --help 2>&1 | %filecheck %s
 #CHECK:   -Tdata=<address>
 #CHECK:   --Tdata <address>
 #CHECK:   -Tdata <address>
-#CHECK:   --Ttext-segment=<address>
-#CHECK:   -Ttext-segment=<address>
-#CHECK:   --Ttext-segment <address>
-#CHECK:   -Ttext-segment <address>
 #CHECK:   --Ttext=<address>
 #CHECK:   -Ttext=<address>
 #CHECK:   --Ttext <address>
@@ -515,8 +518,6 @@ RUN: %link --help 2>&1 | %filecheck %s
 #CHECK:   -(
 #CHECK:   -)
 #CHECK:   --allow-multiple-definition
-#CHECK:   --allow-shlib-undefined
-#CHECK:   -allow-shlib-undefined
 #CHECK:   --as-needed
 #CHECK:   --defsym=symbol=<expression>
 #CHECK:   -defsym=symbol=<expression>
@@ -536,7 +537,6 @@ RUN: %link --help 2>&1 | %filecheck %s
 #CHECK:   --start-lib-thin
 #CHECK:   --start-lib
 #CHECK:   --undefined=<symbol>
-#CHECK:   --use-shlib-undefines
 #CHECK:   -u <symbol>
 #CHECK:   --warn-once
 #END_TEST

--- a/test/Common/standalone/SearchDiagnostics/SearchDiagnostics.test
+++ b/test/Common/standalone/SearchDiagnostics/SearchDiagnostics.test
@@ -15,6 +15,9 @@ NOT-FOUND: Trying to open input `{{.+}}libblablabla.a' of type `archive' for nam
 RUN: %link %linkopts -static --verbose -o %t2.out %t1.o -L%t-lib -la 2>&1 | %filecheck %s --check-prefix=FOUND-STATIC
 FOUND-STATIC: Trying to open input `{{.+}}-lib/liba.a' of type `archive' for namespec `a': found
 
+RUN: %link %linkopts -static --verbose -o %t2.out %t1.o --library-path %t-lib -la 2>&1 | %filecheck %s --check-prefix=FOUND-STATIC
+RUN: %link %linkopts -static --verbose -o %t2.out %t1.o --library-path=%t-lib -la 2>&1 | %filecheck %s --check-prefix=FOUND-STATIC
+
 RUN: %link %linkopts --dynamic --verbose -o %t3.out %t1.o -L%t-lib -la 2>&1 | %filecheck %s --check-prefix=FOUND-DYNOBJ
 FOUND-DYNOBJ: Trying to open input `{{.+}}-lib/liba.so' of type `dynamic object' for namespec `a': found
 


### PR DESCRIPTION
This PR tries to fix #1186 

This PR moves linker driver options that are declared in TableGen but never read by the linker into `grp_compatorignoredopts` so `--help` stops presenting them as functional, and aliases `--library-path` to -L since silently discarding a library search path is a bug rather than an intentional no-op.