### PR TITLE
[command-line] --discard-locals now discard ".L" local temporaries

### DIFF
--- a/lib/Target/GNULDBackend.cpp
+++ b/lib/Target/GNULDBackend.cpp
@@ -1191,12 +1191,15 @@ void GNULDBackend::sizeSymTab() {
     return;
 
   bool isStripLocal = (S == GeneralOptions::StripLocals);
+  bool isStripTemporaries = (S == GeneralOptions::StripTemporaries);
 
   size_t strtab = 1;
   std::vector<ResolveInfo *> &RVect = m_Module.getSymbols();
   uint64_t NumSymbols = 0;
   for (auto &Sym : RVect) {
     if ((isStripLocal && NumSymbols && Sym->isLocal()) ||
+        (isStripTemporaries && Sym->isLocal() &&
+         llvm::StringRef(Sym->name()).starts_with(".L")) ||
         m_SymbolsToRemove.count(Sym)) {
       continue;
     }
@@ -1365,6 +1368,7 @@ GNULDBackend::emitRegNamePools(llvm::FileOutputBuffer &pOutput) {
     return {};
 
   bool isStripLocal = (S == GeneralOptions::StripLocals);
+  bool isStripTemporaries = (S == GeneralOptions::StripTemporaries);
 
   // Check if we have symbol tables
   if (!getSymTab())
@@ -1409,7 +1413,10 @@ GNULDBackend::emitRegNamePools(llvm::FileOutputBuffer &pOutput) {
   for (auto &S : symbols) {
     m_pSymIndexMap[S->outSymbol()] = symIdx;
     // Null symbol is already emitted.
-    if ((isStripLocal && S->isLocal()) || m_SymbolsToRemove.count(S)) {
+    if ((isStripLocal && S->isLocal()) ||
+        (isStripTemporaries && S->isLocal() &&
+         llvm::StringRef(S->name()).starts_with(".L")) ||
+        m_SymbolsToRemove.count(S)) {
       config().raise(Diag::stripping_symbol) << S->name();
       continue;
     }

--- a/test/ARM/standalone/DiscardLocals/DiscardLocals.test
+++ b/test/ARM/standalone/DiscardLocals/DiscardLocals.test
@@ -1,0 +1,31 @@
+#---DiscardLocals.test--------------------------- Executable ------------------#
+#BEGIN_COMMENT
+# This checks that -X/--discard-locals strips assembler-generated .L-prefixed
+# local temporaries, while leaving ordinary local symbols intact.
+# --discard-all/-x continues to strip all local symbols regardless of name.
+# It also checks that symbols are preserved when --emit-relocs is present
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/g.s -o %t.1.o
+
+RUN: %link %linkopts --emit-relocs -X %t.1.o -o %t.discardlocals.out
+RUN: %readelf -s %t.discardlocals.out | %filecheck %s -check-prefix=BASE
+
+RUN: %link %linkopts -X %t.1.o -o %t.discardlocals.out
+RUN: %readelf -s %t.discardlocals.out | %filecheck %s -check-prefix=DISCARDLOCALS
+
+RUN: %link %linkopts --emit-relocs -x %t.1.o -o %t.discardall.out
+RUN: %readelf -s %t.discardall.out | %filecheck %s -check-prefix=BASE
+
+RUN: %link %linkopts -x %t.1.o -o %t.discardall.out
+RUN: %readelf -s %t.discardall.out | %filecheck %s -check-prefix=DISCARDALL
+
+#BASE-DAG: LOCAL DEFAULT {{[0-9]+}} .L_temp_end
+#BASE-DAG: LOCAL DEFAULT {{[0-9]+}} ordinary_local
+
+#DISCARDLOCALS-NOT: LOCAL DEFAULT {{[0-9]+}} .L_temp_end
+#DISCARDLOCALS: LOCAL DEFAULT {{[0-9]+}} ordinary_local
+
+#DISCARDALL-NOT: LOCAL DEFAULT {{[0-9]+}} .L_temp_end
+#DISCARDALL-NOT: LOCAL DEFAULT {{[0-9]+}} ordinary_local
+#END_TEST

--- a/test/ARM/standalone/DiscardLocals/Inputs/g.s
+++ b/test/ARM/standalone/DiscardLocals/Inputs/g.s
@@ -1,0 +1,15 @@
+.text
+.global _start
+_start:
+.word 0
+
+.bss
+.local ordinary_local
+ordinary_local:
+.word 0
+.L_temp:
+.space 4
+.L_temp_end:
+
+.text
+.word .L_temp_end - .

--- a/test/RISCV/standalone/DiscardLocals/DiscardLocals.test
+++ b/test/RISCV/standalone/DiscardLocals/DiscardLocals.test
@@ -1,0 +1,35 @@
+#---DiscardLocals.test--------------------------- Executable ------------------#
+#BEGIN_COMMENT
+# This checks that -X/--discard-locals strips assembler-generated .L-prefixed
+# local temporaries, while leaving ordinary local symbols intact.
+# --discard-all/-x continues to strip all local symbols regardless of name.
+# Also checks the when --keep-labels is set all .L symbols are removed.
+# It also checks that symbols are preserved when --emit-relocs is present
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/g.s -o %t.1.o
+
+RUN: %link %linkopts -X %t.1.o -o %t.discardlocals.out
+RUN: %readelf -s %t.discardlocals.out | %filecheck %s -check-prefix=BASE
+
+RUN: %link %linkopts --no-emit-relocs -X %t.1.o -o %t.discardlocals.out
+RUN: %readelf -s %t.discardlocals.out | %filecheck %s -check-prefix=DISCARDLOCALS
+
+RUN: %link %linkopts --keep-labels -X %t.1.o -o %t.discardlocals.out
+RUN: %readelf -s %t.discardlocals.out | %filecheck %s -check-prefix=DISCARDLOCALS
+
+RUN: %link %linkopts -x %t.1.o -o %t.discardall.out
+RUN: %readelf -s %t.discardall.out | %filecheck %s -check-prefix=BASE
+
+RUN: %link %linkopts --no-emit-relocs -x %t.1.o -o %t.discardall.out
+RUN: %readelf -s %t.discardall.out | %filecheck %s -check-prefix=DISCARDALL
+
+#BASE-DAG: LOCAL DEFAULT {{[0-9]+}} .L_temp_end
+#BASE-DAG: LOCAL DEFAULT {{[0-9]+}} ordinary_local
+
+#DISCARDLOCALS-NOT: LOCAL DEFAULT {{[0-9]+}} .L_temp_end
+#DISCARDLOCALS: LOCAL DEFAULT {{[0-9]+}} ordinary_local
+
+#DISCARDALL-NOT: LOCAL DEFAULT {{[0-9]+}} .L_temp_end
+#DISCARDALL-NOT: LOCAL DEFAULT {{[0-9]+}} ordinary_local
+#END_TEST

--- a/test/RISCV/standalone/DiscardLocals/Inputs/g.s
+++ b/test/RISCV/standalone/DiscardLocals/Inputs/g.s
@@ -1,0 +1,15 @@
+.text
+.global _start
+_start:
+.word 0
+
+.bss
+.local ordinary_local
+ordinary_local:
+.word 0
+.L_temp:
+.space 4
+.L_temp_end:
+
+.text
+.word .L_temp_end - .


### PR DESCRIPTION
The --discard-locals command now discards ".L" prefixed local temporaries.

Fix: qualcomm#1800