### PR TITLE
Fix data-race in multi-threaded version script matching

### DIFF
--- a/include/eld/Script/ScriptSymbol.h
+++ b/include/eld/Script/ScriptSymbol.h
@@ -37,6 +37,10 @@ public:
 
   bool matched(const ResolveInfo &Sym, llvm::StringRef demangledName) const;
 
+  bool matches(const ResolveInfo &Sym) const;
+
+  bool matches(llvm::StringRef demangledName) const;
+
   void addResolveInfoToContainer(const ResolveInfo *Info) const;
 
 private:

--- a/include/eld/Script/VersionScript.h
+++ b/include/eld/Script/VersionScript.h
@@ -8,7 +8,6 @@
 #define ELD_SCRIPT_VERSIONSCRIPT_H
 
 #include "eld/Script/ScriptSymbol.h"
-#include "llvm/ADT/DenseMap.h"
 #include <string>
 namespace eld {
 class StrToken;
@@ -17,10 +16,6 @@ class VersionScriptBlock;
 class VersionScriptNode;
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
 class NamePool;
-
-/// Map from ResolveInfo to its demangled name. Used for extern "C++" matching.
-/// The map is lazily populated during version script matching.
-using DemangledNamesMap = llvm::DenseMap<const ResolveInfo *, std::string>;
 #endif
 
 /*
@@ -77,10 +72,10 @@ public:
   /// the symbol non-versioned name matches the version symbol pattern.
   ///
   /// For extern "C++" symbols, the pattern is matched against the demangled
-  /// name of the symbol. The DemangledNames map is lazily populated.
+  /// name of the symbol.
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
   bool matched(const ResolveInfo &R, const NamePool &NP,
-               DemangledNamesMap &DemangledNames) const;
+               llvm::StringRef demangledName) const;
 #endif
 
 protected:

--- a/lib/Object/ObjectLinker.cpp
+++ b/lib/Object/ObjectLinker.cpp
@@ -536,13 +536,17 @@ void ObjectLinker::assignVersionNodesToSymbols() {
   // Emits diagnostics via ThisConfig.raise which is thread-safe.
   auto assignOneSymbol = [&](ResolveInfo *R) -> VersionSymbol * {
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
-    DemangledNamesMap demangledName;
+    std::optional<std::string> demangledName;
 #endif
     auto matchesR = [&](VersionSymbol *vs) {
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
-      return vs->matched(*R, NP, demangledName);
+      if (vs->isExternCpp() && !demangledName)
+        demangledName = eld::string::getDemangledName(R->getNonVersionedName());
+      return vs->matched(*R, NP,
+                         demangledName ? llvm::StringRef(*demangledName)
+                                       : llvm::StringRef());
 #else
-      return vs->getSymbolPattern()->matched(*R);
+      return vs->getSymbolPattern()->matches(*R);
 #endif
     };
 
@@ -610,8 +614,11 @@ void ObjectLinker::assignVersionNodesToSymbols() {
   // Serial merge: writes to SymbolScopes are single-threaded. Preserves the
   // hash-map's non-concurrent-insert invariant and keeps the diff minimal.
   for (size_t i = 0; i < VSApplicableSymbols.size(); ++i) {
-    if (Results[i])
+    if (Results[i]) {
+      Results[i]->getSymbolPattern()->addResolveInfoToContainer(
+          VSApplicableSymbols[i]);
       getTargetBackend().addSymbolScope(VSApplicableSymbols[i], Results[i]);
+    }
   }
 }
 

--- a/lib/Script/ScriptSymbol.cpp
+++ b/lib/Script/ScriptSymbol.cpp
@@ -38,26 +38,38 @@ void ScriptSymbol::addResolveInfoToContainer(const ResolveInfo *Info) const {
 }
 
 bool ScriptSymbol::matched(const ResolveInfo &Sym) const {
-#ifdef ELD_ENABLE_SYMBOL_VERSIONING
-  llvm::StringRef Name = Sym.getNonVersionedName();
-#else
-  llvm::StringRef Name = Sym.name();
-#endif
-  uint64_t Hash = llvm::hash_combine(Name);
-  if ((hasHash() && hashValue() == Hash) || WildcardPattern::matched(Name)) {
+  if (matches(Sym)) {
     addResolveInfoToContainer(&Sym);
     return true;
   }
   return false;
 }
 
+bool ScriptSymbol::matches(const ResolveInfo &Sym) const {
+#ifdef ELD_ENABLE_SYMBOL_VERSIONING
+  llvm::StringRef Name = Sym.getNonVersionedName();
+#else
+  llvm::StringRef Name = Sym.name();
+#endif
+  uint64_t Hash = llvm::hash_combine(Name);
+  if ((hasHash() && hashValue() == Hash) || WildcardPattern::matched(Name))
+    return true;
+  return false;
+}
+
 bool ScriptSymbol::matched(const ResolveInfo &RI,
                            llvm::StringRef demangledName) const {
-  uint64_t Hash = llvm::hash_combine(demangledName);
-  if ((hasHash() && hashValue() == Hash) ||
-      WildcardPattern::matched(demangledName)) {
+  if (matches(demangledName)) {
     addResolveInfoToContainer(&RI);
     return true;
   }
+  return false;
+}
+
+bool ScriptSymbol::matches(llvm::StringRef demangledName) const {
+  uint64_t Hash = llvm::hash_combine(demangledName);
+  if ((hasHash() && hashValue() == Hash) ||
+      WildcardPattern::matched(demangledName))
+    return true;
   return false;
 }

--- a/lib/Script/VersionScript.cpp
+++ b/lib/Script/VersionScript.cpp
@@ -10,7 +10,6 @@
 #include "eld/Script/SymbolContainer.h"
 #include "eld/Support/Memory.h"
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
-#include "eld/Support/StringRefUtils.h"
 #include "eld/SymbolResolver/NamePool.h"
 #endif
 
@@ -160,7 +159,7 @@ void VersionSymbol::dump(
 
 #ifdef ELD_ENABLE_SYMBOL_VERSIONING
 bool VersionSymbol::matched(const ResolveInfo &R, const NamePool &NP,
-                            DemangledNamesMap &DemangledNames) const {
+                            llvm::StringRef demangledName) const {
   auto *VB = getBlock();
   VersionScriptNode *VN = VB->getNode();
   if (!VN->isAnonymous()) {
@@ -183,17 +182,9 @@ bool VersionSymbol::matched(const ResolveInfo &R, const NamePool &NP,
 
   ScriptSymbol *symbolPattern = getSymbolPattern();
 
-  if (isExternCpp()) {
-    auto It = DemangledNames.find(&R);
-    if (It == DemangledNames.end()) {
-      std::string Demangled =
-          eld::string::getDemangledName(R.getNonVersionedName());
-      It = DemangledNames.insert({&R, std::move(Demangled)}).first;
-    }
-    const std::string &demangledName = It->second;
-    return symbolPattern->matched(R, demangledName);
-  }
+  if (isExternCpp())
+    return symbolPattern->matches(demangledName);
 
-  return symbolPattern->matched(R);
+  return symbolPattern->matches(R);
 }
 #endif


### PR DESCRIPTION
This commit fixes a data-race in multi-threaded version script matching that was caused due to modification of shared resources.

Resolves #1792