### PR TITLE
refactor: rename 'checkUnsignedRange' to 'reportUnsignedOverflow'

### DIFF
--- a/include/eld/Target/Relocator.h
+++ b/include/eld/Target/Relocator.h
@@ -182,8 +182,8 @@ protected:
 Relocator::Result checkSignedRange(Relocation &Rel, Relocator &R, int64_t Value,
                                    unsigned Bits);
 
-Relocator::Result checkUnsignedRange(Relocation &Rel, Relocator &R,
-                                     uint64_t Value, unsigned Bits);
+Relocator::Result reportUnsignedOverflow(Relocation &Rel, Relocator &R,
+                                         uint64_t Value, unsigned Bits);
 
 } // namespace eld
 #endif

--- a/lib/Target/AArch64/AArch64Relocator.cpp
+++ b/lib/Target/AArch64/AArch64Relocator.cpp
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //===----------------------------------------------------------------------===//
 
-
 #include "AArch64Relocator.h"
 #include "AArch64InsnHelpers.h"
 #include "AArch64PLT.h"
@@ -51,8 +50,7 @@ static uint64_t getSigningSchema(const Relocation &pReloc) {
 /// helper_DynRel - Get an relocation entry in .rela.dyn
 Relocation *helper_DynRel_init(ELFObjectFile *Obj, Relocation *R,
                                ResolveInfo *pSym, Fragment *F, uint32_t pOffset,
-                               Relocator::Type pType,
-                               AArch64LDBackend &B) {
+                               Relocator::Type pType, AArch64LDBackend &B) {
   Relocation *rela_entry = nullptr;
 
   if (pType == R_AARCH64_TLSDESC)
@@ -194,9 +192,8 @@ bool AArch64Relocator::relocNeedsDynRel(Relocation &pReloc) const {
                     pReloc.type() == llvm::ELF::R_AARCH64_ABS32 ||
                     pReloc.type() == llvm::ELF::R_AARCH64_ABS16 ||
                     pReloc.type() == llvm::ELF::R_AARCH64_AUTH_ABS64;
-  return getTarget().symbolNeedsDynRel(
-                   *rsym, (rsym->reserved() & ReservePLT),
-                   isAbsReloc);
+  return getTarget().symbolNeedsDynRel(*rsym, (rsym->reserved() & ReservePLT),
+                                       isAbsReloc);
 }
 
 Relocator::Result AArch64Relocator::applyRelocation(Relocation &pRelocation) {
@@ -256,12 +253,10 @@ void AArch64Relocator::scanLocalReloc(InputFile &pInput, Relocation &pReloc,
       rsym->setReserved(rsym->reserved() | ReserveRel);
       getTarget().checkAndSetHasTextRel(pSection);
       // set up the dyn rel directly
-      Relocation::Type relType =
-        isAuthAbs ? llvm::ELF::R_AARCH64_AUTH_RELATIVE
-                  : llvm::ELF::R_AARCH64_RELATIVE;
+      Relocation::Type relType = isAuthAbs ? llvm::ELF::R_AARCH64_AUTH_RELATIVE
+                                           : llvm::ELF::R_AARCH64_RELATIVE;
       helper_DynRel_init(Obj, &pReloc, rsym, pReloc.targetRef()->frag(),
-                         pReloc.targetRef()->offset(), relType,
-                         m_Target);
+                         pReloc.targetRef()->offset(), relType, m_Target);
     }
   }
     return;
@@ -393,8 +388,8 @@ void AArch64Relocator::scanGlobalReloc(InputFile &pInput, Relocation &pReloc,
         // for signed pointers"
         if (isAuthAbs) {
           config().raise(Diag::non_pic_relocation)
-            << getName(pReloc.type()) << pReloc.symInfo()->name()
-            << pReloc.getSourcePath(config().options());
+              << getName(pReloc.type()) << pReloc.symInfo()->name()
+              << pReloc.getSourcePath(config().options());
           m_Target.getModule().setFailure(true);
           return;
         }
@@ -420,10 +415,8 @@ void AArch64Relocator::scanGlobalReloc(InputFile &pInput, Relocation &pReloc,
           relType = isAuthAbs ? llvm::ELF::R_AARCH64_AUTH_RELATIVE
                               : llvm::ELF::R_AARCH64_RELATIVE;
         }
-        helper_DynRel_init(
-            Obj, &pReloc, rsym, pReloc.targetRef()->frag(),
-            pReloc.targetRef()->offset(),
-            relType, m_Target);
+        helper_DynRel_init(Obj, &pReloc, rsym, pReloc.targetRef()->frag(),
+                           pReloc.targetRef()->offset(), relType, m_Target);
       }
     }
   }
