### PR TITLE
Remove duplicate LLVM globals and run llvm_shutdown from LW

### DIFF
--- a/include/eld/Driver/Driver.h
+++ b/include/eld/Driver/Driver.h
@@ -31,6 +31,10 @@ class DLL_A_EXPORT Driver {
 public:
   Driver(DriverFlavor F = DriverFlavor::Invalid);
 
+  /// Linker entry point. This must live in the LinkerWrapper library rather
+  /// than in the ld.eld executable.
+  static int main(int Argc, const char **Argv);
+
   bool setDriverFlavorAndInferredArchFromLinkCommand(
       llvm::ArrayRef<const char *> Args);
 

--- a/lib/LinkerWrapper/Driver.cpp
+++ b/lib/LinkerWrapper/Driver.cpp
@@ -18,11 +18,56 @@
 #include "eld/Support/TargetRegistry.h"
 #include "eld/Support/TargetSelect.h"
 #include "eld/Target/TargetMachine.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/MC/TargetRegistry.h"
+#include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/Process.h"
+#include "llvm/Support/Signals.h"
+#include "llvm/Support/StringSaver.h"
 #include <optional>
+
+// If a command line option starts with "@", the driver reads its suffix as a
+// file, parse its contents as a list of command line options, and insert them
+// at the original @file position. If file cannot be read, @file is not expanded
+// and left unmodified. @file can appear in a response file, so it's a recursive
+// process.
+static llvm::ArrayRef<const char *>
+maybeExpandResponseFiles(llvm::ArrayRef<const char *> Args,
+                         llvm::BumpPtrAllocator &Alloc) {
+  // Expand response files.
+  llvm::SmallVector<const char *, 256> SmallVec;
+  for (const char *Arg : Args)
+    SmallVec.push_back(Arg);
+  llvm::StringSaver Saver(Alloc);
+  llvm::cl::ExpandResponseFiles(Saver, llvm::cl::TokenizeGNUCommandLine,
+                                SmallVec);
+
+  // Pack the results to a C-array and return it.
+  const char **Copy = Alloc.Allocate<const char *>(SmallVec.size() + 1);
+  std::copy(SmallVec.begin(), SmallVec.end(), Copy);
+  Copy[SmallVec.size()] = nullptr;
+  return llvm::ArrayRef(Copy, SmallVec.size() + 1);
+}
+
+int Driver::main(int Argc, const char **Argv) {
+  // Standard set up, so program fails gracefully.
+  llvm::BumpPtrAllocator Alloc;
+  llvm::sys::PrintStackTraceOnErrorSignal(Argv[0]);
+  llvm::PrettyStackTraceProgram StackPrinter(Argc, Argv);
+  llvm::llvm_shutdown_obj Shutdown;
+
+  llvm::ArrayRef<const char *> Args =
+      maybeExpandResponseFiles({Argv, Argv + Argc}, Alloc);
+
+  Driver TheDriver;
+  if (!TheDriver.setDriverFlavorAndInferredArchFromLinkCommand(Args))
+    return LINK_FAIL;
+
+  return TheDriver.getLinkerDriver()->link(Args);
+}
 
 Driver::Driver(DriverFlavor F)
     : DiagEngine(new eld::DiagnosticEngine(shouldColorize())),

--- a/test/Common/standalone/DriverNoLLVMStatics/driver-no-llvm-statics.test
+++ b/test/Common/standalone/DriverNoLLVMStatics/driver-no-llvm-statics.test
@@ -1,0 +1,9 @@
+## UNSUPPORTED: windows
+## Check that there is only ever one copy of LLVM globals.
+
+
+# RUN: %nm --defined-only %eld > %t.syms
+# RUN: FileCheck %s --input-file=%t.syms --implicit-check-not=StaticList \
+# RUN:   --implicit-check-not=llvm_shutdown --implicit-check-not=getDefaultExecutor
+
+# CHECK: main

--- a/tools/eld/CMakeLists.txt
+++ b/tools/eld/CMakeLists.txt
@@ -8,9 +8,10 @@ macro(add_eld_symlink name dest)
   llvm_install_symlink(ELD ${name} ${dest} ALWAYS_GENERATE)
 endmacro()
 
-set(LLVM_LINK_COMPONENTS ${LLVM_TARGETS_TO_BUILD} irreader Support)
-
-add_llvm_executable(ld.eld eld.cpp)
+# No LLVM_LINK_COMPONENTS: eld.cpp only forwards to Driver::main
+# in the LinkerWrapper library. Linking any LLVM component here gives the
+# executable a second copy of LLVM's globals which we don't want.
+add_llvm_executable(ld.eld eld.cpp DISABLE_LLVM_LINK_LLVM_DYLIB)
 add_dependencies(ld.eld update-eld-verinfo)
 
 set(LINKER_WRAPPER_LIB "LW")

--- a/tools/eld/eld.cpp
+++ b/tools/eld/eld.cpp
@@ -10,70 +10,17 @@
 // License. See LICENSE.TXT for details.
 //
 //===----------------------------------------------------------------------===//
-#include "eld/Config/Config.h"
-#include "eld/Driver/Driver.h"
-#include "eld/Driver/GnuLdDriver.h"
-#include "eld/Support/Memory.h"
-#include "eld/Support/TargetRegistry.h"
-#include "eld/Support/TargetSelect.h"
-#include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/StringSwitch.h"
-#include "llvm/ADT/Twine.h"
-#include "llvm/Support/ManagedStatic.h"
-#include "llvm/Support/Path.h"
-#include "llvm/Support/PrettyStackTrace.h"
-#include "llvm/Support/Signals.h"
-#include "llvm/Support/StringSaver.h"
-#include "llvm/Support/Timer.h"
-#include "llvm/Support/raw_ostream.h"
+//
+// This executable is a forwarder into the LinkerWrapper library. Nothing
+// here should call into LLVM, in order to avoid duplicate copies of LLVM
+// globals between libLW.so and ld.eld.
+//
+//===----------------------------------------------------------------------===//
+#include "eld/Support/Defines.h"
 
-using namespace llvm;
-using namespace llvm::sys;
-typedef std::vector<std::string> strings;
+class DLL_A_EXPORT Driver {
+public:
+  static int main(int Argc, const char **Argv);
+};
 
-// If a command line option starts with "@", the driver reads its suffix as a
-// file, parse its contents as a list of command line options, and insert them
-// at the original @file position. If file cannot be read, @file is not expanded
-// and left unmodified. @file can appear in a response file, so it's a recursive
-// process.
-static llvm::ArrayRef<const char *>
-maybeExpandResponseFiles(llvm::ArrayRef<const char *> args,
-                         BumpPtrAllocator &alloc) {
-  // Expand response files.
-  SmallVector<const char *, 256> smallvec;
-  for (const char *arg : args)
-    smallvec.push_back(arg);
-  llvm::StringSaver saver(alloc);
-  llvm::cl::ExpandResponseFiles(saver, llvm::cl::TokenizeGNUCommandLine,
-                                smallvec);
-
-  // Pack the results to a C-array and return it.
-  const char **copy = alloc.Allocate<const char *>(smallvec.size() + 1);
-  std::copy(smallvec.begin(), smallvec.end(), copy);
-  copy[smallvec.size()] = nullptr;
-  return llvm::ArrayRef(copy, smallvec.size() + 1);
-}
-
-/// Universal linker main().
-int main(int Argc, const char **Argv) {
-  // Standard set up, so program fails gracefully.
-  llvm::BumpPtrAllocator Alloc;
-  sys::PrintStackTraceOnErrorSignal(Argv[0]);
-  PrettyStackTraceProgram StackPrinter(Argc, Argv);
-  llvm_shutdown_obj Shutdown;
-
-  std::vector<const char *> Args(Argv, Argv + Argc);
-
-  // Parse all the options.
-  Driver driver;
-
-  Args = maybeExpandResponseFiles(Args, Alloc);
-  if (!driver.setDriverFlavorAndInferredArchFromLinkCommand(Args))
-    return 1;
-
-  GnuLdDriver *LinkerDriver = driver.getLinkerDriver();
-
-  int Status = LinkerDriver->link(Args);
-
-  return Status;
-}
+int main(int Argc, const char **Argv) { return Driver::main(Argc, Argv); }


### PR DESCRIPTION
LLVMSupport was linked into both the ld.eld executable and the LinkerWrapper shared library. This created duplicate LLVM globals that are supposed to be cleaned up by llvm_shutdown, but the shutdown call only came from the executable, not the library.  On windows, this could lead to a race condition between thread creation and process exit.

This patch moves the linker entry point to LinkerWrapper and ensures that we only have one copy of LLVM globals, all in the library rather than the executable.