### PR TITLE
[Script] Remove init() functions from PhdrSpec and OutputSectDesc::Pr…

### DIFF
--- a/include/eld/Script/OutputSectDesc.h
+++ b/include/eld/Script/OutputSectDesc.h
@@ -147,33 +147,20 @@ public:
       return true;
     }
 
-    void init() {
-      OutputSectionVMA = nullptr;
-      ThisType = OutputSectDesc::Type::DEFAULT_TYPE;
-      SectionFlag = OutputSectDesc::Permissions::DEFAULT_PERMISSIONS;
-      OutputSectionLMA = nullptr;
-      Alignment = nullptr;
-      OutputSectionSubaAlign = nullptr;
-      SectionConstraint = OutputSectDesc::Constraint::NO_CONSTRAINT;
-      PluginCmd = nullptr;
-      ThisPlugin = nullptr;
-      HasAlignWithInput = false;
-    }
-
     void setAlignWithInput() { HasAlignWithInput = true; }
 
     bool hasAlignWithInput() const { return HasAlignWithInput; }
 
-    Expression *OutputSectionVMA;
-    Type ThisType;
-    uint32_t SectionFlag;
-    Expression *OutputSectionLMA;
-    Expression *Alignment;
-    Expression *OutputSectionSubaAlign;
-    Constraint SectionConstraint;
-    eld::PluginCmd *PluginCmd;
-    eld::Plugin *ThisPlugin;
-    bool HasAlignWithInput;
+    Expression *OutputSectionVMA = nullptr;
+    Type ThisType = OutputSectDesc::Type::DEFAULT_TYPE;
+    uint32_t SectionFlag = OutputSectDesc::Permissions::DEFAULT_PERMISSIONS;
+    Expression *OutputSectionLMA = nullptr;
+    Expression *Alignment = nullptr;
+    Expression *OutputSectionSubaAlign = nullptr;
+    Constraint SectionConstraint = OutputSectDesc::Constraint::NO_CONSTRAINT;
+    eld::PluginCmd *PluginCmd = nullptr;
+    eld::Plugin *ThisPlugin = nullptr;
+    bool HasAlignWithInput = false;
   };
 
   struct Epilog {

--- a/include/eld/Script/PhdrDesc.h
+++ b/include/eld/Script/PhdrDesc.h
@@ -34,21 +34,12 @@ struct PhdrSpec {
 
   Expression *flags() const { return SectionFlags; }
 
-  void init() {
-    Name = nullptr;
-    ThisType = 0;
-    ScriptHasFileHdr = false;
-    ScriptHasPhdr = false;
-    FixedAddress = nullptr;
-    SectionFlags = nullptr;
-  }
-
-  const StrToken *Name;
-  uint32_t ThisType;
-  bool ScriptHasFileHdr;
-  bool ScriptHasPhdr;
-  Expression *FixedAddress;
-  Expression *SectionFlags;
+  const StrToken *Name = nullptr;
+  uint32_t ThisType = 0;
+  bool ScriptHasFileHdr = false;
+  bool ScriptHasPhdr = false;
+  Expression *FixedAddress = nullptr;
+  Expression *SectionFlags = nullptr;
 };
 
 /** \class PhdrDesc

--- a/lib/ScriptParser/ScriptParser.cpp
+++ b/lib/ScriptParser/ScriptParser.cpp
@@ -628,7 +628,6 @@ void ScriptParser::readOverlayMemberOutputSectionDescription(
   llvm::StringRef OutSectName = unquote(Tok);
 
   OutputSectDesc::Prolog Prologue;
-  Prologue.init();
 
   // Overlay members are just `OutputSectionName { InputSectDesc... }`.
   // They do not support the regular output-section prologue/epilogue syntax.
@@ -872,7 +871,6 @@ InputSectDesc::Spec ScriptParser::readInputSectionDescSpec(StringRef Tok) {
 
 OutputSectDesc::Prolog ScriptParser::readOutputSectDescPrologue() {
   OutputSectDesc::Prolog Prologue;
-  Prologue.init();
   if (peek(LexState::Expr) != ":") {
     if (consume("(")) {
       if (!readOutputSectTypeAndPermissions(Prologue, peek())){
@@ -973,7 +971,6 @@ void ScriptParser::readPhdrs() {
   ThisScriptFile.enterPhdrsCmd();
   while (peek() != "}" && !atEOF()) {
     PhdrSpec PhdrSpec;
-    PhdrSpec.init();
     llvm::StringRef NameTok = next();
     PhdrSpec.Name =
         ThisScriptFile.createParserStr(NameTok.data(), NameTok.size());

--- a/test/UnitTests/ProgramHeaderTests/ProgramHeaderTest.cpp
+++ b/test/UnitTests/ProgramHeaderTests/ProgramHeaderTest.cpp
@@ -1177,7 +1177,6 @@ TEST(CreateProgramHeaders, PhdrsSpecifiedUsesScriptSegments) {
   H.Mod->getScript().setPhdrsSpecified();
 
   PhdrSpec LoadSpec;
-  LoadSpec.init();
   LoadSpec.Name = make<StrToken>("LOAD");
   LoadSpec.ThisType = llvm::ELF::PT_LOAD;
   LoadSpec.ScriptHasFileHdr = true;
@@ -1213,7 +1212,6 @@ TEST(CreateProgramHeaders, PhdrsCommandCreatesSegmentsFromScript) {
 
   auto makeSpec = [&](llvm::StringRef Name, uint32_t Type) {
     PhdrSpec Spec;
-    Spec.init();
     Spec.Name = make<StrToken>(Name.str());
     Spec.ThisType = Type;
     Script.insertPhdrSpec(Spec);


### PR DESCRIPTION
Replace explicit init() methods with C++ default member initializers.