@@ -1060,7 +1053,8 @@ Relocator::Result ld64_got_lo12(Relocation &pReloc, AArch64Relocator &pParent) {
 }
 
 // R_AARCH64_LD64_GOTPAGE_LO15: G(GDAT(S)) - Page(GOT)
-Relocator::Result ld64_gotpage_lo15(Relocation &pReloc, AArch64Relocator &pParent) {
+Relocator::Result ld64_gotpage_lo15(Relocation &pReloc,
+                                    AArch64Relocator &pParent) {
   if (!(pReloc.symInfo()->reserved() & Relocator::ReserveGOT)) {
     return Relocator::BadReloc;
   }
@@ -1131,14 +1125,14 @@ Relocator::Result movw_abs_g(Relocation &pReloc, AArch64Relocator &pParent) {
   switch (pReloc.type()) {
   case llvm::ELF::R_AARCH64_MOVW_UABS_G0:
     if (!llvm::isUInt<16>(X))
-      return checkUnsignedRange(pReloc, pParent, X, 16);
+      return reportUnsignedOverflow(pReloc, pParent, X, 16);
     LLVM_FALLTHROUGH;
   case llvm::ELF::R_AARCH64_MOVW_UABS_G0_NC:
     pReloc.target() = helper_reencode_movzk_imm(pReloc.target(), (X & 0xFFFF));
     break;
   case llvm::ELF::R_AARCH64_MOVW_UABS_G1:
     if (!llvm::isUInt<32>(X))
-      return checkUnsignedRange(pReloc, pParent, X, 32);
+      return reportUnsignedOverflow(pReloc, pParent, X, 32);
     LLVM_FALLTHROUGH;
   case llvm::ELF::R_AARCH64_MOVW_UABS_G1_NC:
     pReloc.target() =
@@ -1146,7 +1140,7 @@ Relocator::Result movw_abs_g(Relocation &pReloc, AArch64Relocator &pParent) {
     break;
   case llvm::ELF::R_AARCH64_MOVW_UABS_G2:
     if (!llvm::isUInt<48>(X))
-      return checkUnsignedRange(pReloc, pParent, X, 48);
+      return reportUnsignedOverflow(pReloc, pParent, X, 48);
     LLVM_FALLTHROUGH;
   case llvm::ELF::R_AARCH64_MOVW_UABS_G2_NC:
     pReloc.target() =
@@ -1238,11 +1232,11 @@ Relocator::Result tls_tprel(Relocation &pReloc, AArch64Relocator &pParent) {
 
   if (pReloc.type() == llvm::ELF::R_AARCH64_TLSLE_ADD_TPREL_HI12) {
     if (!llvm::isUInt<24>(X))
-      return checkUnsignedRange(pReloc, pParent, X, 24);
+      return reportUnsignedOverflow(pReloc, pParent, X, 24);
     pReloc.target() = helper_reencode_add_imm(pReloc.target(), X >> 12);
   } else {
     if (!llvm::isUInt<12>(X))
-      return checkUnsignedRange(pReloc, pParent, X, 12);
+      return reportUnsignedOverflow(pReloc, pParent, X, 12);
     pReloc.target() = helper_reencode_add_imm(pReloc.target(), X);
   }
   return Relocator::OK;

--- a/lib/Target/ARM/ARMRelocator.cpp
+++ b/lib/Target/ARM/ARMRelocator.cpp
@@ -1008,7 +1008,7 @@ static Relocator::Result ldr_pc_group(Relocation &pReloc, ARMRelocator &pParent,
   // R_ARM_LDR_PC_Gn encodes the group residual in the imm12 field.
   uint32_t Imm = helper_get_rem_for_group(pGroup, X);
   if (!llvm::isUInt<12>(Imm))
-    return checkUnsignedRange(pReloc, pParent, Imm, 12);
+    return reportUnsignedOverflow(pReloc, pParent, Imm, 12);
 
   // Preserve the instruction opcode/register fields and replace only U+imm12.
   pReloc.target() = (I & 0xff7ff000) | U | Imm;

--- a/lib/Target/Hexagon/HexagonRelocator.cpp
+++ b/lib/Target/Hexagon/HexagonRelocator.cpp
@@ -711,7 +711,7 @@ Relocator::Result VerifyRelocAsNeededHelper(
     unsigned EffectiveBits = RelocInfo.EffectiveBits + RelocInfo.Shift;
     if (RelocInfo.IsSigned)
       return checkSignedRange(pReloc, Parent, PreShift, EffectiveBits);
-    return checkUnsignedRange(pReloc, Parent, PreShift, EffectiveBits);
+    return reportUnsignedOverflow(pReloc, Parent, PreShift, EffectiveBits);
   }
 
   if ((pRelocDesc.forceVerify) &&

--- a/lib/Target/RISCV/RISCVRelocator.cpp
+++ b/lib/Target/RISCV/RISCVRelocator.cpp
@@ -835,7 +835,7 @@ VerifyRelocAsNeededHelper(Relocation &pReloc, T Result,
         getEncodingBitWidth(RelocInfo.EncType) + RelocInfo.Shift;
     if (RelocInfo.IsSigned)
       return checkSignedRange(pReloc, Parent, Result, EffectiveBits);
-    return checkUnsignedRange(pReloc, Parent, Result, EffectiveBits);
+    return reportUnsignedOverflow(pReloc, Parent, Result, EffectiveBits);
   }
 
   if ((pRelocDesc.forceVerify) && (isTruncatedRISCV(RelocInfo, Result))) {

--- a/lib/Target/Relocator.cpp
+++ b/lib/Target/Relocator.cpp
@@ -359,8 +359,9 @@ Relocator::Result eld::checkSignedRange(Relocation &Rel, Relocator &R,
   return Relocator::Overflow;
 }
 
-Relocator::Result eld::checkUnsignedRange(Relocation &Rel, Relocator &R,
-                                          uint64_t Value, unsigned int Bits) {
+Relocator::Result eld::reportUnsignedOverflow(Relocation &Rel, Relocator &R,
+                                              uint64_t Value,
+                                              unsigned int Bits) {
 
   if (Bits == 64 || Value >> Bits == 0)
     return Relocator::OK;

--- a/lib/Target/X86/x86_64Relocator.cpp
+++ b/lib/Target/X86/x86_64Relocator.cpp
@@ -556,7 +556,7 @@ Relocator::Result VerifyRelocAsNeededHelper(
         getNumberOfBits(RelocInfo.EncType) + RelocInfo.Shift;
     if (RelocInfo.IsSigned)
       return checkSignedRange(pReloc, Parent, PreShift, EffectiveBits);
-    return checkUnsignedRange(pReloc, Parent, PreShift, EffectiveBits);
+    return reportUnsignedOverflow(pReloc, Parent, PreShift, EffectiveBits);
   }
 
   if ((pRelocDesc.forceVerify) && (isTruncatedX86_64(RelocInfo, Result))) {


### PR DESCRIPTION
What's Changed

- Renamed `checkUnsignedRange` to `reportUnsignedOverflow` across `Relocator.h`, `Relocator.cpp` and all `Target/` backends to accurately describe that the function reports an overflow error instead of performing range validation check.

Closes #1738