### PR TITLE
Fetch full QC/main history in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           # We need to use base branch from qualcomm/eld
           git remote add QC https://github.com/qualcomm/eld.git
-          git fetch QC ${{ env.BASE_BRANCH_NAME }} --depth=1
+          git fetch QC ${{ env.BASE_BRANCH_NAME }}
           MERGE_BASE=$(git merge-base QC/${{ env.BASE_BRANCH_NAME }} HEAD)
           CHANGED_FILES=$(git diff --name-only "$MERGE_BASE" HEAD)
           echo "Changed files: $CHANGED_FILES"


### PR DESCRIPTION
This commit fixes CI runs for PRs whose HEAD is behind the mainline branch. Previously, `QC/main` was fetched with `fetch-depth=1`, which could leave the workflow without enough history to compare the PR against mainline correctly.

Resolves #1807