### PR TITLE
[zephyr] disable failing nightly test

### DIFF
--- a/.github/zephyr-quarantine.yml
+++ b/.github/zephyr-quarantine.yml
@@ -151,3 +151,10 @@
   comment: >-
     Stack overflow. Both toolchains allocate the same 4256-byte stack.
     GCC+ELD passes.
+
+- scenarios:
+  - bluetooth.init.test_20
+  platforms:
+  - qemu_cortex_m3/.*
+  comment: >-
+    https://github.com/qualcomm/eld/issues/225


### PR DESCRIPTION
Duplicate EXIDX entries under that test are unmerged by the linker that bfd merges, and there is a memory overflow with eld. Will be re-enabled when https://github.com/qualcomm/eld/issues/225 is resolved.