### PR TITLE
[test] MacOS nightly fail fix - Skip native-execute tests on non-Linux hosts

### DIFF
--- a/test/x86_64/linux/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/BuildingExecutablesWithSymbolVersioning.test
+++ b/test/x86_64/linux/SymbolVersioning/BuildingExecutablesWithSymbolVersioning/BuildingExecutablesWithSymbolVersioning.test
@@ -1,4 +1,4 @@
-REQUIRES: symbol_versioning
+REQUIRES: symbol_versioning, linux
 #---BuildingExecutablesWithSymbolVersioning.test---------------------------------------#
 #BEGIN_COMMENT
 # This test verifies that linker properly creates executables that use

--- a/test/x86_64/linux/SymbolVersioning/BuildingSharedLibsWithSymbolVersioning/BuildingSharedLibsWithSymbolVersioning.test
+++ b/test/x86_64/linux/SymbolVersioning/BuildingSharedLibsWithSymbolVersioning/BuildingSharedLibsWithSymbolVersioning.test
@@ -1,4 +1,4 @@
-REQUIRES: symbol_versioning
+REQUIRES: symbol_versioning, linux
 #---BuildingSharedLibsWithSymbolVersioning.test---------------------------------------#
 #BEGIN_COMMENT
 # This test verifies that linker properly creates shared libraries with

--- a/test/x86_64/linux/SymbolVersioning/UserFlowTests/UserFlowTests.test
+++ b/test/x86_64/linux/SymbolVersioning/UserFlowTests/UserFlowTests.test
@@ -1,4 +1,4 @@
-REQUIRES: symbol_versioning
+REQUIRES: symbol_versioning, linux
 #---UserFlowTests.test---------------------------------------#
 #BEGIN_COMMENT
 # This test verifies some end-to-end symbol versioning workflows.


### PR DESCRIPTION
compile for x86_64-linux-gnu and execute the resulting ELF binaries directly on the CI host, relying on the host itself being Linux (no run_test/sysroot gating). This broke on the new macOS nightly host, which has no Linux libc headers for clang to fall back to.