### PR TITLE
Support TLS offsets across multiple PT_TLS segments for x86_64

### DIFF
--- a/lib/Target/X86/x86_64Relocator.cpp
+++ b/lib/Target/X86/x86_64Relocator.cpp
@@ -14,6 +14,8 @@
 #include "llvm/ADT/Twine.h"
 #include "llvm/BinaryFormat/ELF.h"
 
+#include <algorithm>
+#include <limits>
 using namespace eld;
 
 //===--------------------------------------------------------------------===//
@@ -570,19 +572,35 @@ Relocator::Result VerifyRelocAsNeededHelper(
 void x86_64Relocator::computeTLSOffsets() {
   std::vector<ELFSegment *> tlsSegments =
       getTarget().elfSegmentTable().getSegments(llvm::ELF::PT_TLS);
-
-  if (tlsSegments.empty()) {
+  if (tlsSegments.empty())
     return;
+
+  // The x86-64 TPOFF value is relative to the thread pointer.  With TLS
+  // Variant 2, the thread pointer is placed after the complete TLS image,
+  // rounded up to the required alignment.  A linker script may produce more
+  // than one PT_TLS segment, so use the complete span rather than one
+  // segment's memsz.  Empty PT_TLS segments do not contribute to the image.
+  bool hasNonEmptySegment = false;
+  uint64_t lo = std::numeric_limits<uint64_t>::max();
+  uint64_t hi = 0;
+  uint64_t alignment = 1;
+  for (ELFSegment *Segment : tlsSegments) {
+    if (Segment->memsz() == 0)
+      continue;
+
+    const uint64_t segmentEnd = Segment->vaddr() + Segment->memsz();
+    lo = std::min(lo, Segment->vaddr());
+    hi = std::max(hi, segmentEnd);
+    alignment = std::max(alignment, Segment->align());
+    hasNonEmptySegment = true;
   }
 
-  ASSERT(tlsSegments.size() == 1,
-         "Multiple TLS segments not supported in x86_64 backend");
+  if (!hasNonEmptySegment)
+    return;
 
-  ELFSegment *tlsSegment = tlsSegments[0];
-  uint64_t templateSize = tlsSegment->memsz();
-  uint64_t alignment = tlsSegment->align();
-  templateSize = llvm::alignTo(templateSize, alignment);
-  GNULDBackend::setTLSTemplateSize(templateSize);
+  const uint64_t alignedEnd = llvm::alignTo(hi, alignment);
+  const uint64_t threadPointerOffset = alignedEnd - lo;
+  GNULDBackend::setTLSTemplateSize(threadPointerOffset);
 }
 
 template <typename T>

--- a/test/x86_64/linux/TLSLocalExecMultipleSegments/Inputs/1.c
+++ b/test/x86_64/linux/TLSLocalExecMultipleSegments/Inputs/1.c
@@ -1,0 +1,5 @@
+__thread int u;
+__attribute__((aligned(256))) __thread int v;
+__thread int a = 12;
+__attribute__((aligned(128))) __thread int b = 13;
+int foo(void) { return a; }

--- a/test/x86_64/linux/TLSLocalExecMultipleSegments/Inputs/script.t
+++ b/test/x86_64/linux/TLSLocalExecMultipleSegments/Inputs/script.t
@@ -1,0 +1,12 @@
+PHDRS {
+  CODE PT_LOAD;
+  DATA PT_LOAD;
+  T1 PT_TLS;
+  T2 PT_TLS;
+}
+
+SECTIONS {
+  .text (0x1000) : { *(.text*) } :CODE
+  .tdata (0x4000) : { *(.tdata*) } :DATA :T1
+  .tbss : ALIGN(0x400) { *(.tbss*) } :DATA :T2
+}

--- a/test/x86_64/linux/TLSLocalExecMultipleSegments/TLSLocalExecMultipleSegments.test
+++ b/test/x86_64/linux/TLSLocalExecMultipleSegments/TLSLocalExecMultipleSegments.test
@@ -1,0 +1,15 @@
+#---TLSLocalExecMultipleSegments.test--------------------------- Executable,LS ---------------#
+#BEGIN_COMMENT
+# This checks x86-64 local-exec TLS relocation computation when the image has
+# multiple PT_TLS segments and the TLS segments have alignment padding.
+#END_COMMENT
+#START_TEST
+RUN: %clang %clangopts -c %p/Inputs/1.c -o %t.o
+RUN: %link %linkopts -o %t.out %t.o -T %p/Inputs/script.t
+RUN: %readelf -l %t.out | %filecheck %s --check-prefix=READELF
+RUN: %objdump -d %t.out | %filecheck %s --check-prefix=OBJDUMP
+#END_TEST
+
+READELF: TLS {{.*}} RW 0x400
+READELF: TLS {{.*}} RW 0x400
+OBJDUMP: leaq -0x800


### PR DESCRIPTION
Fixes `x86-64` TLS offset computation for images containing multiple `PT_TLS` segments.

The `x86-64` backend assumed that an output image contained exactly one `PT_TLS` segment and calculated the thread-pointer offset from that segment alone. Linker scripts can generate multiple non-empty TLS segments with padding between them, causing TLS relocations to receive incorrect offsets.

The backend now considers all non-empty `PT_TLS` segments, finds the lowest and highest TLS address, uses the maximum TLS alignment and computes the thread-pointer offset from the complete aligned TLS span.

This fixes failing test cases in `picolibc test suite` that exercise the case of multiple `PT_TLS` segments.